### PR TITLE
fix(website): bump @lynx-js/web-core to ^0.20.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
-        version: 1.2.7(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -45,7 +45,7 @@ importers:
         version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
-        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+        version: 1.2.7(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.8(@swc/helpers@0.5.19))
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -288,28 +288,6 @@ importers:
         version: 1.2.7(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.8(@swc/helpers@0.5.19))
       typescript:
         specifier: ^5.0.0
-        version: 5.9.3
-
-  examples/react-css-inheritance:
-    dependencies:
-      '@lynx-js/react':
-        specifier: ^0.116.0
-        version: 0.116.5(@lynx-js/types@3.7.0)(@types/react@19.2.14)
-    devDependencies:
-      '@lynx-js/react-rsbuild-plugin':
-        specifier: ^0.13.0
-        version: 0.13.0(@lynx-js/lynx-core@0.1.3)(@lynx-js/react@0.116.5(@lynx-js/types@3.7.0)(@types/react@19.2.14))(tslib@2.8.1)(webpack@5.105.4)
-      '@lynx-js/rspeedy':
-        specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
-      '@lynx-js/types':
-        specifier: ^3.7.0
-        version: 3.7.0
-      '@types/react':
-        specifier: ^19.0.0
-        version: 19.2.14
-      typescript:
-        specifier: ~5.9.3
         version: 5.9.3
 
   examples/reactivity:
@@ -638,10 +616,10 @@ importers:
         version: 2.92.2(@floating-ui/dom@1.7.6)(@tiptap/suggestion@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@lynx-js/go-web':
         specifier: ^0.2.1
-        version: 0.2.1(@douyinfe/semi-icons@2.92.2(react@19.2.4))(@douyinfe/semi-ui@2.92.2(@floating-ui/dom@1.7.6)(@tiptap/suggestion@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@lynx-js/web-core@0.19.8(@lynx-js/lynx-core@0.1.3)(@lynx-js/web-elements@0.12.0(tslib@2.8.1)))(@rspress/core@2.0.5(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.47.0)(micromark-util-types@2.0.2)(micromark@4.0.2))(@shikijs/transformers@3.23.0)(qrcode.react@4.2.0(react@19.2.4))(react-copy-to-clipboard@5.1.1(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(swr@2.4.1(react@19.2.4))(vscode-icons-js@11.6.1)
+        version: 0.2.1(@douyinfe/semi-icons@2.92.2(react@19.2.4))(@douyinfe/semi-ui@2.92.2(@floating-ui/dom@1.7.6)(@tiptap/suggestion@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@lynx-js/web-core@0.20.2(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.5(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.47.0)(micromark-util-types@2.0.2)(micromark@4.0.2))(@shikijs/transformers@3.23.0)(qrcode.react@4.2.0(react@19.2.4))(react-copy-to-clipboard@5.1.1(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(swr@2.4.1(react@19.2.4))(vscode-icons-js@11.6.1)
       '@lynx-js/web-core':
-        specifier: ^0.19.8
-        version: 0.19.8(@lynx-js/lynx-core@0.1.3)(@lynx-js/web-elements@0.12.0(tslib@2.8.1))
+        specifier: ^0.20.0
+        version: 0.20.2(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)
       '@lynx-js/web-elements':
         specifier: ^0.12.0
         version: 0.12.0(tslib@2.8.1)
@@ -1243,41 +1221,9 @@ packages:
   '@lynx-js/lynx-core@0.1.3':
     resolution: {integrity: sha512-uWzKKYJUK4Q09ZRZxWSAFINnmZb9piWPbvWF9SkLn+3snBl9u/BJa4ekPRcKWAhBmpbtxWH1x27fxe3Q3p5l3Q==}
 
-  '@lynx-js/offscreen-document@0.1.4':
-    resolution: {integrity: sha512-7OUAXZbpWigxOwpcDUU348R9Iw4JZP8qOsNdJ7+Z+LWTWt2DxbkxIKJ/KawQNOp+tsXeOFwUNbrgGkA7aqAX5w==}
-
   '@lynx-js/qrcode-rsbuild-plugin@0.4.6':
     resolution: {integrity: sha512-KHnvkccapEWEtfRMJ4GxNoZDsv8c0RlfNfc3la/z8G2eP+vb8VtKG1Atk2FVagUVnJcuePeuue8LaivzoM/Irw==}
     engines: {node: '>=18'}
-
-  '@lynx-js/react-alias-rsbuild-plugin@0.13.0':
-    resolution: {integrity: sha512-tmhbkullbiDNhaIyDOvSyypRS39WzCXoPslEOIemw97wV0dCXcdxdZgyuoU2ZlsUl4EmD2W7CpS6zbuCAIF/kA==}
-    engines: {node: '>=18'}
-
-  '@lynx-js/react-refresh-webpack-plugin@0.3.5':
-    resolution: {integrity: sha512-hPweL4nKn2JW1V2tXoSc8vIHog+puTPJWaE4A/iqV8UU4VHA4ClSERzCBeL6IYdbP8XSJo6Xn4z7iatQXTrsAQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@lynx-js/react-webpack-plugin': ^0.3.0 || ^0.4.0 || ^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0
-
-  '@lynx-js/react-rsbuild-plugin@0.13.0':
-    resolution: {integrity: sha512-TCZSqG2mS6LFBkpEsDkJhDytEqWPd1D0BhlKFL35wvzbLEMMxsR4mDCiPrhDHPpHMuDizrVmAa11CufDlkiTyA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@lynx-js/react': ^0.103.0 || ^0.104.0 || ^0.105.0 || ^0.106.0 || ^0.107.0 || ^0.108.0 || ^0.109.0 || ^0.110.0 || ^0.111.0 || ^0.112.0 || ^0.113.0 || ^0.114.0 || ^0.115.0 || ^0.116.0 || ^0.117.0
-    peerDependenciesMeta:
-      '@lynx-js/react':
-        optional: true
-
-  '@lynx-js/react-webpack-plugin@0.8.0':
-    resolution: {integrity: sha512-S45noDout1+JCsEheR/ffa7+boSxLr+KvosdRfg/NiIfUuSuOyfbqCp4u8AwBrDpdImjnRqYqV3kpJYSLHQomw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@lynx-js/react': '*'
-      '@lynx-js/template-webpack-plugin': ^0.4.0 || ^0.5.0 || ^0.6.0 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^0.10.0
-    peerDependenciesMeta:
-      '@lynx-js/react':
-        optional: true
 
   '@lynx-js/react@0.116.5':
     resolution: {integrity: sha512-qhh9mZv7d5hKMQOXoiAOYaWQe/My6MhJ8EcJAi/c9g1EH4TQQoR0Q1o/7dIWj/pZbIiXSt6bgXpTJNQpXr+Qyg==}
@@ -1314,10 +1260,6 @@ packages:
     resolution: {integrity: sha512-2wl6BM2dfWs2W++FLeGjhh1z5wgUdhrITZ9pXteEXoZXDx6/28+mpaLFKUX2/Q13tUgjRXI7IfZKBNCwUGe5Gg==}
     engines: {node: '>=18'}
 
-  '@lynx-js/template-webpack-plugin@0.10.6':
-    resolution: {integrity: sha512-lauDt8xoCE1+6gKOUyfVUFs8d9XHfnpfOtxkuZuEOPKGdzpa/IQ58/jqLJQD8NnV8uae0KqU2YXrcpEdy2mLTA==}
-    engines: {node: '>=18'}
-
   '@lynx-js/testing-environment@0.1.11':
     resolution: {integrity: sha512-mpexU1pHHSNUKWbogKF1uuIAzrodHQh5j3uo2a2eY6O2vro76rqcIpCidSYHLQfkQUuzIP+gVPNJePRqY29g4A==}
 
@@ -1326,14 +1268,6 @@ packages:
 
   '@lynx-js/types@3.7.0':
     resolution: {integrity: sha512-VEcz5HBJ8m938In1VJj2phR06cWyT0Tx+HnwBJrPINiuWPjN9YfrPl1lX87XWr3eMDhKZY+6F+5eFpJ7JFgjXw==}
-
-  '@lynx-js/use-sync-external-store@1.5.0':
-    resolution: {integrity: sha512-iXwLiGUBgfWLozCIh3ICe07x534p9CVlFS3/iGEiFOce58MLX6/PbAvWcE8qEhYaOKiQNe9hqUnS2RbyCqoqGg==}
-    peerDependencies:
-      '@lynx-js/react': '*'
-
-  '@lynx-js/web-constants@0.19.8':
-    resolution: {integrity: sha512-aOk2wmwNu0jJ4ERqU+FBva20uZsQi3Uw1uRwOw8pv3fnetNhW5BlExuGdUzv6XTHbOEd1Jfm4jiOwjrzgXr0PQ==}
 
   '@lynx-js/web-core-wasm@0.0.5':
     resolution: {integrity: sha512-ICvkMf9Myx8/eShv3oCXp9/u+u7yLMC7WTDtHDEZXGyLVkT4dQqtevw7AfOgihu8PQKncOfeMPzO2csFKDejzw==}
@@ -1349,10 +1283,10 @@ packages:
       tslib:
         optional: true
 
-  '@lynx-js/web-core-wasm@0.0.6':
-    resolution: {integrity: sha512-14rwyhlO7BVHhjr2xrHgAaRqf8ORx2aS7iBHjJAnQRzEdvJhJ5F1K49FB5ec43gBLAFYokDfiwZqBcaY9VkNXQ==}
+  '@lynx-js/web-core@0.20.2':
+    resolution: {integrity: sha512-9FlpQSnHOVnxS9yJe2SH2GkO33jf2wDZGGhXBQQRVDP8Hso52wpGE+ik4e4A0g+Pk6RCrXRp3UNA+bo5E96vOQ==}
     peerDependencies:
-      '@lynx-js/css-serializer': 0.1.4
+      '@lynx-js/css-serializer': 0.1.5
       '@lynx-js/lynx-core': 0.1.3
       tslib: ^2.5.0
     peerDependenciesMeta:
@@ -1363,19 +1297,10 @@ packages:
       tslib:
         optional: true
 
-  '@lynx-js/web-core@0.19.8':
-    resolution: {integrity: sha512-8J+T7lZYraWcJNEWWLeVWjeUhRaIRPS7XL6l1x5A+5SC8QCNIezUl1fSYIJiRRQLZjph2xXvBn2K5vzQ3PJREw==}
-    peerDependencies:
-      '@lynx-js/lynx-core': 0.1.3
-      '@lynx-js/web-elements': '>0.7.7'
-
   '@lynx-js/web-elements@0.12.0':
     resolution: {integrity: sha512-7z8PQQSDMUWrxoizySOg1pKGIiSDeGGomOr5FV0Tx9gniHNJYx0e7/h6wQmwhyHdAZYyihyaBks88QkX8DRNEw==}
     peerDependencies:
       tslib: ^2.5.0
-
-  '@lynx-js/web-mainthread-apis@0.19.8':
-    resolution: {integrity: sha512-Ze6u1wg5VZO1htXG6AVRB6CSf1qDcMrxtyl22BMmQhRvm9ut4Ck8k1+e5MIaUCTST1q1j0s59bsKsSstZ/Xlng==}
 
   '@lynx-js/web-rsbuild-server-middleware@0.19.8':
     resolution: {integrity: sha512-wVMa2wE20is4cK0j5y0ZY6Om5NwbPXPlGCNHJXGhnTWsqsDmZai++VZRdK+xAoRimDsBT+3YH1XOJJ9de/pDiA==}
@@ -1383,13 +1308,8 @@ packages:
   '@lynx-js/web-worker-rpc@0.19.8':
     resolution: {integrity: sha512-POkpPZQjU+a0V/LGWNkaqy+/E6B2WEDYnbh+0FtRNLXcNOBOcgvZNg0fo6VVbw3UInmTwO0v+2g/kMjotizwkg==}
 
-  '@lynx-js/web-worker-rpc@0.19.9':
-    resolution: {integrity: sha512-c/QWe1BzAm5tvrfzvqWzfdOftmHPkxcDG/dkvAhtUweEShTxacKa1MwL+nkBqwg2owsOGahXsngPmkt+dgut/Q==}
-
-  '@lynx-js/web-worker-runtime@0.19.8':
-    resolution: {integrity: sha512-lZHnEWQ0QrNIHRGUzYBS22d4ckwyUM+1Gee8D2pCYSAdyqr4aRaNJrUEp8sO8YTh91kohN3c09YQcgRZ8sIstQ==}
-    peerDependencies:
-      '@lynx-js/lynx-core': 0.1.3
+  '@lynx-js/web-worker-rpc@0.20.2':
+    resolution: {integrity: sha512-fbOIku3UsVOa2coXq0z8mJekYgz56614ebwba6q21D96ujgLjJjuowxRmAKQsDC2DFFcf3sAGJd0M0IHsbt9tQ==}
 
   '@lynx-js/webpack-dev-transport@0.2.0':
     resolution: {integrity: sha512-RSy02FSoMsavEn2wna4khSJwT2uGW4XeLduKH8UDT3aCsBNM/rXndUyG6PbwMcywXCeyb8UofkhaQDtJvNJklA==}
@@ -2747,9 +2667,6 @@ packages:
   axios@1.13.6:
     resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
 
-  background-only@0.0.1:
-    resolution: {integrity: sha512-YXR2zshAf3qs3jnpApQaDUG0x4L6YWpSZfLDhdeiCFxfp/n8YwfoAQ1hAigEF3VpXOMOJeZYFWtBbiFv/v2Qfg==}
-
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
@@ -3665,9 +3582,6 @@ packages:
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
     hasBin: true
-
-  hyphenate-style-name@1.1.0:
-    resolution: {integrity: sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==}
 
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
@@ -5534,9 +5448,6 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
-  tiny-invariant@1.3.3:
-    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
-
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -6546,22 +6457,15 @@ snapshots:
     transitivePeerDependencies:
       - webpack
 
-  '@lynx-js/css-extract-webpack-plugin@0.7.0(@lynx-js/template-webpack-plugin@0.10.6(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(webpack@5.105.4)':
-    dependencies:
-      '@lynx-js/template-webpack-plugin': 0.10.6(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)
-      mini-css-extract-plugin: 2.10.1(webpack@5.105.4)
-    transitivePeerDependencies:
-      - webpack
-
   '@lynx-js/css-serializer@0.1.4':
     dependencies:
       css-tree: 3.2.1
 
-  '@lynx-js/go-web@0.2.1(@douyinfe/semi-icons@2.92.2(react@19.2.4))(@douyinfe/semi-ui@2.92.2(@floating-ui/dom@1.7.6)(@tiptap/suggestion@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@lynx-js/web-core@0.19.8(@lynx-js/lynx-core@0.1.3)(@lynx-js/web-elements@0.12.0(tslib@2.8.1)))(@rspress/core@2.0.5(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.47.0)(micromark-util-types@2.0.2)(micromark@4.0.2))(@shikijs/transformers@3.23.0)(qrcode.react@4.2.0(react@19.2.4))(react-copy-to-clipboard@5.1.1(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(swr@2.4.1(react@19.2.4))(vscode-icons-js@11.6.1)':
+  '@lynx-js/go-web@0.2.1(@douyinfe/semi-icons@2.92.2(react@19.2.4))(@douyinfe/semi-ui@2.92.2(@floating-ui/dom@1.7.6)(@tiptap/suggestion@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@lynx-js/web-core@0.20.2(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(@rspress/core@2.0.5(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.47.0)(micromark-util-types@2.0.2)(micromark@4.0.2))(@shikijs/transformers@3.23.0)(qrcode.react@4.2.0(react@19.2.4))(react-copy-to-clipboard@5.1.1(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(swr@2.4.1(react@19.2.4))(vscode-icons-js@11.6.1)':
     dependencies:
       '@douyinfe/semi-icons': 2.92.2(react@19.2.4)
       '@douyinfe/semi-ui': 2.92.2(@floating-ui/dom@1.7.6)(@tiptap/suggestion@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@lynx-js/web-core': 0.19.8(@lynx-js/lynx-core@0.1.3)(@lynx-js/web-elements@0.12.0(tslib@2.8.1))
+      '@lynx-js/web-core': 0.20.2(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)
       '@shikijs/transformers': 3.23.0
       qrcode.react: 4.2.0(react@19.2.4)
       react: 19.2.4
@@ -6572,42 +6476,10 @@ snapshots:
     optionalDependencies:
       '@rspress/core': 2.0.5(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.47.0)(micromark-util-types@2.0.2)(micromark@4.0.2)
 
-  '@lynx-js/lynx-core@0.1.3': {}
-
-  '@lynx-js/offscreen-document@0.1.4': {}
+  '@lynx-js/lynx-core@0.1.3':
+    optional: true
 
   '@lynx-js/qrcode-rsbuild-plugin@0.4.6': {}
-
-  '@lynx-js/react-alias-rsbuild-plugin@0.13.0': {}
-
-  '@lynx-js/react-refresh-webpack-plugin@0.3.5(@lynx-js/react-webpack-plugin@0.8.0(@lynx-js/react@0.116.5(@lynx-js/types@3.7.0)(@types/react@19.2.14))(@lynx-js/template-webpack-plugin@0.10.6(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)))':
-    dependencies:
-      '@lynx-js/react-webpack-plugin': 0.8.0(@lynx-js/react@0.116.5(@lynx-js/types@3.7.0)(@types/react@19.2.14))(@lynx-js/template-webpack-plugin@0.10.6(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))
-
-  '@lynx-js/react-rsbuild-plugin@0.13.0(@lynx-js/lynx-core@0.1.3)(@lynx-js/react@0.116.5(@lynx-js/types@3.7.0)(@types/react@19.2.14))(tslib@2.8.1)(webpack@5.105.4)':
-    dependencies:
-      '@lynx-js/css-extract-webpack-plugin': 0.7.0(@lynx-js/template-webpack-plugin@0.10.6(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(webpack@5.105.4)
-      '@lynx-js/react-alias-rsbuild-plugin': 0.13.0
-      '@lynx-js/react-refresh-webpack-plugin': 0.3.5(@lynx-js/react-webpack-plugin@0.8.0(@lynx-js/react@0.116.5(@lynx-js/types@3.7.0)(@types/react@19.2.14))(@lynx-js/template-webpack-plugin@0.10.6(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)))
-      '@lynx-js/react-webpack-plugin': 0.8.0(@lynx-js/react@0.116.5(@lynx-js/types@3.7.0)(@types/react@19.2.14))(@lynx-js/template-webpack-plugin@0.10.6(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))
-      '@lynx-js/runtime-wrapper-webpack-plugin': 0.1.3
-      '@lynx-js/template-webpack-plugin': 0.10.6(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)
-      '@lynx-js/use-sync-external-store': 1.5.0(@lynx-js/react@0.116.5(@lynx-js/types@3.7.0)(@types/react@19.2.14))
-      background-only: 0.0.1
-    optionalDependencies:
-      '@lynx-js/react': 0.116.5(@lynx-js/types@3.7.0)(@types/react@19.2.14)
-    transitivePeerDependencies:
-      - '@lynx-js/lynx-core'
-      - tslib
-      - webpack
-
-  '@lynx-js/react-webpack-plugin@0.8.0(@lynx-js/react@0.116.5(@lynx-js/types@3.7.0)(@types/react@19.2.14))(@lynx-js/template-webpack-plugin@0.10.6(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))':
-    dependencies:
-      '@lynx-js/template-webpack-plugin': 0.10.6(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)
-      '@lynx-js/webpack-runtime-globals': 0.0.6
-      tiny-invariant: 1.3.3
-    optionalDependencies:
-      '@lynx-js/react': 0.116.5(@lynx-js/types@3.7.0)(@types/react@19.2.14)
 
   '@lynx-js/react@0.116.5(@lynx-js/types@3.7.0)(@types/react@19.2.14)':
     dependencies:
@@ -6665,19 +6537,6 @@ snapshots:
       - '@lynx-js/lynx-core'
       - tslib
 
-  '@lynx-js/template-webpack-plugin@0.10.6(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)':
-    dependencies:
-      '@lynx-js/css-serializer': 0.1.4
-      '@lynx-js/tasm': 0.0.26
-      '@lynx-js/web-core-wasm': 0.0.6(@lynx-js/css-serializer@0.1.4)(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)
-      '@lynx-js/webpack-runtime-globals': 0.0.6
-      '@rspack/lite-tapable': 1.1.0
-      css-tree: 3.2.1
-      object.groupby: 1.0.3
-    transitivePeerDependencies:
-      - '@lynx-js/lynx-core'
-      - tslib
-
   '@lynx-js/testing-environment@0.1.11': {}
 
   '@lynx-js/type-element-api@0.0.3': {}
@@ -6685,14 +6544,6 @@ snapshots:
   '@lynx-js/types@3.7.0':
     dependencies:
       csstype: 3.1.3
-
-  '@lynx-js/use-sync-external-store@1.5.0(@lynx-js/react@0.116.5(@lynx-js/types@3.7.0)(@types/react@19.2.14))':
-    dependencies:
-      '@lynx-js/react': 0.116.5(@lynx-js/types@3.7.0)(@types/react@19.2.14)
-
-  '@lynx-js/web-constants@0.19.8':
-    dependencies:
-      '@lynx-js/web-worker-rpc': 0.19.8
 
   '@lynx-js/web-core-wasm@0.0.5(@lynx-js/css-serializer@0.1.4)(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)':
     dependencies:
@@ -6703,48 +6554,24 @@ snapshots:
       '@lynx-js/lynx-core': 0.1.3
       tslib: 2.8.1
 
-  '@lynx-js/web-core-wasm@0.0.6(@lynx-js/css-serializer@0.1.4)(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)':
+  '@lynx-js/web-core@0.20.2(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)':
     dependencies:
       '@lynx-js/web-elements': 0.12.0(tslib@2.8.1)
-      '@lynx-js/web-worker-rpc': 0.19.9
+      '@lynx-js/web-worker-rpc': 0.20.2
+      wasm-feature-detect: 1.8.0
     optionalDependencies:
-      '@lynx-js/css-serializer': 0.1.4
       '@lynx-js/lynx-core': 0.1.3
       tslib: 2.8.1
-
-  '@lynx-js/web-core@0.19.8(@lynx-js/lynx-core@0.1.3)(@lynx-js/web-elements@0.12.0(tslib@2.8.1))':
-    dependencies:
-      '@lynx-js/lynx-core': 0.1.3
-      '@lynx-js/offscreen-document': 0.1.4
-      '@lynx-js/web-constants': 0.19.8
-      '@lynx-js/web-elements': 0.12.0(tslib@2.8.1)
-      '@lynx-js/web-mainthread-apis': 0.19.8
-      '@lynx-js/web-worker-rpc': 0.19.8
-      '@lynx-js/web-worker-runtime': 0.19.8(@lynx-js/lynx-core@0.1.3)
 
   '@lynx-js/web-elements@0.12.0(tslib@2.8.1)':
     dependencies:
       tslib: 2.8.1
 
-  '@lynx-js/web-mainthread-apis@0.19.8':
-    dependencies:
-      '@lynx-js/web-constants': 0.19.8
-      hyphenate-style-name: 1.1.0
-      wasm-feature-detect: 1.8.0
-
   '@lynx-js/web-rsbuild-server-middleware@0.19.8': {}
 
   '@lynx-js/web-worker-rpc@0.19.8': {}
 
-  '@lynx-js/web-worker-rpc@0.19.9': {}
-
-  '@lynx-js/web-worker-runtime@0.19.8(@lynx-js/lynx-core@0.1.3)':
-    dependencies:
-      '@lynx-js/lynx-core': 0.1.3
-      '@lynx-js/offscreen-document': 0.1.4
-      '@lynx-js/web-constants': 0.19.8
-      '@lynx-js/web-mainthread-apis': 0.19.8
-      '@lynx-js/web-worker-rpc': 0.19.8
+  '@lynx-js/web-worker-rpc@0.20.2': {}
 
   '@lynx-js/webpack-dev-transport@0.2.0': {}
 
@@ -8379,8 +8206,6 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  background-only@0.0.1: {}
-
   bail@2.0.2: {}
 
   balanced-match@1.0.2: {}
@@ -9444,8 +9269,6 @@ snapshots:
       - supports-color
 
   human-id@4.1.3: {}
-
-  hyphenate-style-name@1.1.0: {}
 
   iconv-lite@0.4.24:
     dependencies:
@@ -11673,8 +11496,6 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
-
-  tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
 

--- a/website/package.json
+++ b/website/package.json
@@ -15,7 +15,7 @@
     "@douyinfe/semi-icons": "^2.74.0",
     "@douyinfe/semi-ui": "^2.75.0",
     "@lynx-js/go-web": "^0.2.1",
-    "@lynx-js/web-core": "^0.19.8",
+    "@lynx-js/web-core": "^0.20.0",
     "@lynx-js/web-elements": "^0.12.0",
     "@rspress/core": "^2.0.3",
     "@rspress/plugin-llms": "^2.0.5",


### PR DESCRIPTION
go-web@0.2.1 peer-requires web-core >= 0.20.0 for the `./client` subpath export. The previous `^0.19.8` resolved to 0.19.x which doesn't export `./client`, breaking the Vercel build.