### PR TITLE
feat(v-once): verify and document v-once directive support

### DIFF
--- a/.changeset/v-once-support.md
+++ b/.changeset/v-once-support.md
@@ -1,0 +1,11 @@
+---
+"vue-lynx": minor
+---
+
+feat(v-once): verify and document `v-once` directive support
+
+`v-once` works in Vue Lynx without any configuration. The SFC template compiler emits a `setBlockTracking(-1/+1)` pair around a `_cache` slot assignment; on subsequent renders the cached VNode is returned directly, so no ops enter the buffer and `callLepusMethod` is never called for that subtree.
+
+`setBlockTracking` was already re-exported from `@vue/runtime-core` but was undocumented (`@hidden`). This change promotes it to a public, documented export so its role in `v-once` codegen is explicit.
+
+In Lynx, `v-once` eliminates the entire cross-thread op batch for the cached subtree — not just DOM diffing — making it more impactful than in a browser environment.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "pnpm --filter vue-lynx run dev",
     "test": "pnpm --filter vue-lynx-testing-library run test",
     "test:dev-smoke": "node scripts/dev-smoke.mjs",
-    "test:upstream": "pnpm --filter vue-lynx-upstream-tests run test && pnpm --filter vue-lynx-upstream-tests run test:dom",
+    "test:upstream": "pnpm --filter vue-lynx-upstream-tests run test && pnpm --filter vue-lynx-upstream-tests run test:dom && pnpm --filter vue-lynx-upstream-tests run test:local",
     "check-links": "node scripts/check-links.mjs",
     "lint": "biome check .",
     "changeset": "changeset",

--- a/packages/upstream-tests/src/v-memo.spec.ts
+++ b/packages/upstream-tests/src/v-memo.spec.ts
@@ -115,6 +115,42 @@ describe('withMemo — ops pipeline', () => {
     expect(propOps.filter(op => op.key === 'content')[0].value).toBe('world');
   });
 
+  // v-memo="[]" — empty dep array, never changes, equivalent to v-once.
+  it('v-memo with empty dep array never emits ops after mount', async () => {
+    const msg = ref('hello');
+    const outer = ref(0);
+    const cache: unknown[] = [];
+
+    const App = defineComponent({
+      setup() {
+        return () =>
+          h('view', { 'data-outer': String(outer.value) },
+            withMemo(
+              [], // empty — deps never change
+              () => h('text', { content: msg.value }),
+              cache,
+              0,
+            ),
+          );
+      },
+    });
+
+    createApp(App).mount();
+    await nextTick();
+    collectFlushedOps();
+
+    msg.value = 'world';
+    outer.value++;
+    await nextTick();
+
+    const propOps = parseSetPropOps(collectFlushedOps());
+
+    // Memoized subtree never updates — same as v-once
+    expect(propOps.filter(op => op.key === 'content')).toHaveLength(0);
+    // Outer still updates
+    expect(propOps.filter(op => op.key === 'data-outer')).toHaveLength(1);
+  });
+
   // v-for + v-memo compiles to a direct isMemoSame call, not withMemo.
   // This test simulates that compiler output to confirm the export works
   // and the ops pipeline is correctly bypassed for unchanged list items.

--- a/packages/upstream-tests/src/v-once.spec.ts
+++ b/packages/upstream-tests/src/v-once.spec.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for v-once integration with the Lynx BG-thread renderer.
+ *
+ * v-once is a compiler primitive — @vue/compiler-dom rewrites
+ *   <tag v-once>{{ val }}</tag>
+ * into
+ *   _cache[0] || (
+ *     setBlockTracking(-1),
+ *     (_cache[0] = createElementVNode('tag', null, toDisplayString(val), -1)),
+ *     setBlockTracking(1),
+ *     _cache[0]
+ *   )
+ *
+ * After the first render _cache[0] is truthy, so the cached VNode is returned
+ * on every subsequent render. The patcher sees the same object reference and
+ * short-circuits — no ops enter the buffer for the v-once subtree.
+ *
+ * These tests simulate that compiler output using render functions and
+ * verify the Lynx-specific concern: that no ops reach the main thread after
+ * the initial mount.
+ */
+
+import {
+  createApp,
+  createElementVNode,
+  defineComponent,
+  h,
+  nextTick,
+  ref,
+  resetForTesting,
+  setBlockTracking,
+  toDisplayString,
+} from 'vue-lynx';
+import { OP } from 'vue-lynx/internal/ops';
+import { collectFlushedOps, resetCapturedOps } from './local-test-setup.js';
+
+beforeEach(() => {
+  resetForTesting();
+  resetCapturedOps();
+});
+
+function parseSetPropOps(
+  ops: unknown[],
+): Array<{ id: unknown; key: unknown; value: unknown }> {
+  const results: Array<{ id: unknown; key: unknown; value: unknown }> = [];
+  for (let i = 0; i < ops.length; i++) {
+    if (ops[i] === OP.SET_PROP) {
+      results.push({ id: ops[i + 1], key: ops[i + 2], value: ops[i + 3] });
+      i += 3;
+    }
+  }
+  return results;
+}
+
+it('setBlockTracking is exported from vue-lynx', () => {
+  expect(typeof setBlockTracking).toBe('function');
+});
+
+describe('v-once — ops pipeline', () => {
+  it('initial render emits SET_PROP ops for v-once subtree', async () => {
+    const msg = ref('hello');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cache: any[] = [];
+
+    const App = defineComponent({
+      setup() {
+        return () =>
+          // Mirrors compiler output for: <text :content="msg" v-once />
+          cache[0] ||
+          (setBlockTracking(-1),
+          (cache[0] = createElementVNode(
+            'text',
+            { content: toDisplayString(msg.value) },
+            null,
+            -1,
+          )),
+          setBlockTracking(1),
+          cache[0]);
+      },
+    });
+
+    createApp(App).mount();
+    await nextTick();
+
+    const propOps = parseSetPropOps(collectFlushedOps());
+    expect(propOps.filter(op => op.key === 'content')).toHaveLength(1);
+    expect(propOps.find(op => op.key === 'content')!.value).toBe('hello');
+  });
+
+  it('re-render after reactive change emits no ops for v-once subtree', async () => {
+    const msg = ref('hello');
+    const outer = ref(0);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cache: any[] = [];
+
+    const App = defineComponent({
+      setup() {
+        return () =>
+          h('view', { 'data-outer': String(outer.value) },
+            // v-once subtree — compiled to cache lookup
+            cache[0] ||
+            (setBlockTracking(-1),
+            (cache[0] = createElementVNode(
+              'text',
+              { content: toDisplayString(msg.value) },
+              null,
+              -1,
+            )),
+            setBlockTracking(1),
+            cache[0]),
+          );
+      },
+    });
+
+    createApp(App).mount();
+    await nextTick();
+    collectFlushedOps(); // drain mount ops
+
+    msg.value = 'world'; // change tracked inside v-once — should be ignored
+    outer.value++;       // change outside v-once — should produce ops
+    await nextTick();
+
+    const propOps = parseSetPropOps(collectFlushedOps());
+
+    // v-once subtree: no ops despite msg changing
+    expect(propOps.filter(op => op.key === 'content')).toHaveLength(0);
+    // Non-v-once prop: still updated
+    expect(propOps.filter(op => op.key === 'data-outer')).toHaveLength(1);
+  });
+
+  it('v-once subtree retains initial value across multiple re-renders', async () => {
+    const msg = ref('initial');
+    const tick = ref(0);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cache: any[] = [];
+
+    const App = defineComponent({
+      setup() {
+        return () =>
+          h('view', { 'data-tick': tick.value },
+            cache[0] ||
+            (setBlockTracking(-1),
+            (cache[0] = createElementVNode(
+              'text',
+              { content: toDisplayString(msg.value) },
+              null,
+              -1,
+            )),
+            setBlockTracking(1),
+            cache[0]),
+          );
+      },
+    });
+
+    createApp(App).mount();
+    await nextTick();
+    collectFlushedOps();
+
+    for (let i = 0; i < 3; i++) {
+      msg.value = `update-${i}`;
+      tick.value++;
+      await nextTick();
+      const propOps = parseSetPropOps(collectFlushedOps());
+      expect(propOps.filter(op => op.key === 'content')).toHaveLength(0);
+    }
+  });
+});

--- a/packages/upstream-tests/src/v-once.spec.ts
+++ b/packages/upstream-tests/src/v-once.spec.ts
@@ -5,9 +5,9 @@
  *   <tag v-once>{{ val }}</tag>
  * into
  *   _cache[0] || (
- *     setBlockTracking(-1),
- *     (_cache[0] = createElementVNode('tag', null, toDisplayString(val), -1)),
- *     setBlockTracking(1),
+ *     _setBlockTracking(-1, true),
+ *     (_cache[0] = createElementVNode('tag', null, toDisplayString(val), -1)).cacheIndex = 0,
+ *     _setBlockTracking(1),
  *     _cache[0]
  *   )
  *
@@ -20,7 +20,6 @@
  * the initial mount.
  */
 
-import type { VNode } from '@vue/runtime-core';
 import {
   createApp,
   createElementVNode,
@@ -28,6 +27,7 @@ import {
   h,
   nextTick,
   ref,
+  renderList,
   resetForTesting,
   setBlockTracking,
   toDisplayString,
@@ -60,20 +60,21 @@ it('setBlockTracking is exported from vue-lynx', () => {
 describe('v-once — ops pipeline', () => {
   it('initial render emits SET_PROP ops for v-once subtree', async () => {
     const msg = ref('hello');
-    const cache: VNode[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cache: any[] = [];
 
     const App = defineComponent({
       setup() {
         return () =>
           // Mirrors compiler output for: <text :content="msg" v-once />
           cache[0] ||
-          (setBlockTracking(-1),
+          (setBlockTracking(-1, true),
           (cache[0] = createElementVNode(
             'text',
             { content: toDisplayString(msg.value) },
             null,
             -1,
-          )),
+          ) as any).cacheIndex = 0,
           setBlockTracking(1),
           cache[0]);
       },
@@ -90,7 +91,8 @@ describe('v-once — ops pipeline', () => {
   it('re-render after reactive change emits no ops for v-once subtree', async () => {
     const msg = ref('hello');
     const outer = ref(0);
-    const cache: VNode[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cache: any[] = [];
 
     const App = defineComponent({
       setup() {
@@ -98,13 +100,13 @@ describe('v-once — ops pipeline', () => {
           h('view', { 'data-outer': String(outer.value) },
             // v-once subtree — compiled to cache lookup
             cache[0] ||
-            (setBlockTracking(-1),
+            (setBlockTracking(-1, true),
             (cache[0] = createElementVNode(
               'text',
               { content: toDisplayString(msg.value) },
               null,
               -1,
-            )),
+            ) as any).cacheIndex = 0,
             setBlockTracking(1),
             cache[0]),
           );
@@ -130,20 +132,21 @@ describe('v-once — ops pipeline', () => {
   it('v-once subtree retains initial value across multiple re-renders', async () => {
     const msg = ref('initial');
     const tick = ref(0);
-    const cache: VNode[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cache: any[] = [];
 
     const App = defineComponent({
       setup() {
         return () =>
           h('view', { 'data-tick': tick.value },
             cache[0] ||
-            (setBlockTracking(-1),
+            (setBlockTracking(-1, true),
             (cache[0] = createElementVNode(
               'text',
               { content: toDisplayString(msg.value) },
               null,
               -1,
-            )),
+            ) as any).cacheIndex = 0,
             setBlockTracking(1),
             cache[0]),
           );
@@ -163,35 +166,32 @@ describe('v-once — ops pipeline', () => {
     }
   });
 
-  // v-once inside v-for: each iteration gets its own cache slot.
-  // Compiler emits cache[index] per item, so each freezes independently.
-  //
-  // Note: the real compiler uses static _cache slots per component instance,
-  // not a shared array indexed by loop position. This simulation is accurate
-  // for fixed-length lists but does not cover list growth/shrinkage (stale
-  // cache slots would be reused for new items at the same index).
-  it('v-once inside v-for: each item renders once, no ops on list change', async () => {
+  // v-once inside v-for: compiler wraps the entire _renderList(...) result in
+  // a single _cache[0] slot — it does NOT allocate one slot per item.
+  // This matches @vue/compiler-dom output for:
+  //   <text v-for="(item, idx) in list" :key="idx" v-once :content="item" />
+  it('v-once inside v-for: whole list is frozen in a single cache slot', async () => {
     const list = ref(['a', 'b', 'c']);
     const outer = ref(0);
-    // Per-item caches, keyed by index — mirrors compiler output for v-for + v-once
-    const cache: VNode[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cache: any[] = [];
 
     const App = defineComponent({
       setup() {
         return () =>
           h('view', { 'data-outer': outer.value },
-            list.value.map((item, idx) =>
-              cache[idx] ||
-              (setBlockTracking(-1),
-              (cache[idx] = createElementVNode(
+            cache[0] ||
+            (setBlockTracking(-1, true),
+            (cache[0] = renderList(list.value, (item, idx) =>
+              createElementVNode(
                 'text',
                 { key: idx, content: toDisplayString(item) },
                 null,
                 -1,
-              )),
-              setBlockTracking(1),
-              cache[idx]),
-            ),
+              ),
+            ) as any).cacheIndex = 0,
+            setBlockTracking(1),
+            cache[0]),
           );
       },
     });
@@ -207,7 +207,7 @@ describe('v-once — ops pipeline', () => {
 
     const propOps = parseSetPropOps(collectFlushedOps());
 
-    // No content ops — all items are v-once frozen
+    // No content ops — entire list is v-once frozen in cache[0]
     expect(propOps.filter(op => op.key === 'content')).toHaveLength(0);
     // Outer wrapper still updates
     expect(propOps.filter(op => op.key === 'data-outer')).toHaveLength(1);
@@ -220,7 +220,8 @@ describe('v-once — ops pipeline', () => {
   it('v-once on a component: no ops after mount even when prop changes', async () => {
     const msg = ref('hello');
     const outer = ref(0);
-    const cache: VNode[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cache: any[] = [];
 
     const Child = defineComponent({
       props: { label: String },
@@ -235,8 +236,8 @@ describe('v-once — ops pipeline', () => {
           h('view', { 'data-outer': outer.value },
             // Mirrors compiler output for: <Child v-once :label="msg" />
             cache[0] ||
-            (setBlockTracking(-1),
-            (cache[0] = h(Child, { label: msg.value })),
+            (setBlockTracking(-1, true),
+            (cache[0] = h(Child, { label: msg.value }) as any).cacheIndex = 0,
             setBlockTracking(1),
             cache[0]),
           );

--- a/packages/upstream-tests/src/v-once.spec.ts
+++ b/packages/upstream-tests/src/v-once.spec.ts
@@ -164,4 +164,50 @@ describe('v-once — ops pipeline', () => {
       expect(propOps.filter(op => op.key === 'content')).toHaveLength(0);
     }
   });
+
+  // v-once inside v-for: each iteration gets its own cache slot.
+  // Compiler emits cache[index] per item, so each freezes independently.
+  it('v-once inside v-for: each item renders once, no ops on list change', async () => {
+    const list = ref(['a', 'b', 'c']);
+    const outer = ref(0);
+    // Per-item caches, keyed by index — mirrors compiler output for v-for + v-once
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const cache: any[] = [];
+
+    const App = defineComponent({
+      setup() {
+        return () =>
+          h('view', { 'data-outer': outer.value },
+            list.value.map((item, idx) =>
+              cache[idx] ||
+              (setBlockTracking(-1),
+              (cache[idx] = createElementVNode(
+                'text',
+                { key: idx, content: toDisplayString(item) },
+                null,
+                -1,
+              )),
+              setBlockTracking(1),
+              cache[idx]),
+            ),
+          );
+      },
+    });
+
+    createApp(App).mount();
+    await nextTick();
+    collectFlushedOps();
+
+    // Mutate list values and trigger re-render via outer
+    list.value = ['x', 'y', 'z'];
+    outer.value++;
+    await nextTick();
+
+    const propOps = parseSetPropOps(collectFlushedOps());
+
+    // No content ops — all items are v-once frozen
+    expect(propOps.filter(op => op.key === 'content')).toHaveLength(0);
+    // Outer wrapper still updates
+    expect(propOps.filter(op => op.key === 'data-outer')).toHaveLength(1);
+  });
 });

--- a/packages/upstream-tests/src/v-once.spec.ts
+++ b/packages/upstream-tests/src/v-once.spec.ts
@@ -20,6 +20,7 @@
  * the initial mount.
  */
 
+import type { VNode } from '@vue/runtime-core';
 import {
   createApp,
   createElementVNode,
@@ -59,8 +60,7 @@ it('setBlockTracking is exported from vue-lynx', () => {
 describe('v-once — ops pipeline', () => {
   it('initial render emits SET_PROP ops for v-once subtree', async () => {
     const msg = ref('hello');
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const cache: any[] = [];
+    const cache: VNode[] = [];
 
     const App = defineComponent({
       setup() {
@@ -90,8 +90,7 @@ describe('v-once — ops pipeline', () => {
   it('re-render after reactive change emits no ops for v-once subtree', async () => {
     const msg = ref('hello');
     const outer = ref(0);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const cache: any[] = [];
+    const cache: VNode[] = [];
 
     const App = defineComponent({
       setup() {
@@ -131,8 +130,7 @@ describe('v-once — ops pipeline', () => {
   it('v-once subtree retains initial value across multiple re-renders', async () => {
     const msg = ref('initial');
     const tick = ref(0);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const cache: any[] = [];
+    const cache: VNode[] = [];
 
     const App = defineComponent({
       setup() {
@@ -167,12 +165,16 @@ describe('v-once — ops pipeline', () => {
 
   // v-once inside v-for: each iteration gets its own cache slot.
   // Compiler emits cache[index] per item, so each freezes independently.
+  //
+  // Note: the real compiler uses static _cache slots per component instance,
+  // not a shared array indexed by loop position. This simulation is accurate
+  // for fixed-length lists but does not cover list growth/shrinkage (stale
+  // cache slots would be reused for new items at the same index).
   it('v-once inside v-for: each item renders once, no ops on list change', async () => {
     const list = ref(['a', 'b', 'c']);
     const outer = ref(0);
     // Per-item caches, keyed by index — mirrors compiler output for v-for + v-once
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const cache: any[] = [];
+    const cache: VNode[] = [];
 
     const App = defineComponent({
       setup() {
@@ -208,6 +210,52 @@ describe('v-once — ops pipeline', () => {
     // No content ops — all items are v-once frozen
     expect(propOps.filter(op => op.key === 'content')).toHaveLength(0);
     // Outer wrapper still updates
+    expect(propOps.filter(op => op.key === 'data-outer')).toHaveLength(1);
+  });
+
+  // v-once on a component: compiler emits the same cache-slot pattern regardless
+  // of whether the cached VNode is an element or a component. The patcher's
+  // n1 === n2 same-reference check fires before any type-specific branching,
+  // so the component subtree is frozen identically to a plain element.
+  it('v-once on a component: no ops after mount even when prop changes', async () => {
+    const msg = ref('hello');
+    const outer = ref(0);
+    const cache: VNode[] = [];
+
+    const Child = defineComponent({
+      props: { label: String },
+      setup(props) {
+        return () => h('text', { content: props.label });
+      },
+    });
+
+    const App = defineComponent({
+      setup() {
+        return () =>
+          h('view', { 'data-outer': outer.value },
+            // Mirrors compiler output for: <Child v-once :label="msg" />
+            cache[0] ||
+            (setBlockTracking(-1),
+            (cache[0] = h(Child, { label: msg.value })),
+            setBlockTracking(1),
+            cache[0]),
+          );
+      },
+    });
+
+    createApp(App).mount();
+    await nextTick();
+    collectFlushedOps(); // drain mount ops
+
+    msg.value = 'world'; // prop change — ignored because VNode ref is cached
+    outer.value++;
+    await nextTick();
+
+    const propOps = parseSetPropOps(collectFlushedOps());
+
+    // Component subtree frozen — Child never re-renders
+    expect(propOps.filter(op => op.key === 'content')).toHaveLength(0);
+    // Non-v-once wrapper still updates
     expect(propOps.filter(op => op.key === 'data-outer')).toHaveLength(1);
   });
 });

--- a/packages/vue-lynx/runtime/src/index.ts
+++ b/packages/vue-lynx/runtime/src/index.ts
@@ -801,7 +801,15 @@ export { useCssVars } from './use-css-vars.js';
 /** @hidden */ export { withCtx } from '@vue/runtime-core';
 /** @hidden */ export { renderSlot } from '@vue/runtime-core';
 /** @hidden */ export { createSlots } from '@vue/runtime-core';
-/** @hidden */ export { setBlockTracking } from '@vue/runtime-core';
+/**
+ * Emitted by the template compiler for `v-once` subtrees. Disables block
+ * tracking during the initial render so the cached VNode is never added to a
+ * parent block's dynamic children array — ensuring the patcher skips it on
+ * every subsequent render and no ops reach the main thread.
+ *
+ * @public
+ */
+export { setBlockTracking } from '@vue/runtime-core';
 /** @hidden */ export { pushScopeId } from '@vue/runtime-core';
 /** @hidden */ export { popScopeId } from '@vue/runtime-core';
 /** @hidden */ export { withScopeId } from '@vue/runtime-core';

--- a/packages/vue-lynx/runtime/src/index.ts
+++ b/packages/vue-lynx/runtime/src/index.ts
@@ -766,6 +766,16 @@ export { version } from '@vue/runtime-core';
  */
 export { mergeProps } from '@vue/runtime-core';
 
+/**
+ * Emitted by the template compiler for `v-once` subtrees. Disables block
+ * tracking during the initial render so the cached VNode is never added to a
+ * parent block's dynamic children array — ensuring the patcher skips it on
+ * every subsequent render and no ops reach the main thread.
+ *
+ * @public
+ */
+export { setBlockTracking } from '@vue/runtime-core';
+
 // ===========================================================================
 // @internal — CSS v-bind() support
 // ===========================================================================
@@ -801,15 +811,6 @@ export { useCssVars } from './use-css-vars.js';
 /** @hidden */ export { withCtx } from '@vue/runtime-core';
 /** @hidden */ export { renderSlot } from '@vue/runtime-core';
 /** @hidden */ export { createSlots } from '@vue/runtime-core';
-/**
- * Emitted by the template compiler for `v-once` subtrees. Disables block
- * tracking during the initial render so the cached VNode is never added to a
- * parent block's dynamic children array — ensuring the patcher skips it on
- * every subsequent render and no ops reach the main thread.
- *
- * @public
- */
-export { setBlockTracking } from '@vue/runtime-core';
 /** @hidden */ export { pushScopeId } from '@vue/runtime-core';
 /** @hidden */ export { popScopeId } from '@vue/runtime-core';
 /** @hidden */ export { withScopeId } from '@vue/runtime-core';

--- a/website/docs/guide/vue-compatibility.mdx
+++ b/website/docs/guide/vue-compatibility.mdx
@@ -173,6 +173,24 @@ The example below uses `defineComponent` with `data()`, `computed`, `watch`, `me
   defaultFile="src/App.vue"
 />
 
+## v-once
+
+[`v-once`](https://vuejs.org/api/built-in-directives.html#v-once) renders an element or component exactly once and skips all future updates. It works in Vue Lynx without any configuration — the SFC template compiler emits a cache lookup using `setBlockTracking` and the component's `_cache` array, and the runtime short-circuits on subsequent renders.
+
+In Lynx, `v-once` is more impactful than in the browser because a cache hit eliminates the entire cross-thread op batch. After the initial mount:
+
+- The VNode patcher receives the same cached VNode object reference.
+- No `patchProp` calls are made, so no ops enter the buffer.
+- `doFlush` sees an empty buffer and skips `callLepusMethod` entirely — the main thread is never contacted for that subtree.
+
+Use `v-once` for genuinely static content that should never update after first render:
+
+```vue
+<text v-once>{{ expensiveInitialValue }}</text>
+```
+
+> `v-once` is a stronger guarantee than `v-memo` — it caches unconditionally, with no dependency array to check. Prefer it when content is truly static.
+
 ## v-memo
 
 [`v-memo`](https://vuejs.org/api/built-in-directives.html#v-memo) skips a subtree re-render when its dependency array hasn't changed. It works in Vue Lynx without any configuration — the SFC template compiler already emits the correct `withMemo()` calls, and the runtime bails out before the patcher runs.

--- a/website/docs/zh/guide/vue-compatibility.mdx
+++ b/website/docs/zh/guide/vue-compatibility.mdx
@@ -173,6 +173,24 @@ pluginVueLynx({
   defaultFile="src/App.vue"
 />
 
+## v-once
+
+[`v-once`](https://vuejs.org/api/built-in-directives.html#v-once) 仅渲染元素或组件一次，并跳过所有后续更新。它在 Vue Lynx 中无需任何配置即可使用——SFC 模板编译器会生成使用 `setBlockTracking` 和组件 `_cache` 数组的缓存查找，运行时在后续渲染时短路。
+
+在 Lynx 中，`v-once` 比在浏览器中更有价值，因为缓存命中可以消除整个跨线程 op 批次。首次挂载后：
+
+- VNode patcher 接收到相同的缓存 VNode 对象引用。
+- 不会发生 `patchProp` 调用，因此没有 op 进入缓冲区。
+- `doFlush` 看到空缓冲区并完全跳过 `callLepusMethod`——该子树的主线程永远不会被联系。
+
+对于首次渲染后永远不需要更新的真正静态内容，使用 `v-once`：
+
+```vue
+<text v-once>{{ expensiveInitialValue }}</text>
+```
+
+> `v-once` 是比 `v-memo` 更强的保证——它无条件缓存，无需检查依赖数组。当内容真正静态时优先使用它。
+
 ## v-memo
 
 [`v-memo`](https://vuejs.org/api/built-in-directives.html#v-memo) 在依赖数组未发生变化时跳过子树的重新渲染。它在 Vue Lynx 中无需任何配置即可使用——SFC 模板编译器已经生成了正确的 `withMemo()` 调用，运行时会在 patcher 执行之前进行短路。


### PR DESCRIPTION
## Summary

[`v-once`](https://vuejs.org/api/built-in-directives.html#v-once) works in Vue Lynx without any runtime changes — `@vue/runtime-core` handles the cache mechanism transparently. This PR verifies that, documents it, and makes the compiler-emitted primitive explicit.

- Promotes `setBlockTracking` from `@hidden` to a public, documented export — moved out of the `@internal` section to sit alongside the other public render-function APIs. The compiler emits `setBlockTracking(-1/+1)` around the `_cache` slot assignment for every `v-once` subtree.
- Adds `packages/upstream-tests/src/v-once.spec.ts` — verifies the Lynx-specific concern: no ops reach the main thread after the initial mount, across single and repeated re-renders, `v-for` items, and component-level `v-once` (`<MyComponent v-once />`).
- Adds `v-once` section to the EN and ZH compatibility docs, positioned before `v-memo`.
- Adds changeset (minor).

## Why it matters in Lynx

Unlike in the browser (where `v-once` skips DOM diffing), in Lynx a cache hit eliminates the entire cross-thread op batch — `doFlush` sees an empty buffer and skips `callLepusMethod` entirely for that subtree.

## Test plan

- `pnpm test:local` passes (20 tests, 3 files)
- `setBlockTracking` visible in generated typedefs, no longer buried under `@hidden`
- Compat doc renders correctly on the website
