### PR TITLE
feat: add TypeScript integration example and guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ See the [`examples/`](examples/) directory for complete working examples:
 - [`tailwindcss`](examples/tailwindcss) — Tailwind CSS styling
 - [`gallery`](examples/gallery) — Photo gallery
 - [`swiper`](examples/swiper) — Swiper component
+- [`typescript`](examples/typescript) — TypeScript patterns (generics, typed props, provide/inject)
 - [`7guis`](examples/7guis) — 7GUIs benchmark tasks
 
 ## Contributing

--- a/examples/typescript/lynx.config.ts
+++ b/examples/typescript/lynx.config.ts
@@ -1,0 +1,26 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from '@lynx-js/rspeedy';
+import { pluginVueLynx } from 'vue-lynx/plugin';
+
+const exampleName = path.basename(path.dirname(fileURLToPath(import.meta.url)));
+
+export default defineConfig({
+  environments: {
+    web: {},
+    lynx: {},
+  },
+  output: {
+    assetPrefix: `https://vue.lynxjs.org/examples/${exampleName}/dist/`,
+  },
+  source: {
+    entry: {
+      main: './src/index.ts',
+    },
+  },
+  plugins: [
+    pluginVueLynx({
+      optionsApi: false,
+    }),
+  ],
+});

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@vue-lynx-example/typescript",
+  "version": "0.1.0",
+  "private": false,
+  "description": "Vue-Lynx TypeScript integration patterns",
+  "license": "Apache-2.0",
+  "type": "module",
+  "files": ["dist", "src", "lynx.config.ts", "tsconfig.json"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Huxpro/vue-lynx",
+    "directory": "examples/typescript"
+  },
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev"
+  },
+  "dependencies": {
+    "vue-lynx": "workspace:*"
+  },
+  "devDependencies": {
+    "@lynx-js/rspeedy": "^0.13.5",
+    "@rsbuild/plugin-vue": "^1.2.6",
+    "typescript": "^5.0.0"
+  },
+  "engines": { "node": ">=18" }
+}

--- a/examples/typescript/src/App.vue
+++ b/examples/typescript/src/App.vue
@@ -1,0 +1,113 @@
+<script setup lang="ts">
+/**
+ * Root component demonstrating TypeScript integration patterns:
+ *
+ * 1. Imported interfaces & union types (User, Theme)
+ * 2. Type-safe provide/inject (theme injection)
+ * 3. Generic component usage (GenericList<User>)
+ * 4. defineProps<T>() with withDefaults (UserCard)
+ * 5. Typed reactive state & computed
+ * 6. `as const satisfies` for type-safe config objects
+ */
+import { ref, computed, provide } from 'vue'
+import type { User, Theme } from './types.js'
+import { themes } from './types.js'
+import GenericList from './GenericList.vue'
+import UserCard from './UserCard.vue'
+
+// -- Typed reactive state --
+const isDark = ref(false)
+
+const theme = computed<Theme>(() =>
+  isDark.value ? themes.dark : themes.light,
+)
+
+// provide() is type-safe: inject<Theme>('theme') in descendants
+provide<Theme>('theme', theme.value)
+
+const users = ref<User[]>([
+  { id: 1, name: 'Alice', email: 'alice@example.com', role: 'admin' },
+  { id: 2, name: 'Bob', email: 'bob@example.com', role: 'editor' },
+  { id: 3, name: 'Carol', email: 'carol@example.com', role: 'viewer' },
+])
+
+const selectedUser = ref<User | null>(null)
+
+// -- Generic component callback is fully typed --
+// `user` is inferred as User because GenericList<User> narrows T.
+function onSelectUser(user: User) {
+  selectedUser.value = user
+}
+
+function onRemoveUser(userId: number) {
+  users.value = users.value.filter(u => u.id !== userId)
+  if (selectedUser.value?.id === userId) {
+    selectedUser.value = null
+  }
+}
+
+function toggleTheme() {
+  isDark.value = !isDark.value
+}
+</script>
+
+<template>
+  <view
+    :style="{
+      flex: 1,
+      display: 'flex',
+      flexDirection: 'column',
+      backgroundColor: theme.background,
+      padding: 16,
+    }"
+  >
+    <text :style="{ fontSize: 18, fontWeight: 'bold', color: theme.text, marginBottom: 12 }">
+      TypeScript Patterns
+    </text>
+
+    <!-- Theme toggle -->
+    <view
+      :style="{
+        padding: '8px 16px',
+        backgroundColor: theme.primary,
+        borderRadius: 8,
+        marginBottom: 16,
+        alignSelf: 'flex-start',
+      }"
+      @tap="toggleTheme"
+    >
+      <text :style="{ color: '#fff', fontSize: 14 }">
+        {{ isDark ? 'Light mode' : 'Dark mode' }}
+      </text>
+    </view>
+
+    <!-- Generic component: T is inferred as User from :items -->
+    <text :style="{ fontSize: 14, fontWeight: 'bold', color: theme.text, marginBottom: 8 }">
+      User List (Generic Component)
+    </text>
+    <GenericList
+      :items="users"
+      :label="(u) => `${u.name} (${u.role})`"
+      @select="onSelectUser"
+    />
+
+    <!-- Selected user detail with typed props -->
+    <view v-if="selectedUser" :style="{ marginTop: 16 }">
+      <text :style="{ fontSize: 14, fontWeight: 'bold', color: theme.text, marginBottom: 8 }">
+        Selected User
+      </text>
+      <UserCard
+        :user="selectedUser"
+        :theme="theme"
+        @remove="onRemoveUser"
+      />
+    </view>
+
+    <text
+      v-else
+      :style="{ marginTop: 16, fontSize: 13, color: theme.text, opacity: 0.5 }"
+    >
+      Tap a user above to see details
+    </text>
+  </view>
+</template>

--- a/examples/typescript/src/GenericList.vue
+++ b/examples/typescript/src/GenericList.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts" generic="T extends { id: number }">
+/**
+ * Generic component (Vue 3.3+).
+ *
+ * The `generic` attribute on <script setup> lets you parameterize
+ * a component's props, emits, and slots over a type variable.
+ *
+ * Usage:
+ *   <GenericList :items="users" :label="u => u.name" @select="onSelect" />
+ *
+ * TypeScript will infer T from the `items` prop and enforce that
+ * `label` and `@select` use the same T.
+ */
+
+const props = defineProps<{
+  items: T[];
+  label: (item: T) => string;
+}>()
+
+const emit = defineEmits<{
+  select: [item: T];
+}>()
+</script>
+
+<template>
+  <view :style="{ display: 'flex', flexDirection: 'column', gap: 4 }">
+    <view
+      v-for="item in props.items"
+      :key="item.id"
+      :style="{
+        padding: '8px 12px',
+        backgroundColor: '#fff',
+        borderRadius: 6,
+      }"
+      @tap="emit('select', item)"
+    >
+      <text :style="{ fontSize: 14, color: '#333' }">
+        {{ props.label(item) }}
+      </text>
+    </view>
+  </view>
+</template>

--- a/examples/typescript/src/UserCard.vue
+++ b/examples/typescript/src/UserCard.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+/**
+ * Demonstrates:
+ * - Importing an interface from a shared types file
+ * - defineProps<T>() with an imported interface
+ * - withDefaults() for default values on type-only props
+ * - defineEmits<T>() with a typed payload
+ * - Typed computed properties
+ */
+import { computed } from 'vue'
+import type { User, Theme } from './types.js'
+
+const props = withDefaults(
+  defineProps<{
+    user: User;
+    theme?: Theme;
+    showEmail?: boolean;
+  }>(),
+  {
+    showEmail: true,
+  },
+)
+
+const emit = defineEmits<{
+  remove: [userId: number];
+}>()
+
+const roleBadgeColor = computed<string>(() => {
+  const colors: Record<User['role'], string> = {
+    admin: '#e74c3c',
+    editor: '#f39c12',
+    viewer: '#2ecc71',
+  }
+  return colors[props.user.role]
+})
+
+const bg = computed(() => props.theme?.background ?? '#fff')
+const fg = computed(() => props.theme?.text ?? '#333')
+</script>
+
+<template>
+  <view
+    :style="{
+      display: 'flex',
+      flexDirection: 'column',
+      padding: 12,
+      backgroundColor: bg,
+      borderRadius: 8,
+      marginBottom: 8,
+    }"
+  >
+    <view :style="{ display: 'flex', flexDirection: 'row', justifyContent: 'space-between' }">
+      <text :style="{ fontSize: 16, fontWeight: 'bold', color: fg }">
+        {{ props.user.name }}
+      </text>
+      <view
+        :style="{
+          paddingLeft: 8,
+          paddingRight: 8,
+          paddingTop: 2,
+          paddingBottom: 2,
+          backgroundColor: roleBadgeColor,
+          borderRadius: 10,
+        }"
+      >
+        <text :style="{ fontSize: 11, color: '#fff' }">{{ props.user.role }}</text>
+      </view>
+    </view>
+
+    <text
+      v-if="props.showEmail"
+      :style="{ fontSize: 12, color: fg, marginTop: 4, opacity: 0.7 }"
+    >
+      {{ props.user.email }}
+    </text>
+
+    <view
+      :style="{
+        marginTop: 8,
+        padding: '4px 10px',
+        backgroundColor: '#ff4444',
+        borderRadius: 4,
+        alignSelf: 'flex-start',
+      }"
+      @tap="emit('remove', props.user.id)"
+    >
+      <text :style="{ fontSize: 12, color: '#fff' }">Remove</text>
+    </view>
+  </view>
+</template>

--- a/examples/typescript/src/index.ts
+++ b/examples/typescript/src/index.ts
@@ -1,0 +1,6 @@
+import { createApp } from 'vue-lynx';
+
+import App from './App.vue';
+
+const app = createApp(App);
+app.mount();

--- a/examples/typescript/src/shims-vue.d.ts
+++ b/examples/typescript/src/shims-vue.d.ts
@@ -1,0 +1,11 @@
+declare module '*.vue' {
+  import type { Component } from 'vue-lynx';
+
+  const component: Component;
+  export default component;
+}
+
+declare module '*.png' {
+  const src: string;
+  export default src;
+}

--- a/examples/typescript/src/types.ts
+++ b/examples/typescript/src/types.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared types for the TypeScript example.
+ *
+ * Demonstrates defining domain types in a separate file and importing them
+ * into Vue SFCs — a common pattern in real-world TypeScript projects.
+ */
+
+export interface User {
+  id: number;
+  name: string;
+  email: string;
+  role: 'admin' | 'editor' | 'viewer';
+}
+
+export interface Theme {
+  primary: string;
+  background: string;
+  text: string;
+}
+
+export const themes = {
+  light: {
+    primary: '#0077ff',
+    background: '#f5f5f5',
+    text: '#111',
+  },
+  dark: {
+    primary: '#66b3ff',
+    background: '#1a1a2e',
+    text: '#eee',
+  },
+} as const satisfies Record<string, Theme>;

--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+  },
+  "include": ["src", "lynx.config.ts"],
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -262,6 +262,22 @@ importers:
         specifier: ^5.0.0
         version: 5.9.3
 
+  examples/typescript:
+    dependencies:
+      vue-lynx:
+        specifier: workspace:*
+        version: link:../..
+    devDependencies:
+      '@lynx-js/rspeedy':
+        specifier: ^0.13.5
+        version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
+      '@rsbuild/plugin-vue':
+        specifier: ^1.2.6
+        version: 1.2.7(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
   examples/vue-router:
     dependencies:
       vue-lynx:

--- a/website/docs/guide/quick-start.mdx
+++ b/website/docs/guide/quick-start.mdx
@@ -150,6 +150,7 @@ export default defineConfig({
 
 ## Next Steps
 
+- [Using TypeScript](/guide/typescript) — Type-safe props, emits, generic components, and more
 - [Tutorial: Product Gallery](/guide/tutorial-gallery) — Build a waterfall gallery with interactivity and Main Thread Script
 - [Tutorial: Product Detail](/guide/tutorial-swiper) — Build a touch-swipeable image carousel
 - [API Reference](/guide/api/vue-lynx/) — Explore the vue-lynx API

--- a/website/docs/guide/typescript.mdx
+++ b/website/docs/guide/typescript.mdx
@@ -1,0 +1,232 @@
+# Using TypeScript
+
+Vue Lynx projects created with `create-vue-lynx` are TypeScript-ready out of the box. This guide covers the key patterns for using TypeScript effectively with Vue Lynx.
+
+## Project Setup
+
+A TypeScript Vue Lynx project needs three things:
+
+### 1. `tsconfig.json`
+
+```json title="tsconfig.json"
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true
+  },
+  "include": ["src", "lynx.config.ts"]
+}
+```
+
+### 2. `shims-vue.d.ts`
+
+This tells TypeScript how to handle `.vue` file imports:
+
+```ts title="src/shims-vue.d.ts"
+declare module '*.vue' {
+  import type { Component } from 'vue-lynx';
+  const component: Component;
+  export default component;
+}
+```
+
+### 3. `lang="ts"` in SFCs
+
+Add `lang="ts"` to your `<script setup>` blocks:
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const count = ref(0)
+</script>
+```
+
+That's it — rspeedy handles compilation automatically.
+
+## Type-Safe Props
+
+### `defineProps<T>()`
+
+Instead of the runtime `props` option, use the type-only syntax for full type inference:
+
+```vue
+<script setup lang="ts">
+interface Props {
+  title: string
+  count: number
+  tags?: string[]
+}
+
+const props = defineProps<Props>()
+// props.title  → string
+// props.count  → number
+// props.tags   → string[] | undefined
+</script>
+```
+
+### `withDefaults()`
+
+Provide default values for optional props:
+
+```vue
+<script setup lang="ts">
+interface Props {
+  label: string
+  size?: 'small' | 'medium' | 'large'
+  disabled?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  size: 'medium',
+  disabled: false,
+})
+</script>
+```
+
+### Importing Types
+
+For complex or shared types, define them in a separate file:
+
+```ts title="src/types.ts"
+export interface User {
+  id: number
+  name: string
+  role: 'admin' | 'editor' | 'viewer'
+}
+```
+
+```vue title="src/UserCard.vue"
+<script setup lang="ts">
+import type { User } from './types.js'
+
+const props = defineProps<{
+  user: User
+  showEmail?: boolean
+}>()
+</script>
+```
+
+## Type-Safe Emits
+
+```vue
+<script setup lang="ts">
+const emit = defineEmits<{
+  change: [value: string]
+  update: [id: number, fields: Partial<User>]
+}>()
+
+// TypeScript enforces the payload types:
+emit('change', 'new value')       // OK
+emit('update', 1, { name: 'Al' }) // OK
+// emit('change', 123)            // Error: number is not string
+</script>
+```
+
+## Generic Components
+
+Vue 3.3+ supports the `generic` attribute, which lets you parameterize props, emits, and slots over a type variable:
+
+```vue title="src/GenericList.vue"
+<script setup lang="ts" generic="T extends { id: number }">
+const props = defineProps<{
+  items: T[]
+  label: (item: T) => string
+}>()
+
+const emit = defineEmits<{
+  select: [item: T]
+}>()
+</script>
+
+<template>
+  <view>
+    <view v-for="item in props.items" :key="item.id" @tap="emit('select', item)">
+      <text>{{ props.label(item) }}</text>
+    </view>
+  </view>
+</template>
+```
+
+TypeScript infers `T` from usage — no manual type arguments needed:
+
+```vue
+<script setup lang="ts">
+import type { User } from './types.js'
+import GenericList from './GenericList.vue'
+
+const users: User[] = [
+  { id: 1, name: 'Alice', role: 'admin' },
+]
+
+// T is inferred as User from the `items` prop.
+// `label` and `@select` are type-checked against User.
+function onSelect(user: User) { /* ... */ }
+</script>
+
+<template>
+  <GenericList
+    :items="users"
+    :label="u => u.name"
+    @select="onSelect"
+  />
+</template>
+```
+
+## Typed Reactive State
+
+Explicit type parameters help when the initial value doesn't express the full type:
+
+```vue
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import type { User } from './types.js'
+
+// ref<T>() — needed when initial value is narrower than the actual type
+const selectedUser = ref<User | null>(null)
+const users = ref<User[]>([])
+
+// computed<T>() — return type is inferred, but can be explicit
+const adminCount = computed<number>(
+  () => users.value.filter(u => u.role === 'admin').length
+)
+</script>
+```
+
+## Typed Provide / Inject
+
+Use the `InjectionKey` type from Vue for type-safe dependency injection across components:
+
+```ts title="src/keys.ts"
+import type { InjectionKey, Ref } from '@vue/runtime-core'
+import type { Theme } from './types.js'
+
+export const ThemeKey: InjectionKey<Ref<Theme>> = Symbol('theme')
+```
+
+```vue title="src/App.vue (provider)"
+<script setup lang="ts">
+import { ref, provide } from 'vue'
+import type { Theme } from './types.js'
+import { ThemeKey } from './keys.js'
+
+const theme = ref<Theme>({ primary: '#0077ff', background: '#f5f5f5', text: '#111' })
+provide(ThemeKey, theme) // type-checked
+</script>
+```
+
+```vue title="src/Child.vue (consumer)"
+<script setup lang="ts">
+import { inject } from 'vue'
+import { ThemeKey } from './keys.js'
+
+const theme = inject(ThemeKey) // Ref<Theme> | undefined
+</script>
+```
+
+## Example
+
+See the full working example at [`examples/typescript`](https://github.com/Huxpro/vue-lynx/tree/main/examples/typescript).

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
           sectionHeaderText: 'Get Started',
         },
         { text: 'Quick Start', link: '/guide/quick-start' },
+        { text: 'Using TypeScript', link: '/guide/typescript' },
         { text: 'Tutorial: Product Gallery', link: '/guide/tutorial-gallery' },
         { text: 'Tutorial: Product Swiper', link: '/guide/tutorial-swiper' },
         {


### PR DESCRIPTION
## Summary

Added comprehensive TypeScript integration support to vue-lynx with working examples and documentation.

**Example (`examples/typescript`):** Demonstrates generic components, typed props with `defineProps<T>()` and `withDefaults()`, typed emits, provide/inject patterns, and complex computed types. All patterns compile and build successfully.

**Guide (`website/docs/guide/typescript.mdx`):** Covers project setup (tsconfig, shims-vue.d.ts), type-safe props/emits, generic components, reactive state typing, and dependency injection with `InjectionKey`.

**Navigation:** Added "Using TypeScript" to Quick Start sidebar and next steps to guide users to TS patterns early.

Verified: `pnpm build`, `pnpm build:examples`, `pnpm test`, and `pnpm lint` all pass.