### PR TITLE
feat: add example/option-api to test Options API flag

### DIFF
--- a/examples/option-api/lynx.config.ts
+++ b/examples/option-api/lynx.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from '@lynx-js/rspeedy';
+import { pluginVueLynx } from 'vue-lynx/plugin';
+
+export default defineConfig({
+  environments: {
+    web: {},
+    lynx: {},
+  },
+  source: {
+    entry: {
+      main: './src/index.ts',
+    },
+  },
+  plugins: [
+    pluginVueLynx({
+      optionsApi: true,
+      enableCSSSelector: true,
+    }),
+  ],
+});

--- a/examples/option-api/package.json
+++ b/examples/option-api/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "vue-lynx-example-option-api",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Vue-Lynx Options API demo — validates that optionsApi: true works",
+  "type": "module",
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev"
+  },
+  "dependencies": {
+    "vue-lynx": "workspace:*"
+  },
+  "devDependencies": {
+    "@lynx-js/rspeedy": "^0.13.5",
+    "@rsbuild/plugin-vue": "^1.2.6",
+    "typescript": "^5.0.0"
+  }
+}

--- a/examples/option-api/src/App.vue
+++ b/examples/option-api/src/App.vue
@@ -1,0 +1,88 @@
+<!--
+  App.vue — Options API root component
+  Exercises: data, computed, methods, watch, mounted, components option
+-->
+<script lang="ts">
+import { defineComponent } from 'vue'
+import Counter from './Counter.vue'
+
+export default defineComponent({
+  components: { Counter },
+
+  data() {
+    return {
+      title: 'Vue 3 × Lynx — Options API Demo',
+      history: [] as number[],
+      mountedAt: '',
+    }
+  },
+
+  computed: {
+    historyCount(): number {
+      return this.history.length
+    },
+    lastValue(): number | undefined {
+      return this.history.length > 0
+        ? this.history[this.history.length - 1]
+        : undefined
+    },
+  },
+
+  watch: {
+    historyCount(newVal: number) {
+      if (newVal > 5) {
+        this.history.shift()
+      }
+    },
+  },
+
+  mounted() {
+    this.mountedAt = new Date().toLocaleTimeString()
+  },
+
+  methods: {
+    onCounterIncrement(value: number) {
+      this.history.push(value)
+    },
+  },
+})
+</script>
+
+<template>
+  <view :style="{ flex: 1, display: 'flex', flexDirection: 'column', backgroundColor: '#f5f5f5' }">
+    <!-- interpolation -->
+    <text :style="{ fontSize: 18, fontWeight: 'bold', margin: 16, color: '#111' }">
+      {{ title }}
+    </text>
+
+    <!-- mounted lifecycle hook result -->
+    <text v-if="mountedAt" :style="{ fontSize: 12, color: '#888', marginLeft: 16, marginBottom: 8 }">
+      Mounted at: {{ mountedAt }}
+    </text>
+
+    <!-- child component registered via components option -->
+    <Counter :initial-count="0" @increment="onCounterIncrement" />
+
+    <!-- computed property -->
+    <text v-if="lastValue !== undefined" :style="{ fontSize: 13, color: '#555', margin: '0 16px' }">
+      Last value: {{ lastValue }} ({{ historyCount }} entries)
+    </text>
+
+    <!-- v-for list rendering -->
+    <view v-if="history.length > 0" :style="{ margin: '8px 16px' }">
+      <text :style="{ fontSize: 13, color: '#555', marginBottom: 4 }">History:</text>
+      <view
+        v-for="(val, idx) in history"
+        :key="idx"
+        :style="{
+          padding: '2px 8px',
+          marginBottom: 2,
+          backgroundColor: '#fff',
+          borderRadius: 4,
+        }"
+      >
+        <text :style="{ fontSize: 12, color: '#333' }">#{{ idx + 1 }}: {{ val }}</text>
+      </view>
+    </view>
+  </view>
+</template>

--- a/examples/option-api/src/Counter.vue
+++ b/examples/option-api/src/Counter.vue
@@ -1,0 +1,93 @@
+<!--
+  Counter.vue — Options API sub-component
+  Exercises: props, emits, data, methods, watch, computed
+-->
+<script lang="ts">
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  props: {
+    initialCount: {
+      type: Number,
+      default: 0,
+    },
+  },
+
+  emits: ['increment'],
+
+  data() {
+    return {
+      count: this.initialCount,
+      showDetail: true,
+      tapMessage: '',
+    }
+  },
+
+  computed: {
+    buttonColor(): string {
+      return this.count > 5 ? '#ff4400' : '#0077ff'
+    },
+  },
+
+  watch: {
+    count(newVal: number) {
+      this.tapMessage = `Tapped! Count is now ${newVal}`
+    },
+  },
+
+  methods: {
+    onTap() {
+      this.count++
+      this.$emit('increment', this.count)
+    },
+    onToggle() {
+      this.showDetail = !this.showDetail
+    },
+  },
+})
+</script>
+
+<template>
+  <view :style="{ display: 'flex', flexDirection: 'column', padding: 12 }">
+    <!-- v-if / v-else -->
+    <text v-if="count === 0" :style="{ color: '#999', fontSize: 14 }">
+      No taps yet
+    </text>
+    <text v-else :style="{ fontSize: 22, color: '#222' }">
+      Count: {{ count }}
+    </text>
+
+    <!-- v-show -->
+    <text v-show="showDetail" :style="{ color: '#666', fontSize: 12, marginTop: 4 }">
+      (tap the button to increment)
+    </text>
+
+    <!-- watch result -->
+    <text v-if="tapMessage" :style="{ color: '#0077ff', fontSize: 11, marginTop: 2 }">
+      {{ tapMessage }}
+    </text>
+
+    <!-- @tap event, computed property for dynamic style -->
+    <view
+      :style="{
+        marginTop: 10,
+        padding: '8px 16px',
+        backgroundColor: buttonColor,
+        borderRadius: 8,
+      }"
+      @tap="onTap"
+    >
+      <text :style="{ color: '#fff' }">Tap to increment</text>
+    </view>
+
+    <!-- toggle detail visibility -->
+    <view
+      :style="{ marginTop: 6, padding: '4px 12px', backgroundColor: '#eee', borderRadius: 6 }"
+      @tap="onToggle"
+    >
+      <text :style="{ color: '#555', fontSize: 12 }">
+        {{ showDetail ? 'Hide' : 'Show' }} detail
+      </text>
+    </view>
+  </view>
+</template>

--- a/examples/option-api/src/index.ts
+++ b/examples/option-api/src/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Vue-Lynx Options API demo entry.
+ *
+ * Validates that the `optionsApi: true` plugin flag works correctly:
+ *   - data() reactive state
+ *   - computed properties
+ *   - methods
+ *   - watch
+ *   - lifecycle hooks (mounted)
+ *   - component registration via `components` option
+ */
+
+import { createApp } from 'vue-lynx';
+
+import App from './App.vue';
+
+const app = createApp(App);
+app.mount();

--- a/examples/option-api/src/shims-vue.d.ts
+++ b/examples/option-api/src/shims-vue.d.ts
@@ -1,0 +1,6 @@
+declare module '*.vue' {
+  import type { Component } from 'vue-lynx';
+
+  const component: Component;
+  export default component;
+}

--- a/examples/option-api/tsconfig.json
+++ b/examples/option-api/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["src", "lynx.config.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,22 @@ importers:
         specifier: ^5.0.0
         version: 5.9.3
 
+  examples/option-api:
+    dependencies:
+      vue-lynx:
+        specifier: workspace:*
+        version: link:../..
+    devDependencies:
+      '@lynx-js/rspeedy':
+        specifier: ^0.13.5
+        version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
+      '@rsbuild/plugin-vue':
+        specifier: ^1.2.6
+        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
   examples/standalone:
     dependencies:
       vue-lynx:


### PR DESCRIPTION
Add a new example demonstrating that the vue-lynx plugin's `optionsApi: true` flag works correctly. The example uses Vue's Options API (data, computed, watch, methods, mounted lifecycle) instead of Composition API to validate runtime support and bundle inclusion of Options API code.

## Changes
- New `examples/option-api/` directory with a complete Options API demo
- Demonstrates data reactivity, computed properties, watchers, lifecycle hooks, and methods
- Builds successfully for both web and lynx environments with ~9 kB additional bundle size (Options API runtime code)

Both web and lynx builds verify the flag properly sets `__VUE_OPTIONS_API__`.