### PR TITLE
docs: use generated testing-library API reference

### DIFF
--- a/website/docs/guide/testing-library.mdx
+++ b/website/docs/guide/testing-library.mdx
@@ -456,36 +456,4 @@ For additional examples, see the test cases in the [vue-lynx testing-library sou
 
 ## API Reference
 
-### `render(component, props?)`
-
-Mounts a Vue component through the full dual-thread pipeline and returns a `RenderResult`.
-
-- **`component`** — A Vue component (created with `defineComponent` or `h()`).
-- **`props`** *(optional)* — Root props passed to the component.
-
-Returns:
-
-| Property | Description |
-|---|---|
-| `container` | The JSDOM root element containing all rendered children |
-| `unmount()` | Unmount the current Vue app |
-| `rerender(component, props?)` | Re-render with a new root component, returns a new `RenderResult` |
-| `getByText()`, `queryByText()`, ... | All [`@testing-library/dom`](https://testing-library.com/docs/queries/about) queries, bound to the container |
-
-### `cleanup()`
-
-Unmounts the current Vue app and clears the JSDOM container. Called automatically after each test via `afterEach`.
-
-### `waitForUpdate()`
-
-Waits for all pending Vue reactive updates to flush through the dual-thread pipeline. Equivalent to `await nextTick(); await nextTick()`.
-
-### `fireEvent`
-
-Dispatches Lynx events on JSDOM elements. See [Firing events](#firing-events) for event types and usage.
-
-```ts
-fireEvent.tap(element);
-fireEvent.tap(element, { eventType: 'catchEvent', key: 'value' });
-fireEvent(element, new Event('bindEvent:tap'));
-```
+See the full [vue-lynx/testing-library API Reference](/guide/api/testing-library/) for details on `render`, `fireEvent`, `cleanup`, `waitForUpdate`, and other exports.

--- a/website/scripts/generate-api.ts
+++ b/website/scripts/generate-api.ts
@@ -236,50 +236,30 @@ Vue Lynx Testing Library provides simple utilities for testing Vue 3 Lynx compon
 
 > Inspired by [Vue Testing Library](https://testing-library.com/docs/vue-testing-library/intro/) and [@lynx-js/react/testing-library](https://lynxjs.org/api/reactlynx-testing-library/)
 
-## Setup
+For setup instructions and examples, see the [VueLynx Testing Library guide](/guide/testing-library).
 
-Install and configure vitest with \`@lynx-js/testing-environment\`:
-
-\`\`\`js
-// vitest.config.js
-import { defineConfig } from 'vitest/config';
-
-export default defineConfig({
-  test: {
-    environment: '@lynx-js/testing-environment',
-  },
-});
-\`\`\`
-
-## Usage
-
-\`\`\`vue
-<!-- Counter.vue -->
-<script setup>
-import { ref } from 'vue-lynx';
-const count = ref(0);
-<\/script>
-
-<template>
-  <view>
-    <text data-testid="count">{{ count }}</text>
-    <text data-testid="increment" bindtap="count++">+1</text>
-  </view>
-</template>
-\`\`\`
+## Quick Example
 
 \`\`\`ts
-import { test, expect } from 'vitest';
-import { render, fireEvent } from 'vue-lynx/testing-library';
-import Counter from './Counter.vue';
+import { expect, it, vi } from 'vitest';
+import { h, defineComponent } from 'vue-lynx';
+import { render, fireEvent } from 'vue-lynx-testing-library';
 
-test('increments count on tap', async () => {
-  const { getByTestId } = render(Counter);
+it('fires tap event', () => {
+  const onClick = vi.fn();
+  const Comp = defineComponent({
+    setup() {
+      return () => h('view', { bindtap: onClick }, [
+        h('text', null, 'Click me'),
+      ]);
+    },
+  });
 
-  expect(getByTestId('count').textContent).toBe('0');
+  const { container, getByText } = render(Comp);
+  fireEvent.tap(container.querySelector('view')!);
 
-  await fireEvent(getByTestId('increment'), 'tap');
-  expect(getByTestId('count').textContent).toBe('1');
+  expect(onClick).toHaveBeenCalledTimes(1);
+  expect(getByText('Click me')).not.toBeNull();
 });
 \`\`\`
 


### PR DESCRIPTION
## Summary

- Remove duplicate hand-written API Reference section from testing-library.mdx and link to generated docs at /guide/api/testing-library/ instead
- Fix generated testing-library index page: replace broken .vue SFC example (unsupported data-testid attribute) with working quick example using h() and proper querying patterns  
- Fix incorrect import path in generated example from 'vue-lynx/testing-library' to 'vue-lynx-testing-library'

This improves documentation by eliminating redundancy with the auto-generated API reference while providing correct, runnable examples.