### PR TITLE
chore(website): update hero badge link and add OG image

### DIFF
--- a/website/docs/index.mdx
+++ b/website/docs/index.mdx
@@ -4,7 +4,7 @@ pageType: home
 hero:
   badge:
     text: "Pre-Alpha · How I Vibed This in 2 Weeks →"
-    link: https://x.com/anthropics
+    link: https://x.com/Huxpro/status/2036993665965416601
   name: <span class="hero-title"><span class="dynamic-text">Unlock</span> <span class="brand">Native</span><span class="normal"> for </span><span class="brand">Vue</span></span>
   tagline: Develop Lynx with the familiar Vue 3
   actions:

--- a/website/docs/public/og-image.svg
+++ b/website/docs/public/og-image.svg
@@ -1,0 +1,115 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630">
+  <defs>
+    <!-- Brand gradient: vue-green → emerald → teal -->
+    <linearGradient id="brand" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#42b883"/>
+      <stop offset="50%" stop-color="#34d399"/>
+      <stop offset="100%" stop-color="#00ddff"/>
+    </linearGradient>
+    <linearGradient id="brand-v" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#42b883"/>
+      <stop offset="50%" stop-color="#34d399"/>
+      <stop offset="100%" stop-color="#00ddff"/>
+    </linearGradient>
+
+    <!-- Meteor gradients (head bright, tail fades) -->
+    <linearGradient id="meteor1" x1="0" y1="1" x2="0" y2="0">
+      <stop offset="0%" stop-color="#42b883" stop-opacity="0.7"/>
+      <stop offset="5%" stop-color="#00ddff" stop-opacity="0.5"/>
+      <stop offset="100%" stop-color="#00ddff" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="meteor2" x1="1" y1="0" x2="0" y2="0">
+      <stop offset="0%" stop-color="#42b883" stop-opacity="0.6"/>
+      <stop offset="5%" stop-color="#00ddff" stop-opacity="0.4"/>
+      <stop offset="100%" stop-color="#00ddff" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="meteor3" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#42b883" stop-opacity="0.5"/>
+      <stop offset="5%" stop-color="#00ddff" stop-opacity="0.35"/>
+      <stop offset="100%" stop-color="#00ddff" stop-opacity="0"/>
+    </linearGradient>
+
+    <!-- Hero glow (like the conic-gradient blur on the website) -->
+    <radialGradient id="hero-glow" cx="50%" cy="45%" r="35%">
+      <stop offset="0%" stop-color="#42b883" stop-opacity="0.06"/>
+      <stop offset="50%" stop-color="#00ddff" stop-opacity="0.03"/>
+      <stop offset="100%" stop-color="#00ddff" stop-opacity="0"/>
+    </radialGradient>
+
+    <!-- Badge pill gradient border -->
+    <linearGradient id="badge-border" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="rgba(255,255,255,0.12)"/>
+      <stop offset="100%" stop-color="rgba(255,255,255,0.06)"/>
+    </linearGradient>
+  </defs>
+
+  <!-- ===== Background (dark, matching :root.dark) ===== -->
+  <rect width="1200" height="630" fill="#1b1b1f"/>
+
+  <!-- ===== Grid lines (like MeteorsBackground, gridSize=120, gray 0.1 opacity) ===== -->
+  <g stroke="rgba(128,128,128,0.1)" stroke-width="1">
+    <!-- Vertical lines every 120px -->
+    <line x1="0" y1="0" x2="0" y2="630"/>
+    <line x1="120" y1="0" x2="120" y2="630"/>
+    <line x1="240" y1="0" x2="240" y2="630"/>
+    <line x1="360" y1="0" x2="360" y2="630"/>
+    <line x1="480" y1="0" x2="480" y2="630"/>
+    <line x1="600" y1="0" x2="600" y2="630"/>
+    <line x1="720" y1="0" x2="720" y2="630"/>
+    <line x1="840" y1="0" x2="840" y2="630"/>
+    <line x1="960" y1="0" x2="960" y2="630"/>
+    <line x1="1080" y1="0" x2="1080" y2="630"/>
+    <line x1="1200" y1="0" x2="1200" y2="630"/>
+    <!-- Horizontal lines every 120px -->
+    <line x1="0" y1="0" x2="1200" y2="0"/>
+    <line x1="0" y1="120" x2="1200" y2="120"/>
+    <line x1="0" y1="240" x2="1200" y2="240"/>
+    <line x1="0" y1="360" x2="1200" y2="360"/>
+    <line x1="0" y1="480" x2="1200" y2="480"/>
+    <line x1="0" y1="600" x2="1200" y2="600"/>
+  </g>
+
+  <!-- ===== Meteor trails (snapping to grid lines like the website) ===== -->
+  <!-- Meteor 1: going up on x=360 -->
+  <line x1="360" y1="180" x2="360" y2="480" stroke="url(#meteor1)" stroke-width="2" stroke-linecap="round"/>
+  <!-- Meteor 2: going right on y=240 -->
+  <line x1="780" y1="240" x2="480" y2="240" stroke="url(#meteor2)" stroke-width="2" stroke-linecap="round"/>
+  <!-- Meteor 3: going down on x=840 -->
+  <line x1="840" y1="400" x2="840" y2="120" stroke="url(#meteor3)" stroke-width="2" stroke-linecap="round"/>
+
+  <!-- ===== Hero glow (blurred circle behind hero, like the website's ::before) ===== -->
+  <rect width="1200" height="630" fill="url(#hero-glow)"/>
+
+  <!-- ===== Badge pill (like .rp-home-hero__badge) ===== -->
+  <rect x="410" y="110" width="380" height="40" rx="20" fill="rgba(255,255,255,0.08)" stroke="rgba(255,255,255,0.12)" stroke-width="1"/>
+  <text x="600" y="136" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', sans-serif" font-size="16" font-weight="500" fill="rgba(255,255,255,0.85)">
+    Pre-Alpha · Unlock Native for Vue
+  </text>
+
+  <!-- ===== Hero title: "Unlock Native for Vue" ===== -->
+  <text x="600" y="250" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Segoe UI', sans-serif" font-size="84" font-weight="800" letter-spacing="-2">
+    <tspan fill="#ffffff">Unlock </tspan>
+    <tspan fill="url(#brand)">Native</tspan>
+  </text>
+  <text x="600" y="345" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Display', 'Segoe UI', sans-serif" font-size="84" font-weight="800" letter-spacing="-2">
+    <tspan fill="#ffffff">for </tspan>
+    <tspan fill="url(#brand)">Vue</tspan>
+  </text>
+
+  <!-- ===== Tagline (like .rp-home-hero__tagline) ===== -->
+  <text x="600" y="405" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', sans-serif" font-size="28" font-weight="400" fill="rgba(255,255,255,0.65)">
+    Develop Lynx with the familiar Vue 3
+  </text>
+
+  <!-- ===== Command box (like .hero-command-box) ===== -->
+  <rect x="330" y="445" width="540" height="52" rx="14" fill="rgba(255,255,255,0.03)" stroke="rgba(255,255,255,0.08)" stroke-width="1"/>
+  <!-- $ prompt -->
+  <text x="365" y="478" font-family="'SF Mono', 'Fira Code', 'Cascadia Code', monospace" font-size="17" font-weight="600" fill="#5dd5a8" opacity="0.8">$</text>
+  <!-- command text -->
+  <text x="388" y="478" font-family="'SF Mono', 'Fira Code', 'Cascadia Code', monospace" font-size="17" font-weight="400" fill="rgba(255,255,255,0.85)">npm create vue-lynx@latest</text>
+
+  <!-- ===== URL at bottom ===== -->
+  <text x="600" y="555" text-anchor="middle" font-family="-apple-system, BlinkMacSystemFont, 'SF Pro Text', 'Segoe UI', sans-serif" font-size="18" font-weight="500" fill="rgba(255,255,255,0.4)">
+    vue.lynxjs.org
+  </text>
+</svg>

--- a/website/docs/zh/index.mdx
+++ b/website/docs/zh/index.mdx
@@ -4,7 +4,7 @@ pageType: home
 hero:
   badge:
     text: "Pre-Alpha · 我如何两周 Vibe 出这个项目 →"
-    link: https://x.com/anthropics
+    link: https://x.com/Huxpro/status/2036993665965416601
   name: <span class="hero-title"><span class="dynamic-text">Unlock</span> <span class="brand">Native</span><span class="normal"> for </span><span class="brand">Vue</span></span>
   tagline: 使用熟悉的 Vue 3 开发 Lynx 应用
   actions:


### PR DESCRIPTION
## Summary
- Update hero badge link to point to the actual blog post tweet
- Add SVG OG image (1200x630) matching the website's dark-mode hero style (grid, meteors, brand gradient)

## Test plan
- [ ] Verify hero badge links to correct tweet on both EN and ZH pages
- [ ] Preview OG image renders correctly