### PR TITLE
fix: use __CreateText for built-in text elements

### DIFF
--- a/main-thread/src/ops-apply.ts
+++ b/main-thread/src/ops-apply.ts
@@ -46,6 +46,8 @@ function createTypedElement(
   switch (type) {
     case 'view':
       return __CreateView(parentComponentUniqueId);
+    case 'text':
+      return __CreateText(parentComponentUniqueId);
     case 'image':
       return __CreateImage(parentComponentUniqueId);
     case 'scroll-view':


### PR DESCRIPTION
Use the typed PAPI creator __CreateText instead of the generic __CreateElement for <text> elements. This enables type-specific rendering optimizations from the Lynx engine, matching the pattern already in place for view, image, and scroll-view elements.

**Why:** text elements now correctly use the specialized __CreateText PAPI creator, which provides rendering optimizations that the generic __CreateElement cannot deliver.

**Testing:** pnpm build and tailwindcss example build both pass successfully.