### PR TITLE
Docs/withkeys noop investigation

### DIFF
--- a/packages/vue-lynx/runtime/src/index.ts
+++ b/packages/vue-lynx/runtime/src/index.ts
@@ -1072,10 +1072,15 @@ export function withModifiers(
 }
 
 /**
- * No-op on Lynx. Lynx's native layer (`touch_event_handler.cc`) converts
- * keyboard input to named custom events (e.g. `confirm`) before they reach
- * the JS thread — `event.key` is never populated on any Lynx target, including
- * hardware keyboards and the web preview. Use `@confirm` directly on `<input>`.
+ * No-op on native Lynx. The native runtime converts keyboard input to named
+ * custom events (e.g. `confirm`) before they reach the JS thread —
+ * `event.key` is never populated on iOS/Android regardless of whether the
+ * keyboard is virtual or hardware. Use `@confirm` directly on `<input>` for
+ * native targets.
+ *
+ * Works on web preview (lynx-stack#2594). Native support depends on an
+ * upstream runtime change to forward `UIKeyboardEvent`/`KeyEvent` into the
+ * Lynx JS event pipeline — not yet tracked upstream.
  *
  * @internal
  */

--- a/packages/vue-lynx/runtime/src/index.ts
+++ b/packages/vue-lynx/runtime/src/index.ts
@@ -1077,7 +1077,6 @@ export function withModifiers(
  * the JS thread — `event.key` is never populated on any Lynx target, including
  * hardware keyboards and the web preview. Use `@confirm` directly on `<input>`.
  *
- * @see {@link https://github.com/Huxpro/vue-lynx/issues/ | Tracking issue}
  * @internal
  */
 export function withKeys(

--- a/packages/vue-lynx/runtime/src/index.ts
+++ b/packages/vue-lynx/runtime/src/index.ts
@@ -1071,7 +1071,15 @@ export function withModifiers(
   return fn;
 }
 
-/** @internal Lynx stub for withKeys (keyboard event modifier helper). */
+/**
+ * No-op on Lynx. Lynx's native layer (`touch_event_handler.cc`) converts
+ * keyboard input to named custom events (e.g. `confirm`) before they reach
+ * the JS thread — `event.key` is never populated on any Lynx target, including
+ * hardware keyboards and the web preview. Use `@confirm` directly on `<input>`.
+ *
+ * @see {@link https://github.com/Huxpro/vue-lynx/issues/ | Tracking issue}
+ * @internal
+ */
 export function withKeys(
   fn: (...args: unknown[]) => unknown,
   _keys: string[],

--- a/website/docs/guide/vue-compatibility.mdx
+++ b/website/docs/guide/vue-compatibility.mdx
@@ -143,4 +143,4 @@ Some Vue built-in features are not yet adapted to the dual-thread native environ
 | `<KeepAlive>` | Requires an internal storage container (`createElement('div')`) with no native equivalent | Manual state caching |
 | `<Teleport>` | Requires `querySelector` to resolve string targets, unavailable in the dual-thread architecture | Conditional rendering at the target location |
 | `<Transition>` auto-duration | `getComputedStyle()` is unavailable on the background thread | Always pass an explicit `:duration` prop |
-| `withKeys` key modifiers | Lynx's native layer converts keyboard input to named events (e.g. `confirm`) before reaching JS — `event.key` is never populated, including on hardware keyboards and web preview | Use `@confirm` directly on `<input>` |
+| `withKeys` key modifiers | No-op on native — Lynx's native runtime converts keyboard input to named events (e.g. `confirm`) before reaching JS, so `event.key` is never populated on iOS/Android. Works on web preview ([lynx-stack#2594](https://github.com/lynx-family/lynx-stack/pull/2594)). Native support requires an upstream runtime change. | Native: use `@confirm` directly on `<input>` |

--- a/website/docs/guide/vue-compatibility.mdx
+++ b/website/docs/guide/vue-compatibility.mdx
@@ -143,3 +143,4 @@ Some Vue built-in features are not yet adapted to the dual-thread native environ
 | `<KeepAlive>` | Requires an internal storage container (`createElement('div')`) with no native equivalent | Manual state caching |
 | `<Teleport>` | Requires `querySelector` to resolve string targets, unavailable in the dual-thread architecture | Conditional rendering at the target location |
 | `<Transition>` auto-duration | `getComputedStyle()` is unavailable on the background thread | Always pass an explicit `:duration` prop |
+| `withKeys` key modifiers | Lynx's native layer converts keyboard input to named events (e.g. `confirm`) before reaching JS — `event.key` is never populated, including on hardware keyboards and web preview | Use `@confirm` directly on `<input>` |

--- a/website/docs/zh/guide/vue-compatibility.mdx
+++ b/website/docs/zh/guide/vue-compatibility.mdx
@@ -143,3 +143,4 @@ pluginVueLynx({
 | `<KeepAlive>` | 需要一个内部存储容器（`createElement('div')`），在原生环境中没有对应实现 | 手动缓存状态 |
 | `<Teleport>` | 需要 `querySelector` 来解析字符串目标，在双线程架构中不可用 | 在目标位置使用条件渲染 |
 | `<Transition>` 自动时长 | 后台线程无法使用 `getComputedStyle()` | 始终传递显式的 `:duration` prop |
+| `withKeys` 按键修饰符 | Lynx 原生层（`touch_event_handler.cc`）在事件到达 JS 线程之前已将键盘输入转换为具名事件（如 `confirm`）—— 包括硬件键盘和 web 预览在内的任何 Lynx 平台均不会填充 `event.key` | 在 `<input>` 上直接使用 `@confirm` |

--- a/website/docs/zh/guide/vue-compatibility.mdx
+++ b/website/docs/zh/guide/vue-compatibility.mdx
@@ -143,4 +143,4 @@ pluginVueLynx({
 | `<KeepAlive>` | 需要一个内部存储容器（`createElement('div')`），在原生环境中没有对应实现 | 手动缓存状态 |
 | `<Teleport>` | 需要 `querySelector` 来解析字符串目标，在双线程架构中不可用 | 在目标位置使用条件渲染 |
 | `<Transition>` 自动时长 | 后台线程无法使用 `getComputedStyle()` | 始终传递显式的 `:duration` prop |
-| `withKeys` 按键修饰符 | Lynx 原生层（`touch_event_handler.cc`）在事件到达 JS 线程之前已将键盘输入转换为具名事件（如 `confirm`）—— 包括硬件键盘和 web 预览在内的任何 Lynx 平台均不会填充 `event.key` | 在 `<input>` 上直接使用 `@confirm` |
+| `withKeys` 按键修饰符 | 原生平台为 no-op —— Lynx 原生运行时在事件到达 JS 线程之前已将键盘输入转换为具名事件（如 `confirm`），iOS/Android 上的 `event.key` 始终为空。Web 预览在 [lynx-stack#2594](https://github.com/lynx-family/lynx-stack/pull/2594) 后可正常使用。原生端支持有赖于上游运行时变更。 | 原生端在 `<input>` 上直接使用 `@confirm` |


### PR DESCRIPTION
## Investigation

Before implementing `withKeys`, I investigated whether Lynx exposes `event.key` on any platform.

### Web preview — original finding was wrong

The original investigation concluded that `keydown` fired but `event.key` was stripped at the Worker boundary (`createCrossThreadEvent`). That conclusion was incorrect — the `params: {}` payload was a symptom of the event pipeline crashing entirely, not of `createCrossThreadEvent` deliberately omitting keyboard fields.

Three separate bugs were responsible:

1. `createCrossThreadEvent` had no branch for `keydown`/`keyup` — `key`, `code`, `keyCode`, and modifier flags were never serialised.
2. Listeners were attached to `rootDom` (a `ShadowRoot`) — keyboard events from focused elements outside the shadow root never propagate into it.
3. `publishEvent` crashed silently when the bubble path was empty (as it always is for global keyboard events), dropping the event entirely at the WASM boundary.

All three are fixed in lynx-family/lynx-stack#2594. After that PR, `global-bindkeydown` and `global-bindkeyup` work correctly on web preview.

### Native — confirmed no-op

Tested via simulator with a physical Mac keyboard (`BKSHIDKeyboardDevice`, layout "Australian"). The iOS `UIEvent` type 4 (keyboard) was received and recognised, but Lynx's C++ core intercepted it before JS:

```
Keyboard receives keyEvent type: 4; subtype: 0
Keyboard adds a string
[touch_event_handler.cc(367)] SendCustomEvent event name:confirm tag:29
```

`touch_event_handler.cc` converts Enter directly to `confirm`. No `keydown` is ever emitted to the JS layer — regardless of whether the keyboard is virtual or physical. This is independently verifiable from the logs.

### Updated conclusion

| Platform | keydown fires? | event.key available? |
|---|---|---|
| Lynx web preview | ✅ Yes (after lynx-stack#2594) | ✅ Yes — all fields forwarded |
| Lynx native (virtual keyboard) | ❌ No | N/A |
| Lynx native (hardware keyboard) | ❌ No — converted to `confirm` by `touch_event_handler.cc` | N/A |

Native support would require the Lynx runtime to forward `UIKeyboardEvent` (iOS) / `KeyEvent` (Android) into the JS event pipeline. That change is not yet tracked upstream — the related DevTool CDP issues (lynx-family/lynx#6527, lynx-family/lynx#6529) are scoped to test automation tooling, not end-user keyboard input in a shipped app.

The existing stub (`return fn`) remains correct for native. The only change here is the documentation.

## Changes

- JSDoc on `withKeys` — no-op on native, works on web preview after lynx-stack#2594
- Row updated in the unsupported features table in `vue-compatibility` (en + zh)
- No implementation, no tests, no example app

Closes #170
