### PR TITLE
feat: add Pinia state management example

### DIFF
--- a/examples/pinia/lynx.config.ts
+++ b/examples/pinia/lynx.config.ts
@@ -1,0 +1,24 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { defineConfig } from '@lynx-js/rspeedy';
+import { pluginVueLynx } from 'vue-lynx/plugin';
+
+export default defineConfig({
+  environments: {
+    web: {},
+    lynx: {},
+  },
+  source: {
+    entry: {
+      main: './src/index.ts',
+    },
+  },
+  plugins: [
+    pluginVueLynx({
+      optionsApi: false,
+      enableCSSSelector: true,
+    }),
+  ],
+});

--- a/examples/pinia/package.json
+++ b/examples/pinia/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "vue-lynx-example-pinia",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Vue-Lynx + Pinia state management demo",
+  "license": "Apache-2.0",
+  "type": "module",
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev"
+  },
+  "dependencies": {
+    "pinia": "^3.0.2",
+    "vue-lynx": "workspace:*"
+  },
+  "devDependencies": {
+    "@lynx-js/rspeedy": "^0.13.5",
+    "@rsbuild/plugin-vue": "^1.2.6",
+    "typescript": "^5.0.0"
+  },
+  "engines": { "node": ">=18" }
+}

--- a/examples/pinia/src/App.vue
+++ b/examples/pinia/src/App.vue
@@ -1,0 +1,24 @@
+<!-- Copyright 2025 The Lynx Authors. All rights reserved.
+     Licensed under the Apache License Version 2.0 that can be found in the
+     LICENSE file in the root directory of this source tree. -->
+
+<!--
+  App.vue — Pinia state management demo
+  Demonstrates: createPinia, defineStore (setup syntax), multiple stores,
+  state/getters/actions in SFC components
+-->
+<script setup lang="ts">
+import CounterSection from './CounterSection.vue';
+import TodoSection from './TodoSection.vue';
+</script>
+
+<template>
+  <view :style="{ flex: 1, display: 'flex', flexDirection: 'column', backgroundColor: '#f5f5f5' }">
+    <text :style="{ fontSize: 18, fontWeight: 'bold', margin: 16, color: '#111' }">
+      Vue-Lynx + Pinia
+    </text>
+
+    <CounterSection />
+    <TodoSection />
+  </view>
+</template>

--- a/examples/pinia/src/CounterSection.vue
+++ b/examples/pinia/src/CounterSection.vue
@@ -1,0 +1,45 @@
+<!-- Copyright 2025 The Lynx Authors. All rights reserved.
+     Licensed under the Apache License Version 2.0 that can be found in the
+     LICENSE file in the root directory of this source tree. -->
+
+<script setup lang="ts">
+import { useCounterStore } from './stores/counter';
+
+const counter = useCounterStore();
+</script>
+
+<template>
+  <view :style="{ margin: 16, padding: 16, backgroundColor: '#fff', borderRadius: 8 }">
+    <text :style="{ fontSize: 16, fontWeight: 'bold', color: '#333', marginBottom: 8 }">
+      Counter Store
+    </text>
+
+    <text :style="{ fontSize: 14, color: '#555', marginBottom: 4 }">
+      Count: {{ counter.count }}
+    </text>
+    <text :style="{ fontSize: 14, color: '#555', marginBottom: 12 }">
+      Double: {{ counter.doubleCount }}
+    </text>
+
+    <view :style="{ display: 'flex', flexDirection: 'row', gap: 8 }">
+      <text
+        :style="{ fontSize: 14, color: '#fff', backgroundColor: '#4CAF50', padding: '6px 16px', borderRadius: 4 }"
+        @tap="counter.decrement"
+      >
+        −
+      </text>
+      <text
+        :style="{ fontSize: 14, color: '#fff', backgroundColor: '#2196F3', padding: '6px 16px', borderRadius: 4 }"
+        @tap="counter.increment"
+      >
+        +
+      </text>
+      <text
+        :style="{ fontSize: 14, color: '#fff', backgroundColor: '#9E9E9E', padding: '6px 16px', borderRadius: 4 }"
+        @tap="counter.reset"
+      >
+        Reset
+      </text>
+    </view>
+  </view>
+</template>

--- a/examples/pinia/src/TodoSection.vue
+++ b/examples/pinia/src/TodoSection.vue
@@ -1,0 +1,59 @@
+<!-- Copyright 2025 The Lynx Authors. All rights reserved.
+     Licensed under the Apache License Version 2.0 that can be found in the
+     LICENSE file in the root directory of this source tree. -->
+
+<script setup lang="ts">
+import { useTodoStore } from './stores/todos';
+
+const todoStore = useTodoStore();
+
+const sampleTodos = ['Learn Vue-Lynx', 'Try Pinia', 'Build an app'];
+let sampleIdx = 0;
+
+function addSample() {
+  const text = sampleIdx < sampleTodos.length
+    ? sampleTodos[sampleIdx]!
+    : `Todo #${sampleIdx + 1}`;
+  todoStore.addTodo(text);
+  sampleIdx++;
+}
+</script>
+
+<template>
+  <view :style="{ margin: '0 16px 16px', padding: 16, backgroundColor: '#fff', borderRadius: 8 }">
+    <text :style="{ fontSize: 16, fontWeight: 'bold', color: '#333', marginBottom: 8 }">
+      Todo Store
+    </text>
+
+    <view :style="{ display: 'flex', flexDirection: 'row', marginBottom: 12, gap: 8 }">
+      <text
+        :style="{ fontSize: 14, color: '#fff', backgroundColor: '#FF9800', padding: '6px 16px', borderRadius: 4 }"
+        @tap="addSample"
+      >
+        + Add Todo
+      </text>
+      <text :style="{ fontSize: 13, color: '#777', lineHeight: 30 }">
+        {{ todoStore.doneCount }}/{{ todoStore.totalCount }} done
+      </text>
+    </view>
+
+    <view v-if="todoStore.todos.length === 0">
+      <text :style="{ fontSize: 13, color: '#999' }">No todos yet. Tap "Add Todo" to start.</text>
+    </view>
+
+    <view v-for="todo in todoStore.todos" :key="todo.id" :style="{ display: 'flex', flexDirection: 'row', alignItems: 'center', marginBottom: 6, padding: '6px 8px', backgroundColor: todo.done ? '#E8F5E9' : '#F5F5F5', borderRadius: 4 }">
+      <text
+        :style="{ flex: 1, fontSize: 14, color: todo.done ? '#81C784' : '#333', textDecoration: todo.done ? 'line-through' : 'none' }"
+        @tap="todoStore.toggleTodo(todo.id)"
+      >
+        {{ todo.text }}
+      </text>
+      <text
+        :style="{ fontSize: 12, color: '#EF5350', padding: '2px 8px' }"
+        @tap="todoStore.removeTodo(todo.id)"
+      >
+        ✕
+      </text>
+    </view>
+  </view>
+</template>

--- a/examples/pinia/src/index.ts
+++ b/examples/pinia/src/index.ts
@@ -1,0 +1,22 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * Vue-Lynx + Pinia demo entry.
+ *
+ * Demonstrates integrating Pinia state management with vue-lynx:
+ *   - createPinia() + app.use(pinia)
+ *   - defineStore with setup syntax (ref, computed, functions)
+ *   - Multiple stores (counter + todos)
+ *   - Using stores in SFC components with <script setup>
+ */
+
+import { createApp } from 'vue-lynx';
+import { createPinia } from 'pinia';
+
+import App from './App.vue';
+
+const app = createApp(App);
+app.use(createPinia());
+app.mount();

--- a/examples/pinia/src/shims-vue.d.ts
+++ b/examples/pinia/src/shims-vue.d.ts
@@ -1,0 +1,9 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+declare module '*.vue' {
+  import type { Component } from 'vue-lynx';
+
+  const component: Component;
+  export default component;
+}

--- a/examples/pinia/src/stores/counter.ts
+++ b/examples/pinia/src/stores/counter.ts
@@ -1,0 +1,25 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { computed, ref } from 'vue';
+import { defineStore } from 'pinia';
+
+export const useCounterStore = defineStore('counter', () => {
+  const count = ref(0);
+  const doubleCount = computed(() => count.value * 2);
+
+  function increment() {
+    count.value++;
+  }
+
+  function decrement() {
+    count.value--;
+  }
+
+  function reset() {
+    count.value = 0;
+  }
+
+  return { count, doubleCount, increment, decrement, reset };
+});

--- a/examples/pinia/src/stores/todos.ts
+++ b/examples/pinia/src/stores/todos.ts
@@ -1,0 +1,35 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { computed, ref } from 'vue';
+import { defineStore } from 'pinia';
+
+export interface Todo {
+  id: number;
+  text: string;
+  done: boolean;
+}
+
+export const useTodoStore = defineStore('todos', () => {
+  const todos = ref<Todo[]>([]);
+  let nextId = 1;
+
+  const doneCount = computed(() => todos.value.filter((t) => t.done).length);
+  const totalCount = computed(() => todos.value.length);
+
+  function addTodo(text: string) {
+    todos.value.push({ id: nextId++, text, done: false });
+  }
+
+  function toggleTodo(id: number) {
+    const todo = todos.value.find((t) => t.id === id);
+    if (todo) todo.done = !todo.done;
+  }
+
+  function removeTodo(id: number) {
+    todos.value = todos.value.filter((t) => t.id !== id);
+  }
+
+  return { todos, doneCount, totalCount, addTodo, toggleTodo, removeTodo };
+});

--- a/examples/pinia/tsconfig.json
+++ b/examples/pinia/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["src", "lynx.config.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,7 +79,7 @@ importers:
         version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
-        version: 1.2.7(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -135,6 +135,25 @@ importers:
         specifier: ^5.0.0
         version: 5.9.3
 
+  examples/pinia:
+    dependencies:
+      pinia:
+        specifier: ^3.0.2
+        version: 3.0.4(typescript@5.9.3)(vue@3.5.30(typescript@5.9.3))
+      vue-lynx:
+        specifier: workspace:*
+        version: link:../..
+    devDependencies:
+      '@lynx-js/rspeedy':
+        specifier: ^0.13.5
+        version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
+      '@rsbuild/plugin-vue':
+        specifier: ^1.2.6
+        version: 1.2.7(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.8(@swc/helpers@0.5.19))(vue@3.5.30(typescript@5.9.3))
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
   examples/swiper:
     dependencies:
       vue-lynx:
@@ -168,10 +187,10 @@ importers:
         version: 0.4.0(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
-        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+        version: 1.2.7(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.8(@swc/helpers@0.5.19))
       rsbuild-plugin-tailwindcss:
         specifier: ^0.2.3
-        version: 0.2.4(@rsbuild/core@1.7.3)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))
+        version: 0.2.4(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))
       tailwindcss:
         specifier: ^3.4.17
         version: 3.4.19(tsx@4.21.0)(yaml@2.8.2)
@@ -1999,6 +2018,15 @@ packages:
   '@vue/devtools-api@6.6.4':
     resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
 
+  '@vue/devtools-api@7.7.9':
+    resolution: {integrity: sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==}
+
+  '@vue/devtools-kit@7.7.9':
+    resolution: {integrity: sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==}
+
+  '@vue/devtools-shared@7.7.9':
+    resolution: {integrity: sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==}
+
   '@vue/reactivity@3.5.30':
     resolution: {integrity: sha512-179YNgKATuwj9gB+66snskRDOitDiuOZqkYia7mHKJaidOMo/WJxHKF8DuGc4V4XbYTJANlfEKb0yxTQotnx4Q==}
 
@@ -2229,6 +2257,9 @@ packages:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
 
+  birpc@2.9.0:
+    resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
+
   body-parser@1.20.3:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -2403,6 +2434,10 @@ packages:
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
+  copy-anything@4.0.5:
+    resolution: {integrity: sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==}
     engines: {node: '>=18'}
 
   copy-text-to-clipboard@2.2.0:
@@ -3025,6 +3060,9 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
+  hookable@5.5.3:
+    resolution: {integrity: sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==}
+
   hookable@6.0.1:
     resolution: {integrity: sha512-uKGyY8BuzN/a5gvzvA+3FVWo0+wUjgtfSdnmjtrOVwQCZPHpHDH2WRO3VZSOeluYrHoDCiXFffZXs8Dj1ULWtw==}
 
@@ -3220,6 +3258,10 @@ packages:
   is-weakset@2.0.4:
     resolution: {integrity: sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==}
     engines: {node: '>= 0.4'}
+
+  is-what@5.5.0:
+    resolution: {integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==}
+    engines: {node: '>=18'}
 
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
@@ -3624,6 +3666,9 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
+
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
@@ -3750,6 +3795,9 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  perfect-debounce@1.0.0:
+    resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -3764,6 +3812,15 @@ packages:
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
+
+  pinia@3.0.4:
+    resolution: {integrity: sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==}
+    peerDependencies:
+      typescript: '>=4.5.0'
+      vue: ^3.5.11
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
@@ -4282,6 +4339,9 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
   rollup@4.59.0:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -4608,6 +4668,10 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  speakingurl@14.0.1:
+    resolution: {integrity: sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==}
+    engines: {node: '>=0.10.0'}
+
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
@@ -4690,6 +4754,10 @@ packages:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  superjson@2.2.6:
+    resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
+    engines: {node: '>=16'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -7057,6 +7125,24 @@ snapshots:
 
   '@vue/devtools-api@6.6.4': {}
 
+  '@vue/devtools-api@7.7.9':
+    dependencies:
+      '@vue/devtools-kit': 7.7.9
+
+  '@vue/devtools-kit@7.7.9':
+    dependencies:
+      '@vue/devtools-shared': 7.7.9
+      birpc: 2.9.0
+      hookable: 5.5.3
+      mitt: 3.0.1
+      perfect-debounce: 1.0.0
+      speakingurl: 14.0.1
+      superjson: 2.2.6
+
+  '@vue/devtools-shared@7.7.9':
+    dependencies:
+      rfdc: 1.4.1
+
   '@vue/reactivity@3.5.30':
     dependencies:
       '@vue/shared': 3.5.30
@@ -7295,6 +7381,8 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
+  birpc@2.9.0: {}
+
   body-parser@1.20.3:
     dependencies:
       bytes: 3.1.2
@@ -7470,6 +7558,10 @@ snapshots:
   cookie@0.7.2: {}
 
   cookie@1.1.1: {}
+
+  copy-anything@4.0.5:
+    dependencies:
+      is-what: 5.5.0
 
   copy-text-to-clipboard@2.2.0: {}
 
@@ -8238,6 +8330,8 @@ snapshots:
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
 
+  hookable@5.5.3: {}
+
   hookable@6.0.1: {}
 
   html-encoding-sniffer@4.0.0:
@@ -8436,6 +8530,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
+
+  is-what@5.5.0: {}
 
   is-wsl@2.2.0:
     dependencies:
@@ -9104,6 +9200,8 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  mitt@3.0.1: {}
+
   mri@1.2.0: {}
 
   mrmime@2.0.1: {}
@@ -9224,6 +9322,8 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  perfect-debounce@1.0.0: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -9231,6 +9331,13 @@ snapshots:
   picomatch@4.0.3: {}
 
   pify@2.3.0: {}
+
+  pinia@3.0.4(typescript@5.9.3)(vue@3.5.30(typescript@5.9.3)):
+    dependencies:
+      '@vue/devtools-api': 7.7.9
+      vue: 3.5.30(typescript@5.9.3)
+    optionalDependencies:
+      typescript: 5.9.3
 
   pirates@4.0.7: {}
 
@@ -9829,6 +9936,8 @@ snapshots:
 
   reusify@1.1.0: {}
 
+  rfdc@1.4.1: {}
+
   rollup@4.59.0:
     dependencies:
       '@types/estree': 1.0.8
@@ -9885,11 +9994,11 @@ snapshots:
     optionalDependencies:
       '@rsbuild/core': 1.3.19
 
-  rsbuild-plugin-tailwindcss@0.2.4(@rsbuild/core@1.7.3)(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2)):
+  rsbuild-plugin-tailwindcss@0.2.4(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
       tailwindcss: 3.4.19(tsx@4.21.0)(yaml@2.8.2)
     optionalDependencies:
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 2.0.0-beta.6(core-js@3.47.0)
 
   rslog@1.3.2: {}
 
@@ -10211,6 +10320,8 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  speakingurl@14.0.1: {}
+
   sprintf-js@1.0.3: {}
 
   stackback@0.0.2: {}
@@ -10301,6 +10412,10 @@ snapshots:
       pirates: 4.0.7
       tinyglobby: 0.2.15
       ts-interface-checker: 0.1.13
+
+  superjson@2.2.6:
+    dependencies:
+      copy-anything: 4.0.5
 
   supports-color@7.2.0:
     dependencies:

--- a/website/docs/guide/pinia.mdx
+++ b/website/docs/guide/pinia.mdx
@@ -1,0 +1,67 @@
+# Using Pinia
+
+[Pinia](https://pinia.vuejs.org/) is the official state management library for Vue. It provides a type-safe, extensible, and modular store with an intuitive API built on the Composition API.
+
+See also: [Vue.js — State Management](https://vuejs.org/guide/scaling-up/state-management.html#pinia)
+
+<Go example="pinia" defaultFile="src/App.vue" defaultEntryName="main" />
+
+## Installation
+
+```bash
+npm install pinia
+```
+
+## Setup
+
+Register Pinia with your vue-lynx app:
+
+```ts title="src/index.ts"
+import { createApp } from 'vue-lynx';
+import { createPinia } from 'pinia';
+import App from './App.vue';
+
+const app = createApp(App);
+app.use(createPinia());
+app.mount();
+```
+
+## Defining a Store
+
+Use `defineStore` with the [setup syntax](https://pinia.vuejs.org/core-concepts/#setup-stores) to create a store:
+
+```ts title="src/stores/counter.ts"
+import { ref, computed } from 'vue';
+import { defineStore } from 'pinia';
+
+export const useCounterStore = defineStore('counter', () => {
+  const count = ref(0);
+  const doubleCount = computed(() => count.value * 2);
+
+  function increment() {
+    count.value++;
+  }
+
+  return { count, doubleCount, increment };
+});
+```
+
+## Using the Store in a Component
+
+```vue title="src/CounterSection.vue"
+<script setup lang="ts">
+import { useCounterStore } from './stores/counter';
+
+const counter = useCounterStore();
+</script>
+
+<template>
+  <view>
+    <text>Count: {{ counter.count }}</text>
+    <text>Double: {{ counter.doubleCount }}</text>
+    <text @tap="counter.increment">+1</text>
+  </view>
+</template>
+```
+
+See [Pinia — Core Concepts](https://pinia.vuejs.org/core-concepts/) for additional resources.

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -60,6 +60,7 @@ export default defineConfig({
         {
           sectionHeaderText: 'Example',
         },
+        { text: 'Pinia', link: '/guide/pinia' },
         { text: 'Vue Router', link: '/guide/routing' },
         { text: '7 GUIs', link: '/guide/7guis' },
         { text: 'Tailwind CSS', link: '/guide/tailwindcss' },


### PR DESCRIPTION
## Summary

Replaces #16 (which targeted the wrong base branch).

- Adds `examples/pinia/` with counter + todo stores using `defineStore` with setup syntax
- Adds "Using Pinia" doc page (`website/docs/guide/pinia.mdx`) with `<Go>` component defaulting to **Web** tab (no `img` prop, fixing the broken Preview tab in #16)
- Adds "Pinia" as first item in sidebar Example section

## Test plan
- [x] `pnpm build` succeeds (pinia example: web + lynx bundles)
- [x] `pnpm test` passes (31/31)
- [x] Website builds successfully with new pinia page
- [ ] Verify on LynxExplorer: counter buttons work, todo add/toggle/remove work