### PR TITLE
feat: implement Transition and TransitionGroup components

### DIFF
--- a/examples/transition/lynx.config.ts
+++ b/examples/transition/lynx.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from '@lynx-js/rspeedy';
+import { pluginVueLynx } from 'vue-lynx/plugin';
+
+export default defineConfig({
+  environments: {
+    web: {},
+    lynx: {},
+  },
+  source: {
+    entry: {
+      transition: './src/index.ts',
+    },
+  },
+  plugins: [
+    pluginVueLynx({
+      optionsApi: false,
+      enableCSSSelector: true,
+    }),
+  ],
+});

--- a/examples/transition/package.json
+++ b/examples/transition/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "vue-lynx-example-transition",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Vue-Lynx Transition & TransitionGroup demo",
+  "license": "Apache-2.0",
+  "type": "module",
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev"
+  },
+  "dependencies": {
+    "vue-lynx": "workspace:*"
+  },
+  "devDependencies": {
+    "@lynx-js/rspeedy": "^0.13.5",
+    "@rsbuild/plugin-vue": "^1.2.6",
+    "typescript": "^5.0.0"
+  },
+  "engines": { "node": ">=18" }
+}

--- a/examples/transition/src/App.vue
+++ b/examples/transition/src/App.vue
@@ -1,0 +1,248 @@
+<!--
+  Transition Demo — exercises <Transition> and <TransitionGroup>
+
+  Scenarios covered:
+    1. Basic fade (CSS transition)
+    2. Named slide-fade (CSS transition)
+    3. Bounce (CSS @keyframes animation)
+    4. Transition mode="out-in" (component switch)
+    5. Transition with appear
+    6. Explicit :duration prop
+    7. TransitionGroup — list enter/leave
+    8. JS hooks (onBeforeEnter / onEnter / onLeave)
+-->
+<script setup lang="ts">
+import { ref } from 'vue'
+
+// 1. Basic fade
+const showFade = ref(true)
+
+// 2. Slide-fade
+const showSlide = ref(true)
+
+// 3. Bounce
+const showBounce = ref(true)
+
+// 4. Mode out-in (toggle between two views)
+const activeView = ref<'A' | 'B'>('A')
+
+// 5. Appear
+const showAppear = ref(true)
+
+// 6. Explicit duration
+const showDuration = ref(true)
+
+// 7. TransitionGroup list
+const listItems = ref([1, 2, 3])
+let listCounter = 3
+function addItem() {
+  listCounter++
+  const pos = Math.floor(Math.random() * (listItems.value.length + 1))
+  listItems.value.splice(pos, 0, listCounter)
+}
+function removeItem() {
+  if (listItems.value.length === 0) return
+  const pos = Math.floor(Math.random() * listItems.value.length)
+  listItems.value.splice(pos, 1)
+}
+
+// 8. JS hooks
+const showHooks = ref(true)
+function onBeforeEnter(el: any) {
+  el._transitionClasses?.add?.('hook-before-enter')
+}
+function onEnter(_el: any, done: () => void) {
+  // Auto-complete after 300ms
+  setTimeout(done, 300)
+}
+function onLeave(_el: any, done: () => void) {
+  setTimeout(done, 300)
+}
+</script>
+
+<template>
+  <scroll-view scroll-orientation="vertical" :style="{ flex: 1, backgroundColor: '#f0f0f0', padding: 16 }">
+    <text :style="{ fontSize: 20, fontWeight: 'bold', marginBottom: 16 }">Transition Demos</text>
+
+    <!-- 1. Basic Fade -->
+    <view :style="{ marginBottom: 16 }">
+      <text :style="{ fontSize: 14, fontWeight: 'bold', marginBottom: 4 }">1. Fade</text>
+      <view @tap="showFade = !showFade"
+            :style="{ backgroundColor: '#4a90d9', padding: 8, borderRadius: 4, marginBottom: 4 }">
+        <text :style="{ color: '#fff', fontSize: 13 }">Toggle Fade</text>
+      </view>
+      <Transition name="fade" :duration="300">
+        <view v-if="showFade" :style="{ backgroundColor: '#fff', padding: 12, borderRadius: 4 }">
+          <text :style="{ fontSize: 13 }">Hello, I fade in and out!</text>
+        </view>
+      </Transition>
+    </view>
+
+    <!-- 2. Slide Fade -->
+    <view :style="{ marginBottom: 16 }">
+      <text :style="{ fontSize: 14, fontWeight: 'bold', marginBottom: 4 }">2. Slide Fade</text>
+      <view @tap="showSlide = !showSlide"
+            :style="{ backgroundColor: '#4a90d9', padding: 8, borderRadius: 4, marginBottom: 4 }">
+        <text :style="{ color: '#fff', fontSize: 13 }">Toggle Slide</text>
+      </view>
+      <Transition name="slide-fade" :duration="{ enter: 300, leave: 500 }">
+        <view v-if="showSlide" :style="{ backgroundColor: '#fff', padding: 12, borderRadius: 4 }">
+          <text :style="{ fontSize: 13 }">I slide and fade!</text>
+        </view>
+      </Transition>
+    </view>
+
+    <!-- 3. Bounce (CSS animation) -->
+    <view :style="{ marginBottom: 16 }">
+      <text :style="{ fontSize: 14, fontWeight: 'bold', marginBottom: 4 }">3. Bounce</text>
+      <view @tap="showBounce = !showBounce"
+            :style="{ backgroundColor: '#4a90d9', padding: 8, borderRadius: 4, marginBottom: 4 }">
+        <text :style="{ color: '#fff', fontSize: 13 }">Toggle Bounce</text>
+      </view>
+      <Transition name="bounce" type="animation" :duration="500">
+        <view v-if="showBounce" :style="{ backgroundColor: '#fff', padding: 12, borderRadius: 4 }">
+          <text :style="{ fontSize: 13 }">Bouncy!</text>
+        </view>
+      </Transition>
+    </view>
+
+    <!-- 4. Mode out-in -->
+    <view :style="{ marginBottom: 16 }">
+      <text :style="{ fontSize: 14, fontWeight: 'bold', marginBottom: 4 }">4. Mode: out-in</text>
+      <view @tap="activeView = activeView === 'A' ? 'B' : 'A'"
+            :style="{ backgroundColor: '#4a90d9', padding: 8, borderRadius: 4, marginBottom: 4 }">
+        <text :style="{ color: '#fff', fontSize: 13 }">Switch View</text>
+      </view>
+      <Transition name="fade" mode="out-in" :duration="200">
+        <view v-if="activeView === 'A'" key="a" :style="{ backgroundColor: '#e8f5e9', padding: 12, borderRadius: 4 }">
+          <text :style="{ fontSize: 13 }">View A</text>
+        </view>
+        <view v-else key="b" :style="{ backgroundColor: '#e3f2fd', padding: 12, borderRadius: 4 }">
+          <text :style="{ fontSize: 13 }">View B</text>
+        </view>
+      </Transition>
+    </view>
+
+    <!-- 5. Appear -->
+    <view :style="{ marginBottom: 16 }">
+      <text :style="{ fontSize: 14, fontWeight: 'bold', marginBottom: 4 }">5. Appear on mount</text>
+      <Transition name="fade" appear :duration="500">
+        <view :style="{ backgroundColor: '#fff3e0', padding: 12, borderRadius: 4 }">
+          <text :style="{ fontSize: 13 }">I faded in on initial mount!</text>
+        </view>
+      </Transition>
+    </view>
+
+    <!-- 6. Explicit Duration -->
+    <view :style="{ marginBottom: 16 }">
+      <text :style="{ fontSize: 14, fontWeight: 'bold', marginBottom: 4 }">6. Explicit Duration (1000ms)</text>
+      <view @tap="showDuration = !showDuration"
+            :style="{ backgroundColor: '#4a90d9', padding: 8, borderRadius: 4, marginBottom: 4 }">
+        <text :style="{ color: '#fff', fontSize: 13 }">Toggle</text>
+      </view>
+      <Transition name="fade" :duration="1000">
+        <view v-if="showDuration" :style="{ backgroundColor: '#fff', padding: 12, borderRadius: 4 }">
+          <text :style="{ fontSize: 13 }">Slow transition (1s)</text>
+        </view>
+      </Transition>
+    </view>
+
+    <!-- 7. TransitionGroup -->
+    <view :style="{ marginBottom: 16 }">
+      <text :style="{ fontSize: 14, fontWeight: 'bold', marginBottom: 4 }">7. TransitionGroup (list)</text>
+      <view :style="{ flexDirection: 'row', marginBottom: 4 }">
+        <view @tap="addItem"
+              :style="{ backgroundColor: '#4caf50', padding: 8, borderRadius: 4, marginRight: 8 }">
+          <text :style="{ color: '#fff', fontSize: 13 }">Add</text>
+        </view>
+        <view @tap="removeItem"
+              :style="{ backgroundColor: '#f44336', padding: 8, borderRadius: 4 }">
+          <text :style="{ color: '#fff', fontSize: 13 }">Remove</text>
+        </view>
+      </view>
+      <TransitionGroup name="list" tag="view" :duration="300">
+        <view v-for="item in listItems" :key="item"
+              :style="{ backgroundColor: '#fff', padding: 8, marginBottom: 4, borderRadius: 4 }">
+          <text :style="{ fontSize: 13 }">Item {{ item }}</text>
+        </view>
+      </TransitionGroup>
+    </view>
+
+    <!-- 8. JS Hooks -->
+    <view :style="{ marginBottom: 16 }">
+      <text :style="{ fontSize: 14, fontWeight: 'bold', marginBottom: 4 }">8. JS Hooks</text>
+      <view @tap="showHooks = !showHooks"
+            :style="{ backgroundColor: '#4a90d9', padding: 8, borderRadius: 4, marginBottom: 4 }">
+        <text :style="{ color: '#fff', fontSize: 13 }">Toggle (JS hooks)</text>
+      </view>
+      <Transition
+        name="fade"
+        :duration="300"
+        @before-enter="onBeforeEnter"
+        @enter="onEnter"
+        @leave="onLeave"
+      >
+        <view v-if="showHooks" :style="{ backgroundColor: '#f3e5f5', padding: 12, borderRadius: 4 }">
+          <text :style="{ fontSize: 13 }">JS hooks control my lifecycle!</text>
+        </view>
+      </Transition>
+    </view>
+  </scroll-view>
+</template>
+
+<style>
+/* 1. Fade */
+.fade-enter-active, .fade-leave-active {
+  transition-property: opacity;
+  transition-duration: 300ms;
+}
+.fade-enter-from, .fade-leave-to {
+  opacity: 0;
+}
+
+/* 2. Slide Fade */
+.slide-fade-enter-active {
+  transition-property: opacity, transform;
+  transition-duration: 300ms;
+  transition-timing-function: ease-out;
+}
+.slide-fade-leave-active {
+  transition-property: opacity, transform;
+  transition-duration: 500ms;
+  transition-timing-function: cubic-bezier(1, 0.5, 0.8, 1);
+}
+.slide-fade-enter-from, .slide-fade-leave-to {
+  transform: translateX(20px);
+  opacity: 0;
+}
+
+/* 3. Bounce (CSS animation) */
+.bounce-enter-active {
+  animation-name: bounce-in;
+  animation-duration: 500ms;
+}
+.bounce-leave-active {
+  animation-name: bounce-in;
+  animation-duration: 500ms;
+  animation-direction: reverse;
+}
+@keyframes bounce-in {
+  0% { transform: scale(0); }
+  50% { transform: scale(1.25); }
+  100% { transform: scale(1); }
+}
+
+/* 7. TransitionGroup list */
+.list-enter-active, .list-leave-active {
+  transition-property: opacity, transform;
+  transition-duration: 300ms;
+}
+.list-enter-from {
+  opacity: 0;
+  transform: translateX(30px);
+}
+.list-leave-to {
+  opacity: 0;
+  transform: translateX(-30px);
+}
+</style>

--- a/examples/transition/src/index.ts
+++ b/examples/transition/src/index.ts
@@ -1,0 +1,9 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { createApp } from 'vue-lynx';
+import App from './App.vue';
+
+const app = createApp(App);
+app.mount();

--- a/examples/transition/src/shims-vue.d.ts
+++ b/examples/transition/src/shims-vue.d.ts
@@ -1,0 +1,14 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+declare module '*.vue' {
+  import type { Component } from 'vue-lynx';
+
+  const component: Component;
+  export default component;
+}
+
+declare module '*.png' {
+  const src: string;
+  export default src;
+}

--- a/examples/transition/tsconfig.json
+++ b/examples/transition/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+  },
+  "include": ["src", "lynx.config.ts"],
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,22 @@ importers:
         specifier: ^5.0.0
         version: 5.9.3
 
+  examples/transition:
+    dependencies:
+      vue-lynx:
+        specifier: workspace:*
+        version: link:../..
+    devDependencies:
+      '@lynx-js/rspeedy':
+        specifier: ^0.13.5
+        version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
+      '@rsbuild/plugin-vue':
+        specifier: ^1.2.6
+        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
   packages/create-vue-lynx:
     dependencies:
       create-rstack:

--- a/runtime/src/Transition.ts
+++ b/runtime/src/Transition.ts
@@ -1,0 +1,326 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * <Transition> component for vue-lynx.
+ *
+ * Wraps Vue's platform-agnostic BaseTransition with Lynx-specific CSS class
+ * management and transition-end detection.  The approach mirrors @vue/runtime-dom's
+ * Transition but replaces DOM APIs (rAF, getComputedStyle, classList) with
+ * vue-lynx's ops-based class management and flush-ack timing.
+ */
+
+import {
+  BaseTransition,
+  type BaseTransitionProps,
+  type FunctionalComponent,
+  h,
+  queuePostFlushCb,
+} from '@vue/runtime-core';
+
+import { waitForFlush } from './flush.js';
+import { resolveClass } from './node-ops.js';
+import { OP, pushOp } from './ops.js';
+import { register, unregister } from './event-registry.js';
+import { scheduleFlush } from './flush.js';
+import type { ShadowElement } from './shadow-element.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TransitionProps extends BaseTransitionProps<ShadowElement> {
+  name?: string;
+  type?: 'transition' | 'animation';
+  duration?: number | { enter: number; leave: number };
+  enterFromClass?: string;
+  enterActiveClass?: string;
+  enterToClass?: string;
+  leaveFromClass?: string;
+  leaveActiveClass?: string;
+  leaveToClass?: string;
+  appearFromClass?: string;
+  appearActiveClass?: string;
+  appearToClass?: string;
+  // User JS hooks (passed through to BaseTransition)
+  onBeforeEnter?: (el: ShadowElement) => void;
+  onEnter?: (el: ShadowElement, done: () => void) => void;
+  onAfterEnter?: (el: ShadowElement) => void;
+  onEnterCancelled?: (el: ShadowElement) => void;
+  onBeforeLeave?: (el: ShadowElement) => void;
+  onLeave?: (el: ShadowElement, done: () => void) => void;
+  onAfterLeave?: (el: ShadowElement) => void;
+  onLeaveCancelled?: (el: ShadowElement) => void;
+  onBeforeAppear?: (el: ShadowElement) => void;
+  onAppear?: (el: ShadowElement, done: () => void) => void;
+  onAfterAppear?: (el: ShadowElement) => void;
+  onAppearCancelled?: (el: ShadowElement) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Transition class helpers
+// ---------------------------------------------------------------------------
+
+function addTransitionClass(el: ShadowElement, cls: string): void {
+  el._transitionClasses.add(cls);
+  pushOp(OP.SET_CLASS, el.id, resolveClass(el));
+  scheduleFlush();
+}
+
+function removeTransitionClass(el: ShadowElement, cls: string): void {
+  el._transitionClasses.delete(cls);
+  pushOp(OP.SET_CLASS, el.id, resolveClass(el));
+  scheduleFlush();
+}
+
+// ---------------------------------------------------------------------------
+// nextFrame — waits for MT to apply the current ops batch before proceeding.
+//
+// In DOM land, Vue uses double-rAF to ensure the browser has rendered the
+// enter-from state before switching to enter-to.  In our dual-thread model
+// we need two things:
+//
+// 1. Wait for doFlush() to run (it's a post-flush callback queued by
+//    scheduleFlush).  We use queuePostFlushCb so our callback runs AFTER
+//    doFlush in the same post-flush cycle.
+//
+// 2. Wait for the MT ack (waitForFlush) — ensures the first batch of ops
+//    (enter-from / leave-from classes) has been applied on the Main Thread.
+//
+// 3. On web/dev, requestAnimationFrame provides a real frame boundary so
+//    the browser has painted the initial state before we apply the next.
+//    On native BG thread, the cross-thread round-trip already provides this.
+// ---------------------------------------------------------------------------
+
+function nextFrame(cb: () => void): void {
+  // Step 1: run after doFlush has taken the current ops and sent them to MT
+  queuePostFlushCb(() => {
+    // Step 2: wait for MT to acknowledge it applied the ops
+    waitForFlush().then(() => {
+      // Step 3: ensure at least one frame so the initial state is rendered
+      if (typeof requestAnimationFrame === 'function') {
+        requestAnimationFrame(cb);
+      } else {
+        cb();
+      }
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// whenTransitionEnds — listens for transitionend/animationend on the element.
+//
+// Because we can't call getComputedStyle() from the BG thread, we rely on
+// either the actual event or an explicit `duration` prop as a timeout fallback.
+// ---------------------------------------------------------------------------
+
+function whenTransitionEnds(
+  el: ShadowElement,
+  expectedType: 'transition' | 'animation' | undefined,
+  done: () => void,
+): void {
+  const eventName =
+    expectedType === 'animation' ? 'animationend' : 'transitionend';
+
+  let settled = false;
+  const finish = () => {
+    if (settled) return;
+    settled = true;
+    unregister(sign);
+    pushOp(OP.REMOVE_EVENT, el.id, 'bindEvent', eventName);
+    scheduleFlush();
+    done();
+  };
+
+  const sign = register((_data: unknown) => {
+    finish();
+  });
+
+  pushOp(OP.SET_EVENT, el.id, 'bindEvent', eventName, sign);
+  scheduleFlush();
+}
+
+// ---------------------------------------------------------------------------
+// Duration normalization
+// ---------------------------------------------------------------------------
+
+interface NormalizedDuration {
+  enter: number;
+  leave: number;
+}
+
+function normalizeDuration(
+  duration: TransitionProps['duration'],
+): NormalizedDuration {
+  if (typeof duration === 'number') {
+    return { enter: duration, leave: duration };
+  }
+  if (duration && typeof duration === 'object') {
+    return { enter: duration.enter, leave: duration.leave };
+  }
+  return { enter: 0, leave: 0 };
+}
+
+function hasExplicitDuration(props: TransitionProps): boolean {
+  return props.duration != null;
+}
+
+// ---------------------------------------------------------------------------
+// Hook helpers
+// ---------------------------------------------------------------------------
+
+// biome-ignore lint/suspicious/noExplicitAny: hooks have varying signatures
+function callHook(hook: ((...args: any[]) => void) | undefined, args: unknown[]): void {
+  if (hook) {
+    hook(...args);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// resolveTransitionProps — converts user-facing TransitionProps into
+// BaseTransitionProps with concrete lifecycle hooks.
+// ---------------------------------------------------------------------------
+
+function resolveTransitionProps(
+  rawProps: TransitionProps,
+): BaseTransitionProps<ShadowElement> {
+  const name = rawProps.name || 'v';
+  const {
+    type,
+    duration,
+    enterFromClass = `${name}-enter-from`,
+    enterActiveClass = `${name}-enter-active`,
+    enterToClass = `${name}-enter-to`,
+    leaveFromClass = `${name}-leave-from`,
+    leaveActiveClass = `${name}-leave-active`,
+    leaveToClass = `${name}-leave-to`,
+    appearFromClass = rawProps.appear ? enterFromClass : undefined,
+    appearActiveClass = rawProps.appear ? enterActiveClass : undefined,
+    appearToClass = rawProps.appear ? enterToClass : undefined,
+  } = rawProps;
+
+  // Pass through non-hook props (mode, appear, persisted, etc.)
+  const baseProps: BaseTransitionProps<ShadowElement> = {
+    mode: rawProps.mode,
+    appear: rawProps.appear,
+    persisted: rawProps.persisted,
+
+    onBeforeEnter(el) {
+      callHook(rawProps.onBeforeEnter, [el]);
+      addTransitionClass(el, enterFromClass);
+      addTransitionClass(el, enterActiveClass);
+    },
+
+    onEnter(el, done) {
+      nextFrame(() => {
+        removeTransitionClass(el, enterFromClass);
+        addTransitionClass(el, enterToClass);
+
+        if (!hasExplicitDuration(rawProps)) {
+          whenTransitionEnds(el, type, done);
+        } else {
+          setTimeout(done, normalizeDuration(duration).enter);
+        }
+      });
+      callHook(rawProps.onEnter, [el, done]);
+    },
+
+    onAfterEnter(el) {
+      removeTransitionClass(el, enterActiveClass);
+      removeTransitionClass(el, enterToClass);
+      callHook(rawProps.onAfterEnter, [el]);
+    },
+
+    onEnterCancelled(el) {
+      removeTransitionClass(el, enterFromClass);
+      removeTransitionClass(el, enterActiveClass);
+      removeTransitionClass(el, enterToClass);
+      callHook(rawProps.onEnterCancelled, [el]);
+    },
+
+    onBeforeLeave(el) {
+      callHook(rawProps.onBeforeLeave, [el]);
+      addTransitionClass(el, leaveFromClass);
+      addTransitionClass(el, leaveActiveClass);
+    },
+
+    onLeave(el, done) {
+      nextFrame(() => {
+        removeTransitionClass(el, leaveFromClass);
+        addTransitionClass(el, leaveToClass);
+
+        if (!hasExplicitDuration(rawProps)) {
+          whenTransitionEnds(el, type, done);
+        } else {
+          setTimeout(done, normalizeDuration(duration).leave);
+        }
+      });
+      callHook(rawProps.onLeave, [el, done]);
+    },
+
+    onAfterLeave(el) {
+      removeTransitionClass(el, leaveActiveClass);
+      removeTransitionClass(el, leaveToClass);
+      callHook(rawProps.onAfterLeave, [el]);
+    },
+
+    onLeaveCancelled(el) {
+      removeTransitionClass(el, leaveFromClass);
+      removeTransitionClass(el, leaveActiveClass);
+      removeTransitionClass(el, leaveToClass);
+      callHook(rawProps.onLeaveCancelled, [el]);
+    },
+  };
+
+  // Appear hooks — only if appear is enabled
+  if (rawProps.appear && appearFromClass && appearActiveClass && appearToClass) {
+    baseProps.onBeforeAppear = (el) => {
+      callHook(rawProps.onBeforeAppear, [el]);
+      addTransitionClass(el, appearFromClass);
+      addTransitionClass(el, appearActiveClass);
+    };
+
+    baseProps.onAppear = (el, done) => {
+      nextFrame(() => {
+        removeTransitionClass(el, appearFromClass);
+        addTransitionClass(el, appearToClass);
+
+        if (!hasExplicitDuration(rawProps)) {
+          whenTransitionEnds(el, type, done);
+        } else {
+          setTimeout(done, normalizeDuration(duration).enter);
+        }
+      });
+      callHook(rawProps.onAppear, [el, done]);
+    };
+
+    baseProps.onAfterAppear = (el) => {
+      removeTransitionClass(el, appearActiveClass);
+      removeTransitionClass(el, appearToClass);
+      callHook(rawProps.onAfterAppear, [el]);
+    };
+
+    baseProps.onAppearCancelled = (el) => {
+      removeTransitionClass(el, appearFromClass);
+      removeTransitionClass(el, appearActiveClass);
+      removeTransitionClass(el, appearToClass);
+      callHook(rawProps.onAppearCancelled, [el]);
+    };
+  }
+
+  return baseProps;
+}
+
+// ---------------------------------------------------------------------------
+// <Transition> — functional component wrapper around BaseTransition
+// ---------------------------------------------------------------------------
+
+export const Transition: FunctionalComponent<TransitionProps> = (
+  props,
+  { slots },
+) => {
+  return h(BaseTransition, resolveTransitionProps(props), slots);
+};
+
+Transition.displayName = 'Transition';

--- a/runtime/src/TransitionGroup.ts
+++ b/runtime/src/TransitionGroup.ts
@@ -1,0 +1,257 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * <TransitionGroup> component for vue-lynx.
+ *
+ * Renders a real container element (default: 'view') and applies enter/leave
+ * transition hooks to each child independently.  Move animations (FLIP) are
+ * not supported in this phase because they require synchronous bounding-rect
+ * queries which are not available from the Background Thread.
+ */
+
+import {
+  type SetupContext,
+  defineComponent,
+  getCurrentInstance,
+  h,
+  queuePostFlushCb,
+  resolveTransitionHooks,
+  setTransitionHooks,
+  useTransitionState,
+  getTransitionRawChildren,
+} from '@vue/runtime-core';
+
+import { waitForFlush } from './flush.js';
+import { resolveClass } from './node-ops.js';
+import { OP, pushOp } from './ops.js';
+import { register, unregister } from './event-registry.js';
+import { scheduleFlush } from './flush.js';
+import type { ShadowElement } from './shadow-element.js';
+import type { TransitionProps } from './Transition.js';
+
+// ---------------------------------------------------------------------------
+// Transition class helpers (same as Transition.ts)
+// ---------------------------------------------------------------------------
+
+function addTransitionClass(el: ShadowElement, cls: string): void {
+  el._transitionClasses.add(cls);
+  pushOp(OP.SET_CLASS, el.id, resolveClass(el));
+  scheduleFlush();
+}
+
+function removeTransitionClass(el: ShadowElement, cls: string): void {
+  el._transitionClasses.delete(cls);
+  pushOp(OP.SET_CLASS, el.id, resolveClass(el));
+  scheduleFlush();
+}
+
+function nextFrame(cb: () => void): void {
+  queuePostFlushCb(() => {
+    waitForFlush().then(() => {
+      if (typeof requestAnimationFrame === 'function') {
+        requestAnimationFrame(cb);
+      } else {
+        cb();
+      }
+    });
+  });
+}
+
+function whenTransitionEnds(
+  el: ShadowElement,
+  expectedType: 'transition' | 'animation' | undefined,
+  done: () => void,
+): void {
+  const eventName =
+    expectedType === 'animation' ? 'animationend' : 'transitionend';
+
+  let settled = false;
+  const finish = () => {
+    if (settled) return;
+    settled = true;
+    unregister(sign);
+    pushOp(OP.REMOVE_EVENT, el.id, 'bindEvent', eventName);
+    scheduleFlush();
+    done();
+  };
+
+  const sign = register((_data: unknown) => {
+    finish();
+  });
+
+  pushOp(OP.SET_EVENT, el.id, 'bindEvent', eventName, sign);
+  scheduleFlush();
+}
+
+interface NormalizedDuration {
+  enter: number;
+  leave: number;
+}
+
+function normalizeDuration(
+  duration: TransitionProps['duration'],
+): NormalizedDuration {
+  if (typeof duration === 'number') {
+    return { enter: duration, leave: duration };
+  }
+  if (duration && typeof duration === 'object') {
+    return { enter: duration.enter, leave: duration.leave };
+  }
+  return { enter: 0, leave: 0 };
+}
+
+function hasExplicitDuration(props: TransitionProps): boolean {
+  return props.duration != null;
+}
+
+// biome-ignore lint/suspicious/noExplicitAny: hooks have varying signatures
+function callHook(hook: ((...args: any[]) => void) | undefined, args: unknown[]): void {
+  if (hook) {
+    hook(...args);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// TransitionGroup Props (extends TransitionProps with tag)
+// ---------------------------------------------------------------------------
+
+export interface TransitionGroupProps extends TransitionProps {
+  tag?: string;
+  moveClass?: string;
+}
+
+// ---------------------------------------------------------------------------
+// <TransitionGroup>
+// ---------------------------------------------------------------------------
+
+export const TransitionGroup = defineComponent({
+  name: 'TransitionGroup',
+
+  props: {
+    tag: { type: String, default: 'view' },
+    name: { type: String, default: 'v' },
+    type: { type: String as () => 'transition' | 'animation' },
+    duration: {
+      type: [Number, Object] as unknown as () =>
+        | number
+        | { enter: number; leave: number },
+    },
+    appear: Boolean,
+    persisted: Boolean,
+    enterFromClass: String,
+    enterActiveClass: String,
+    enterToClass: String,
+    leaveFromClass: String,
+    leaveActiveClass: String,
+    leaveToClass: String,
+    appearFromClass: String,
+    appearActiveClass: String,
+    appearToClass: String,
+    moveClass: String,
+  },
+
+  setup(props: TransitionGroupProps, { slots }: SetupContext) {
+    const instance = getCurrentInstance()!;
+    const state = useTransitionState();
+
+    return () => {
+      const rawChildren = slots.default ? slots.default() : [];
+      const children = getTransitionRawChildren(rawChildren);
+
+      const name = props.name || 'v';
+      const enterFromClass = props.enterFromClass || `${name}-enter-from`;
+      const enterActiveClass = props.enterActiveClass || `${name}-enter-active`;
+      const enterToClass = props.enterToClass || `${name}-enter-to`;
+      const leaveFromClass = props.leaveFromClass || `${name}-leave-from`;
+      const leaveActiveClass = props.leaveActiveClass || `${name}-leave-active`;
+      const leaveToClass = props.leaveToClass || `${name}-leave-to`;
+
+      for (const child of children) {
+        if (child.key == null) continue;
+
+        const hooks = resolveTransitionHooks(
+          child,
+          {
+            mode: undefined, // TransitionGroup has no mode
+            appear: state.isMounted ? false : !!props.appear,
+            persisted: false,
+
+            onBeforeEnter(el: ShadowElement) {
+              callHook(props.onBeforeEnter, [el]);
+              addTransitionClass(el, enterFromClass);
+              addTransitionClass(el, enterActiveClass);
+            },
+
+            onEnter(el: ShadowElement, done: () => void) {
+              nextFrame(() => {
+                removeTransitionClass(el, enterFromClass);
+                addTransitionClass(el, enterToClass);
+
+                if (!hasExplicitDuration(props)) {
+                  whenTransitionEnds(el, props.type, done);
+                } else {
+                  setTimeout(done, normalizeDuration(props.duration).enter);
+                }
+              });
+              callHook(props.onEnter, [el, done]);
+            },
+
+            onAfterEnter(el: ShadowElement) {
+              removeTransitionClass(el, enterActiveClass);
+              removeTransitionClass(el, enterToClass);
+              callHook(props.onAfterEnter, [el]);
+            },
+
+            onEnterCancelled(el: ShadowElement) {
+              removeTransitionClass(el, enterFromClass);
+              removeTransitionClass(el, enterActiveClass);
+              removeTransitionClass(el, enterToClass);
+              callHook(props.onEnterCancelled, [el]);
+            },
+
+            onBeforeLeave(el: ShadowElement) {
+              callHook(props.onBeforeLeave, [el]);
+              addTransitionClass(el, leaveFromClass);
+              addTransitionClass(el, leaveActiveClass);
+            },
+
+            onLeave(el: ShadowElement, done: () => void) {
+              nextFrame(() => {
+                removeTransitionClass(el, leaveFromClass);
+                addTransitionClass(el, leaveToClass);
+
+                if (!hasExplicitDuration(props)) {
+                  whenTransitionEnds(el, props.type, done);
+                } else {
+                  setTimeout(done, normalizeDuration(props.duration).leave);
+                }
+              });
+              callHook(props.onLeave, [el, done]);
+            },
+
+            onAfterLeave(el: ShadowElement) {
+              removeTransitionClass(el, leaveActiveClass);
+              removeTransitionClass(el, leaveToClass);
+              callHook(props.onAfterLeave, [el]);
+            },
+
+            onLeaveCancelled(el: ShadowElement) {
+              removeTransitionClass(el, leaveFromClass);
+              removeTransitionClass(el, leaveActiveClass);
+              removeTransitionClass(el, leaveToClass);
+              callHook(props.onLeaveCancelled, [el]);
+            },
+          },
+          state,
+          instance,
+        );
+
+        setTransitionHooks(child, hooks);
+      }
+
+      return h(props.tag!, null, children);
+    };
+  },
+});

--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -44,6 +44,8 @@ import {
 } from './run-on-background.js';
 import { ShadowElement, createPageRoot } from './shadow-element.js';
 import { transformToWorklet } from './transform-to-worklet.js';
+import { Transition } from './Transition.js';
+import { TransitionGroup } from './TransitionGroup.js';
 
 export type { App, Component, ComponentPublicInstance };
 
@@ -387,6 +389,7 @@ export function Teleport(): void {
 // Transition internals:  BaseTransition, BaseTransitionPropsValidators,
 //                        resolveTransitionHooks, setTransitionHooks,
 //                        getTransitionRawChildren, useTransitionState
+//   (BaseTransition is consumed internally by our Transition/TransitionGroup)
 // SSR internals:         ssrContextKey, ssrUtils, createHydrationRenderer
 // Hydration (SSR):       hydrateOnIdle, hydrateOnVisible,
 //                        hydrateOnMediaQuery, hydrateOnInteraction
@@ -446,6 +449,12 @@ export function withKeys(
 ): (...args: unknown[]) => unknown {
   return fn;
 }
+
+// ---------------------------------------------------------------------------
+// Built-in components — Transition
+// ---------------------------------------------------------------------------
+
+export { Transition, TransitionGroup };
 
 // ---------------------------------------------------------------------------
 // Testing utilities

--- a/runtime/src/node-ops.ts
+++ b/runtime/src/node-ops.ts
@@ -80,6 +80,18 @@ function parseEventProp(key: string): EventSpec | null {
 const elementEventSigns = new Map<number, Map<string, string>>();
 
 // ---------------------------------------------------------------------------
+// Class resolution — merges user :class with transition classes
+// ---------------------------------------------------------------------------
+
+export function resolveClass(el: ShadowElement): string {
+  if (el._transitionClasses.size === 0) return el._baseClass;
+  const parts: string[] = [];
+  if (el._baseClass) parts.push(el._baseClass);
+  for (const cls of el._transitionClasses) parts.push(cls);
+  return parts.join(' ');
+}
+
+// ---------------------------------------------------------------------------
 // RendererOptions implementation
 // ---------------------------------------------------------------------------
 
@@ -249,7 +261,8 @@ export const nodeOps: RendererOptions<ShadowElement, ShadowElement> = {
       const effective = el._vShowHidden ? { ...style, display: 'none' } : style;
       pushOp(OP.SET_STYLE, el.id, effective);
     } else if (key === 'class') {
-      pushOp(OP.SET_CLASS, el.id, nextValue);
+      el._baseClass = (nextValue as string) ?? '';
+      pushOp(OP.SET_CLASS, el.id, resolveClass(el));
     } else if (key === 'id') {
       pushOp(OP.SET_ID, el.id, nextValue);
     } else {

--- a/runtime/src/shadow-element.ts
+++ b/runtime/src/shadow-element.ts
@@ -34,6 +34,13 @@ export class ShadowElement {
   // Set to true by vShow when the element should be hidden.
   _vShowHidden = false;
 
+  // Class management for Transition support.
+  // _baseClass: the class string set by the user via :class / class prop.
+  // _transitionClasses: classes added/removed by <Transition> hooks.
+  // The effective class sent to MT = _baseClass + _transitionClasses joined.
+  _baseClass = '';
+  _transitionClasses: Set<string> = new Set();
+
   constructor(type: string, forceId?: number) {
     if (forceId === undefined) {
       this.id = ShadowElement.nextId++;


### PR DESCRIPTION
## Summary

- Implemented `<Transition>` component wrapping Vue's `BaseTransition` with Lynx-specific CSS class management and transition-end detection
- Implemented `<TransitionGroup>` component for list enter/leave animations with per-child hooks
- Fixed dual-thread timing issue: `nextFrame` now uses `queuePostFlushCb` + `waitForFlush` + `requestAnimationFrame` to ensure class changes land in separate ops batches
- Added class state management to ShadowElement (`_baseClass` + `_transitionClasses`) merged via `resolveClass` helper
- Event-based transition-end detection via existing sign-based event registry (with fallback to explicit `duration` prop)
- Comprehensive demo app covering fade, slide-fade, bounce, mode out-in, appear, explicit duration, TransitionGroup list, and JS hooks

## Test plan

- All 31 existing tests pass
- Lint passes (biome)
- Build succeeds (runtime + examples)
- Examples build and run (pnpm build in examples/transition)
- Demo app tested on web and native (after nextFrame timing fix)