### PR TITLE
chore: release v0.1.0

### DIFF
--- a/packages/create-vue-lynx/package.json
+++ b/packages/create-vue-lynx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-vue-lynx",
-  "version": "0.1.0-pre-alpha.2",
+  "version": "0.1.0",
   "description": "Create a new Vue Lynx project",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/vue-lynx/package.json
+++ b/packages/vue-lynx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-lynx",
-  "version": "0.1.0-pre-alpha.2",
+  "version": "0.1.0",
   "private": false,
   "description": "Vue 3 framework for building Lynx apps",
   "keywords": [


### PR DESCRIPTION
## Summary
- Bump `vue-lynx` from `0.1.0-pre-alpha.2` to `0.1.0`
- Bump `create-vue-lynx` from `0.1.0-pre-alpha.2` to `0.1.0`

This promotes both packages out of pre-alpha so the npm `@latest` dist-tag works with `npm create vue-lynx@latest`.

## After merge
Push tags to trigger publish workflows:
```
git tag v0.1.0 <merge-commit>
git tag create-vue-lynx@0.1.0 <merge-commit>
git push origin v0.1.0 create-vue-lynx@0.1.0
```