### PR TITLE
docs: clarify VueLynx mount() has no selector parameter

### DIFF
--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -62,7 +62,12 @@ const _createApp = _renderer.createApp;
  * @public
  */
 export interface VueLynxApp {
-  /** Mount the root component onto the Lynx page root. No selector needed — the Lynx page root is always ready. */
+  /**
+   * Mount the root component onto the Lynx page root.
+   *
+   * Unlike Vue on the web, there is no container selector — Lynx has a single
+   * page root and all content is always mounted there.
+   */
   mount(): void;
   /** Unmount the application and clean up all components. */
   unmount(): void;


### PR DESCRIPTION
## Summary
- Improve JSDoc for VueLynxApp.mount() to explicitly document that it takes no selector parameter
- Unlike Vue on the web, Lynx has a single page root and all content mounts there

## Context
The method signature was already correct (no parameters), but the documentation could be clearer. This aligns with the API design discussed in #63's PR discussion about Vue root being the page.