### PR TITLE
fix: export isMemoSame for v-for + v-memo compiler output

### DIFF
--- a/packages/upstream-tests/src/v-memo.spec.ts
+++ b/packages/upstream-tests/src/v-memo.spec.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for v-memo / withMemo integration with the Lynx BG-thread renderer.
+ *
+ * v-memo is a compiler primitive — @vue/compiler-dom rewrites
+ *   <tag v-memo="[dep]">...</tag>
+ * into
+ *   withMemo([dep], () => createElementVNode('tag', ...), _cache, 0)
+ *
+ * Vue's own upstream suite covers withMemo's VNode-level bailout behaviour.
+ * These tests cover the Lynx-specific concern: that a cache hit correctly
+ * prevents ops from entering the buffer and reaching the main thread.
+ */
+
+import {
+  createApp,
+  defineComponent,
+  h,
+  nextTick,
+  ref,
+  resetForTesting,
+  isMemoSame,
+  withMemo,
+} from 'vue-lynx';
+import { OP } from 'vue-lynx/internal/ops';
+import { collectFlushedOps, resetCapturedOps } from './local-test-setup.js';
+
+beforeEach(() => {
+  resetForTesting();
+  resetCapturedOps();
+});
+
+/** Extract all SET_PROP ops from a flat ops buffer. */
+function parseSetPropOps(
+  ops: unknown[],
+): Array<{ id: unknown; key: unknown; value: unknown }> {
+  const results: Array<{ id: unknown; key: unknown; value: unknown }> = [];
+  for (let i = 0; i < ops.length; i++) {
+    if (ops[i] === OP.SET_PROP) {
+      results.push({ id: ops[i + 1], key: ops[i + 2], value: ops[i + 3] });
+      i += 3;
+    }
+  }
+  return results;
+}
+
+// Both must be exported — compiler codegen imports them from vue-lynx.
+// isMemoSame is emitted directly for v-for + v-memo combinations;
+// withMemo is emitted for standalone v-memo.
+it('withMemo and isMemoSame are exported from vue-lynx', () => {
+  expect(typeof withMemo).toBe('function');
+  expect(typeof isMemoSame).toBe('function');
+});
+
+describe('withMemo — ops pipeline', () => {
+  it('produces no SET_PROP for memoized element when deps are unchanged', async () => {
+    const outer = ref(0);  // triggers re-renders, NOT in memo deps
+    const inner = ref('hello');  // IS in memo deps
+    const cache: unknown[] = [];
+
+    const App = defineComponent({
+      setup() {
+        return () =>
+          h('view', { 'data-outer': String(outer.value) },
+            withMemo(
+              [inner.value],
+              () => h('text', { content: inner.value }),
+              cache,
+              0,
+            ),
+          );
+      },
+    });
+
+    createApp(App).mount();
+    await nextTick();
+    collectFlushedOps(); // drain mount ops
+
+    outer.value++;
+    await nextTick();
+
+    const propOps = parseSetPropOps(collectFlushedOps());
+
+    // Memoized subtree — no ops to MT
+    expect(propOps.filter(op => op.key === 'content')).toHaveLength(0);
+    // Non-memoized outer prop — still updated
+    expect(propOps.filter(op => op.key === 'data-outer')).toHaveLength(1);
+  });
+
+  it('produces SET_PROP for memoized element when dep changes', async () => {
+    const inner = ref('hello');
+    const cache: unknown[] = [];
+
+    const App = defineComponent({
+      setup() {
+        return () =>
+          withMemo(
+            [inner.value],
+            () => h('text', { content: inner.value }),
+            cache,
+            0,
+          );
+      },
+    });
+
+    createApp(App).mount();
+    await nextTick();
+    collectFlushedOps(); // drain mount ops
+
+    inner.value = 'world';
+    await nextTick();
+
+    const propOps = parseSetPropOps(collectFlushedOps());
+
+    expect(propOps.filter(op => op.key === 'content')).toHaveLength(1);
+    expect(propOps.filter(op => op.key === 'content')[0].value).toBe('world');
+  });
+
+  // v-for + v-memo compiles to a direct isMemoSame call, not withMemo.
+  // This test simulates that compiler output to confirm the export works
+  // and the ops pipeline is correctly bypassed for unchanged list items.
+  it('v-for + v-memo pattern: unchanged list items produce no ops', async () => {
+    type Item = { label: string; selected: boolean };
+    const list = ref<Item[]>([
+      { label: 'a', selected: false },
+      { label: 'b', selected: false },
+    ]);
+    const cache: any[] = [];
+
+    const App = defineComponent({
+      setup() {
+        return () =>
+          h('view', null,
+            // Mirrors compiler output for: v-for="(item, idx) in list" v-memo="[item.selected, item.label]"
+            list.value.map((item, idx) => {
+              const _memo = [item.selected, item.label];
+              const _cached = cache[idx];
+              if (_cached && _cached.key === idx && isMemoSame(_cached, _memo)) return _cached;
+              const vnode = h('text', { key: idx, content: item.label });
+              (vnode as any).memo = _memo;
+              return (cache[idx] = vnode);
+            }),
+          );
+      },
+    });
+
+    createApp(App).mount();
+    await nextTick();
+    collectFlushedOps(); // drain mount ops
+
+    // Change only item[1].label — item[0] memo deps are unchanged
+    list.value = [
+      { label: 'a', selected: false },   // unchanged — memo hit
+      { label: 'b_new', selected: false }, // label changed — memo miss
+    ];
+    await nextTick();
+
+    const propOps = parseSetPropOps(collectFlushedOps());
+    const contentOps = propOps.filter(op => op.key === 'content');
+
+    // Only item[1] should produce a SET_PROP — item[0] was memoized
+    expect(contentOps).toHaveLength(1);
+    expect(contentOps[0].value).toBe('b_new');
+  });
+});

--- a/packages/vue-lynx/runtime/src/index.ts
+++ b/packages/vue-lynx/runtime/src/index.ts
@@ -782,6 +782,7 @@ export { useCssVars } from './use-css-vars.js';
 /** @hidden */ export { toHandlerKey } from '@vue/runtime-core';
 /** @hidden */ export { toHandlers } from '@vue/runtime-core';
 /** @hidden */ export { withMemo } from '@vue/runtime-core';
+/** @hidden */ export { isMemoSame } from '@vue/runtime-core';
 /** @hidden */ export { guardReactiveProps } from '@vue/runtime-core';
 // @ts-expect-error withAsyncContext is exported at runtime but missing from Vue's .d.ts
 /** @hidden */ export { withAsyncContext } from '@vue/runtime-core';
@@ -907,8 +908,7 @@ export function Teleport(): void {
 //                        handleError, ErrorCodes, ErrorTypeStrings
 // Dev/debug internals:   warn, devtools, setDevtoolsHook, initCustomFormatter,
 //                        registerRuntimeCompiler, DeprecationTypes, compatUtils
-// Rendering internals:   isMemoSame, isRuntimeOnly, guardReactiveProps,
-//                        transformVNodeArgs, assertNumber
+// Rendering internals:   isRuntimeOnly, transformVNodeArgs, assertNumber
 // Transition internals:  BaseTransition, BaseTransitionPropsValidators,
 //                        resolveTransitionHooks, setTransitionHooks,
 //                        getTransitionRawChildren, useTransitionState

--- a/website/docs/guide/vue-compatibility.mdx
+++ b/website/docs/guide/vue-compatibility.mdx
@@ -162,11 +162,10 @@ For render functions written in JavaScript, `withMemo` is exported directly from
 import { defineComponent, h, ref } from 'vue'
 import { withMemo } from 'vue-lynx'
 
-const cache: unknown[] = []
-
 export default defineComponent({
   setup() {
     const dep = ref('')
+    const cache: unknown[] = [] // per-instance, mirrors SFC _cache
     return () => withMemo([dep.value], () => h('view', { content: dep.value }), cache, 0)
   },
 })

--- a/website/docs/guide/vue-compatibility.mdx
+++ b/website/docs/guide/vue-compatibility.mdx
@@ -134,6 +134,40 @@ The example below uses `defineComponent` with `data()`, `computed`, `watch`, `me
   defaultFile="src/App.vue"
 />
 
+## v-memo
+
+[`v-memo`](https://vuejs.org/api/built-in-directives.html#v-memo) skips a subtree re-render when its dependency array hasn't changed. It works in Vue Lynx without any configuration — the SFC template compiler already emits the correct `withMemo()` calls, and the runtime bails out before the patcher runs.
+
+In Lynx, `v-memo` is more impactful than in the browser because a cache hit eliminates the entire cross-thread op batch, not just DOM diffing. When deps are unchanged:
+
+- The VNode patcher short-circuits (same VNode object reference).
+- No `patchProp` calls are made, so no ops enter the buffer.
+- `doFlush` sees an empty buffer and skips `callLepusMethod` entirely — the main thread is never contacted for that subtree.
+
+The primary use case is `v-for` lists where only some items change on each update:
+
+```vue
+<list-item
+  v-for="item in list"
+  :key="item.id"
+  v-memo="[item.selected, item.label]"
+>
+  <!-- Only re-renders when selected or label changes -->
+</list-item>
+```
+
+For render functions written in JavaScript, `withMemo` is exported directly from `vue-lynx`:
+
+```ts
+import { withMemo } from 'vue-lynx'
+
+const cache: unknown[] = []
+
+setup() {
+  return () => withMemo([dep.value], () => h('view', { content: dep.value }), cache, 0)
+}
+```
+
 ## Unsupported Features
 
 Some Vue built-in features are not yet adapted to the dual-thread native environment:

--- a/website/docs/guide/vue-compatibility.mdx
+++ b/website/docs/guide/vue-compatibility.mdx
@@ -159,13 +159,17 @@ The primary use case is `v-for` lists where only some items change on each updat
 For render functions written in JavaScript, `withMemo` is exported directly from `vue-lynx`:
 
 ```ts
+import { defineComponent, h, ref } from 'vue'
 import { withMemo } from 'vue-lynx'
 
 const cache: unknown[] = []
 
-setup() {
-  return () => withMemo([dep.value], () => h('view', { content: dep.value }), cache, 0)
-}
+export default defineComponent({
+  setup() {
+    const dep = ref('')
+    return () => withMemo([dep.value], () => h('view', { content: dep.value }), cache, 0)
+  },
+})
 ```
 
 ## Unsupported Features

--- a/website/docs/zh/guide/vue-compatibility.mdx
+++ b/website/docs/zh/guide/vue-compatibility.mdx
@@ -134,6 +134,40 @@ pluginVueLynx({
   defaultFile="src/App.vue"
 />
 
+## v-memo
+
+[`v-memo`](https://vuejs.org/api/built-in-directives.html#v-memo) 在依赖数组未发生变化时跳过子树的重新渲染。它在 Vue Lynx 中无需任何配置即可使用——SFC 模板编译器已经生成了正确的 `withMemo()` 调用，运行时会在 patcher 执行之前进行短路。
+
+在 Lynx 中，`v-memo` 比在浏览器中更有价值，因为缓存命中可以消除整个跨线程 op 批次，而不仅仅是 DOM diff。当依赖未变化时：
+
+- VNode patcher 立即短路（返回相同的 VNode 对象引用）。
+- 不会调用 `patchProp`，因此 ops 缓冲区保持为空。
+- `doFlush` 发现缓冲区为空，完全跳过 `callLepusMethod`——主线程对该子树不会有任何联系。
+
+主要使用场景是 `v-for` 列表，其中每次更新只有部分项目发生变化：
+
+```vue
+<list-item
+  v-for="item in list"
+  :key="item.id"
+  v-memo="[item.selected, item.label]"
+>
+  <!-- 仅在 selected 或 label 变化时重新渲染 -->
+</list-item>
+```
+
+对于用 JavaScript 编写的渲染函数，`withMemo` 可直接从 `vue-lynx` 导入：
+
+```ts
+import { withMemo } from 'vue-lynx'
+
+const cache: unknown[] = []
+
+setup() {
+  return () => withMemo([dep.value], () => h('view', { content: dep.value }), cache, 0)
+}
+```
+
 ## 不支持的特性
 
 部分 Vue 内置特性尚未适配双线程原生环境：

--- a/website/docs/zh/guide/vue-compatibility.mdx
+++ b/website/docs/zh/guide/vue-compatibility.mdx
@@ -159,13 +159,17 @@ pluginVueLynx({
 对于用 JavaScript 编写的渲染函数，`withMemo` 可直接从 `vue-lynx` 导入：
 
 ```ts
+import { defineComponent, h, ref } from 'vue'
 import { withMemo } from 'vue-lynx'
 
 const cache: unknown[] = []
 
-setup() {
-  return () => withMemo([dep.value], () => h('view', { content: dep.value }), cache, 0)
-}
+export default defineComponent({
+  setup() {
+    const dep = ref('')
+    return () => withMemo([dep.value], () => h('view', { content: dep.value }), cache, 0)
+  },
+})
 ```
 
 ## 不支持的特性

--- a/website/docs/zh/guide/vue-compatibility.mdx
+++ b/website/docs/zh/guide/vue-compatibility.mdx
@@ -162,11 +162,10 @@ pluginVueLynx({
 import { defineComponent, h, ref } from 'vue'
 import { withMemo } from 'vue-lynx'
 
-const cache: unknown[] = []
-
 export default defineComponent({
   setup() {
     const dep = ref('')
+    const cache: unknown[] = [] // 每实例独立，对应 SFC 编译产物中的 _cache
     return () => withMemo([dep.value], () => h('view', { content: dep.value }), cache, 0)
   },
 })


### PR DESCRIPTION
## Summary

- **Fix:** Export `isMemoSame` from `vue-lynx` — compiler codegen for `v-for` + `v-memo` emits direct `_isMemoSame(...)` calls alongside `withMemo`, but only `withMemo` was previously exported. Without this, any SFC using `v-memo` inside a `v-for` fails at build time with `ESModulesLinkingError`.
- **Tests:** Add `packages/upstream-tests/src/v-memo.spec.ts` covering the Lynx-specific ops-pipeline concern: that a cache hit produces zero `SET_PROP` ops and a cache miss correctly produces them. Vue's own upstream suite covers the VNode-level bailout behaviour; these tests cover what Vue's suite cannot — the `pushOp` → `doFlush` → `callLepusMethod` path.
- **Docs:** Document `v-memo` support in `vue-compatibility.mdx` (EN + ZH), including the Lynx-specific performance explanation (zero MT IPC on cache hit).

## What the compiler generates

Standalone `v-memo` emits `withMemo(...)` (already exported):
```js
withMemo([dep], () => createElementVNode('div', ...), _cache, 0)
```

`v-for` + `v-memo` emits `isMemoSame(...)` directly (was missing):
```js
if (_cached && _cached.key === idx && _isMemoSame(_cached, _memo)) return _cached;
```

Both are now exported as `@hidden` compiler internals alongside the existing `withMemo` re-export.

## Test plan

- [ ] `pnpm test:local` in `packages/upstream-tests` — all 4 tests in `v-memo.spec.ts` pass
- [ ] Build an SFC that uses `v-memo` inside `v-for` — previously failed with `ESModulesLinkingError: export 'isMemoSame' was not found in 'vue'`
- [ ] No ops emitted for memoized subtree when deps are unchanged (verified by ops-level tests)
