### PR TITLE
fix(plugin): exclude main-thread chunks from splitChunks

### DIFF
--- a/plugin/src/entry.ts
+++ b/plugin/src/entry.ts
@@ -270,7 +270,7 @@ export function applyEntry(
 
     if (rspackConfig.optimization.splitChunks) {
       const prev = rspackConfig.optimization.splitChunks.chunks;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // biome-ignore lint/suspicious/noExplicitAny: rspack Chunk type not importable
       rspackConfig.optimization.splitChunks.chunks = (chunk: any) => {
         if (chunk.name?.includes('__main-thread')) return false;
         if (typeof prev === 'function') return prev(chunk);


### PR DESCRIPTION
## Summary

Align with `@lynx-js/react-rsbuild-plugin`'s `splitChunks` handling: main-thread chunks are excluded from chunk splitting so each remains self-contained.

- When `splitChunks` is `false` (e.g. `all-in-one` strategy), convert to an equivalent object form so the `chunks` filter can be applied
- Main-thread chunks (`__main-thread`) always return `false` from the filter
- Non-main-thread chunks respect the user's original `splitChunks.chunks` config

Reference: [`@lynx-js/react-rsbuild-plugin/src/splitChunks.ts`](https://github.com/nicholasxjy/lynx-stack/blob/main/packages/rspeedy/plugin-react/src/splitChunks.ts#L89-L93)

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` — 33/33 tests pass
- [x] `examples/basic` multi-entry build (main + h-counter) succeeds