### PR TITLE
refactor(examples): use viewport units for root container CSS

### DIFF
--- a/examples/gallery/src/gallery.css
+++ b/examples/gallery/src/gallery.css
@@ -9,7 +9,7 @@
 /* ─── Gallery Wrapper ─────────────────────────────────── */
 
 .gallery-wrapper {
-  height: 100%;
+  height: 100vh;
   background-color: black;
 }
 
@@ -63,7 +63,7 @@
 /* ─── List ────────────────────────────────────────────── */
 
 .list {
-  width: 100%;
+  width: 100vw;
   padding-bottom: 20px;
   padding-left: 20px;
   padding-right: 20px;

--- a/examples/swiper/src/swiper.css
+++ b/examples/swiper/src/swiper.css
@@ -1,7 +1,7 @@
 /* Safe Area */
 .safe-area {
-  width: 100%;
-  height: 100%;
+  width: 100vw;
+  height: 100vh;
   padding-bottom: 20px;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

Align CSS dimensions for root containers in gallery and swiper examples with React Gallery's compiled output. Changed from percentage units (100%) to viewport units (100vw/100vh).

**Changes:**
- `examples/gallery`: .gallery-wrapper height and .list width
- `examples/swiper`: .safe-area width and height

## Rationale

React Gallery's Lynx CSS compiler converts root-level 100% to 100vh (height) and 100vw (width), ensuring content fills the viewport. Vue examples now match this behavior for consistent layout across both implementations.