### PR TITLE
fix(create-vue-lynx): bump required Node.js to >=20

### DIFF
--- a/packages/create-vue-lynx/package.json
+++ b/packages/create-vue-lynx/package.json
@@ -29,5 +29,5 @@
     "vue-lynx": "workspace:*",
     "typescript": "^5.0.0"
   },
-  "engines": { "node": ">=18" }
+  "engines": { "node": ">=20" }
 }


### PR DESCRIPTION
Closes #117

## Root Cause
`create-rstack@1.8.x` (which `create-vue-lynx` depends on via `^1.0.0`) uses `styleText` from `node:util`, which was only introduced in Node.js v20.12.

The previous `engines: { node: ">=18" }` declaration was inaccurate and misleading.

## Fix
Bump the `engines` requirement to `>=20` to match the actual runtime requirements of `create-rstack`.