### PR TITLE
feat: add fullscreen button to swiper with tab header chrome

### DIFF
--- a/examples/swiper/src/Components/TabHeader.vue
+++ b/examples/swiper/src/Components/TabHeader.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+defineProps<{
+  tabs: string[];
+  activeTab: number;
+  isFullscreen: boolean;
+}>();
+
+const emit = defineEmits<{
+  'tab-change': [index: number];
+  'toggle-fullscreen': [];
+}>();
+</script>
+
+<template>
+  <view :class="['tab-header', isFullscreen ? 'tab-header-fullscreen' : '']">
+    <view class="tab-header-tabs">
+      <view
+        v-for="(tab, index) in tabs"
+        :key="index"
+        :class="['tab-item', index === activeTab ? 'tab-item-active' : '']"
+        @tap="emit('tab-change', index)"
+      >
+        <text
+          :class="[
+            'tab-item-label',
+            index === activeTab ? 'tab-item-label-active' : '',
+          ]"
+        >
+          {{ tab }}
+        </text>
+        <view
+          v-if="index === activeTab"
+          class="tab-item-indicator"
+        />
+      </view>
+    </view>
+    <view class="tab-header-actions">
+      <view class="fullscreen-btn" @tap="emit('toggle-fullscreen')">
+        <text class="fullscreen-btn-icon">
+          {{ isFullscreen ? '✕' : '⛶' }}
+        </text>
+      </view>
+    </view>
+  </view>
+</template>

--- a/examples/swiper/src/Swiper/App.vue
+++ b/examples/swiper/src/Swiper/App.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+import { ref } from 'vue';
+import Swiper from './Swiper.vue';
+import Page from '../Components/Page.vue';
+import TabHeader from '../Components/TabHeader.vue';
+import SafeArea from '../Components/SafeArea.vue';
+import { picsArr } from '../utils/pics.js';
+import { easings } from '../utils/useAnimate.js';
+
+const tabs = ['Photos', 'Details'];
+const activeTab = ref(0);
+const isFullscreen = ref(false);
+
+function onTabChange(index: number) {
+  activeTab.value = index;
+}
+
+function toggleFullscreen() {
+  isFullscreen.value = !isFullscreen.value;
+}
+</script>
+
+<template>
+  <!-- Normal mode: standard layout -->
+  <Page v-if="!isFullscreen">
+    <view class="tab-strip">
+      <TabHeader
+        :tabs="tabs"
+        :active-tab="activeTab"
+        :is-fullscreen="false"
+        @tab-change="onTabChange"
+        @toggle-fullscreen="toggleFullscreen"
+      />
+    </view>
+    <Swiper
+      v-if="activeTab === 0"
+      :data="picsArr"
+      :duration="300"
+      :main-thread-easing="easings.easeInOutQuad"
+    />
+    <view v-if="activeTab === 1" class="details-tab">
+      <text class="details-title">Product Details</text>
+      <text class="details-text">
+        Premium single leather seat with ergonomic design.
+        Crafted from high-quality genuine leather with a
+        reinforced steel frame for lasting durability.
+      </text>
+    </view>
+  </Page>
+
+  <!-- Fullscreen mode: player fills the entire viewport -->
+  <SafeArea v-if="isFullscreen">
+    <view class="fullscreen-container">
+      <!-- Floating tab header overlay -->
+      <view class="fullscreen-header-wrap">
+        <TabHeader
+          :tabs="tabs"
+          :active-tab="activeTab"
+          :is-fullscreen="true"
+          @tab-change="onTabChange"
+          @toggle-fullscreen="toggleFullscreen"
+        />
+      </view>
+
+      <!-- Content fills the screen -->
+      <Swiper
+        v-if="activeTab === 0"
+        :data="picsArr"
+        :duration="300"
+        :main-thread-easing="easings.easeInOutQuad"
+      />
+      <view v-if="activeTab === 1" class="details-tab details-tab-fullscreen">
+        <text class="details-title">Product Details</text>
+        <text class="details-text">
+          Premium single leather seat with ergonomic design.
+          Crafted from high-quality genuine leather with a
+          reinforced steel frame for lasting durability.
+        </text>
+      </view>
+    </view>
+  </SafeArea>
+</template>

--- a/examples/swiper/src/Swiper/index.ts
+++ b/examples/swiper/src/Swiper/index.ts
@@ -1,23 +1,6 @@
-import { createApp, defineComponent, h } from 'vue-lynx';
+import { createApp } from 'vue-lynx';
 
 import '../swiper.css';
-import Swiper from './Swiper.vue';
-import Page from '../Components/Page.vue';
-import { picsArr } from '../utils/pics.js';
-import { easings } from '../utils/useAnimate.js';
-
-const App = defineComponent({
-  setup() {
-    return () =>
-      h(Page, null, {
-        default: () =>
-          h(Swiper, {
-            data: picsArr,
-            duration: 300,
-            'main-thread-easing': easings.easeInOutQuad,
-          }),
-      });
-  },
-});
+import App from './App.vue';
 
 createApp(App).mount();

--- a/examples/swiper/src/swiper.css
+++ b/examples/swiper/src/swiper.css
@@ -142,3 +142,104 @@
   align-items: flex-end;
   justify-content: center;
 }
+
+/* Tab Header */
+.tab-strip {
+  width: 100%;
+}
+.tab-header {
+  width: 100%;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background-color: #111113;
+  padding: 0 16px;
+}
+.tab-header-fullscreen {
+  background-color: rgba(17, 17, 19, 0.82);
+}
+.tab-header-tabs {
+  display: flex;
+  flex: 1;
+  align-items: center;
+}
+.tab-item {
+  margin-right: 24px;
+  padding: 8px 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+.tab-item-label {
+  font-size: 15px;
+  color: rgba(255, 255, 255, 0.5);
+  font-weight: 400;
+}
+.tab-item-label-active {
+  color: #ffffff;
+  font-weight: 600;
+}
+.tab-item-indicator {
+  width: 20px;
+  height: 3px;
+  border-radius: 2px;
+  background-color: #ff6740;
+  margin-top: 4px;
+}
+.tab-header-actions {
+  display: flex;
+  align-items: center;
+}
+.fullscreen-btn {
+  width: 36px;
+  height: 36px;
+  border-radius: 18px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(255, 255, 255, 0.12);
+}
+.fullscreen-btn-icon {
+  font-size: 18px;
+  color: #ffffff;
+}
+
+/* Fullscreen */
+.fullscreen-container {
+  flex: 1;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  background-color: #000;
+}
+.fullscreen-header-wrap {
+  width: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: 10;
+}
+
+/* Details Tab */
+.details-tab {
+  flex: 1;
+  width: 100%;
+  padding: 24px 20px;
+  display: flex;
+  flex-direction: column;
+}
+.details-tab-fullscreen {
+  padding-top: 68px;
+}
+.details-title {
+  font-size: 20px;
+  font-weight: 600;
+  color: #ffffff;
+  margin-bottom: 12px;
+}
+.details-text {
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.7);
+  line-height: 22px;
+}


### PR DESCRIPTION
Add a TabHeader component with tab switching (Photos/Details) and a
fullscreen toggle button. In fullscreen mode the image player fills
the viewport while keeping the tab header as a translucent overlay,
allowing users to switch tabs and exit fullscreen. iOS Safari safe
area is respected via the existing SafeArea component.

https://claude.ai/code/session_01THQqxvRWssKFjiJAx2Bmg2