### PR TITLE
docs: reorganize sidebar navigation

### DIFF
--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -48,24 +48,30 @@ export default defineConfig({
     sidebar: {
       '/guide/': [
         {
-          sectionHeaderText: 'Guide',
+          sectionHeaderText: 'Get Started',
         },
-        { text: 'What is Vue Lynx?', link: '/guide/introduction' },
         { text: 'Quick Start', link: '/guide/quick-start' },
-        { text: 'Product Gallery', link: '/guide/tutorial-gallery' },
-        { text: 'Product Detail (Swiper)', link: '/guide/tutorial-swiper' },
-        { text: 'Main Thread Script', link: '/guide/main-thread-script' },
+        { text: 'Tutorial: Product Gallery', link: '/guide/tutorial-gallery' },
+        { text: 'Tutorial: Product Swiper', link: '/guide/tutorial-swiper' },
         {
           dividerType: 'solid',
         },
         {
-          sectionHeaderText: 'Example',
+          sectionHeaderText: 'Learn VueLynx',
+        },
+        { text: 'What is VueLynx?', link: '/guide/introduction' },
+        { text: 'Main Thread Script', link: '/guide/main-thread-script' },
+        { text: 'VueLynx Testing Library', link: '/guide/testing-library' },
+        {
+          dividerType: 'solid',
+        },
+        {
+          sectionHeaderText: 'Examples',
         },
         { text: 'Pinia', link: '/guide/pinia' },
         { text: 'Vue Router', link: '/guide/routing' },
         { text: '7 GUIs', link: '/guide/7guis' },
         { text: 'Tailwind CSS', link: '/guide/tailwindcss' },
-        { text: 'VueLynx Testing Library', link: '/guide/testing-library' },
         { text: 'Vue Feature Coverage', link: '/guide/vue-feature-coverage' },
         {
           dividerType: 'solid',


### PR DESCRIPTION
## Summary

Reorganize guide sidebar into clearer sections: Get Started, Learn VueLynx, and Examples. This improves navigation by grouping onboarding content separately from learning material and examples.

## Changes

- **Get Started**: Quick Start, Tutorial: Product Gallery, Tutorial: Product Swiper
- **Learn VueLynx**: What is VueLynx?, Main Thread Script, VueLynx Testing Library  
- **Examples**: Pinia, Vue Router, 7 GUIs, Tailwind CSS, Vue Feature Coverage
- Renamed section headers for clarity (Example → Examples)