### PR TITLE
fix(website): enable web bundle preview on Vercel with loading UI

### DIFF
--- a/website/scripts/prepare-examples.mjs
+++ b/website/scripts/prepare-examples.mjs
@@ -5,12 +5,14 @@
  * Replaces the lynx-website pattern of publishing @lynx-example/* npm packages.
  */
 
+import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const EXAMPLES_SRC = path.resolve(__dirname, '../../examples');
+const REPO_ROOT = path.resolve(__dirname, '../..');
+const EXAMPLES_SRC = path.resolve(REPO_ROOT, 'examples');
 const EXAMPLES_DEST = path.resolve(__dirname, '../docs/public/examples');
 const EXAMPLE_GIT_BASE_URL = 'https://github.com/huxpro/vue-lynx/tree/main/examples';
 
@@ -199,11 +201,39 @@ if (fs.existsSync(EXAMPLES_DEST)) {
 }
 fs.mkdirSync(EXAMPLES_DEST, { recursive: true });
 
-// Process each example
+// Discover example directories
 const examples = fs.readdirSync(EXAMPLES_SRC, { withFileTypes: true })
   .filter((d) => d.isDirectory() && !SKIP_DIRS.has(d.name))
   .map((d) => d.name);
 
+// Build examples that don't have dist/ yet (e.g. on CI/Vercel where dist is gitignored)
+const needsBuild = examples.some((example) =>
+  !fs.existsSync(path.join(EXAMPLES_SRC, example, 'dist')),
+);
+
+if (needsBuild) {
+  // Examples depend on vue-lynx (workspace:*), so build the lib first if needed
+  const libBuilt = fs.existsSync(path.join(REPO_ROOT, 'plugin/dist/index.js'));
+  if (!libBuilt) {
+    console.info('Building vue-lynx library (required by examples)...');
+    execSync('pnpm build', { cwd: REPO_ROOT, stdio: 'inherit' });
+  }
+
+  for (const example of examples) {
+    const exampleDir = path.join(EXAMPLES_SRC, example);
+    const distDir = path.join(exampleDir, 'dist');
+    if (!fs.existsSync(distDir)) {
+      console.info(`Building example: ${example} (no dist/ found)`);
+      try {
+        execSync('pnpm build', { cwd: exampleDir, stdio: 'inherit' });
+      } catch (err) {
+        console.error(`  ⚠ Failed to build ${example}:`, err.message);
+      }
+    }
+  }
+}
+
+// Process each example
 for (const example of examples) {
   processExample(example);
 }

--- a/website/src/components/go/example-preview/components/web-iframe.tsx
+++ b/website/src/components/go/example-preview/components/web-iframe.tsx
@@ -21,6 +21,11 @@ interface WebIframeProps {
   src: string;
 }
 
+const LOGO_LIGHT =
+  'https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/lynx-dark-logo.svg';
+const LOGO_DARK =
+  'https://lf-lynx.tiktok-cdns.com/obj/lynx-artifacts-oss-sg/lynx-website/assets/lynx-light-logo.svg';
+
 // Shared promise so multiple WebIframe instances don't re-import
 let runtimeReady: Promise<void> | null = null;
 function ensureRuntime() {
@@ -33,11 +38,79 @@ function ensureRuntime() {
   return runtimeReady;
 }
 
+function useIsDark() {
+  const [dark, setDark] = useState(false);
+  useEffect(() => {
+    const check = () =>
+      setDark(document.documentElement.classList.contains('dark'));
+    check();
+    const mo = new MutationObserver(check);
+    mo.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class'],
+    });
+    return () => mo.disconnect();
+  }, []);
+  return dark;
+}
+
+const LoadingOverlay = ({ visible }: { visible: boolean }) => {
+  const isDark = useIsDark();
+  if (!visible) return null;
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        inset: 0,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: '12px',
+        zIndex: 1,
+        background: isDark ? '#1b1b1f' : '#ffffff',
+      }}
+    >
+      <img
+        src={isDark ? LOGO_DARK : LOGO_LIGHT}
+        alt="Lynx"
+        width={40}
+        height={40}
+        style={{ opacity: 0.5 }}
+      />
+      <div style={{ display: 'flex', gap: '6px' }}>
+        {[0, 1, 2].map((i) => (
+          <div
+            key={i}
+            style={{
+              width: '6px',
+              height: '6px',
+              borderRadius: '50%',
+              background: isDark ? 'rgba(255,255,255,0.35)' : 'rgba(0,0,0,0.25)',
+              animation: `web-iframe-bounce 1.2s ${i * 0.15}s ease-in-out infinite`,
+            }}
+          />
+        ))}
+        <style>{`@keyframes web-iframe-bounce {
+  0%, 80%, 100% { opacity: 0.3; transform: scale(0.8); }
+  40% { opacity: 1; transform: scale(1.2); }
+}`}</style>
+      </div>
+    </div>
+  );
+};
+
 export const WebIframe = ({ show, src }: WebIframeProps) => {
   const lynxViewRef = useRef<LynxView>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [ready, setReady] = useState(false);
+  const [rendered, setRendered] = useState(false);
   const [isVisible, setIsVisible] = useState(false);
+
+  // Reset rendered state when src changes
+  useEffect(() => {
+    setRendered(false);
+  }, [src]);
 
   // O1: IntersectionObserver — only activate when near viewport
   useEffect(() => {
@@ -76,19 +149,20 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
         ),
       };
 
-      // Rewrite relative asset paths in the template to be absolute,
-      // based on the bundle URL's directory. Without this, the browser
-      // resolves relative <img src> against the page URL instead of
-      // the bundle URL.
+      // Rewrite webpack's public path in the bundle JS so that asset
+      // URLs (images etc.) resolve relative to the bundle location,
+      // not the page URL. The bundles are built with the default
+      // publicPath "/" but served from e.g. /examples/hello-world/dist/.
       const baseUrl = src.substring(0, src.lastIndexOf('/') + 1);
       // @ts-ignore
       lynxViewRef.current.customTemplateLoader = async (url: string) => {
         const res = await fetch(url);
         const text = await res.text();
-        // Rewrite relative paths (e.g. "static/image/foo.png") to absolute
+        // Replace webpack public path assignment (e.g. .p="/") with
+        // the actual base URL of the bundle directory
         const rewritten = text.replace(
-          /(")(static\/[^"]+)/g,
-          (_, quote, path) => `${quote}${baseUrl}${path}`,
+          new RegExp('\\.p=\\\\".\\\\"', 'g'),
+          `.p=\\"${baseUrl}\\"`,
         );
         const template = JSON.parse(rewritten);
 
@@ -112,8 +186,30 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
       };
 
       lynxViewRef.current.url = src;
+
+      // Detect when lynx-view has rendered content via MutationObserver
+      // on its shadow root
+      const el = lynxViewRef.current as unknown as HTMLElement;
+      const shadow = el.shadowRoot;
+      if (shadow) {
+        const mo = new MutationObserver(() => {
+          if (shadow.childElementCount > 0) {
+            setRendered(true);
+            mo.disconnect();
+          }
+        });
+        mo.observe(shadow, { childList: true, subtree: true });
+      }
+
+      // Fallback: hide loading after timeout
+      const timer = setTimeout(() => setRendered(true), 5000);
+      return () => {
+        clearTimeout(timer);
+      };
     }
   }, [ready, show, src]);
+
+  const loading = show && (!ready || !rendered);
 
   return (
     <div
@@ -127,6 +223,7 @@ export const WebIframe = ({ show, src }: WebIframeProps) => {
         position: 'relative',
       }}
     >
+      <LoadingOverlay visible={loading} />
       {isVisible && show && src && (
         <lynx-view
           ref={lynxViewRef}


### PR DESCRIPTION
## Summary

Cherry-pick of #17 targeting `main` (was mistakenly merged into `Huxpro/add-favicon` after #12 had already merged).

- Build examples during `prepare-examples` when `dist/` is missing (Vercel/CI)
- Fix SWC regex parse error in `web-iframe.tsx`
- Add loading overlay with Lynx logo for web preview

## Test plan

- [ ] Verify Vercel production deployment shows Web tab in `<Go>` previews