### PR TITLE
fix(create-vue-lynx): add missing vue dep, fix workspace:* leak

### DIFF
--- a/.github/workflows/publish-create-vue-lynx.yml
+++ b/.github/workflows/publish-create-vue-lynx.yml
@@ -29,7 +29,7 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           if [[ "$VERSION" == *-* ]]; then
             TAG=$(echo "$VERSION" | sed 's/[0-9]*\.[0-9]*\.[0-9]*-\(.*\)\.[0-9]*/\1/')
-            npm publish --access public --tag "$TAG"
+            pnpm publish --access public --tag "$TAG" --no-git-checks
           else
-            npm publish --access public
+            pnpm publish --access public --no-git-checks
           fi

--- a/packages/create-vue-lynx/package.json
+++ b/packages/create-vue-lynx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-vue-lynx",
-  "version": "0.1.0-pre-alpha.0",
+  "version": "0.1.0-pre-alpha.1",
   "description": "Create a new Vue Lynx project",
   "license": "Apache-2.0",
   "type": "module",
@@ -23,6 +23,7 @@
     "@lynx-js/qrcode-rsbuild-plugin": "^0.4.6",
     "@lynx-js/rspeedy": "^0.13.5",
     "@rsbuild/plugin-vue": "^1.2.6",
+    "vue": "^3.5.0",
     "vue-lynx": "workspace:*",
     "typescript": "^5.0.0"
   },

--- a/packages/create-vue-lynx/template-vue-js/package.json
+++ b/packages/create-vue-lynx/template-vue-js/package.json
@@ -8,6 +8,7 @@
     "preview": "rspeedy preview"
   },
   "dependencies": {
+    "vue": "workspace:*",
     "vue-lynx": "workspace:*"
   },
   "devDependencies": {

--- a/packages/create-vue-lynx/template-vue-ts/package.json
+++ b/packages/create-vue-lynx/template-vue-ts/package.json
@@ -8,6 +8,7 @@
     "preview": "rspeedy preview"
   },
   "dependencies": {
+    "vue": "workspace:*",
     "vue-lynx": "workspace:*"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,10 +295,13 @@ importers:
         version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
-        version: 1.2.7(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+        version: 1.2.7(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.8(@swc/helpers@0.5.19))(vue@3.5.30(typescript@5.9.3))
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
+      vue:
+        specifier: ^3.5.0
+        version: 3.5.30(typescript@5.9.3)
       vue-lynx:
         specifier: workspace:*
         version: link:../..


### PR DESCRIPTION
## Summary

- Add `vue` to template dependencies and `create-vue-lynx` devDependencies — scaffolded projects were missing `vue`, causing `@vitejs/plugin-vue requires vue` error
- Switch `npm publish` to `pnpm publish` in the workflow — `npm publish` doesn't resolve `workspace:*` protocols, so the published package had literal `workspace:*` in devDependencies
- Bump to `0.1.0-pre-alpha.1`

## Test plan

- [ ] After merge, push `create-vue-lynx@0.1.0-pre-alpha.1` tag
- [ ] Verify `npm view create-vue-lynx@0.1.0-pre-alpha.1 devDependencies` shows real version for vue-lynx
- [ ] Run `npx create-vue-lynx@0.1.0-pre-alpha.1 test-app --template vue-ts`
- [ ] `cd test-app && npm install && npx rspeedy dev` should work without errors