### PR TITLE
fix(runtime): export guardReactiveProps for scoped slot v-bind

### DIFF
--- a/runtime/src/index.ts
+++ b/runtime/src/index.ts
@@ -765,6 +765,7 @@ export { mergeProps } from '@vue/runtime-core';
 /** @hidden */ export { toHandlerKey } from '@vue/runtime-core';
 /** @hidden */ export { toHandlers } from '@vue/runtime-core';
 /** @hidden */ export { withMemo } from '@vue/runtime-core';
+/** @hidden */ export { guardReactiveProps } from '@vue/runtime-core';
 // @ts-expect-error withAsyncContext is exported at runtime but missing from Vue's .d.ts
 /** @hidden */ export { withAsyncContext } from '@vue/runtime-core';
 /** @hidden */ export { Text } from '@vue/runtime-core';


### PR DESCRIPTION
## Summary

- Export `guardReactiveProps` from `@vue/runtime-core` in the vue-lynx runtime entry
- Vue's template compiler generates `guardReactiveProps()` when `<slot v-bind="obj">` is used for scoped slot forwarding
- Without this export, any component using `<slot name="x" v-bind="item">` fails with `ESModulesLinkingError: export 'guardReactiveProps' was not found in 'vue'`

## Root Cause

The re-export list in `runtime/src/index.ts` covers most template compiler helpers (`renderSlot`, `createSlots`, `withMemo`, etc.) but missed `guardReactiveProps`. This is a one-line addition consistent with the existing pattern.

## Test plan

- [x] `rslib build` passes
- [ ] Verify `<slot v-bind="obj">` pattern works in vant-lynx Calendar component (previously broken)