### PR TITLE
fix(docs): add en locale to themeConfig so plugin-llms generates english md files

### DIFF
--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -157,6 +157,20 @@ export default defineConfig({
     ],
     locales: [
       {
+        lang: 'en',
+        label: 'English',
+        nav: [
+          {
+            text: 'Guide',
+            link: '/guide/quick-start',
+          },
+          {
+            text: 'API',
+            link: '/guide/api/vue-lynx/',
+          },
+        ],
+      },
+      {
         lang: 'zh',
         label: '简体中文',
         nav: [


### PR DESCRIPTION
## Description
Fixes an issue where `@rspress/plugin-llms` was not outputting `.md` files for English documentation (e.g. `guide/quick-start.md`). The plugin requires explicit definition in `themeConfig.locales` for each language variant when multiple languages are used.

## Changes
- Explicitly defined the `en` locale inside `themeConfig.locales` within `website/rspress.config.ts`, bringing it parity with `zh`.