### PR TITLE
fix: configure Vercel build for Rspress website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ upstream-tests/core/
 .DS_Store
 website/docs/guide/api/
 website/api-sidebar.json
+.vercel

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "pnpm run build",
+  "outputDirectory": "doc_build"
+}


### PR DESCRIPTION
## Summary

- Vercel deployment failed with `STATIC_BUILD_NO_OUT_DIR` — no framework was detected and no build command was configured, so Vercel skipped the build and looked for a static `public/` directory
- Add `website/vercel.json` with `buildCommand` (`pnpm run build`) and `outputDirectory` (`doc_build`) to match Rspress output

## Test plan

- [ ] Verify Vercel deployment succeeds after merge