### PR TITLE
fix(create-vue-lynx): move bin to publishConfig to avoid install warning

### DIFF
--- a/packages/create-vue-lynx/package.json
+++ b/packages/create-vue-lynx/package.json
@@ -4,8 +4,10 @@
   "description": "Create a new Vue Lynx project",
   "license": "Apache-2.0",
   "type": "module",
-  "bin": {
-    "create-vue-lynx": "./dist/index.js"
+  "publishConfig": {
+    "bin": {
+      "create-vue-lynx": "./dist/index.js"
+    }
   },
   "files": [
     "dist",


### PR DESCRIPTION
## Summary
- Moves `bin` from top-level to `publishConfig` in `create-vue-lynx/package.json`
- `bin` pointing to `dist/index.js` caused pnpm to warn during `pnpm install` on fresh clones because `dist/` is gitignored and hasn't been built yet
- `publishConfig.bin` only takes effect when publishing to npm (where `dist/` is always present), eliminating the warning during local development

Closes #111

## Test plan
- [ ] `pnpm install` on a fresh clone produces no `create-vue-lynx` warning
- [ ] `npm create vue-lynx@latest` still works after publishing (bin is present in published package)

🤖 Generated with [Claude Code](https://claude.com/claude-code)