### PR TITLE
fix: configure Vercel build for Rspress website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ upstream-tests/core/
 .DS_Store
 website/docs/guide/api/
 website/api-sidebar.json
+.vercel

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "pnpm run build",
+  "outputDirectory": "doc_build"
+}


### PR DESCRIPTION
## Summary

Cherry-pick of #5 targeting `main` (production branch).

- Add `website/vercel.json` with `buildCommand` and `outputDirectory` (`doc_build`) so Vercel knows how to build the Rspress site

## Test plan

- [ ] Verify Vercel production deployment succeeds after merge