### PR TITLE
ci: use generated GitHub release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,9 +43,17 @@ jobs:
         run: pnpm build && pnpm --filter create-vue-lynx run build && pnpm build:examples:publishable
 
       - name: Create Release Pull Request or Publish to npm
+        id: changesets
         uses: changesets/action@v1
         with:
           publish: pnpm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Use GitHub generated release notes
+        if: steps.changesets.outputs.published == 'true'
+        run: node scripts/sync-github-release-notes.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}

--- a/scripts/sync-github-release-notes.mjs
+++ b/scripts/sync-github-release-notes.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+
+const DEFAULT_API_BASE_URL = 'https://api.github.com';
+
+export function tagNameForPackage(pkg) {
+  return `${pkg.name}@${pkg.version}`;
+}
+
+export function findPreviousReleaseTag(releases, packageName, currentTagName) {
+  const prefix = `${packageName}@`;
+
+  return releases.find((release) => {
+    const tagName = release.tag_name;
+    return tagName !== currentTagName && tagName.startsWith(prefix);
+  })?.tag_name;
+}
+
+export async function syncGeneratedReleaseNotes({
+  apiBaseUrl = DEFAULT_API_BASE_URL,
+  fetchImpl = globalThis.fetch,
+  publishedPackagesJson,
+  repository,
+  token,
+}) {
+  if (!repository) {
+    throw new Error('GITHUB_REPOSITORY is required.');
+  }
+  if (!token) {
+    throw new Error('GITHUB_TOKEN is required.');
+  }
+
+  const packages = parsePublishedPackages(publishedPackagesJson);
+  if (packages.length === 0) {
+    console.info('No published packages found; skipping GitHub release notes sync.');
+    return [];
+  }
+
+  const releases = await listReleases({ apiBaseUrl, fetchImpl, repository, token });
+  const synced = [];
+
+  for (const pkg of packages) {
+    const tagName = tagNameForPackage(pkg);
+    const release = await requestJson({
+      apiBaseUrl,
+      fetchImpl,
+      method: 'GET',
+      path: `/repos/${repository}/releases/tags/${encodeURIComponent(tagName)}`,
+      token,
+    });
+    const previousTagName = findPreviousReleaseTag(releases, pkg.name, tagName);
+    const notesBody = {
+      tag_name: tagName,
+      ...(previousTagName ? { previous_tag_name: previousTagName } : {}),
+    };
+    const generatedNotes = await requestJson({
+      apiBaseUrl,
+      body: notesBody,
+      fetchImpl,
+      method: 'POST',
+      path: `/repos/${repository}/releases/generate-notes`,
+      token,
+    });
+
+    await requestJson({
+      apiBaseUrl,
+      body: { body: generatedNotes.body },
+      fetchImpl,
+      method: 'PATCH',
+      path: `/repos/${repository}/releases/${release.id}`,
+      token,
+    });
+
+    console.info(`Updated GitHub release notes for ${tagName}.`);
+    synced.push({ tagName, releaseId: release.id });
+  }
+
+  return synced;
+}
+
+function parsePublishedPackages(publishedPackagesJson) {
+  if (!publishedPackagesJson) {
+    return [];
+  }
+
+  const packages = JSON.parse(publishedPackagesJson);
+  if (!Array.isArray(packages)) {
+    throw new Error('PUBLISHED_PACKAGES must be a JSON array.');
+  }
+
+  return packages.filter((pkg) => pkg?.name && pkg?.version);
+}
+
+async function listReleases({ apiBaseUrl, fetchImpl, repository, token }) {
+  const releases = [];
+
+  for (let page = 1; ; page += 1) {
+    const pageReleases = await requestJson({
+      apiBaseUrl,
+      fetchImpl,
+      method: 'GET',
+      path: `/repos/${repository}/releases?per_page=100&page=${page}`,
+      token,
+    });
+
+    releases.push(...pageReleases);
+    if (pageReleases.length < 100) {
+      return releases;
+    }
+  }
+}
+
+async function requestJson({ apiBaseUrl, body, fetchImpl, method, path, token }) {
+  const response = await fetchImpl(`${apiBaseUrl}${path}`, {
+    method,
+    headers: {
+      Accept: 'application/vnd.github+json',
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      'X-GitHub-Api-Version': '2022-11-28',
+    },
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `GitHub API ${method} ${path} failed with ${response.status}: ${await response.text()}`,
+    );
+  }
+
+  return response.json();
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await syncGeneratedReleaseNotes({
+    apiBaseUrl: process.env.GITHUB_API_URL || DEFAULT_API_BASE_URL,
+    publishedPackagesJson: process.env.PUBLISHED_PACKAGES,
+    repository: process.env.GITHUB_REPOSITORY,
+    token: process.env.GITHUB_TOKEN,
+  });
+}

--- a/scripts/sync-github-release-notes.test.mjs
+++ b/scripts/sync-github-release-notes.test.mjs
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  findPreviousReleaseTag,
+  syncGeneratedReleaseNotes,
+  tagNameForPackage,
+} from './sync-github-release-notes.mjs';
+
+test('tagNameForPackage matches Changesets package release tags', () => {
+  assert.equal(
+    tagNameForPackage({ name: 'vue-lynx', version: '0.4.0' }),
+    'vue-lynx@0.4.0',
+  );
+  assert.equal(
+    tagNameForPackage({ name: '@vue-lynx-example/basic', version: '0.2.5' }),
+    '@vue-lynx-example/basic@0.2.5',
+  );
+});
+
+test('findPreviousReleaseTag picks the previous release for the same package', () => {
+  const releases = [
+    { tag_name: '@vue-lynx-example/basic@0.2.5' },
+    { tag_name: 'vue-lynx@0.4.0' },
+    { tag_name: '@vue-lynx-example/slots@0.2.5' },
+    { tag_name: '@vue-lynx-example/basic@0.2.4' },
+    { tag_name: '@vue-lynx-example/basic@0.2.3' },
+  ];
+
+  assert.equal(
+    findPreviousReleaseTag(
+      releases,
+      '@vue-lynx-example/basic',
+      '@vue-lynx-example/basic@0.2.5',
+    ),
+    '@vue-lynx-example/basic@0.2.4',
+  );
+});
+
+test('syncGeneratedReleaseNotes replaces release body with GitHub generated notes', async () => {
+  const calls = [];
+  const fetchImpl = (url, options = {}) => {
+    calls.push({ url, options });
+
+    if (url.endsWith('/releases?per_page=100&page=1')) {
+      return jsonResponse([
+        { tag_name: 'vue-lynx@0.4.0' },
+        { tag_name: 'vue-lynx@0.3.1' },
+      ]);
+    }
+
+    if (url.endsWith('/releases?per_page=100&page=2')) {
+      return jsonResponse([]);
+    }
+
+    if (url.endsWith('/releases/tags/vue-lynx%400.4.0')) {
+      return jsonResponse({ id: 123, tag_name: 'vue-lynx@0.4.0' });
+    }
+
+    if (url.endsWith('/releases/generate-notes')) {
+      assert.deepEqual(JSON.parse(options.body), {
+        tag_name: 'vue-lynx@0.4.0',
+        previous_tag_name: 'vue-lynx@0.3.1',
+      });
+      return jsonResponse({
+        name: 'vue-lynx@0.4.0',
+        body: '## Minor Changes\n\n- feat: demo (#1) — @Huxpro',
+      });
+    }
+
+    if (url.endsWith('/releases/123')) {
+      assert.equal(options.method, 'PATCH');
+      assert.deepEqual(JSON.parse(options.body), {
+        body: '## Minor Changes\n\n- feat: demo (#1) — @Huxpro',
+      });
+      return jsonResponse({ id: 123 });
+    }
+
+    throw new Error(`Unexpected request: ${url}`);
+  };
+
+  const result = await syncGeneratedReleaseNotes({
+    apiBaseUrl: 'https://api.github.test',
+    fetchImpl,
+    publishedPackagesJson: JSON.stringify([
+      { name: 'vue-lynx', version: '0.4.0' },
+    ]),
+    repository: 'Huxpro/vue-lynx',
+    token: 'token',
+  });
+
+  assert.deepEqual(result, [{ tagName: 'vue-lynx@0.4.0', releaseId: 123 }]);
+  assert.equal(calls.at(-1).options.headers.Authorization, 'Bearer token');
+});
+
+function jsonResponse(value) {
+  return {
+    ok: true,
+    status: 200,
+    json() {
+      return value;
+    },
+    text() {
+      return JSON.stringify(value);
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- post-process Changesets-created GitHub Releases with GitHub generated release notes
- keep package CHANGELOG.md output unchanged
- use the Changesets publishedPackages output to update each package release by tag

## Validation
- node --test scripts/sync-github-release-notes.test.mjs
- pnpm lint