### PR TITLE
docs: improve quick start guide with setup alternatives and production guidance

### DIFF
--- a/website/docs/guide/quick-start.mdx
+++ b/website/docs/guide/quick-start.mdx
@@ -55,9 +55,9 @@ The dev server produces three URLs:
 
 ### Preview on the Web
 
-Open the **Web Preview** URL in your browser. You'll see a live preview of your app that updates automatically as you edit code.
+Open the **Web Preview** URL in your browser. You'll see a live preview of your app rendered on the Web, updating automatically as you edit code.
 
-<Go example="hello-world" defaultFile="src/App.vue" defaultEntryFile="dist/main.web.bundle" defaultTab="web" />
+<Go example="hello-world" defaultFile="src/App.vue" defaultEntryFile="dist/main.lynx.bundle" />
 
 #### Make your first change
 
@@ -118,7 +118,7 @@ Download the [Lynx DevTool](https://github.com/lynx-family/lynx-devtool/releases
 
 The Vue Lynx project you created is a **frontend** project — it produces JavaScript bundles that a Lynx-enabled native app loads and renders. Lynx Explorer is a pre-built native app for development, but for production you'll need your own native app.
 
-- **Create a new native app** (greenfield) — Use [Lynx CLI](https://github.com/lynx-community/cli) (community) or [Sparkling](https://tiktok.github.io/sparkling) to scaffold a native app project (Xcode / Android Studio) with Lynx built in. This is similar to creating a React Native app — the result is a native app that runs your Lynx bundles.
+- **Create a new native app** (greenfield) — Use [Lynx CLI](https://github.com/lynx-community/cli) (community) or [Sparkling](https://tiktok.github.io/sparkling) to scaffold a native app project (Xcode / Android Studio) with Lynx built in.
 - **Integrate into an existing app** (brownfield) — Follow the [Lynx integration guide](https://lynxjs.org/guide/start/integrate-with-existing-apps) to embed Lynx views into your existing iOS, Android, or Web application.
 
 ## Next Steps


### PR DESCRIPTION
Align our quick start guide with standards from lynx-website. Improves developer experience with clearer setup options, community resources, and production guidance.

**Key improvements:**
- Separate iOS download links (clickable) from extraction commands
- Add community App Store/Play Store versions and build-from-source options
- Clarify mobile (Lynx Explorer) vs web (Rspeedy preview) development workflows
- Add "Going to Production" section with integration and scaffolding tools
- Enrich Next Steps section with foundational documentation links