### PR TITLE
test(v-once): mirror v-for compiler block shape

### DIFF
--- a/packages/upstream-tests/src/v-once.spec.ts
+++ b/packages/upstream-tests/src/v-once.spec.ts
@@ -22,10 +22,13 @@
 
 import {
   createApp,
+  createElementBlock,
   createElementVNode,
   defineComponent,
+  Fragment,
   h,
   nextTick,
+  openBlock,
   ref,
   renderList,
   resetForTesting,
@@ -167,10 +170,10 @@ describe('v-once — ops pipeline', () => {
   });
 
   // v-once inside v-for: compiler wraps the entire _renderList(...) result in
-  // a single _cache[0] slot — it does NOT allocate one slot per item.
+  // a single cached Fragment block — it does NOT allocate one slot per item.
   // This matches @vue/compiler-dom output for:
   //   <text v-for="(item, idx) in list" :key="idx" v-once :content="item" />
-  it('v-once inside v-for: whole list is frozen in a single cache slot', async () => {
+  it('v-once inside v-for: whole list is frozen in a single cached fragment', async () => {
     const list = ref(['a', 'b', 'c']);
     const outer = ref(0);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -182,12 +185,22 @@ describe('v-once — ops pipeline', () => {
           h('view', { 'data-outer': outer.value },
             cache[0] ||
             (setBlockTracking(-1, true),
-            (cache[0] = renderList(list.value, (item, idx) =>
-              createElementVNode(
-                'text',
-                { key: idx, content: toDisplayString(item) },
+            (cache[0] = (
+              openBlock(true),
+              createElementBlock(
+                Fragment,
                 null,
-                -1,
+                renderList(list.value, (item, idx) => (
+                  openBlock(),
+                  createElementBlock(
+                    'text',
+                    { key: idx, content: item },
+                    null,
+                    8,
+                    ['content'],
+                  )
+                )),
+                128,
               ),
             ) as any).cacheIndex = 0,
             setBlockTracking(1),
@@ -199,6 +212,10 @@ describe('v-once — ops pipeline', () => {
     createApp(App).mount();
     await nextTick();
     collectFlushedOps();
+
+    expect(Array.isArray(cache[0])).toBe(false);
+    expect(cache[0].type).toBe(Fragment);
+    expect(cache[0].patchFlag).toBe(128);
 
     // Mutate list values and trigger re-render via outer
     list.value = ['x', 'y', 'z'];


### PR DESCRIPTION
## Summary

Follow-up to #176. The `v-once` test for `v-for` now mirrors the compiler's block tree shape more closely:

- wraps the cached list in a `Fragment` block via `openBlock(true)` and `createElementBlock(Fragment, ...)`
- uses `KEYED_FRAGMENT` (`128`) on the cached fragment
- asserts the cached value is a Fragment VNode rather than the raw `renderList` array

## Why

#176 already fixed the cache slot semantics, but the test still skipped the compiler's Fragment/block wrapper. This keeps the hand-written render function aligned with `@vue/compiler-dom` output and avoids giving a raw-array shape accidental coverage.

## Validation

- `pnpm --filter vue-lynx-upstream-tests run test:local`
- `pnpm lint`
