### PR TITLE
fix(examples): set assetPrefix for Lynx bundle image assets

### DIFF
--- a/examples/7guis/lynx.config.ts
+++ b/examples/7guis/lynx.config.ts
@@ -1,10 +1,17 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from '@lynx-js/rspeedy';
 import { pluginVueLynx } from 'vue-lynx/plugin';
+
+const exampleName = path.basename(path.dirname(fileURLToPath(import.meta.url)));
 
 export default defineConfig({
   environments: {
     web: {},
     lynx: {},
+  },
+  output: {
+    assetPrefix: `https://vue.lynxjs.org/examples/${exampleName}/dist/`,
   },
   source: {
     entry: {

--- a/examples/basic/lynx.config.ts
+++ b/examples/basic/lynx.config.ts
@@ -1,10 +1,17 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from '@lynx-js/rspeedy';
 import { pluginVueLynx } from 'vue-lynx/plugin';
+
+const exampleName = path.basename(path.dirname(fileURLToPath(import.meta.url)));
 
 export default defineConfig({
   environments: {
     web: {},
     lynx: {},
+  },
+  output: {
+    assetPrefix: `https://vue.lynxjs.org/examples/${exampleName}/dist/`,
   },
   source: {
     entry: {

--- a/examples/gallery/lynx.config.ts
+++ b/examples/gallery/lynx.config.ts
@@ -1,10 +1,17 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from '@lynx-js/rspeedy';
 import { pluginVueLynx } from 'vue-lynx/plugin';
+
+const exampleName = path.basename(path.dirname(fileURLToPath(import.meta.url)));
 
 export default defineConfig({
   environments: {
     web: {},
     lynx: {},
+  },
+  output: {
+    assetPrefix: `https://vue.lynxjs.org/examples/${exampleName}/dist/`,
   },
   source: {
     entry: {

--- a/examples/hello-world/lynx.config.ts
+++ b/examples/hello-world/lynx.config.ts
@@ -1,10 +1,17 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from '@lynx-js/rspeedy';
 import { pluginVueLynx } from 'vue-lynx/plugin';
+
+const exampleName = path.basename(path.dirname(fileURLToPath(import.meta.url)));
 
 export default defineConfig({
   environments: {
     web: {},
     lynx: {},
+  },
+  output: {
+    assetPrefix: `https://vue.lynxjs.org/examples/${exampleName}/dist/`,
   },
   source: {
     entry: {

--- a/examples/main-thread/lynx.config.ts
+++ b/examples/main-thread/lynx.config.ts
@@ -1,5 +1,9 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from '@lynx-js/rspeedy';
 import { pluginVueLynx } from 'vue-lynx/plugin';
+
+const exampleName = path.basename(path.dirname(fileURLToPath(import.meta.url)));
 
 export default defineConfig({
   environments: {
@@ -23,5 +27,6 @@ export default defineConfig({
   ],
   output: {
     filename: '[name].[platform].bundle',
+    assetPrefix: `https://vue.lynxjs.org/examples/${exampleName}/dist/`,
   },
 });

--- a/examples/option-api/lynx.config.ts
+++ b/examples/option-api/lynx.config.ts
@@ -1,10 +1,17 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from '@lynx-js/rspeedy';
 import { pluginVueLynx } from 'vue-lynx/plugin';
+
+const exampleName = path.basename(path.dirname(fileURLToPath(import.meta.url)));
 
 export default defineConfig({
   environments: {
     web: {},
     lynx: {},
+  },
+  output: {
+    assetPrefix: `https://vue.lynxjs.org/examples/${exampleName}/dist/`,
   },
   source: {
     entry: {

--- a/examples/pinia/lynx.config.ts
+++ b/examples/pinia/lynx.config.ts
@@ -1,10 +1,17 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from '@lynx-js/rspeedy';
 import { pluginVueLynx } from 'vue-lynx/plugin';
+
+const exampleName = path.basename(path.dirname(fileURLToPath(import.meta.url)));
 
 export default defineConfig({
   environments: {
     web: {},
     lynx: {},
+  },
+  output: {
+    assetPrefix: `https://vue.lynxjs.org/examples/${exampleName}/dist/`,
   },
   source: {
     entry: {

--- a/examples/suspense/lynx.config.ts
+++ b/examples/suspense/lynx.config.ts
@@ -1,10 +1,17 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from '@lynx-js/rspeedy';
 import { pluginVueLynx } from 'vue-lynx/plugin';
+
+const exampleName = path.basename(path.dirname(fileURLToPath(import.meta.url)));
 
 export default defineConfig({
   environments: {
     web: {},
     lynx: {},
+  },
+  output: {
+    assetPrefix: `https://vue.lynxjs.org/examples/${exampleName}/dist/`,
   },
   source: {
     entry: {

--- a/examples/swiper/lynx.config.ts
+++ b/examples/swiper/lynx.config.ts
@@ -1,10 +1,17 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from '@lynx-js/rspeedy';
 import { pluginVueLynx } from 'vue-lynx/plugin';
+
+const exampleName = path.basename(path.dirname(fileURLToPath(import.meta.url)));
 
 export default defineConfig({
   environments: {
     web: {},
     lynx: {},
+  },
+  output: {
+    assetPrefix: `https://vue.lynxjs.org/examples/${exampleName}/dist/`,
   },
   source: {
     entry: {

--- a/examples/tailwindcss/lynx.config.ts
+++ b/examples/tailwindcss/lynx.config.ts
@@ -1,12 +1,19 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from '@lynx-js/rspeedy';
 import { pluginQRCode } from '@lynx-js/qrcode-rsbuild-plugin';
 import { pluginTailwindCSS } from 'rsbuild-plugin-tailwindcss';
 import { pluginVueLynx } from 'vue-lynx/plugin';
 
+const exampleName = path.basename(path.dirname(fileURLToPath(import.meta.url)));
+
 export default defineConfig({
   environments: {
     lynx: {},
     web: {},
+  },
+  output: {
+    assetPrefix: `https://vue.lynxjs.org/examples/${exampleName}/dist/`,
   },
   source: {
     entry: {

--- a/examples/todomvc/lynx.config.ts
+++ b/examples/todomvc/lynx.config.ts
@@ -1,7 +1,14 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from '@lynx-js/rspeedy';
 import { pluginVueLynx } from 'vue-lynx/plugin';
 
+const exampleName = path.basename(path.dirname(fileURLToPath(import.meta.url)));
+
 export default defineConfig({
+  output: {
+    assetPrefix: `https://vue.lynxjs.org/examples/${exampleName}/dist/`,
+  },
   plugins: [
     pluginVueLynx({
       optionsApi: false,

--- a/examples/transition/lynx.config.ts
+++ b/examples/transition/lynx.config.ts
@@ -1,10 +1,17 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from '@lynx-js/rspeedy';
 import { pluginVueLynx } from 'vue-lynx/plugin';
+
+const exampleName = path.basename(path.dirname(fileURLToPath(import.meta.url)));
 
 export default defineConfig({
   environments: {
     web: {},
     lynx: {},
+  },
+  output: {
+    assetPrefix: `https://vue.lynxjs.org/examples/${exampleName}/dist/`,
   },
   source: {
     entry: {

--- a/examples/vue-router/lynx.config.ts
+++ b/examples/vue-router/lynx.config.ts
@@ -1,10 +1,17 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from '@lynx-js/rspeedy';
 import { pluginVueLynx } from 'vue-lynx/plugin';
+
+const exampleName = path.basename(path.dirname(fileURLToPath(import.meta.url)));
 
 export default defineConfig({
   environments: {
     web: {},
     lynx: {},
+  },
+  output: {
+    assetPrefix: `https://vue.lynxjs.org/examples/${exampleName}/dist/`,
   },
   source: {
     entry: {


### PR DESCRIPTION
## Summary

Fixed image asset resolution in Lynx bundles deployed to https://vue.lynxjs.org/. All 13 example `lynx.config.ts` files now set `output.assetPrefix` to `https://vue.lynxjs.org/examples/{exampleName}/dist/`, ensuring images resolve to correct absolute URLs instead of relative paths that break when bundles run on guide pages.

## How it works

The example name is computed dynamically from the directory path using `import.meta.url`, so each config automatically references the correct deployment URL. This approach mirrors how ~/github/lynx-examples handles gallery and other image-heavy examples.

## Examples affected

- swiper, gallery, hello-world (have images)  
- All other examples (preventive fix)

Tests pass. Ready to deploy.