### PR TITLE
fix(ci): add pnpm version to publish workflows

### DIFF
--- a/.github/workflows/publish-create-vue-lynx.yml
+++ b/.github/workflows/publish-create-vue-lynx.yml
@@ -10,9 +10,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          version: 10
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/publish-examples.yml
+++ b/.github/workflows/publish-examples.yml
@@ -12,9 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          version: 10
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,9 +10,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        with:
+          version: 10
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: 'https://registry.npmjs.org'
 
       - run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

- Add `version: 10` to `pnpm/action-setup@v4` in all three publish workflows
- Use node 22 to match `ci.yml`

Fixes the publish workflow failures from `v0.1.0-pre-alpha.0` tag push.

## Test plan

- [ ] After merge, delete old tags, re-push `v0.1.0-pre-alpha.0` and `create-vue-lynx@0.1.0-pre-alpha.0` to re-trigger