### PR TITLE
Fix/agents vue llms url

### DIFF
--- a/.changeset/tidy-vue-lynx-agents.md
+++ b/.changeset/tidy-vue-lynx-agents.md
@@ -1,0 +1,5 @@
+---
+"create-vue-lynx": patch
+---
+
+Add Vue Lynx agent guidance to scaffolded projects.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,10 @@
 # Vue Lynx — Agent Guidelines
 
+## Read in Advance
+
+- Vue Lynx: [llms.txt](https://vue.lynxjs.org/llms.txt), **REQUIRED**.
+  Read this before working on any Vue Lynx task — it covers the Vue Lynx API, dual-thread architecture, and Lynx-specific caveats from a Vue perspective.
+
 ## Debugging Checklist
 
 When investigating runtime errors in Lynx bundles:

--- a/examples/hello-world/AGENTS.md
+++ b/examples/hello-world/AGENTS.md
@@ -6,8 +6,8 @@ You are an expert in JavaScript, Rspeedy, and Lynx application development. You 
 
 Read docs below in advance to help you understand the library or frameworks this project depends on.
 
-- Lynx: [llms.txt](https://lynxjs.org/next/llms.txt), **REQUIRED**.
-  While dealing with a Lynx task, an agent **MUST** read this doc because it is an entry point of all available docs about Lynx.
+- Vue Lynx: [llms.txt](https://vue.lynxjs.org/llms.txt), **REQUIRED**.
+  While dealing with a Vue Lynx task, an agent **MUST** read this doc because it is an entry point of all available docs about Vue Lynx.
 
 ## Commands
 

--- a/packages/create-vue-lynx/template-common/AGENTS.md
+++ b/packages/create-vue-lynx/template-common/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+You are an expert in JavaScript, Rspeedy, and Vue Lynx application development. You write maintainable, performant, and accessible code.
+
+## Read in Advance
+
+- Vue Lynx: [llms.txt](https://vue.lynxjs.org/llms.txt), **REQUIRED**.
+  While dealing with a Vue Lynx task, an agent **MUST** read this doc because it is an entry point of all available docs about Vue Lynx.
+
+## Commands
+
+- `npm run dev` - Start the dev server
+
+- `npm run build` - Build the app for production
+
+- `npm run preview` - Preview the production build locally
+
+- `npm exec rspeedy inspect` - Inspect the Rspeedy config and Rspack config of the project.
+
+## Related Docs
+
+- Rsbuild: <https://rsbuild.rs/llms.txt>
+
+- Rspack: <https://rspack.rs/llms.txt>


### PR DESCRIPTION
## Context

`examples/hello-world/AGENTS.md` marks `https://lynxjs.org/next/llms.txt` as required reading for AI agents. That doc is entirely React-specific — ReactLynx, dual-thread React, React lifecycle throughout. An agent reading it will skew toward React patterns when working on Vue code.

[https://vue.lynxjs.org/llms.txt](https://vue.lynxjs.org/llms.txt) already exists and is Vue-focused, but nothing in this repo currently points agents there.

The `create-vue-lynx` scaffold templates also have no `AGENTS.md` at all — so projects created with `npm create vue-lynx` give agents no context by default.

## Changes

- `examples/hello-world/AGENTS.md` — swap `lynxjs.org/next/llms.txt` to `vue.lynxjs.org/llms.txt`
- Root `AGENTS.md` — add a `## Read in Advance` section pointing at `vue.lynxjs.org/llms.txt`
- `create-vue-lynx/template-common/AGENTS.md` — new file so every scaffolded project gets Vue context by default

[issue](https://github.com/Huxpro/vue-lynx/pull/173)
