### PR TITLE
fix(runtime): stringify numeric flex style values

### DIFF
--- a/runtime/src/node-ops.ts
+++ b/runtime/src/node-ops.ts
@@ -38,12 +38,22 @@ const _warnedProps: Set<string> | undefined = __DEV__ ? new Set() : undefined;
 function normalizeStyle(
   style: Record<string, unknown>,
 ): Record<string, unknown> {
-  if (!__VUE_LYNX_AUTO_PIXEL_UNIT__) return style;
-
   const out: Record<string, unknown> = {};
   for (const key of Object.keys(style)) {
     const val = style[key];
-    if (typeof val === 'number' && !DIMENSIONLESS.has(key)) {
+    // TODO(huxpro): Remove this workaround once the Lynx engine fixes
+    // inline style object handling for `flex: 1`.
+    //
+    // Today the engine may read an int32 numeric `flex` value as 0 when
+    // it arrives through the object-style `__SetInlineStyles` path, so we
+    // stringify numeric `flex` here to force the engine onto its string parser.
+    if (key === 'flex' && typeof val === 'number') {
+      out[key] = `${val}`;
+    } else if (
+      __VUE_LYNX_AUTO_PIXEL_UNIT__
+      && typeof val === 'number'
+      && !DIMENSIONLESS.has(key)
+    ) {
       if (__DEV__ && val !== 0 && !_warnedProps!.has(key)) {
         _warnedProps!.add(key);
         console.warn(

--- a/testing-library/src/__tests__/styles.test.ts
+++ b/testing-library/src/__tests__/styles.test.ts
@@ -6,8 +6,26 @@
 import { describe, it, expect } from 'vitest';
 import { h, defineComponent, ref, nextTick } from 'vue-lynx';
 import { render } from '../index.js';
+import { OP } from '../../../internal/src/ops.js';
+import { nodeOps } from '../../../runtime/src/node-ops.js';
+import { takeOps } from '../../../runtime/src/ops.js';
+import { ShadowElement } from '../../../runtime/src/shadow-element.js';
 
 describe('styles', () => {
+  it('stringifies numeric flex in SET_STYLE payloads', () => {
+    const el = new ShadowElement('view', 42);
+
+    nodeOps.patchProp(el, 'style', null, { flex: 1, fontSize: 16 });
+
+    const ops = takeOps();
+    expect(ops[0]).toBe(OP.SET_STYLE);
+    expect(ops[1]).toBe(42);
+    expect(ops[2]).toMatchObject({
+      flex: '1',
+      fontSize: '16px',
+    });
+  });
+
   it('applies inline styles', () => {
     const Comp = defineComponent({
       render() {


### PR DESCRIPTION
Add a temporary runtime workaround for the Lynx engine bug that can read inline object-style `flex: 1` as 0. The renderer now stringifies numeric `flex` values before emitting `SET_STYLE`, with a TODO comment to remove this once the engine is fixed. A regression test was added to assert the emitted payload keeps `flex` as a string while preserving the existing px conversion for non-dimensionless numeric styles.\n\nVerification: `pnpm test -- --run testing-library/src/__tests__/styles.test.ts`