### PR TITLE
fix(types): widen class prop to accept Vue class binding forms

### DIFF
--- a/.changeset/mighty-socks-divide.md
+++ b/.changeset/mighty-socks-divide.md
@@ -1,0 +1,5 @@
+---
+"vue-lynx": patch
+---
+
+fix(types): widen `class` prop to accept Vue class binding forms

--- a/packages/testing-library/src/__tests__/class-binding.test.ts
+++ b/packages/testing-library/src/__tests__/class-binding.test.ts
@@ -1,0 +1,208 @@
+/**
+ * class binding tests — verify that string, array, and object `:class` forms
+ * all reach the Main Thread correctly:
+ * Vue patchProp('class', ...) → SET_CLASS op → __SetClasses → JSDOM class attr
+ */
+
+import { describe, it, expect } from 'vitest'
+import { defineComponent, h, ref } from 'vue-lynx'
+import { render, waitForUpdate } from '../index.js'
+
+import { OP } from '../../../vue-lynx/internal/src/ops.js'
+import { nodeOps } from '../../../vue-lynx/runtime/src/node-ops.js'
+import { takeOps } from '../../../vue-lynx/runtime/src/ops.js'
+import { ShadowElement } from '../../../vue-lynx/runtime/src/shadow-element.js'
+
+// ---------------------------------------------------------------------------
+// SET_CLASS (nodeOps level)
+// ---------------------------------------------------------------------------
+
+describe('SET_CLASS (nodeOps)', () => {
+  it('string value emits SET_CLASS with the verbatim string', () => {
+    const el = new ShadowElement('view', 100)
+
+    nodeOps.patchProp(el, 'class', null, 'foo bar')
+
+    const ops = takeOps()
+    expect(ops[0]).toBe(OP.SET_CLASS)
+    expect(ops[1]).toBe(100)
+    expect(ops[2]).toBe('foo bar')
+  })
+
+  it('empty string emits SET_CLASS with empty string', () => {
+    const el = new ShadowElement('view', 101)
+
+    nodeOps.patchProp(el, 'class', 'previous', '')
+
+    const ops = takeOps()
+    expect(ops[0]).toBe(OP.SET_CLASS)
+    expect(ops[2]).toBe('')
+  })
+
+  it('null value emits SET_CLASS with empty string', () => {
+    const el = new ShadowElement('view', 102)
+
+    nodeOps.patchProp(el, 'class', 'previous', null)
+
+    const ops = takeOps()
+    expect(ops[0]).toBe(OP.SET_CLASS)
+    expect(ops[2]).toBe('')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// class binding forms (full pipeline)
+// ---------------------------------------------------------------------------
+
+describe('class binding — string form', () => {
+  it('renders the class directly', () => {
+    const Comp = defineComponent({
+      setup() {
+        return () => h('view', { class: 'flex flex-col' })
+      },
+    })
+
+    const { container } = render(Comp)
+    expect(container.querySelector('view')!.getAttribute('class')).toBe('flex flex-col')
+  })
+
+  it('ternary expression picks the correct branch', () => {
+    const large = true
+    const Comp = defineComponent({
+      setup() {
+        return () => h('view', { class: large ? 'text-lg' : 'text-sm' })
+      },
+    })
+
+    const { container } = render(Comp)
+    const classes = container.querySelector('view')!.getAttribute('class')!.split(' ')
+    expect(classes).toContain('text-lg')
+    expect(classes).not.toContain('text-sm')
+  })
+})
+
+describe('class binding — object form', () => {
+  it('includes keys whose value is truthy, excludes falsy keys', () => {
+    const Comp = defineComponent({
+      setup() {
+        return () => h('view', { class: { active: true, hidden: false, visible: true } })
+      },
+    })
+
+    const { container } = render(Comp)
+    const classes = container.querySelector('view')!.getAttribute('class')!.split(' ')
+    expect(classes).toContain('active')
+    expect(classes).toContain('visible')
+    expect(classes).not.toContain('hidden')
+  })
+})
+
+describe('class binding — array form', () => {
+  it('joins truthy string entries, drops falsy values', () => {
+    const Comp = defineComponent({
+      setup() {
+        return () => h('view', { class: ['base', 'extra', false, null, undefined] })
+      },
+    })
+
+    const { container } = render(Comp)
+    const classes = container.querySelector('view')!.getAttribute('class')!.split(' ')
+    expect(classes).toContain('base')
+    expect(classes).toContain('extra')
+    expect(classes).not.toContain('false')
+    expect(classes).not.toContain('null')
+    expect(classes).not.toContain('undefined')
+  })
+
+  it('supports conditional ternary inside the array', () => {
+    const isLarge = true
+    const Comp = defineComponent({
+      setup() {
+        return () => h('view', { class: [isLarge ? 'text-lg' : 'text-sm', 'font-bold'] })
+      },
+    })
+
+    const { container } = render(Comp)
+    const classes = container.querySelector('view')!.getAttribute('class')!.split(' ')
+    expect(classes).toContain('text-lg')
+    expect(classes).toContain('font-bold')
+    expect(classes).not.toContain('text-sm')
+  })
+
+  it('supports mixed string and object entries', () => {
+    const Comp = defineComponent({
+      setup() {
+        return () => h('view', { class: ['base', { active: true, disabled: false }] })
+      },
+    })
+
+    const { container } = render(Comp)
+    const classes = container.querySelector('view')!.getAttribute('class')!.split(' ')
+    expect(classes).toContain('base')
+    expect(classes).toContain('active')
+    expect(classes).not.toContain('disabled')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// reactive updates
+// ---------------------------------------------------------------------------
+
+describe('class binding — reactivity', () => {
+  it('updates when a reactive string condition changes', async () => {
+    const isMd = ref(false)
+
+    const Comp = defineComponent({
+      setup() {
+        return () => h('view', { class: isMd.value ? 'flex-row gap-4' : 'flex-col' })
+      },
+    })
+
+    const { container } = render(Comp)
+    expect(container.querySelector('view')!.getAttribute('class')).toBe('flex-col')
+
+    isMd.value = true
+    await waitForUpdate()
+
+    expect(container.querySelector('view')!.getAttribute('class')).toBe('flex-row gap-4')
+  })
+
+  it('updates when a reactive value inside an array changes', async () => {
+    const isActive = ref(false)
+
+    const Comp = defineComponent({
+      setup() {
+        return () => h('view', { class: ['base', isActive.value && 'active'] })
+      },
+    })
+
+    const { container } = render(Comp)
+    expect(container.querySelector('view')!.getAttribute('class')).not.toContain('active')
+
+    isActive.value = true
+    await waitForUpdate()
+
+    const classes = container.querySelector('view')!.getAttribute('class')!.split(' ')
+    expect(classes).toContain('active')
+    expect(classes).toContain('base')
+  })
+
+  it('updates when a reactive value inside an object changes', async () => {
+    const highlighted = ref(false)
+
+    const Comp = defineComponent({
+      setup() {
+        return () => h('view', { class: { card: true, highlighted: highlighted.value } })
+      },
+    })
+
+    const { container } = render(Comp)
+    expect(container.querySelector('view')!.getAttribute('class')).toContain('card')
+    expect(container.querySelector('view')!.getAttribute('class')).not.toContain('highlighted')
+
+    highlighted.value = true
+    await waitForUpdate()
+
+    expect(container.querySelector('view')!.getAttribute('class')).toContain('highlighted')
+  })
+})

--- a/packages/testing-library/src/__tests__/class-binding.test.ts
+++ b/packages/testing-library/src/__tests__/class-binding.test.ts
@@ -95,6 +95,21 @@ describe('class binding — object form', () => {
     expect(classes).toContain('visible')
     expect(classes).not.toContain('hidden')
   })
+
+  it('supports truthy non-boolean values in object form', () => {
+    const Comp = defineComponent({
+      setup() {
+        return () => h('view', { class: { active: 1, hidden: 0, visible: 'yes', empty: '' } })
+      },
+    })
+
+    const { container } = render(Comp)
+    const classes = container.querySelector('view')!.getAttribute('class')!.split(' ')
+    expect(classes).toContain('active')
+    expect(classes).toContain('visible')
+    expect(classes).not.toContain('hidden')
+    expect(classes).not.toContain('empty')
+  })
 })
 
 describe('class binding — array form', () => {
@@ -141,6 +156,19 @@ describe('class binding — array form', () => {
     expect(classes).toContain('base')
     expect(classes).toContain('active')
     expect(classes).not.toContain('disabled')
+  })
+
+  it('supports nested arrays', () => {
+    const Comp = defineComponent({
+      setup() {
+        return () => h('view', { class: [['base'], { active: true }] })
+      },
+    })
+
+    const { container } = render(Comp)
+    const classes = container.querySelector('view')!.getAttribute('class')!.split(' ')
+    expect(classes).toContain('base')
+    expect(classes).toContain('active')
   })
 })
 

--- a/packages/vue-lynx/types/src/elements/index.ts
+++ b/packages/vue-lynx/types/src/elements/index.ts
@@ -1,5 +1,5 @@
-import type { DefineComponent } from "vue";
-import type {IntrinsicElements} from '@lynx-js/types'
+import type { DefineComponent } from 'vue';
+import type { IntrinsicElements } from '@lynx-js/types'
 
 type ExtractBindAsOn<T> = {
   [P in keyof T as P extends `bind${infer Rest}` ? `on${Capitalize<Rest>}` : never]: T[P]
@@ -7,7 +7,47 @@ type ExtractBindAsOn<T> = {
 
 type NonBindProps<T> = Omit<T, `bind${string}` | 'className'>
 
-type VueLynxProps<T> = ExtractBindAsOn<T> & NonBindProps<T>
+/**
+ * Vue-compatible class binding type.
+ *
+ * In Vue 3, `:class` accepts a string, an array of strings/objects, or a
+ * record of `{ [className]: boolean }`. The underlying Lynx `StandardProps`
+ * interface types `class` as a plain `string` because that is what the native
+ * engine ultimately receives. However, restricting the prop to `string` at the
+ * Vue template level would break the standard Vue idioms that every developer
+ * expects to work:
+ *
+ * ```vue
+ * <!-- All three forms should be accepted without a TypeScript error -->
+ * <view :class="isActive ? 'active' : 'idle'" />
+ * <view :class="['base', isActive && 'active']" />
+ * <view :class="{ active: isActive, 'text-sm': small }" />
+ * ```
+ *
+ * Vue's runtime-core normalises any of these shapes into a single space-joined
+ * string before calling `patchProp`, so the native engine always receives a
+ * plain string regardless of which form the template uses. Widening the type
+ * here is therefore safe and restores the idiomatic Vue developer experience.
+ */
+type VueClassBinding =
+  | string
+  | Record<string, boolean | undefined | null>
+  | (string | Record<string, boolean | undefined | null> | false | null | undefined)[]
+
+/**
+ * Maps Lynx intrinsic element props to Vue-friendly props:
+ *
+ * - Converts `bindXxx` props to Vue-style `onXxx` event handlers.
+ * - Removes the React-style `className` alias (Lynx carries both; Vue only
+ *   needs `class`).
+ * - Widens `class` from `string` to the full {@link VueClassBinding} union so
+ *   that array-syntax and object-syntax `:class` bindings pass TypeScript
+ *   without errors.
+ */
+type VueLynxProps<T> =
+  ExtractBindAsOn<T> &
+  Omit<NonBindProps<T>, 'class'> &
+  { class?: VueClassBinding }
 
 type VueLynxComponent<T> = DefineComponent<VueLynxProps<T>>
 

--- a/packages/vue-lynx/types/src/elements/index.ts
+++ b/packages/vue-lynx/types/src/elements/index.ts
@@ -9,30 +9,12 @@ type NonBindProps<T> = Omit<T, `bind${string}` | 'className'>
 
 /**
  * Vue-compatible class binding type.
- *
- * In Vue 3, `:class` accepts a string, an array of strings/objects, or a
- * record of `{ [className]: boolean }`. The underlying Lynx `StandardProps`
- * interface types `class` as a plain `string` because that is what the native
- * engine ultimately receives. However, restricting the prop to `string` at the
- * Vue template level would break the standard Vue idioms that every developer
- * expects to work:
- *
- * ```vue
- * <!-- All three forms should be accepted without a TypeScript error -->
- * <view :class="isActive ? 'active' : 'idle'" />
- * <view :class="['base', isActive && 'active']" />
- * <view :class="{ active: isActive, 'text-sm': small }" />
- * ```
- *
- * Vue's runtime-core normalises any of these shapes into a single space-joined
- * string before calling `patchProp`, so the native engine always receives a
- * plain string regardless of which form the template uses. Widening the type
- * here is therefore safe and restores the idiomatic Vue developer experience.
+ * @see https://vuejs.org/guide/essentials/class-and-style
  */
-type VueClassBinding =
+export type VueClassBinding =
   | string
-  | Record<string, boolean | undefined | null>
-  | (string | Record<string, boolean | undefined | null> | false | null | undefined)[]
+  | Record<string, unknown>
+  | (VueClassBinding | false | null | undefined)[]
 
 /**
  * Maps Lynx intrinsic element props to Vue-friendly props:
@@ -44,7 +26,7 @@ type VueClassBinding =
  *   that array-syntax and object-syntax `:class` bindings pass TypeScript
  *   without errors.
  */
-type VueLynxProps<T> =
+export type VueLynxProps<T> =
   ExtractBindAsOn<T> &
   Omit<NonBindProps<T>, 'class'> &
   { class?: VueClassBinding }

--- a/packages/vue-lynx/types/src/elements/index.ts
+++ b/packages/vue-lynx/types/src/elements/index.ts
@@ -1,5 +1,5 @@
 import type { DefineComponent } from 'vue';
-import type { IntrinsicElements } from '@lynx-js/types'
+import type { IntrinsicElements } from '@lynx-js/types';
 
 type ExtractBindAsOn<T> = {
   [P in keyof T as P extends `bind${infer Rest}` ? `on${Capitalize<Rest>}` : never]: T[P]
@@ -11,7 +11,7 @@ type NonBindProps<T> = Omit<T, `bind${string}` | 'className'>
  * Vue-compatible class binding type.
  * @see https://vuejs.org/guide/essentials/class-and-style
  */
-export type VueClassBinding =
+type VueClassBinding =
   | string
   | Record<string, unknown>
   | (VueClassBinding | false | null | undefined)[]
@@ -26,7 +26,7 @@ export type VueClassBinding =
  *   that array-syntax and object-syntax `:class` bindings pass TypeScript
  *   without errors.
  */
-export type VueLynxProps<T> =
+type VueLynxProps<T> =
   ExtractBindAsOn<T> &
   Omit<NonBindProps<T>, 'class'> &
   { class?: VueClassBinding }


### PR DESCRIPTION
Vue 3 `:class` accepts a string, an array, or a record of `{ [className]: boolean }`.
The current types restrict `class` to `string`, which causes a TypeScript error
for the two non-string forms even though the runtime already handles them correctly —
Vue normalises every class binding to a plain string before calling `patchProp`.
core changes:
- introduce `VueClassBinding` union type (string | object | array) in `types/src/elements/index.ts`
- use `Omit<NonBindProps<T>, 'class'> & { class?: VueClassBinding }` in `VueLynxProps<T>` to override the native `string`-typed `class` without affecting other props
testing:
- add `packages/testing-library/src/__tests__/class-binding.test.ts`
  - low-level: `nodeOps.patchProp` SET_CLASS op for string / empty / null values
  - full pipeline: all three binding forms (string, object, array) render correctly
  - reactivity: updates propagate for all three forms