### PR TITLE
fix(website): add cleanUrls to Vercel config to fix 404 flash

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "pnpm run build",
-  "outputDirectory": "doc_build"
+  "outputDirectory": "doc_build",
+  "cleanUrls": true
 }


### PR DESCRIPTION
## Summary
- Rspress is configured with `cleanUrls: true`, generating links without `.html` extensions (e.g. `/guide/routing`)
- Vercel wasn't configured to serve `routing.html` for `/guide/routing`, so every clean URL request returned HTTP 404 with the `404.html` fallback
- The client-side JS would then hydrate and render the correct page, causing a visible "404 flash" on every page load
- Fix: add `"cleanUrls": true` to `vercel.json`

## Test plan
- [ ] Deploy to Vercel preview
- [ ] Navigate directly to `https://vue.lynxjs.org/guide/routing` — should return 200 (not 404)
- [ ] Verify no "PAGE NOT FOUND" flash on any page load