### PR TITLE
feat: add v-model component example and documentation

### DIFF
--- a/examples/v-model/lynx.config.ts
+++ b/examples/v-model/lynx.config.ts
@@ -1,0 +1,26 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from '@lynx-js/rspeedy';
+import { pluginVueLynx } from 'vue-lynx/plugin';
+
+const exampleName = path.basename(path.dirname(fileURLToPath(import.meta.url)));
+
+export default defineConfig({
+  environments: {
+    web: {},
+    lynx: {},
+  },
+  output: {
+    assetPrefix: `https://vue.lynxjs.org/examples/${exampleName}/dist/`,
+  },
+  source: {
+    entry: {
+      main: './src/index.ts',
+    },
+  },
+  plugins: [
+    pluginVueLynx({
+      optionsApi: false,
+    }),
+  ],
+});

--- a/examples/v-model/package.json
+++ b/examples/v-model/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@vue-lynx-example/v-model",
+  "version": "0.1.0",
+  "private": false,
+  "type": "module",
+  "files": ["dist", "src", "lynx.config.ts", "tsconfig.json"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Huxpro/vue-lynx",
+    "directory": "examples/v-model"
+  },
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev"
+  },
+  "dependencies": {
+    "vue-lynx": "workspace:*"
+  },
+  "devDependencies": {
+    "@lynx-js/rspeedy": "^0.13.5",
+    "@rsbuild/plugin-vue": "^1.2.6",
+    "typescript": "~5.9.3"
+  },
+  "engines": { "node": ">=18" }
+}

--- a/examples/v-model/src/App.vue
+++ b/examples/v-model/src/App.vue
@@ -1,0 +1,95 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import ModelCounter from './ModelCounter.vue'
+import NamedModels from './NamedModels.vue'
+
+// ── Section 1: Component v-model (defineModel) ──
+const parentCount = ref(0)
+
+function resetCount() {
+  parentCount.value = 0
+}
+
+// ── Section 2: Named models ──
+const docTitle = ref('Hello')
+const docBody = ref('World')
+
+function setValues() {
+  docTitle.value = 'Reset Title'
+  docBody.value = 'Reset Body'
+}
+
+// ── Section 3: Manual two-way binding (workaround for native input) ──
+const inputText = ref('')
+</script>
+
+<template>
+  <view :style="{ flex: 1, display: 'flex', flexDirection: 'column', backgroundColor: '#f5f5f5', padding: 16 }">
+
+    <text :style="{ fontSize: 18, fontWeight: 'bold', color: '#111', marginBottom: 12 }">
+      v-model Demo
+    </text>
+
+    <!-- ═══════════════════════════════════════════ -->
+    <!-- SECTION 1: Component v-model (WORKS)       -->
+    <!-- ═══════════════════════════════════════════ -->
+    <text :style="{ fontSize: 14, fontWeight: 'bold', color: '#0077ff', marginBottom: 4 }">
+      1. Component v-model (defineModel)
+    </text>
+    <text :style="{ fontSize: 12, color: '#666', marginBottom: 8 }">
+      Parent count: {{ parentCount }}
+    </text>
+
+    <!-- v-model on component — compiles to :modelValue + @update:modelValue -->
+    <ModelCounter v-model="parentCount" />
+
+    <view
+      :style="{ padding: '4px 10px', backgroundColor: '#555', borderRadius: 4, marginBottom: 16, alignSelf: 'flex-start' }"
+      @tap="resetCount"
+    >
+      <text :style="{ color: '#fff', fontSize: 12 }">Reset from parent</text>
+    </view>
+
+    <!-- ═══════════════════════════════════════════ -->
+    <!-- SECTION 2: Named models (WORKS)            -->
+    <!-- ═══════════════════════════════════════════ -->
+    <text :style="{ fontSize: 14, fontWeight: 'bold', color: '#0077ff', marginBottom: 4 }">
+      2. Named v-model (v-model:title, v-model:body)
+    </text>
+    <text :style="{ fontSize: 12, color: '#666' }">
+      Parent title: "{{ docTitle }}" | body: "{{ docBody }}"
+    </text>
+
+    <NamedModels v-model:title="docTitle" v-model:body="docBody" />
+
+    <view
+      :style="{ padding: '4px 10px', backgroundColor: '#555', borderRadius: 4, marginBottom: 16, alignSelf: 'flex-start' }"
+      @tap="setValues"
+    >
+      <text :style="{ color: '#fff', fontSize: 12 }">Reset from parent</text>
+    </view>
+
+    <!-- ═══════════════════════════════════════════ -->
+    <!-- SECTION 3: Native input (NOT SUPPORTED)    -->
+    <!-- ═══════════════════════════════════════════ -->
+    <text :style="{ fontSize: 14, fontWeight: 'bold', color: '#ff4400', marginBottom: 4 }">
+      3. Native input v-model (NOT supported)
+    </text>
+    <text :style="{ fontSize: 12, color: '#666', marginBottom: 4 }">
+      v-model on &lt;input&gt; is stubbed. Use manual :value + @input instead.
+    </text>
+    <text :style="{ fontSize: 12, color: '#666', marginBottom: 8 }">
+      Text: "{{ inputText }}"
+    </text>
+
+    <!-- Manual workaround — this is how you do two-way input binding today -->
+    <input
+      type="text"
+      placeholder="Type here (manual binding)"
+      :value="inputText"
+      :style="{ padding: 8, borderRadius: 4, fontSize: 14, backgroundColor: '#fff' }"
+      @input="(e: any) => inputText = e.detail.value"
+    />
+
+  </view>
+</template>

--- a/examples/v-model/src/ModelCounter.vue
+++ b/examples/v-model/src/ModelCounter.vue
@@ -1,0 +1,26 @@
+<script setup lang="ts">
+/**
+ * A child component that uses defineModel() (Vue 3.4+).
+ * defineModel() creates a two-way binding prop automatically.
+ * Under the hood it's: defineProps(['modelValue']) + defineEmits(['update:modelValue'])
+ */
+const count = defineModel<number>({ default: 0 })
+
+function onTap() {
+  count.value++
+}
+</script>
+
+<template>
+  <view :style="{ display: 'flex', flexDirection: 'column', padding: 12, backgroundColor: '#fff', borderRadius: 8, marginBottom: 8 }">
+    <text :style="{ fontSize: 14, color: '#222' }">
+      Child (defineModel): {{ count }}
+    </text>
+    <view
+      :style="{ marginTop: 8, padding: '6px 12px', backgroundColor: '#0077ff', borderRadius: 6 }"
+      @tap="onTap"
+    >
+      <text :style="{ color: '#fff', fontSize: 13 }">Increment from child</text>
+    </view>
+  </view>
+</template>

--- a/examples/v-model/src/NamedModels.vue
+++ b/examples/v-model/src/NamedModels.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+/**
+ * Demonstrates named v-model bindings (v-model:title, v-model:body).
+ * Uses defineModel('name') for each named model.
+ */
+const title = defineModel<string>('title', { default: '' })
+const body = defineModel<string>('body', { default: '' })
+
+function clearTitle() {
+  title.value = ''
+}
+
+function clearBody() {
+  body.value = ''
+}
+</script>
+
+<template>
+  <view :style="{ display: 'flex', flexDirection: 'column', padding: 12, backgroundColor: '#fff', borderRadius: 8, marginBottom: 8 }">
+    <text :style="{ fontSize: 14, color: '#222', marginBottom: 4 }">
+      Child (named models):
+    </text>
+    <text :style="{ fontSize: 12, color: '#666' }">title = "{{ title }}"</text>
+    <text :style="{ fontSize: 12, color: '#666' }">body = "{{ body }}"</text>
+
+    <view :style="{ display: 'flex', flexDirection: 'row', marginTop: 8 }">
+      <view
+        :style="{ padding: '4px 10px', backgroundColor: '#ff4400', borderRadius: 4, marginRight: 8 }"
+        @tap="clearTitle"
+      >
+        <text :style="{ color: '#fff', fontSize: 12 }">Clear title</text>
+      </view>
+      <view
+        :style="{ padding: '4px 10px', backgroundColor: '#ff4400', borderRadius: 4 }"
+        @tap="clearBody"
+      >
+        <text :style="{ color: '#fff', fontSize: 12 }">Clear body</text>
+      </view>
+    </view>
+  </view>
+</template>

--- a/examples/v-model/src/index.ts
+++ b/examples/v-model/src/index.ts
@@ -1,0 +1,6 @@
+import { createApp } from 'vue-lynx';
+
+import App from './App.vue';
+
+const app = createApp(App);
+app.mount();

--- a/examples/v-model/src/shims-vue.d.ts
+++ b/examples/v-model/src/shims-vue.d.ts
@@ -1,0 +1,6 @@
+declare module '*.vue' {
+  import type { Component } from 'vue-lynx';
+
+  const component: Component;
+  export default component;
+}

--- a/examples/v-model/src/tsconfig.json
+++ b/examples/v-model/src/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+
+    "noEmit": true,
+  },
+  "include": ["./**/*.ts", "./**/*.vue"],
+}

--- a/examples/v-model/tsconfig.json
+++ b/examples/v-model/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+  },
+  "references": [
+    { "path": "./tsconfig.node.json" },
+    { "path": "./src" },
+  ],
+  "files": [],
+}

--- a/examples/v-model/tsconfig.node.json
+++ b/examples/v-model/tsconfig.node.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+
+    // Rspeedy uses Node.js's module resolution
+    "module": "node16",
+    "moduleResolution": "node16",
+    "erasableSyntaxOnly": true,
+
+    // Node.js 18+
+    "lib": ["es2023"],
+    "target": "es2022",
+
+    "noEmit": true,
+  },
+  "include": ["./lynx.config.ts"],
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -262,6 +262,22 @@ importers:
         specifier: ^5.0.0
         version: 5.9.3
 
+  examples/v-model:
+    dependencies:
+      vue-lynx:
+        specifier: workspace:*
+        version: link:../..
+    devDependencies:
+      '@lynx-js/rspeedy':
+        specifier: ^0.13.5
+        version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
+      '@rsbuild/plugin-vue':
+        specifier: ^1.2.6
+        version: 1.2.7(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+
   examples/vue-router:
     dependencies:
       vue-lynx:

--- a/website/docs/guide/vue-feature-coverage.mdx
+++ b/website/docs/guide/vue-feature-coverage.mdx
@@ -53,6 +53,27 @@ The example below shows two patterns:
   defaultFile="src/App.vue"
 />
 
+## Component v-model
+
+Vue's `v-model` on components creates a two-way binding between parent and child. The child uses [`defineModel()`](https://vuejs.org/api/sfc-script-setup.html#definemodel) (Vue 3.4+) to declare a model prop, and the parent binds it with `v-model`.
+
+The example demonstrates:
+1. **Default model** — `defineModel<number>()` with `v-model="count"` for a counter
+2. **Named models** — `defineModel('title')` + `defineModel('body')` with `v-model:title` / `v-model:body`
+3. **Manual input binding** — the workaround for native `<input>` (see caveat below)
+
+:::warning Caveat
+`v-model` on **native `<input>` elements** is not yet supported. Lynx inputs use synchronous Main Thread APIs (`getValue()` / `setValue()`) that are inaccessible from the background thread where Vue runs. Use `:value` + `@input` manually instead:
+```vue
+<input :value="text" @input="(e) => text = e.detail.value" />
+```
+:::
+
+<Go
+  example="v-model"
+  defaultFile="src/App.vue"
+/>
+
 {/* ## KeepAlive
 
 `<KeepAlive>` is **not supported** on Lynx. It requires an internal storage container created via `createElement('div')`, which produces an orphan native element with undefined behavior. Use manual state caching if you need component persistence.


### PR DESCRIPTION
## Summary

Add a comprehensive v-model example showcasing Vue 3.4+ component patterns and update feature coverage documentation.

**Changes:**
- New `examples/v-model/` with ModelCounter (default v-model) and NamedModels (named v-model) components
- Demonstrates defineModel() patterns and parent/child two-way binding
- Includes manual input binding workaround (native input v-model not yet supported due to Lynx dual-thread architecture)
- Added "Component v-model" section to Vue Feature Coverage docs with caveats and examples

**Testing:**
Example builds successfully for both web and lynx environments. Runtime behavior should be verified on go-web/simulator.