### PR TITLE
fix: transpile node_modules JS for Lynx engine compatibility

### DIFF
--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -117,6 +117,21 @@ export function pluginVueLynx(
 
       setup(api) {
         api.modifyRsbuildConfig((config, { mergeRsbuildConfig }) => {
+          // By default, Rsbuild does not compile JavaScript files under
+          // node_modules via SWC. Many npm packages ship ES2021+ syntax
+          // (e.g. ??=, ||=) which the Lynx JS engine does not support.
+          // Match the behavior of pluginReactLynx: compile all JS files
+          // (including those in node_modules) unless the user explicitly
+          // sets source.include.
+          const userConfig = api.getRsbuildConfig('original');
+          if (typeof userConfig.source?.include === 'undefined') {
+            config = mergeRsbuildConfig(config, {
+              source: {
+                include: [/\.(?:js|mjs|cjs)$/],
+              },
+            });
+          }
+
           return mergeRsbuildConfig(config, {
             source: {
               define: {


### PR DESCRIPTION
## Summary

- Rsbuild does not compile JS files under `node_modules` by default. Many npm packages ship ES2021+ syntax (e.g. `??=`, `||=`) which the Lynx JS engine does not support, causing `SyntaxError` at runtime.
- Match `pluginReactLynx`'s behavior: set `source.include` to compile all `.js/.mjs/.cjs` files (including `node_modules`) unless the user explicitly configures `source.include` themselves.
- Root cause discovered via Pinia example: `pinia` → `@vue/devtools-api` → `@vue/devtools-kit` → `birpc@2.9.0`, which uses `??=` in its dist.

## Test plan

- [x] `pnpm build` succeeds for all existing examples (basic, gallery, standalone, swiper)
- [x] Dev build (`NODE_ENV=development`) of pinia example produces bundle with zero `??=`/`||=`/`&&=` occurrences
- [ ] Verify on LynxExplorer that pinia example loads without `SyntaxError`