### PR TITLE
Add example build step to release workflow and script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         run: pnpm install
 
       - name: Build
-        run: pnpm build && pnpm --filter create-vue-lynx run build
+        run: pnpm build && pnpm --filter create-vue-lynx run build && pnpm build:examples:publishable
 
       - name: Create Release Pull Request or Publish to npm
         uses: changesets/action@v1

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "build": "pnpm --filter vue-lynx run build",
     "build:examples": "pnpm --filter './examples/*' --parallel run build",
+    "build:examples:publishable": "node scripts/build-publishable-examples.mjs",
     "dev": "pnpm --filter vue-lynx run dev",
     "test": "pnpm --filter vue-lynx-testing-library run test",
     "test:dev-smoke": "node scripts/dev-smoke.mjs",
@@ -12,7 +13,7 @@
     "lint": "biome check .",
     "changeset": "changeset",
     "version-packages": "changeset version",
-    "release": "pnpm build && pnpm --filter create-vue-lynx run build && changeset publish"
+    "release": "pnpm build && pnpm --filter create-vue-lynx run build && pnpm build:examples:publishable && changeset publish"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/scripts/build-publishable-examples.mjs
+++ b/scripts/build-publishable-examples.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = join(dirname(fileURLToPath(import.meta.url)), '..');
+const examplesDir = join(rootDir, 'examples');
+const dryRun = process.argv.includes('--dry-run');
+
+const packages = readdirSync(examplesDir, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => {
+    const packagePath = join(examplesDir, entry.name, 'package.json');
+    const packageJson = JSON.parse(readFileSync(packagePath, 'utf8'));
+
+    return {
+      dir: entry.name,
+      name: packageJson.name,
+      private: packageJson.private === true,
+    };
+  })
+  .filter((pkg) => !pkg.private && pkg.name?.startsWith('@vue-lynx-example/'))
+  .sort((a, b) => a.name.localeCompare(b.name));
+
+if (packages.length === 0) {
+  console.error('No publishable Vue Lynx example packages found.');
+  process.exit(1);
+}
+
+if (dryRun) {
+  for (const pkg of packages) {
+    console.info(`${pkg.name} (${pkg.dir})`);
+  }
+  process.exit(0);
+}
+
+const filterArgs = packages.flatMap((pkg) => ['--filter', pkg.name]);
+const result = spawnSync('pnpm', [...filterArgs, '--parallel', 'run', 'build'], {
+  cwd: rootDir,
+  stdio: 'inherit',
+  shell: process.platform === 'win32',
+});
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary
Build publishable Vue Lynx example packages before release publishing so npm tarballs include their generated dist artifacts.

Fixes #162

## Key Changes
- Added build:examples:publishable to build only public @vue-lynx-example/* packages.
- Updated the release script and Release workflow to run build:examples:publishable before changeset publish.
- Skips private example workspaces so release publishing is not blocked by demos that are not npm publish targets.

## Validation
- pnpm lint
- pnpm build:examples:publishable
- pnpm --dir examples/basic pack --pack-destination /tmp/vue-lynx-pack-green confirmed dist/*.lynx.bundle and dist/*.web.bundle are included.