### PR TITLE
chore: prepare remaining examples for npm publish

### DIFF
--- a/examples/7guis/package.json
+++ b/examples/7guis/package.json
@@ -1,10 +1,16 @@
 {
-  "name": "vue-lynx-example-7guis",
+  "name": "@vue-lynx-example/7guis",
   "version": "0.1.0",
-  "private": true,
+  "private": false,
   "description": "7 GUIs benchmark — Counter, Temperature Converter, Flight Booker, Timer, CRUD, Circle Drawer, Cells",
   "license": "Apache-2.0",
   "type": "module",
+  "files": ["dist", "src", "lynx.config.ts", "tsconfig.json"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Huxpro/vue-lynx",
+    "directory": "examples/7guis"
+  },
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev"

--- a/examples/main-thread/package.json
+++ b/examples/main-thread/package.json
@@ -1,9 +1,15 @@
 {
-  "name": "vue-lynx-example-main-thread",
+  "name": "@vue-lynx-example/main-thread",
   "version": "0.1.0",
-  "private": true,
+  "private": false,
   "description": "Vue-Lynx main thread demo — draggable examples comparing Main Thread vs Background Thread updates",
   "type": "module",
+  "files": ["dist", "src", "lynx.config.ts", "tsconfig.json"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Huxpro/vue-lynx",
+    "directory": "examples/main-thread"
+  },
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev"

--- a/examples/option-api/package.json
+++ b/examples/option-api/package.json
@@ -1,9 +1,15 @@
 {
-  "name": "vue-lynx-example-option-api",
+  "name": "@vue-lynx-example/option-api",
   "version": "0.1.0",
-  "private": true,
+  "private": false,
   "description": "Vue-Lynx Options API demo — validates that optionsApi: true works",
   "type": "module",
+  "files": ["dist", "src", "lynx.config.ts", "tsconfig.json"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Huxpro/vue-lynx",
+    "directory": "examples/option-api"
+  },
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev"

--- a/examples/pinia/package.json
+++ b/examples/pinia/package.json
@@ -1,10 +1,16 @@
 {
-  "name": "vue-lynx-example-pinia",
+  "name": "@vue-lynx-example/pinia",
   "version": "0.1.0",
-  "private": true,
+  "private": false,
   "description": "Vue-Lynx + Pinia state management demo",
   "license": "Apache-2.0",
   "type": "module",
+  "files": ["dist", "src", "lynx.config.ts", "tsconfig.json"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Huxpro/vue-lynx",
+    "directory": "examples/pinia"
+  },
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev"

--- a/examples/suspense/package.json
+++ b/examples/suspense/package.json
@@ -1,9 +1,15 @@
 {
-  "name": "vue-lynx-example-suspense",
+  "name": "@vue-lynx-example/suspense",
   "version": "0.1.0",
-  "private": true,
+  "private": false,
   "description": "Vue-Lynx Suspense demo — async setup, defineAsyncComponent, error handling",
   "type": "module",
+  "files": ["dist", "src", "lynx.config.ts", "tsconfig.json"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Huxpro/vue-lynx",
+    "directory": "examples/suspense"
+  },
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev"

--- a/examples/tailwindcss/package.json
+++ b/examples/tailwindcss/package.json
@@ -1,8 +1,14 @@
 {
-  "name": "vue-lynx-example-tailwindcss",
+  "name": "@vue-lynx-example/tailwindcss",
   "version": "0.1.0",
-  "private": true,
+  "private": false,
   "type": "module",
+  "files": ["dist", "src", "lynx.config.ts", "tsconfig.json"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Huxpro/vue-lynx",
+    "directory": "examples/tailwindcss"
+  },
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev"

--- a/examples/todomvc/package.json
+++ b/examples/todomvc/package.json
@@ -1,9 +1,15 @@
 {
-  "name": "vue-lynx-example-todomvc",
+  "name": "@vue-lynx-example/todomvc",
   "version": "0.1.0",
-  "private": true,
+  "private": false,
   "description": "TodoMVC built with Vue 3 × Lynx",
   "type": "module",
+  "files": ["dist", "src", "lynx.config.ts", "tsconfig.json"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Huxpro/vue-lynx",
+    "directory": "examples/todomvc"
+  },
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev"

--- a/examples/transition/package.json
+++ b/examples/transition/package.json
@@ -1,10 +1,16 @@
 {
-  "name": "vue-lynx-example-transition",
+  "name": "@vue-lynx-example/transition",
   "version": "0.1.0",
-  "private": true,
+  "private": false,
   "description": "Vue-Lynx Transition & TransitionGroup demo",
   "license": "Apache-2.0",
   "type": "module",
+  "files": ["dist", "src", "lynx.config.ts", "tsconfig.json"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Huxpro/vue-lynx",
+    "directory": "examples/transition"
+  },
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev"

--- a/examples/vue-router/package.json
+++ b/examples/vue-router/package.json
@@ -1,10 +1,16 @@
 {
-  "name": "vue-lynx-example-vue-router",
+  "name": "@vue-lynx-example/vue-router",
   "version": "0.1.0",
-  "private": true,
+  "private": false,
   "description": "Vue-Lynx + Vue Router demo using createMemoryHistory",
   "license": "Apache-2.0",
   "type": "module",
+  "files": ["dist", "src", "lynx.config.ts", "tsconfig.json"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Huxpro/vue-lynx",
+    "directory": "examples/vue-router"
+  },
   "scripts": {
     "build": "rspeedy build",
     "dev": "rspeedy dev"


### PR DESCRIPTION
## Summary

- Rename 9 remaining example packages to `@vue-lynx-example/*` scope
- Set `"private": false`, add `files` and `repository` fields
- All 13 examples are now publishable under `@vue-lynx-example`

## Test plan

- [ ] CI passes
- [ ] After merge, trigger Publish Examples workflow