### PR TITLE
Improve homepage and guide sidebar

### DIFF
--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -68,9 +68,9 @@ export default defineConfig({
         {
           sectionHeaderText: 'Examples',
         },
-        { text: 'Pinia', link: '/guide/pinia' },
-        { text: 'Vue Router', link: '/guide/routing' },
         { text: '7 GUIs', link: '/guide/7guis' },
+        { text: 'Vue Router', link: '/guide/routing' },
+        { text: 'Pinia', link: '/guide/pinia' },
         { text: 'Tailwind CSS', link: '/guide/tailwindcss' },
         { text: 'Vue Feature Coverage', link: '/guide/vue-feature-coverage' },
         {

--- a/website/src/components/home-comps/features/index.tsx
+++ b/website/src/components/home-comps/features/index.tsx
@@ -58,6 +58,10 @@ const featuresConfig = [
     ),
     title: 'Compatible with Vue Ecosystem',
     desc: 'Bring your favorite Vue libraries and enjoy the rich Vue ecosystem on Lynx.',
+    actions: [
+      { text: 'Vue Router', link: '/guide/routing' },
+      { text: 'Pinia', link: '/guide/pinia' },
+    ],
   },
 ];
 


### PR DESCRIPTION
Add Vue Router and Pinia action buttons to the "Compatible with Vue Ecosystem" feature card on the homepage. Reorder the Examples section in the guide sidebar to: 7 GUIs, Vue Router, Pinia, Tailwind CSS.