### PR TITLE
docs: categorize examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@ pnpm dev
 
 - [`todomvc`](examples/todomvc) — TodoMVC
 - [`7guis`](examples/7guis) — 7GUIs benchmark tasks
-- [`hackernews-css`](examples/hackernews-css) — HackerNews (CSS)
-- [`hackernews-tailwind`](examples/hackernews-tailwind) — HackerNews (Tailwind CSS)
+- [`hackernews-tailwind`](examples/hackernews-tailwind) — HackerNews
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- Organize examples into four categories: Tutorials, Vue Features, Ecosystem, and Benchmarks
- Add missing examples (v-model, slots, provide-inject, transition, css-features, main-thread, networking, hackernews-css, hackernews-tailwind)
- Consolidate run instructions at the top of the Examples section
- Fix doc links to use clean URLs