### PR TITLE
refactor: inline worklet-runtime into main-thread.js

### DIFF
--- a/.plans/0319-1-inline-worklet-runtime.md
+++ b/.plans/0319-1-inline-worklet-runtime.md
@@ -1,0 +1,53 @@
+# Refactor: Inline worklet-runtime into main-thread.js
+
+**Date**: 2026-03-19
+**Status**: Completed ✅
+
+---
+
+## Background
+
+Previously, worklet-runtime (from `@lynx-js/react/worklet-runtime`) was injected as a **separate Lepus chunk** named `'worklet-runtime'`:
+
+1. `VueWorkletRuntimePlugin` hooked into `LynxTemplatePlugin.beforeEncode` and pushed the chunk into `lepusCode.chunks`
+2. `entry-main.ts` called `__LoadLepusChunk('worklet-runtime', { chunkType: 0 })` at startup to load it
+3. Native Lynx loaded the chunk, making `globalThis.runWorklet` / `registerWorkletInternal` / `lynxWorkletImpl` available
+
+The layer-based architecture plan (`0309-5`) explicitly kept this design:
+> **Keep `VueWorkletRuntimePlugin`** (unchanged — still needed to inject worklet-runtime Lepus chunk).
+
+## Motivation
+
+The separate-chunk approach added unnecessary complexity:
+
+- A dedicated webpack plugin (`VueWorkletRuntimePlugin`, ~50 lines) to inject the chunk via `beforeEncode`
+- `fs.readFileSync` at compile time to read the worklet-runtime source
+- `__LoadLepusChunk` call at runtime with fallback error handling for load failure
+- A "half-initialized" failure mode: main-thread boots but worklet dispatch is broken
+
+Since the layer-based refactor already made webpack handle the main-thread entry natively, the worklet-runtime can simply be another module in that entry — no special chunk mechanism needed.
+
+## Change
+
+1. **`plugin/src/entry.ts`**: Add `workletRuntimePath` as a webpack entry import in the main-thread bundle (after `entry-main.js`, before user imports). Remove `VueWorkletRuntimePlugin` class and its usage. Remove unused `fs` import.
+
+2. **`main-thread/src/entry-main.ts`**: Remove the `__LoadLepusChunk('worklet-runtime', ...)` block (~30 lines).
+
+## Key Risk: Does Native Lynx require `__LoadLepusChunk` as a signal?
+
+The original code commented:
+> Native Lynx requires this chunk to be loaded via __LoadLepusChunk so it knows to call runWorklet() when a worklet event fires.
+
+**Verified on LynxExplorer (iOS simulator)**: `examples/main-thread` draggable demo works correctly — worklet events fire, MT draggable responds to touch with zero latency. Native Lynx dispatches to `runWorklet()` based on the presence of the global function, not the chunk-loading signal.
+
+## Trade-offs
+
+### Pros
+- Simpler plugin code (−80 lines)
+- No separate Lepus chunk concept in vue-lynx
+- Atomic loading: worklet-runtime succeeds or fails with the entire main-thread entry
+- More predictable bundle structure: one `lepusCode.root`, no `lepusCode.chunks`
+
+### Cons
+- Cannot independently cache worklet-runtime across entries (minor — it's ~10 kB)
+- Execution order depends on webpack module scheduling (mitigated: entry-main.js is listed first)

--- a/main-thread/src/entry-main.ts
+++ b/main-thread/src/entry-main.ts
@@ -27,37 +27,10 @@ g['SystemInfo'] = (typeof lynx !== 'undefined' && lynx.SystemInfo) ?? {};
 // as a bare identifier (the SWC transform generates `runOnBackground(_jsFnK)`).
 g['runOnBackground'] = runOnBackground;
 
-// Load the worklet-runtime Lepus chunk which provides:
+// The worklet-runtime (from @lynx-js/react) is bundled into this
+// main-thread entry by the vue-lynx plugin — it provides:
 //   globalThis.runWorklet, globalThis.registerWorkletInternal,
 //   globalThis.lynxWorkletImpl (with Element class, Animation, etc.)
-// Native Lynx requires this chunk to be loaded via __LoadLepusChunk so it
-// knows to call runWorklet() when a worklet event fires.
-declare function __LoadLepusChunk(
-  name: string,
-  options: Record<string, unknown>,
-): boolean;
-declare const globDynamicComponentEntry: string | undefined;
-
-if (typeof __LoadLepusChunk === 'undefined') {
-  console.warn(
-    '[vue-mt] __LoadLepusChunk not available, worklet events will not work',
-  );
-} else {
-  const chunkOpts: Record<string, unknown> = { chunkType: 0 };
-  if (typeof globDynamicComponentEntry !== 'undefined') {
-    chunkOpts['dynamicComponentEntry'] = globDynamicComponentEntry;
-  }
-  const loaded = __LoadLepusChunk('worklet-runtime', chunkOpts);
-  if (loaded) {
-    console.info('[vue-mt] worklet-runtime chunk loaded');
-  } else {
-    console.error(
-      '[vue-mt] __LoadLepusChunk("worklet-runtime") returned false — '
-        + 'registerWorkletInternal will not be available. '
-        + 'Check browser console for loadScriptSync errors.',
-    );
-  }
-}
 
 /** PAGE_ROOT_ID must match the value in runtime/src/shadow-element.ts */
 const PAGE_ROOT_ID = 1;

--- a/plugin/src/entry.ts
+++ b/plugin/src/entry.ts
@@ -2,7 +2,6 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -22,7 +21,7 @@ const PLUGIN_TEMPLATE = 'lynx:vue-template';
 const PLUGIN_RUNTIME_WRAPPER = 'lynx:vue-runtime-wrapper';
 const PLUGIN_ENCODE = 'lynx:vue-encode';
 const PLUGIN_MARK_MAIN_THREAD = 'lynx:vue-mark-main-thread';
-const PLUGIN_WORKLET_RUNTIME = 'lynx:vue-worklet-runtime';
+// worklet-runtime is now bundled directly into main-thread.js (no separate chunk).
 const PLUGIN_WEB_ENCODE = 'lynx:vue-web-encode';
 
 /** Minimal typing for a webpack Chunk (avoids importing @rspack/core). */
@@ -146,60 +145,6 @@ class VueMarkMainThreadPlugin {
   }
 }
 
-/**
- * VueWorkletRuntimePlugin injects the React worklet-runtime as a Lepus chunk
- * named 'worklet-runtime' so that __LoadLepusChunk('worklet-runtime', ...)
- * can load it at runtime. Native Lynx requires this chunk to be present for
- * worklet event dispatch (main-thread:bindtap etc.) to work.
- */
-class VueWorkletRuntimePlugin {
-  constructor(private readonly workletRuntimePath: string) {}
-
-  apply(compiler: WebpackCompiler): void {
-    compiler.hooks.thisCompilation.tap(
-      PLUGIN_WORKLET_RUNTIME,
-      (compilation) => {
-        const hooks = LynxTemplatePlugin.getLynxTemplatePluginHooks(
-          // @ts-expect-error Rspack x Webpack compilation type mismatch
-          compilation,
-        ) as {
-          beforeEncode: {
-            tap(
-              name: string,
-              fn: (args: Record<string, unknown>) => Record<string, unknown>,
-            ): void;
-          };
-        };
-        const { RawSource } = compiler.webpack.sources;
-        hooks.beforeEncode.tap(PLUGIN_WORKLET_RUNTIME, (args) => {
-          const encodeData = args['encodeData'] as {
-            lepusCode: {
-              root?: { source: { source(): string } };
-              chunks: Array<{
-                name: string;
-                source: unknown;
-                info: Record<string, unknown>;
-              }>;
-            };
-          };
-          const lepusCode = encodeData.lepusCode;
-          // Always include worklet-runtime when we have main-thread code.
-          // (Phase 2 could gate this on registerWorkletInternal presence.)
-          if (lepusCode.root) {
-            lepusCode.chunks.push({
-              name: 'worklet-runtime',
-              source: new RawSource(
-                fs.readFileSync(this.workletRuntimePath, 'utf8'),
-              ),
-              info: { 'lynx:main-thread': true },
-            });
-          }
-          return args;
-        });
-      },
-    );
-  }
-}
 
 const PLUGIN_CSS_CONFIG = 'lynx:vue-css-config';
 
@@ -412,6 +357,12 @@ export function applyEntry(
     // Collect all main-thread filenames to mark with lynx:main-thread
     const mainThreadFilenames: string[] = [];
 
+    // Resolve worklet-runtime from @lynx-js/react (reuse existing impl).
+    // Bundled directly into main-thread.js as an entry import.
+    const workletRuntimePath = require.resolve(
+      '@lynx-js/react/worklet-runtime',
+    );
+
     for (const [entryName, entryPoint] of Object.entries(entries)) {
       // Collect user imports from the original entry
       const imports: string[] = [];
@@ -454,7 +405,7 @@ export function applyEntry(
         .entry(mainThreadEntry)
         .add({
           layer: LAYERS.MAIN_THREAD,
-          import: [path.resolve(vueLynxRoot, 'main-thread/dist/entry-main.js'), ...imports],
+          import: [path.resolve(vueLynxRoot, 'main-thread/dist/entry-main.js'), workletRuntimePath, ...imports],
           filename: mainThreadName,
         })
         .when(enabledHMR, entry => {
@@ -541,15 +492,6 @@ export function applyEntry(
       chain
         .plugin(PLUGIN_MARK_MAIN_THREAD)
         .use(VueMarkMainThreadPlugin, [mainThreadFilenames])
-        .end();
-
-      // Resolve worklet-runtime from @lynx-js/react (reuse existing impl)
-      const workletRuntimePath = require.resolve(
-        '@lynx-js/react/worklet-runtime',
-      );
-      chain
-        .plugin(PLUGIN_WORKLET_RUNTIME)
-        .use(VueWorkletRuntimePlugin, [workletRuntimePath])
         .end();
     }
 


### PR DESCRIPTION
## Summary

- Bundle `@lynx-js/react/worklet-runtime` directly as a webpack entry import in the main-thread bundle, instead of injecting it as a separate Lepus chunk via `VueWorkletRuntimePlugin` + `__LoadLepusChunk`
- Remove `VueWorkletRuntimePlugin` class (~50 lines) and `__LoadLepusChunk` runtime logic (~30 lines)
- Add `.plans/0319-1-inline-worklet-runtime.md` reflection doc

## Motivation

The layer-based architecture refactor (#60) already made webpack handle the main-thread entry natively. The worklet-runtime can simply be another module in that entry — no special chunk injection needed.

## Theoretical Advantages

1. **Simpler plugin code (-80 lines)**: Remove `VueWorkletRuntimePlugin` (compile-time `fs.readFileSync` + `beforeEncode` hook pushing chunk) and `entry-main.ts` `__LoadLepusChunk` runtime logic. The concept of "extra Lepus chunks" no longer exists in vue-lynx.
2. **Eliminates half-initialized failure mode**: Previously, if `__LoadLepusChunk` returned false, the main thread continued with incomplete state — `renderPage` worked but worklet events silently failed. Now worklet-runtime is part of the entry — either the entire bundle loads or it doesn't.
3. **More predictable output structure**: One entry produces one `lepusCode.root`, no `lepusCode.chunks`. No implicit `beforeEncode` hook dynamically pushing chunks.
4. **One fewer chunk load at runtime**: Previously: main-thread.js starts then calls `__LoadLepusChunk`, Lynx loads second bytecode chunk, worklet globals become available. Now: worklet globals are set up directly during entry execution.

## Verification

- All 32 unit tests pass
- All 13 examples build successfully
- **LynxExplorer (iOS)**: `examples/main-thread` draggable demo verified — worklet events fire correctly, MT draggable responds with zero latency. Native Lynx dispatches to `runWorklet()` based on global function presence, not the chunk-loading signal.

## Test plan

- [x] `pnpm test` — 32/32 pass
- [x] `pnpm build:examples` — all 13 examples build
- [x] LynxExplorer: MTS draggable demo worklet events fire correctly
