### PR TITLE
feat: add Vue Router example with createMemoryHistory

### DIFF
--- a/examples/vue-router/README.md
+++ b/examples/vue-router/README.md
@@ -1,0 +1,29 @@
+# Vue Router Example
+
+Demonstrates [Vue Router](https://router.vuejs.org/) running in a Lynx environment using `createMemoryHistory()`.
+
+## Why Memory History?
+
+Lynx has no `window.location` or History API, so the standard `createWebHistory()` and `createWebHashHistory()` won't work. `createMemoryHistory()` keeps all routing state in-process — similar to React Router's `MemoryRouter` or TanStack Router's memory history.
+
+## Key Patterns
+
+- **`NavLink.vue`** — Lynx has no `<a>` tag, so `RouterLink`'s default rendering doesn't apply. This component uses `RouterLink`'s `custom` + `v-slot` API to render native `<text>` elements with `@tap` handlers while preserving `isActive` state for styling.
+- **Programmatic navigation** — `router.push()`, `router.back()` work as expected.
+- **Dynamic route params** — `/users/:id` with `useRoute().params`.
+
+## Getting Started
+
+Install dependencies from the repo root:
+
+```bash
+pnpm install
+```
+
+Then build or run the dev server:
+
+```bash
+pnpm run dev
+# or
+pnpm run build
+```

--- a/examples/vue-router/lynx.config.ts
+++ b/examples/vue-router/lynx.config.ts
@@ -1,0 +1,19 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { defineConfig } from '@lynx-js/rspeedy';
+import { pluginVueLynx } from 'vue-lynx/plugin';
+
+export default defineConfig({
+  environments: {
+    web: {},
+    lynx: {},
+  },
+  plugins: [
+    pluginVueLynx({
+      optionsApi: false,
+      enableCSSSelector: true,
+    }),
+  ],
+});

--- a/examples/vue-router/package.json
+++ b/examples/vue-router/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "vue-lynx-example-vue-router",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Vue-Lynx + Vue Router demo using createMemoryHistory",
+  "license": "Apache-2.0",
+  "type": "module",
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev"
+  },
+  "dependencies": {
+    "vue-lynx": "workspace:*",
+    "vue-router": "^4.5.0"
+  },
+  "devDependencies": {
+    "@lynx-js/rspeedy": "^0.13.5",
+    "@rsbuild/plugin-vue": "^1.2.6",
+    "typescript": "^5.0.0"
+  },
+  "engines": { "node": ">=18" }
+}

--- a/examples/vue-router/src/App.vue
+++ b/examples/vue-router/src/App.vue
@@ -1,0 +1,33 @@
+<!-- Copyright 2025 The Lynx Authors. All rights reserved.
+     Licensed under the Apache License Version 2.0 that can be found in the
+     LICENSE file in the root directory of this source tree. -->
+
+<!--
+  App.vue — Router shell with tab-style navigation
+
+  Lynx has no <a> tag, so we use RouterLink's `custom` v-slot to render
+  native <text> elements with @tap handlers for navigation.
+-->
+<script setup lang="ts">
+import { RouterView, RouterLink } from 'vue-router';
+import NavLink from './NavLink.vue';
+</script>
+
+<template>
+  <view :style="{ flex: 1, display: 'flex', flexDirection: 'column', backgroundColor: '#f5f5f5' }">
+    <!-- Header -->
+    <text :style="{ fontSize: 18, fontWeight: 'bold', padding: 16, color: '#111', backgroundColor: '#fff' }">
+      Vue Router + Lynx
+    </text>
+
+    <!-- Navigation bar -->
+    <view :style="{ display: 'flex', flexDirection: 'row', backgroundColor: '#fff', paddingLeft: 8, paddingRight: 8, paddingBottom: 8 }">
+      <NavLink to="/" label="Home" />
+      <NavLink to="/about" label="About" />
+      <NavLink to="/users" label="Users" />
+    </view>
+
+    <!-- Route outlet -->
+    <RouterView />
+  </view>
+</template>

--- a/examples/vue-router/src/NavLink.vue
+++ b/examples/vue-router/src/NavLink.vue
@@ -1,0 +1,36 @@
+<!-- Copyright 2025 The Lynx Authors. All rights reserved.
+     Licensed under the Apache License Version 2.0 that can be found in the
+     LICENSE file in the root directory of this source tree. -->
+
+<!--
+  NavLink.vue — Lynx-compatible RouterLink wrapper
+
+  Uses RouterLink's `custom` + v-slot API to render a tappable <text>
+  instead of the default <a> tag (which doesn't exist in Lynx).
+-->
+<script setup lang="ts">
+import { RouterLink } from 'vue-router';
+
+defineProps<{
+  to: string;
+  label: string;
+}>();
+</script>
+
+<template>
+  <RouterLink :to="to" custom v-slot="{ navigate, isActive }">
+    <text
+      @tap="navigate"
+      :style="{
+        fontSize: 14,
+        padding: '8px 12px',
+        marginRight: 4,
+        borderRadius: 16,
+        color: isActive ? '#fff' : '#333',
+        backgroundColor: isActive ? '#1a73e8' : '#e8e8e8',
+      }"
+    >
+      {{ label }}
+    </text>
+  </RouterLink>
+</template>

--- a/examples/vue-router/src/index.ts
+++ b/examples/vue-router/src/index.ts
@@ -1,0 +1,31 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * Vue Router demo entry.
+ *
+ * Demonstrates Vue Router with createMemoryHistory() in a Lynx environment
+ * where window.location / window.navigator are unavailable.
+ *
+ * Features exercised:
+ *   - createMemoryHistory (no browser APIs needed)
+ *   - RouterView for rendering matched routes
+ *   - RouterLink with custom v-slot (Lynx has no <a> tag)
+ *   - Programmatic navigation via router.push()
+ *   - Dynamic route params (/users/:id)
+ *   - useRoute / useRouter composables
+ */
+
+import { createApp } from 'vue-lynx';
+import router from './router';
+import App from './App.vue';
+
+const app = createApp(App);
+app.use(router);
+
+// createMemoryHistory doesn't trigger initial navigation automatically,
+// so we must push the initial route before mounting.
+router.push('/');
+
+app.mount();

--- a/examples/vue-router/src/router.ts
+++ b/examples/vue-router/src/router.ts
@@ -1,0 +1,23 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { createRouter, createMemoryHistory } from 'vue-router';
+import Home from './views/Home.vue';
+import About from './views/About.vue';
+import UserList from './views/UserList.vue';
+import UserDetail from './views/UserDetail.vue';
+
+const router = createRouter({
+  // Lynx has no window.location / window.navigator, so we must use
+  // memory history (similar to React Router's MemoryRouter).
+  history: createMemoryHistory(),
+  routes: [
+    { path: '/', name: 'home', component: Home },
+    { path: '/about', name: 'about', component: About },
+    { path: '/users', name: 'users', component: UserList },
+    { path: '/users/:id', name: 'user-detail', component: UserDetail },
+  ],
+});
+
+export default router;

--- a/examples/vue-router/src/views/About.vue
+++ b/examples/vue-router/src/views/About.vue
@@ -1,0 +1,25 @@
+<!-- Copyright 2025 The Lynx Authors. All rights reserved.
+     Licensed under the Apache License Version 2.0 that can be found in the
+     LICENSE file in the root directory of this source tree. -->
+
+<script setup lang="ts">
+import { useRoute } from 'vue-router';
+
+const route = useRoute();
+</script>
+
+<template>
+  <view :style="{ padding: 16 }">
+    <text :style="{ fontSize: 20, fontWeight: 'bold', color: '#111', marginBottom: 8 }">
+      About
+    </text>
+    <text :style="{ fontSize: 14, color: '#555', lineHeight: 20 }">
+      Vue Router works in Lynx by using createMemoryHistory() instead of
+      createWebHistory(). This avoids any dependency on window.location or
+      the History API.
+    </text>
+    <text :style="{ fontSize: 12, color: '#999', marginTop: 12 }">
+      Current path: {{ route.fullPath }}
+    </text>
+  </view>
+</template>

--- a/examples/vue-router/src/views/Home.vue
+++ b/examples/vue-router/src/views/Home.vue
@@ -1,0 +1,39 @@
+<!-- Copyright 2025 The Lynx Authors. All rights reserved.
+     Licensed under the Apache License Version 2.0 that can be found in the
+     LICENSE file in the root directory of this source tree. -->
+
+<script setup lang="ts">
+import { useRouter } from 'vue-router';
+
+const router = useRouter();
+
+function goToUsers() {
+  router.push('/users');
+}
+</script>
+
+<template>
+  <view :style="{ padding: 16 }">
+    <text :style="{ fontSize: 20, fontWeight: 'bold', color: '#111', marginBottom: 8 }">
+      Home
+    </text>
+    <text :style="{ fontSize: 14, color: '#555', marginBottom: 16, lineHeight: 20 }">
+      This example demonstrates Vue Router with createMemoryHistory in Lynx.
+      Since Lynx has no browser navigation APIs, memory history keeps the
+      routing state entirely in-process.
+    </text>
+    <text
+      @tap="goToUsers"
+      :style="{
+        fontSize: 14,
+        color: '#1a73e8',
+        padding: '8px 16px',
+        backgroundColor: '#e8f0fe',
+        borderRadius: 8,
+        alignSelf: 'flex-start',
+      }"
+    >
+      Browse Users →
+    </text>
+  </view>
+</template>

--- a/examples/vue-router/src/views/UserDetail.vue
+++ b/examples/vue-router/src/views/UserDetail.vue
@@ -1,0 +1,60 @@
+<!-- Copyright 2025 The Lynx Authors. All rights reserved.
+     Licensed under the Apache License Version 2.0 that can be found in the
+     LICENSE file in the root directory of this source tree. -->
+
+<!--
+  UserDetail.vue — Dynamic route params (/users/:id)
+  Demonstrates useRoute().params and router.back() for navigation.
+-->
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+
+const route = useRoute();
+const router = useRouter();
+
+const users: Record<string, { name: string; role: string; bio: string }> = {
+  '1': { name: 'Alice', role: 'Engineer', bio: 'Builds cross-platform renderers with Vue and Lynx.' },
+  '2': { name: 'Bob', role: 'Designer', bio: 'Crafts pixel-perfect interfaces for mobile experiences.' },
+  '3': { name: 'Charlie', role: 'PM', bio: 'Coordinates teams to ship features on time.' },
+};
+
+const userId = computed(() => route.params.id as string);
+const user = computed(() => users[userId.value]);
+
+function goBack() {
+  router.back();
+}
+</script>
+
+<template>
+  <view :style="{ padding: 16 }">
+    <text
+      @tap="goBack"
+      :style="{ fontSize: 14, color: '#1a73e8', marginBottom: 12 }"
+    >
+      ← Back to Users
+    </text>
+
+    <view v-if="user" :style="{ backgroundColor: '#fff', borderRadius: 8, padding: 16 }">
+      <text :style="{ fontSize: 22, fontWeight: 'bold', color: '#111' }">
+        {{ user.name }}
+      </text>
+      <text :style="{ fontSize: 13, color: '#1a73e8', marginTop: 4 }">
+        {{ user.role }}
+      </text>
+      <text :style="{ fontSize: 14, color: '#555', marginTop: 12, lineHeight: 20 }">
+        {{ user.bio }}
+      </text>
+      <text :style="{ fontSize: 11, color: '#aaa', marginTop: 16 }">
+        Route param :id = {{ userId }}
+      </text>
+    </view>
+
+    <view v-else :style="{ padding: 16 }">
+      <text :style="{ fontSize: 14, color: '#e53935' }">
+        User not found (id: {{ userId }})
+      </text>
+    </view>
+  </view>
+</template>

--- a/examples/vue-router/src/views/UserList.vue
+++ b/examples/vue-router/src/views/UserList.vue
@@ -1,0 +1,56 @@
+<!-- Copyright 2025 The Lynx Authors. All rights reserved.
+     Licensed under the Apache License Version 2.0 that can be found in the
+     LICENSE file in the root directory of this source tree. -->
+
+<!--
+  UserList.vue — Demonstrates v-for + programmatic navigation to dynamic routes
+-->
+<script setup lang="ts">
+import { useRouter } from 'vue-router';
+
+const router = useRouter();
+
+const users = [
+  { id: 1, name: 'Alice', role: 'Engineer' },
+  { id: 2, name: 'Bob', role: 'Designer' },
+  { id: 3, name: 'Charlie', role: 'PM' },
+];
+
+function goToUser(id: number) {
+  router.push(`/users/${id}`);
+}
+</script>
+
+<template>
+  <view :style="{ padding: 16 }">
+    <text :style="{ fontSize: 20, fontWeight: 'bold', color: '#111', marginBottom: 12 }">
+      Users
+    </text>
+
+    <view
+      v-for="user in users"
+      :key="user.id"
+      @tap="goToUser(user.id)"
+      :style="{
+        display: 'flex',
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        padding: 12,
+        marginBottom: 8,
+        backgroundColor: '#fff',
+        borderRadius: 8,
+      }"
+    >
+      <view>
+        <text :style="{ fontSize: 15, fontWeight: 'bold', color: '#111' }">
+          {{ user.name }}
+        </text>
+        <text :style="{ fontSize: 12, color: '#777', marginTop: 2 }">
+          {{ user.role }}
+        </text>
+      </view>
+      <text :style="{ fontSize: 14, color: '#1a73e8' }">→</text>
+    </view>
+  </view>
+</template>

--- a/examples/vue-router/tsconfig.json
+++ b/examples/vue-router/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["src", "lynx.config.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,7 +66,7 @@ importers:
         version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
-        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))(vue@3.5.30(typescript@5.9.3))
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -82,7 +82,7 @@ importers:
         version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
-        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))(vue@3.5.30(typescript@5.9.3))
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -101,7 +101,7 @@ importers:
         version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
-        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))(vue@3.5.30(typescript@5.9.3))
       typescript:
         specifier: ~5.9.3
         version: 5.9.3
@@ -117,7 +117,26 @@ importers:
         version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
-        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))(vue@3.5.30(typescript@5.9.3))
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
+  examples/vue-router:
+    dependencies:
+      vue-lynx:
+        specifier: workspace:*
+        version: link:../..
+      vue-router:
+        specifier: ^4.5.0
+        version: 4.6.4(vue@3.5.30(typescript@5.9.3))
+    devDependencies:
+      '@lynx-js/rspeedy':
+        specifier: ^0.13.5
+        version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
+      '@rsbuild/plugin-vue':
+        specifier: ^1.2.6
+        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))(vue@3.5.30(typescript@5.9.3))
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -136,7 +155,7 @@ importers:
         version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
-        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))(vue@3.5.30(typescript@5.9.3))
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -1238,6 +1257,9 @@ packages:
 
   '@vue/compiler-ssr@3.5.30':
     resolution: {integrity: sha512-NsYK6OMTnx109PSL2IAyf62JP6EUdk4Dmj6AkWcJGBvN0dQoMYtVekAmdqgTtWQgEJo+Okstbf/1p7qZr5H+bA==}
+
+  '@vue/devtools-api@6.6.4':
+    resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
 
   '@vue/reactivity@3.5.30':
     resolution: {integrity: sha512-179YNgKATuwj9gB+66snskRDOitDiuOZqkYia7mHKJaidOMo/WJxHKF8DuGc4V4XbYTJANlfEKb0yxTQotnx4Q==}
@@ -3062,6 +3084,11 @@ packages:
       jsdom:
         optional: true
 
+  vue-router@4.6.4:
+    resolution: {integrity: sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==}
+    peerDependencies:
+      vue: ^3.5.0
+
   vue@3.5.30:
     resolution: {integrity: sha512-hTHLc6VNZyzzEH/l7PFGjpcTvUgiaPK5mdLkbjrTeWSRcEfxFrv56g/XckIYlE9ckuobsdwqd5mk2g1sBkMewg==}
     peerDependencies:
@@ -3745,7 +3772,7 @@ snapshots:
 
   '@rsbuild/plugin-vue@1.2.7(@rsbuild/core@1.3.19)(@rspack/core@1.7.8(@swc/helpers@0.5.19))':
     dependencies:
-      rspack-vue-loader: 17.5.0(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+      rspack-vue-loader: 17.5.0(@rspack/core@1.7.8(@swc/helpers@0.5.19))(vue@3.5.30(typescript@5.9.3))
     optionalDependencies:
       '@rsbuild/core': 1.3.19
     transitivePeerDependencies:
@@ -3753,9 +3780,9 @@ snapshots:
       - '@vue/compiler-sfc'
       - vue
 
-  '@rsbuild/plugin-vue@1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))':
+  '@rsbuild/plugin-vue@1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))(vue@3.5.30(typescript@5.9.3))':
     dependencies:
-      rspack-vue-loader: 17.5.0(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+      rspack-vue-loader: 17.5.0(@rspack/core@1.7.8(@swc/helpers@0.5.19))(vue@3.5.30(typescript@5.9.3))
     optionalDependencies:
       '@rsbuild/core': 1.7.3
     transitivePeerDependencies:
@@ -4213,6 +4240,8 @@ snapshots:
     dependencies:
       '@vue/compiler-dom': 3.5.30
       '@vue/shared': 3.5.30
+
+  '@vue/devtools-api@6.6.4': {}
 
   '@vue/reactivity@3.5.30':
     dependencies:
@@ -5711,12 +5740,13 @@ snapshots:
 
   rslog@1.3.2: {}
 
-  rspack-vue-loader@17.5.0(@rspack/core@1.7.8(@swc/helpers@0.5.19)):
+  rspack-vue-loader@17.5.0(@rspack/core@1.7.8(@swc/helpers@0.5.19))(vue@3.5.30(typescript@5.9.3)):
     dependencies:
       '@rspack/lite-tapable': 1.1.0
       chalk: 4.1.2
     optionalDependencies:
       '@rspack/core': 1.7.8(@swc/helpers@0.5.19)
+      vue: 3.5.30(typescript@5.9.3)
 
   sade@1.8.1:
     dependencies:
@@ -6158,6 +6188,11 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vue-router@4.6.4(vue@3.5.30(typescript@5.9.3)):
+    dependencies:
+      '@vue/devtools-api': 6.6.4
+      vue: 3.5.30(typescript@5.9.3)
 
   vue@3.5.30(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## Summary
Demonstrates Vue Router running in Lynx using createMemoryHistory (since Lynx has no window.location). Includes tab-based navigation, dynamic route params (/users/:id), and a custom NavLink component that adapts RouterLink to render native Lynx elements.

## Features
- Memory-based routing for non-browser context
- RouterLink custom v-slot for native <text> @tap navigation
- Dynamic params with useRoute/useRouter composables
- Example views: Home, About, Users list, and User detail pages