### PR TITLE
fix: use h-full on scroll-view for proper scroll constraint

### DIFF
--- a/examples/tailwindcss/src/App.vue
+++ b/examples/tailwindcss/src/App.vue
@@ -96,7 +96,7 @@ const planBadgeClass = computed(() =>
 
 <template>
   <scroll-view
-    class="w-full min-h-full bg-background"
+    class="w-full h-full bg-background"
     scroll-orientation="vertical"
     :style="themeStyle"
   >


### PR DESCRIPTION
## Summary

Fix scroll-view not scrolling in the tailwindcss example. The scroll-view was using `min-h-full` instead of `h-full`, causing it to expand to fit all content (making scrollHeight === clientHeight) and preventing scrolling.

## Root Cause

- **Before**: `<scroll-view class="w-full min-h-full bg-background">`
  - min-height: 100% allows expansion beyond viewport
  - scrollHeight (1054px) === clientHeight (1054px)
  - No scroll possible

- **After**: `<scroll-view class="w-full h-full bg-background">`
  - height: 100% constrains to viewport (720px)
  - scrollHeight (1054px) > clientHeight (720px)
  - Scrolling works on web and native

## Testing

✅ Verified web preview scrolls correctly
✅ Build passes (pnpm build)