### PR TITLE
feat: add example/suspense to test Suspense API

### DIFF
--- a/examples/suspense/lynx.config.ts
+++ b/examples/suspense/lynx.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from '@lynx-js/rspeedy';
+import { pluginVueLynx } from 'vue-lynx/plugin';
+
+export default defineConfig({
+  environments: {
+    web: {},
+    lynx: {},
+  },
+  source: {
+    entry: {
+      main: './src/index.ts',
+    },
+  },
+  plugins: [
+    pluginVueLynx({
+      enableCSSSelector: true,
+    }),
+  ],
+});

--- a/examples/suspense/package.json
+++ b/examples/suspense/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "vue-lynx-example-suspense",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Vue-Lynx Suspense demo — async setup, defineAsyncComponent, error handling",
+  "type": "module",
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev"
+  },
+  "dependencies": {
+    "vue-lynx": "workspace:*"
+  },
+  "devDependencies": {
+    "@lynx-js/rspeedy": "^0.13.5",
+    "@rsbuild/plugin-vue": "^1.2.6",
+    "typescript": "^5.0.0"
+  }
+}

--- a/examples/suspense/src/App.vue
+++ b/examples/suspense/src/App.vue
@@ -1,0 +1,80 @@
+<!--
+  App.vue — Suspense demo root
+  Exercises: <Suspense>, #default/#fallback slots, defineAsyncComponent
+
+  Note: async setup() (top-level await in <script setup>) is NOT supported
+  because vue-lynx does not export `withAsyncContext`. This example focuses
+  on defineAsyncComponent which does trigger the Suspense fallback.
+-->
+<script setup lang="ts">
+import { ref, defineAsyncComponent, Suspense } from 'vue-lynx'
+
+// Lazy-loaded component — triggers Suspense fallback during chunk loading
+const LazyCounter = defineAsyncComponent(() => import('./LazyCounter.vue'))
+
+// Simulated slow async component — 1.5s artificial delay
+const SlowComponent = defineAsyncComponent(
+  () =>
+    new Promise<typeof import('./SlowContent.vue')>((resolve) => {
+      setTimeout(() => resolve(import('./SlowContent.vue')), 1500)
+    }),
+)
+
+const showAsync = ref(true)
+
+function toggleAsync() {
+  showAsync.value = !showAsync.value
+}
+</script>
+
+<template>
+  <view :style="{ flex: 1, display: 'flex', flexDirection: 'column', backgroundColor: '#f5f5f5' }">
+    <text :style="{ fontSize: 18, fontWeight: 'bold', margin: 16, color: '#111' }">
+      Vue 3 × Lynx — Suspense Demo
+    </text>
+
+    <!-- Toggle button -->
+    <view
+      :style="{ margin: '0 16px 12px', padding: '8px 16px', backgroundColor: '#0077ff', borderRadius: 8 }"
+      @tap="toggleAsync"
+    >
+      <text :style="{ color: '#fff', fontSize: 14 }">
+        {{ showAsync ? 'Unmount' : 'Remount' }} async components
+      </text>
+    </view>
+
+    <!-- 1. defineAsyncComponent with simulated delay -->
+    <view v-if="showAsync" :style="{ margin: '0 16px 12px' }">
+      <text :style="{ fontSize: 14, fontWeight: 'bold', color: '#333', marginBottom: 6 }">
+        1. Slow async component (1.5s delay)
+      </text>
+      <Suspense>
+        <template #default>
+          <SlowComponent />
+        </template>
+        <template #fallback>
+          <view :style="{ padding: 12, backgroundColor: '#fff3cd', borderRadius: 6 }">
+            <text :style="{ color: '#856404', fontSize: 13 }">⏳ Loading slow component...</text>
+          </view>
+        </template>
+      </Suspense>
+    </view>
+
+    <!-- 2. defineAsyncComponent (dynamic import, instant after chunk load) -->
+    <view v-if="showAsync" :style="{ margin: '0 16px 12px' }">
+      <text :style="{ fontSize: 14, fontWeight: 'bold', color: '#333', marginBottom: 6 }">
+        2. Lazy-loaded counter (dynamic import)
+      </text>
+      <Suspense>
+        <template #default>
+          <LazyCounter />
+        </template>
+        <template #fallback>
+          <view :style="{ padding: 12, backgroundColor: '#fff3cd', borderRadius: 6 }">
+            <text :style="{ color: '#856404', fontSize: 13 }">⏳ Loading chunk...</text>
+          </view>
+        </template>
+      </Suspense>
+    </view>
+  </view>
+</template>

--- a/examples/suspense/src/LazyCounter.vue
+++ b/examples/suspense/src/LazyCounter.vue
@@ -1,0 +1,27 @@
+<!--
+  LazyCounter.vue — Lazy-loaded component via defineAsyncComponent
+  Exercises: code-splitting, Suspense with dynamic import
+-->
+<script setup lang="ts">
+import { ref } from 'vue-lynx'
+
+const count = ref(0)
+
+function onTap() {
+  count.value++
+}
+</script>
+
+<template>
+  <view :style="{ padding: 12, backgroundColor: '#cce5ff', borderRadius: 6, display: 'flex', flexDirection: 'column' }">
+    <text :style="{ color: '#004085', fontSize: 14 }">
+      Lazy-loaded counter: {{ count }}
+    </text>
+    <view
+      :style="{ marginTop: 8, padding: '6px 12px', backgroundColor: '#004085', borderRadius: 6 }"
+      @tap="onTap"
+    >
+      <text :style="{ color: '#fff', fontSize: 13 }">Tap to increment</text>
+    </view>
+  </view>
+</template>

--- a/examples/suspense/src/SlowContent.vue
+++ b/examples/suspense/src/SlowContent.vue
@@ -1,0 +1,17 @@
+<!--
+  SlowContent.vue — Content that appears after the artificial delay
+  The delay is applied in the defineAsyncComponent wrapper in App.vue,
+  so this component itself is synchronous.
+-->
+<script setup lang="ts">
+const loadedAt = new Date().toLocaleTimeString()
+</script>
+
+<template>
+  <view :style="{ padding: 12, backgroundColor: '#d4edda', borderRadius: 6 }">
+    <text :style="{ color: '#155724', fontSize: 14 }">Slow component loaded!</text>
+    <text :style="{ color: '#155724', fontSize: 11, marginTop: 4 }">
+      Resolved at: {{ loadedAt }}
+    </text>
+  </view>
+</template>

--- a/examples/suspense/src/index.ts
+++ b/examples/suspense/src/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Vue-Lynx Suspense demo entry.
+ *
+ * Validates that `<Suspense>` works on Lynx:
+ *   - #default / #fallback slot rendering
+ *   - Async setup() with top-level await
+ *   - defineAsyncComponent (lazy-loaded component)
+ *   - onErrorCaptured for async error boundaries
+ */
+
+import { createApp } from 'vue-lynx';
+
+import App from './App.vue';
+
+const app = createApp(App);
+app.mount();

--- a/examples/suspense/src/shims-vue.d.ts
+++ b/examples/suspense/src/shims-vue.d.ts
@@ -1,0 +1,6 @@
+declare module '*.vue' {
+  import type { Component } from 'vue-lynx';
+
+  const component: Component;
+  export default component;
+}

--- a/examples/suspense/tsconfig.json
+++ b/examples/suspense/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["src", "lynx.config.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,7 +63,7 @@ importers:
         version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
-        version: 1.2.7(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -79,7 +79,7 @@ importers:
         version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
-        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+        version: 1.2.7(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.8(@swc/helpers@0.5.19))
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -150,6 +150,22 @@ importers:
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
         version: 1.2.7(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.8(@swc/helpers@0.5.19))(vue@3.5.30(typescript@5.9.3))
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
+  examples/suspense:
+    dependencies:
+      vue-lynx:
+        specifier: workspace:*
+        version: link:../..
+    devDependencies:
+      '@lynx-js/rspeedy':
+        specifier: ^0.13.5
+        version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
+      '@rsbuild/plugin-vue':
+        specifier: ^1.2.6
+        version: 1.2.7(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.8(@swc/helpers@0.5.19))
       typescript:
         specifier: ^5.0.0
         version: 5.9.3

--- a/website/docs/guide/vue-feature-coverage.mdx
+++ b/website/docs/guide/vue-feature-coverage.mdx
@@ -37,12 +37,22 @@ pluginVueLynx({
 ```
 */}
 
-{/* ## Suspense
+## Suspense
 
-Vue's `<Suspense>` displays fallback content while waiting for async components or async `setup()` to resolve.
+Vue's [`<Suspense>`](https://vuejs.org/guide/built-ins/suspense.html) displays fallback content while waiting for async components to resolve. On Lynx, `<Suspense>` works with `defineAsyncComponent` for lazy-loading and code-splitting.
 
-> **Status: Experimental** — Basic `<Suspense>` with `#default` / `#fallback` slots works. Edge cases around error handling and nested suspense are not fully validated.
-*/}
+:::warning Caveat
+**Async `setup()` is not supported.** Top-level `await` in `<script setup>` requires `withAsyncContext`, which vue-lynx does not export. Use `defineAsyncComponent` or load data in `onMounted` instead.
+:::
+
+The example below shows two patterns:
+1. **Slow async component** — `defineAsyncComponent` with a simulated 1.5s delay, showing the `#fallback` slot while loading
+2. **Lazy-loaded counter** — dynamic `import()` for code-splitting, with Suspense as the loading boundary
+
+<Go
+  example="suspense"
+  defaultFile="src/App.vue"
+/>
 
 {/* ## KeepAlive
 


### PR DESCRIPTION
## Summary
- Add `examples/suspense/` with `defineAsyncComponent` + `<Suspense>` fallback demos
- Update `vue-feature-coverage.mdx` with Suspense section documenting that async `setup()` is unsupported (`withAsyncContext` not exported)

## Test plan
- [x] `pnpm build` passes for both web and lynx environments
- [x] Website builds successfully with new doc section