### PR TITLE
refactor(main-thread): remove noisy debug logs

### DIFF
--- a/main-thread/src/entry-main.ts
+++ b/main-thread/src/entry-main.ts
@@ -46,7 +46,6 @@ g['processData'] = function(data: unknown, _processorName?: string): unknown {
 // We create the root page element and store it as id=1 so Background ops that
 // target the root can resolve it correctly.
 g['renderPage'] = function(_data: unknown): void {
-  console.info('[vue-mt] renderPage called');
   // Clear all element state from the previous page. This is essential for:
   // 1. Testing: prevents duplicate batch detection from skipping ops
   //    when ShadowElement IDs restart from 2 between test renders.
@@ -59,7 +58,6 @@ g['renderPage'] = function(_data: unknown): void {
   setPageUniqueId(__GetElementUniqueID(page));
   elements.set(PAGE_ROOT_ID, page);
   __FlushElementTree(page);
-  console.info('[vue-mt] renderPage done, page root id=1 stored');
 };
 
 // Lynx may call updatePage / updateGlobalProps after data changes.

--- a/main-thread/src/ops-apply.ts
+++ b/main-thread/src/ops-apply.ts
@@ -178,18 +178,6 @@ export function applyOps(ops: unknown[]): void {
         const eventName = ops[i++] as string;
         const sign = ops[i++];
         const el = elements.get(id);
-        console.info(
-          '[vue-mt] SET_EVENT id=',
-          id,
-          'type=',
-          eventType,
-          'name=',
-          eventName,
-          'sign=',
-          sign,
-          'el found=',
-          el != null,
-        );
         if (el) __AddEvent(el, eventType, eventName, sign as string);
         break;
       }

--- a/main-thread/src/worklet-apply.ts
+++ b/main-thread/src/worklet-apply.ts
@@ -48,18 +48,6 @@ export function applySetWorkletEvent(
   ctx: Record<string, unknown>,
 ): void {
   const el = elements.get(id);
-  console.info(
-    '[vue-mt] SET_WORKLET_EVENT id=',
-    id,
-    'type=',
-    eventType,
-    'name=',
-    eventName,
-    'ctx=',
-    ctx,
-    'el found=',
-    el != null,
-  );
   if (el) {
     // Native Lynx requires _workletType on the value to route the event
     // to runWorklet() instead of publishEvent(). React sets this in
@@ -75,14 +63,6 @@ export function applySetWorkletEvent(
 /** SET_MT_REF: bind a MainThreadRef to a native element via worklet-runtime */
 export function applySetMtRef(id: number, refImpl: unknown): void {
   const el = elements.get(id);
-  console.info(
-    '[vue-mt] SET_MT_REF id=',
-    id,
-    'refImpl=',
-    refImpl,
-    'el found=',
-    el != null,
-  );
   // Store in workletRefMap so worklet-runtime can resolve _wvid -> element.
   // The worklet-runtime's updateWorkletRef expects the ref to already exist
   // in _workletRefMap (populated during React's hydration step). For Vue,


### PR DESCRIPTION
## Summary

- Remove 5 `console.info` debug logs from `main-thread/src/` that fire on every `SET_EVENT`, `SET_WORKLET_EVENT`, `SET_MT_REF`, and `renderPage` operation, polluting the console.
- All 10 remaining `console.warn` in `runtime/src/` were reviewed and kept — they are legitimate user-facing warnings (unsupported APIs, deprecation notices, wrong-thread misuse), all `__DEV__`-gated.

## Test plan

- [x] `pnpm test` — all 33 tests pass
- [x] Typecheck errors are pre-existing (cross-package rootDir constraint), unrelated to this change