### PR TITLE
feat(runtime): support <Teleport> component

### DIFF
--- a/.changeset/teleport-support.md
+++ b/.changeset/teleport-support.md
@@ -1,0 +1,12 @@
+---
+"vue-lynx": minor
+---
+
+feat(runtime): support `<Teleport>` component
+
+Implement `querySelector` via BG-side `idRegistry` to enable `<Teleport to="#target">`
+pattern without cross-thread infrastructure changes.
+
+- `to` supports `#id` string selectors
+- Dev warning emitted for unsupported selector types
+- idRegistry cleaned up on element removal

--- a/packages/testing-library/src/__tests__/teleport.test.ts
+++ b/packages/testing-library/src/__tests__/teleport.test.ts
@@ -127,6 +127,72 @@ describe('Teleport', () => {
     expect(target!.textContent).toContain('Second');
   });
 
+  it('moves content when `to` target changes dynamically', async () => {
+    const target = ref('#a');
+
+    const Comp = defineComponent({
+      setup() {
+        return { target };
+      },
+      render() {
+        return h('view', null, [
+          h('view', { id: 'a' }),
+          h('view', { id: 'b' }),
+          h(Teleport, { to: this.target }, teleportSlot(() => [
+            h('text', null, 'Moving'),
+          ])),
+        ]);
+      },
+    });
+
+    const { container } = render(Comp);
+    const a = container.querySelector('[id="a"]');
+    const b = container.querySelector('[id="b"]');
+    expect(a!.textContent).toBe('Moving');
+    expect(b!.textContent).toBe('');
+
+    target.value = '#b';
+    await flush();
+    expect(a!.textContent).toBe('');
+    expect(b!.textContent).toBe('Moving');
+  });
+
+  it('toggles disabled — moves content between in-place and target', async () => {
+    const disabled = ref(true);
+
+    const Comp = defineComponent({
+      setup() {
+        return { disabled };
+      },
+      render() {
+        return h('view', null, [
+          h('view', { id: 'target' }),
+          h(Teleport, { to: '#target', disabled: this.disabled }, teleportSlot(() => [
+            h('text', null, 'Toggle'),
+          ])),
+        ]);
+      },
+    });
+
+    const { container } = render(Comp);
+    const tgt = container.querySelector('[id="target"]');
+
+    // Initially disabled — content is in-place, not in target
+    expect(tgt!.textContent).toBe('');
+    expect(container.textContent).toContain('Toggle');
+
+    // Enable teleport — content moves to target
+    disabled.value = false;
+    await flush();
+    expect(tgt!.textContent).toBe('Toggle');
+
+    // Disable again — content moves back in-place
+    disabled.value = true;
+    await flush();
+    expect(tgt!.textContent).toBe('');
+    expect(container.textContent).toContain('Toggle');
+  });
+
   it('handles non-existent target gracefully', () => {
     // Vue emits its own warning for missing targets; content should not crash.
     const Comp = defineComponent({

--- a/packages/testing-library/src/__tests__/teleport.test.ts
+++ b/packages/testing-library/src/__tests__/teleport.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Teleport tests — verify that <Teleport> moves content to the target
+ * element identified by `to="#id"` through the full dual-thread pipeline.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { h, defineComponent, ref, nextTick, Teleport } from 'vue-lynx';
+import { render } from '../index.js';
+
+async function flush() {
+  await nextTick();
+  await nextTick();
+}
+
+function teleportSlot(children: () => unknown[]) {
+  return { default: children };
+}
+
+describe('Teleport', () => {
+  it('teleports content to target element by id', () => {
+    const Comp = defineComponent({
+      render() {
+        return h('view', null, [
+          h('view', { id: 'target' }),
+          h(Teleport, { to: '#target' }, teleportSlot(() => [
+            h('text', null, 'Hello'),
+          ])),
+        ]);
+      },
+    });
+
+    const { container } = render(Comp);
+    const target = container.querySelector('[id="target"]');
+    expect(target).not.toBeNull();
+    expect(target!.textContent).toBe('Hello');
+  });
+
+  it('updates teleported content reactively', async () => {
+    const msg = ref('first');
+
+    const Comp = defineComponent({
+      setup() {
+        return { msg };
+      },
+      render() {
+        return h('view', null, [
+          h('view', { id: 'target' }),
+          h(Teleport, { to: '#target' }, teleportSlot(() => [
+            h('text', null, this.msg),
+          ])),
+        ]);
+      },
+    });
+
+    const { container } = render(Comp);
+    const target = container.querySelector('[id="target"]');
+    expect(target!.textContent).toBe('first');
+
+    msg.value = 'second';
+    await flush();
+    expect(target!.textContent).toBe('second');
+  });
+
+  it('removes teleported content on unmount', async () => {
+    const show = ref(true);
+
+    const Comp = defineComponent({
+      render() {
+        return h('view', null, [
+          h('view', { id: 'target' }),
+          show.value
+            ? h(Teleport, { to: '#target' }, teleportSlot(() => [
+                h('text', null, 'Content'),
+              ]))
+            : null,
+        ]);
+      },
+    });
+
+    const { container } = render(Comp);
+    const target = container.querySelector('[id="target"]');
+    expect(target!.textContent).toBe('Content');
+
+    show.value = false;
+    await flush();
+    expect(target!.textContent).toBe('');
+  });
+});

--- a/packages/testing-library/src/__tests__/teleport.test.ts
+++ b/packages/testing-library/src/__tests__/teleport.test.ts
@@ -157,6 +157,67 @@ describe('Teleport', () => {
     expect(b!.textContent).toBe('Moving');
   });
 
+  it('updates target lookup when an element id changes', async () => {
+    const targetId = ref('a');
+
+    const Comp = defineComponent({
+      setup() {
+        return { targetId };
+      },
+      render() {
+        return h('view', null, [
+          h('view', { id: this.targetId }),
+          h(Teleport, { to: `#${this.targetId}` }, teleportSlot(() => [
+            h('text', null, 'Retargeted'),
+          ])),
+        ]);
+      },
+    });
+
+    const { container } = render(Comp);
+    const target = container.querySelector('[id="a"]');
+    expect(target!.textContent).toBe('Retargeted');
+
+    targetId.value = 'b';
+    await flush();
+
+    expect(container.querySelector('[id="a"]')).toBeNull();
+    expect(container.querySelector('[id="b"]')).toBe(target);
+    expect(target!.textContent).toBe('Retargeted');
+  });
+
+  it('removes target lookup when an element id is removed', async () => {
+    const targetId = ref<string | null>('target');
+    const showTeleport = ref(false);
+
+    const Comp = defineComponent({
+      setup() {
+        return { targetId, showTeleport };
+      },
+      render() {
+        return h('view', null, [
+          h('view', { id: this.targetId }),
+          this.showTeleport
+            ? h(Teleport, { to: '#target' }, teleportSlot(() => [
+                h('text', null, 'Detached'),
+              ]))
+            : null,
+        ]);
+      },
+    });
+
+    const { container } = render(Comp);
+    const target = container.querySelector('[id="target"]');
+    expect(target!.textContent).toBe('');
+
+    targetId.value = null;
+    showTeleport.value = true;
+    await flush();
+
+    expect(container.querySelector('[id="target"]')).toBeNull();
+    expect(target!.textContent).toBe('');
+  });
+
   it('toggles disabled — moves content between in-place and target', async () => {
     const disabled = ref(true);
 

--- a/packages/testing-library/src/__tests__/teleport.test.ts
+++ b/packages/testing-library/src/__tests__/teleport.test.ts
@@ -85,4 +85,62 @@ describe('Teleport', () => {
     await flush();
     expect(target!.textContent).toBe('');
   });
+
+  it('renders content in-place when disabled', () => {
+    const Comp = defineComponent({
+      render() {
+        return h('view', null, [
+          h('view', { id: 'target' }),
+          h(Teleport, { to: '#target', disabled: true }, teleportSlot(() => [
+            h('text', null, 'InPlace'),
+          ])),
+        ]);
+      },
+    });
+
+    const { container } = render(Comp);
+    // When disabled, content should NOT be in target
+    const target = container.querySelector('[id="target"]');
+    expect(target!.textContent).toBe('');
+    // Content should be rendered in-place (inside the root view)
+    expect(container.textContent).toContain('InPlace');
+  });
+
+  it('multiple teleports to the same target', () => {
+    const Comp = defineComponent({
+      render() {
+        return h('view', null, [
+          h('view', { id: 'target' }),
+          h(Teleport, { to: '#target' }, teleportSlot(() => [
+            h('text', null, 'First'),
+          ])),
+          h(Teleport, { to: '#target' }, teleportSlot(() => [
+            h('text', null, 'Second'),
+          ])),
+        ]);
+      },
+    });
+
+    const { container } = render(Comp);
+    const target = container.querySelector('[id="target"]');
+    expect(target!.textContent).toContain('First');
+    expect(target!.textContent).toContain('Second');
+  });
+
+  it('handles non-existent target gracefully', () => {
+    // Vue emits its own warning for missing targets; content should not crash.
+    const Comp = defineComponent({
+      render() {
+        return h('view', null, [
+          h(Teleport, { to: '#does-not-exist' }, teleportSlot(() => [
+            h('text', null, 'Lost'),
+          ])),
+        ]);
+      },
+    });
+
+    // Should not throw
+    const { container } = render(Comp);
+    expect(container).not.toBeNull();
+  });
 });

--- a/packages/upstream-tests/README.md
+++ b/packages/upstream-tests/README.md
@@ -4,19 +4,19 @@
 
 This package runs the official `vuejs/core` test suites against our **ShadowElement-backed custom renderer**, validating that our linked-list tree implementation satisfies Vue's renderer contract. Source: `vuejs/core` v3.5.12, pinned via git submodule at `core/`.
 
-**Total: 975 tests across 50 suites -- 856 pass, 119 skip, 0 fail**
+**Total: 1013 tests across 51 suites -- 882 pass, 131 skip, 0 fail**
 
 | Config                                         | Suites | Pass    | Skip   | Fail  |
 | ---------------------------------------------- | ------ | ------- | ------ | ----- |
-| `pnpm test` (runtime-core, reactivity, shared) | 43     | 798     | 77     | 0     |
+| `pnpm test` (runtime-core, reactivity, shared) | 44     | 824     | 89     | 0     |
 | `pnpm test:dom` (runtime-dom)                  | 7      | 58      | 42     | 0     |
-| **Total**                                      | **50** | **856** | **119** | **0** |
+| **Total**                                      | **51** | **882** | **131** | **0** |
 
 ### By package
 
 | Package      | Suites | Pass | Skip |
 | ------------ | ------ | ---- | ---- |
-| runtime-core | 23     | 407  | 59   |
+| runtime-core | 24     | 433  | 71   |
 | reactivity   | 15     | 345  | 18   |
 | shared       | 5      | 46   | 0    |
 | runtime-dom  | 7      | 58   | 42   |
@@ -112,7 +112,7 @@ Since we run upstream test files from outside the `vuejs/core` monorepo, three m
 
 ## Skip Analysis
 
-119 skips break down into three categories: structurally impossible (cannot pass outside the Vue monorepo), substantive (related to platform differences or our pipeline), and vModel-specific (Lynx element/event model differences).
+131 skips break down into four categories: structurally impossible (cannot pass outside the Vue monorepo), substantive (related to platform differences or our pipeline), Teleport-specific (tests requiring DOM renderer or template compiler), and vModel-specific (Lynx element/event model differences).
 
 ### Structurally impossible (77 skips)
 
@@ -149,6 +149,16 @@ Lynx doesn't support certain Web platform capabilities. If Lynx adds support for
 | Subcategory                 | Count | Root cause                                                |
 | --------------------------- | ----- | --------------------------------------------------------- |
 | `JSON.stringify` limitation | 3     | `Symbol` values lost in cross-thread serialization        |
+
+### Teleport-specific skips (12 skips)
+
+The `components/Teleport.spec.ts` suite has 38 tests; 26 pass through our adapter, 12 are skipped.
+
+| Subcategory                        | Count | Root cause                                                 |
+| ---------------------------------- | ----- | ---------------------------------------------------------- |
+| DOM renderer (`domRender`/`createDOMApp`) | 8 | Tests mount into `document.createElement('div')` via the DOM renderer; our adapter only provides the test renderer — `parent._se` is undefined on HTMLElement |
+| Template compiler (`compile()`)    | 2     | `compile` is not available in this build (requires `vue/dist/vue.esm-bundler.js`) |
+| Name collision (`"should work"`)   | 2     | Accidentally matched by existing skiplist entry for directives suite |
 
 ### vModel-specific skips (22 skips)
 

--- a/packages/upstream-tests/skiplist.json
+++ b/packages/upstream-tests/skiplist.json
@@ -90,7 +90,14 @@
     "attempting to write plain value to a readonly ref nested in a reactive object should fail",
     "can not run an inactive scope",
 
-    "handle error in async onActivated"
+    "handle error in async onActivated",
+
+    "should work with SVG",
+    "should work with block tree",
+    "toggle sibling node inside target node",
+    "unmount previous sibling node inside target node",
+    "should be able to target content appearing later than the teleport with defer",
+    "defer mode should work inside suspense"
   ],
   "_categories": {
     "scheduler": "Tests internal scheduler API directly, not renderer contract",
@@ -107,6 +114,8 @@
     "apiExpose_ref_owner": "Adapter createApp().render() doesn't set proper ref owner context for template refs on exposed instances",
     "apiAsyncComponent_ref_forwarding": "Template ref forwarding on async wrapper components not supported by adapter",
     "scopeId_suspense": "Suspense content scopeId attachment requires internal Suspense implementation detail",
-    "keepAlive_async_onActivated": "Adapter's TestElement wrapper triggers Vue warning about enumerating component instance keys; unrelated to KeepAlive logic"
+    "keepAlive_async_onActivated": "Adapter's TestElement wrapper triggers Vue warning about enumerating component instance keys; unrelated to KeepAlive logic",
+    "teleport_dom_renderer": "Tests use domRender/createDOMApp (DOM renderer), our adapter only provides the test renderer — parent._se is undefined on HTMLElement",
+    "teleport_compile": "Tests use compile() (runtime template compiler), not available in this build"
   }
 }

--- a/packages/upstream-tests/src/lynx-runtime-test.spec.ts
+++ b/packages/upstream-tests/src/lynx-runtime-test.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+
+import {
+  nodeOps,
+  patchProp,
+  resetOps,
+} from './lynx-runtime-test.js';
+
+describe('lynx-runtime-test id registry', () => {
+  beforeEach(() => {
+    resetOps();
+  });
+
+  it('cleans descendant ids when removing a subtree', () => {
+    const root = nodeOps.createElement('view');
+    const outer = nodeOps.createElement('view');
+    const inner = nodeOps.createElement('view');
+
+    nodeOps.insert(outer, root);
+    nodeOps.insert(inner, outer);
+    patchProp(inner, 'id', null, 'target');
+
+    expect(nodeOps.querySelector('#target')).toBe(inner);
+
+    nodeOps.remove(outer);
+
+    expect(nodeOps.querySelector('#target')).toBeNull();
+  });
+
+  it('cleans descendant ids when replacing children with text', () => {
+    const root = nodeOps.createElement('view');
+    const inner = nodeOps.createElement('view');
+
+    nodeOps.insert(inner, root);
+    patchProp(inner, 'id', null, 'target');
+
+    expect(nodeOps.querySelector('#target')).toBe(inner);
+
+    nodeOps.setElementText(root, 'replacement');
+
+    expect(nodeOps.querySelector('#target')).toBeNull();
+  });
+});

--- a/packages/upstream-tests/src/lynx-runtime-test.ts
+++ b/packages/upstream-tests/src/lynx-runtime-test.ts
@@ -263,6 +263,18 @@ function insert(
   parent._se.insertBefore(child._se, ref ? ref._se : null);
 }
 
+function cleanupTestIds(node: TestNode): void {
+  if (node.type === TestNodeTypes.ELEMENT && node.props.id != null) {
+    testIdRegistry.delete(String(node.props.id));
+  }
+
+  let child = node._se.firstChild;
+  while (child) {
+    cleanupTestIds(getTestNode(child));
+    child = child.next;
+  }
+}
+
 function remove(child: TestNode): void {
   const parentSE = child._se.parent;
   if (parentSE) {
@@ -272,6 +284,7 @@ function remove(child: TestNode): void {
       targetNode: child,
       parentNode: parent,
     });
+    cleanupTestIds(child);
     parentSE.removeChild(child._se);
   }
 }
@@ -284,7 +297,9 @@ function setElementText(el: TestElement, text: string): void {
   });
   // Remove all children from the ShadowElement linked list
   while (el._se.firstChild) {
-    el._se.removeChild(el._se.firstChild);
+    const child = getTestNode(el._se.firstChild);
+    cleanupTestIds(child);
+    el._se.removeChild(child._se);
   }
   if (text) {
     const textNode = makeTestText(text);

--- a/packages/upstream-tests/src/lynx-runtime-test.ts
+++ b/packages/upstream-tests/src/lynx-runtime-test.ts
@@ -123,6 +123,7 @@ export function logNodeOp(op: NodeOp): void {
 
 export function resetOps(): void {
   recordedNodeOps = [];
+  testIdRegistry.clear();
 }
 
 export function dumpOps(): NodeOp[] {
@@ -301,8 +302,14 @@ function nextSibling(node: TestNode): TestNode | null {
   return nextSE ? getTestNode(nextSE) : null;
 }
 
-function querySelector(): never {
-  throw new Error('querySelector not supported in test renderer.');
+// Registry for Teleport target resolution in the test renderer.
+const testIdRegistry = new Map<string, TestElement>();
+
+function querySelector(selector: string): TestElement | null {
+  if (selector.startsWith('#')) {
+    return testIdRegistry.get(selector.slice(1)) ?? null;
+  }
+  return null;
 }
 
 function setScopeId(el: TestElement, id: string): void {
@@ -349,6 +356,11 @@ export function patchProp(
     propNextValue: nextValue,
   });
   el.props[key] = nextValue;
+  if (key === 'id') {
+    // Maintain testIdRegistry for querySelector / Teleport support
+    if (prevValue != null) testIdRegistry.delete(String(prevValue));
+    if (nextValue != null) testIdRegistry.set(String(nextValue), el);
+  }
   if (isOn(key)) {
     const event = key[2] === ':' ? key.slice(3) : key.slice(2).toLowerCase();
     if (!el.eventListeners) el.eventListeners = {};

--- a/packages/upstream-tests/vitest.config.ts
+++ b/packages/upstream-tests/vitest.config.ts
@@ -200,6 +200,8 @@ const runtimeCoreTests = [
   'scopeId',
   // Phase 4 — KeepAlive
   'components/KeepAlive',
+  // Phase 5 — Teleport
+  'components/Teleport',
 ].map((name) => `${runtimeCoreDir}/${name}.spec.ts`);
 
 const reactivityTests = [

--- a/packages/vue-lynx/runtime/src/index.ts
+++ b/packages/vue-lynx/runtime/src/index.ts
@@ -867,21 +867,7 @@ export function createStaticVNode(
 export const Static: symbol = Symbol.for('v-stc');
 
 
-/**
- * @deprecated Teleport requires `querySelector` renderer option to resolve
- * string targets (e.g. `to="#modal"`). Vue Lynx does not implement
- * `querySelector`. In dev mode, Vue will warn and the content will not be
- * teleported. Direct element references are also unsupported because Lynx
- * native elements are not accessible from the Background Thread.
- * @internal
- */
-export function Teleport(): void {
-  if (__DEV__) {
-    console.warn(
-      '[vue-lynx] Teleport is not supported — Lynx renderer has no querySelector.',
-    );
-  }
-}
+export { Teleport } from '@vue/runtime-core';
 
 // ===========================================================================
 // Intentionally NOT re-exported — @vue/runtime-core internal APIs

--- a/packages/vue-lynx/runtime/src/node-ops.ts
+++ b/packages/vue-lynx/runtime/src/node-ops.ts
@@ -239,6 +239,10 @@ export const nodeOps: RendererOptions<ShadowElement, ShadowElement> = {
   },
 
   remove(child: ShadowElement): void {
+    // Vue's Teleport iterates its children on unmount even when target
+    // resolution failed at mount (see @vue/runtime-core TeleportImpl.remove).
+    // Those children were never mounted, so `vnode.el` is undefined — null
+    // guard is required here, not just for the `!parent` case.
     if (child?.parent) {
       const parentId = child.parent.id;
       child.parent.removeChild(child);
@@ -370,7 +374,7 @@ export const nodeOps: RendererOptions<ShadowElement, ShadowElement> = {
       pushOp(OP.SET_CLASS, el.id, finalClass);
     } else if (key === 'id') {
       if (el._id) idRegistry.delete(el._id);
-      el._id = nextValue as string | undefined;
+      el._id = nextValue != null ? String(nextValue) : undefined;
       if (el._id) idRegistry.set(el._id, el);
       pushOp(OP.SET_ID, el.id, nextValue);
     } else {

--- a/packages/vue-lynx/runtime/src/node-ops.ts
+++ b/packages/vue-lynx/runtime/src/node-ops.ts
@@ -123,6 +123,9 @@ interface OnceWrapper {
 }
 const onceWrappers = new Map<string, OnceWrapper>();
 
+// Registry for Teleport target resolution: id string → ShadowElement.
+const idRegistry = new Map<string, ShadowElement>();
+
 // ---------------------------------------------------------------------------
 // Class resolution — merges user :class with transition classes
 // ---------------------------------------------------------------------------
@@ -355,6 +358,9 @@ export const nodeOps: RendererOptions<ShadowElement, ShadowElement> = {
       const finalClass = resolveClass(el);
       pushOp(OP.SET_CLASS, el.id, finalClass);
     } else if (key === 'id') {
+      if (el._id) idRegistry.delete(el._id);
+      el._id = nextValue as string | undefined;
+      if (el._id) idRegistry.set(el._id, el);
       pushOp(OP.SET_ID, el.id, nextValue);
     } else {
       pushOp(OP.SET_PROP, el.id, key, nextValue);
@@ -377,10 +383,18 @@ export const nodeOps: RendererOptions<ShadowElement, ShadowElement> = {
   nextSibling(node: ShadowElement): ShadowElement | null {
     return node.next;
   },
+
+  querySelector(selector: string): ShadowElement | null {
+    if (selector.startsWith('#')) {
+      return idRegistry.get(selector.slice(1)) ?? null;
+    }
+    return null;
+  },
 };
 
 /** Reset module state – for testing only. */
 export function resetNodeOpsState(): void {
   elementEventSigns.clear();
   onceWrappers.clear();
+  idRegistry.clear();
 }

--- a/packages/vue-lynx/runtime/src/node-ops.ts
+++ b/packages/vue-lynx/runtime/src/node-ops.ts
@@ -188,6 +188,7 @@ export const nodeOps: RendererOptions<ShadowElement, ShadowElement> = {
     while (el.firstChild) {
       const child = el.firstChild;
       el.removeChild(child);
+      cleanupIds(child);
       pushOp(OP.REMOVE, el.id, child.id);
     }
     // Set text content directly on the element
@@ -375,6 +376,11 @@ export const nodeOps: RendererOptions<ShadowElement, ShadowElement> = {
     } else if (key === 'id') {
       if (el._id) idRegistry.delete(el._id);
       el._id = nextValue != null ? String(nextValue) : undefined;
+      if (__DEV__ && el._id && idRegistry.has(el._id) && idRegistry.get(el._id) !== el) {
+        console.warn(
+          `[vue-lynx] Duplicate id "${el._id}" detected. Teleport target resolution may be unreliable.`,
+        );
+      }
       if (el._id) idRegistry.set(el._id, el);
       pushOp(OP.SET_ID, el.id, nextValue);
     } else {

--- a/packages/vue-lynx/runtime/src/node-ops.ts
+++ b/packages/vue-lynx/runtime/src/node-ops.ts
@@ -126,6 +126,16 @@ const onceWrappers = new Map<string, OnceWrapper>();
 // Registry for Teleport target resolution: id string → ShadowElement.
 const idRegistry = new Map<string, ShadowElement>();
 
+/** Recursively clean up idRegistry for a subtree being removed. */
+function cleanupIds(el: ShadowElement): void {
+  if (el._id) idRegistry.delete(el._id);
+  let child = el.firstChild;
+  while (child) {
+    cleanupIds(child);
+    child = child.next;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Class resolution — merges user :class with transition classes
 // ---------------------------------------------------------------------------
@@ -232,7 +242,7 @@ export const nodeOps: RendererOptions<ShadowElement, ShadowElement> = {
     if (child?.parent) {
       const parentId = child.parent.id;
       child.parent.removeChild(child);
-      if (child._id) idRegistry.delete(child._id);
+      cleanupIds(child);
       pushOp(OP.REMOVE, parentId, child.id);
       scheduleFlush();
     }

--- a/packages/vue-lynx/runtime/src/node-ops.ts
+++ b/packages/vue-lynx/runtime/src/node-ops.ts
@@ -229,9 +229,10 @@ export const nodeOps: RendererOptions<ShadowElement, ShadowElement> = {
   },
 
   remove(child: ShadowElement): void {
-    if (child.parent) {
+    if (child?.parent) {
       const parentId = child.parent.id;
       child.parent.removeChild(child);
+      if (child._id) idRegistry.delete(child._id);
       pushOp(OP.REMOVE, parentId, child.id);
       scheduleFlush();
     }
@@ -387,6 +388,11 @@ export const nodeOps: RendererOptions<ShadowElement, ShadowElement> = {
   querySelector(selector: string): ShadowElement | null {
     if (selector.startsWith('#')) {
       return idRegistry.get(selector.slice(1)) ?? null;
+    }
+    if (__DEV__) {
+      console.warn(
+        `[vue-lynx] querySelector only supports #id selectors, got "${selector}".`,
+      );
     }
     return null;
   },

--- a/packages/vue-lynx/runtime/src/shadow-element.ts
+++ b/packages/vue-lynx/runtime/src/shadow-element.ts
@@ -46,6 +46,9 @@ export class ShadowElement {
   _vModelHandler: ((data: unknown) => void) | undefined = undefined;
   _vModelEventProp: string | undefined = undefined;
 
+  // ID for Teleport target resolution (idRegistry lookup).
+  _id: string | undefined = undefined;
+
   constructor(type: string, forceId?: number) {
     if (forceId === undefined) {
       this.id = ShadowElement.nextId++;

--- a/website/docs/guide/vue-compatibility.mdx
+++ b/website/docs/guide/vue-compatibility.mdx
@@ -210,11 +210,14 @@ export default defineComponent({
 })
 ```
 
+## Teleport
+
+`<Teleport>` is supported for `to="#id"` string selectors. Direct element refs and non-ID selectors are not yet supported.
+
 ## Unsupported Features
 
 Some Vue built-in features are not yet adapted to the dual-thread native environment:
 
 | Feature | Reason | Alternative |
 |---------|--------|-------------|
-| `<Teleport>` | Requires `querySelector` to resolve string targets, unavailable in the dual-thread architecture | Conditional rendering at the target location |
 | `<Transition>` auto-duration | `getComputedStyle()` is unavailable on the background thread | Always pass an explicit `:duration` prop |

--- a/website/docs/zh/guide/api/vue-lynx/index.mdx
+++ b/website/docs/zh/guide/api/vue-lynx/index.mdx
@@ -35,7 +35,7 @@ import { ref, computed, onMounted, defineComponent } from 'vue-lynx';
 | `<TransitionGroup>` | 实验性 | 逐子元素进入/离开动画。不支持移动 (FLIP) 动画 — 后台线程无法使用 `getBoundingClientRect()`。 |
 | `<Suspense>` | 支持 | 从 Vue 重新导出。与 `defineAsyncComponent()` 配合使用。 |
 | `<KeepAlive>` | 不支持 | 需要 Lynx 渲染器中不可用的元素回收功能。 |
-| `<Teleport>` | 不支持 | 需要未实现的 `querySelector` 渲染器选项。 |
+| `<Teleport>` | 支持 | 仅支持 `to="#id"` 字符串选择器。暂不支持直接传入元素 ref 或非 ID 选择器。 |
 
 :::warning
 `<Transition>` 和 `<TransitionGroup>` 是**实验性的**。请始终传递显式的 `:duration` prop — 后台线程无法使用 `getComputedStyle()`。`<TransitionGroup>` 不支持移动 (FLIP) 动画。

--- a/website/docs/zh/guide/vue-compatibility.mdx
+++ b/website/docs/zh/guide/vue-compatibility.mdx
@@ -210,11 +210,14 @@ export default defineComponent({
 })
 ```
 
+## Teleport
+
+`<Teleport>` 支持 `to="#id"` 字符串选择器。暂不支持直接传入元素 ref 或非 ID 选择器。
+
 ## 不支持的特性
 
 部分 Vue 内置特性尚未适配双线程原生环境：
 
 | 特性 | 原因 | 替代方案 |
 |---------|--------|-------------|
-| `<Teleport>` | 需要 `querySelector` 来解析字符串目标，在双线程架构中不可用 | 在目标位置使用条件渲染 |
 | `<Transition>` 自动时长 | 后台线程无法使用 `getComputedStyle()` | 始终传递显式的 `:duration` prop |

--- a/website/scripts/generate-api.ts
+++ b/website/scripts/generate-api.ts
@@ -210,7 +210,7 @@ ${lynxApis.map(fmtRow).join('\n')}
 | \`<TransitionGroup>\` | Experimental | Per-child enter/leave animations. Move (FLIP) animations not supported — \`getBoundingClientRect()\` is unavailable from the background thread. |
 | \`<Suspense>\` | Supported | Re-exported from Vue. Works with \`defineAsyncComponent()\`. |
 | \`<KeepAlive>\` | Supported | Caches inactive component instances. Supports \`include\`, \`exclude\`, and \`max\` props. |
-| \`<Teleport>\` | Not Supported | Requires \`querySelector\` renderer option not implemented. |
+| \`<Teleport>\` | Supported | Supports \`to="#id"\` string selectors only. Direct element refs and non-ID selectors are not yet supported. |
 
 :::warning
 \`<Transition>\` and \`<TransitionGroup>\` are **experimental**. Always pass an explicit \`:duration\` prop — \`getComputedStyle()\` is unavailable from the background thread. Move (FLIP) animations in \`<TransitionGroup>\` are not supported.


### PR DESCRIPTION
## Summary

  Implement `<Teleport>` component support via a BG-side `idRegistry`, enabling the `to="#target"` pattern without cross-thread infrastructure changes. Closes #81.

  ## Problem

  Teleport resolves its `to` target via the `querySelector` renderer option. vue-lynx deliberately omitted this because:

  1. Lynx has no `document.querySelector()` on the BG thread
  2. Native elements exist on the Main Thread, but Vue runs on the Background Thread
  3. ShadowElement is a lightweight linked-list with no query capability

  The component was previously stubbed with a dev warning.

  ## Solution

  The ops layer already handles `INSERT[parent, child, anchor]` for any parent — the only missing piece was BG-side target resolution.

  **`idRegistry` approach:**
  - Maintain a `Map<string, ShadowElement>` in `node-ops.ts`
  - Populate when `patchProp` sets an `id` attribute
  - Implement `querySelector` that looks up from the registry (supports `#id` selectors only)
  - Replace Teleport stub with real `Teleport` from `@vue/runtime-core`

  No new ops, no MT changes required.

  ## Files Changed

  - `runtime/src/shadow-element.ts` — Add `_id` property
  - `runtime/src/node-ops.ts` — Add `idRegistry`, `querySelector`, cleanup on `remove()`, dev warning for unsupported selectors
  - `runtime/src/index.ts` — Replace Teleport stub with re-export from `@vue/runtime-core`

  ## Testing

  - All existing tests pass (58 tests)
  - 3 new integration tests covering mount, reactive update, and unmount lifecycle

  ## Limitations

  - `to` only supports `#id` string selectors (not `.class`, tag selectors, etc.)
  - Direct element references (Vue 3.3+ `to` accepts a raw node) are not supported — ShadowElement lacks
  DOM properties (`__vnode`) that Vue's patch logic requires. This needs further investigation.