### PR TITLE
fix: escape generated release note tags

### DIFF
--- a/scripts/sync-github-release-notes.mjs
+++ b/scripts/sync-github-release-notes.mjs
@@ -15,6 +15,26 @@ export function findPreviousReleaseTag(releases, packageName, currentTagName) {
   })?.tag_name;
 }
 
+export function escapeMarkdownHtmlTags(markdown) {
+  return markdown
+    .split('\n')
+    .map((line) =>
+      line
+        .split(/(`[^`]*`)/g)
+        .map((part) => {
+          if (part.startsWith('`') && part.endsWith('`')) {
+            return part;
+          }
+
+          return part.replace(/<\/?[A-Za-z][A-Za-z0-9.-]*(?:\s[^<>]*)?>/g, (tag) =>
+            tag.replaceAll('<', '&lt;').replaceAll('>', '&gt;'),
+          );
+        })
+        .join(''),
+    )
+    .join('\n');
+}
+
 export async function syncGeneratedReleaseNotes({
   apiBaseUrl = DEFAULT_API_BASE_URL,
   fetchImpl = globalThis.fetch,
@@ -63,7 +83,7 @@ export async function syncGeneratedReleaseNotes({
 
     await requestJson({
       apiBaseUrl,
-      body: { body: generatedNotes.body },
+      body: { body: escapeMarkdownHtmlTags(generatedNotes.body) },
       fetchImpl,
       method: 'PATCH',
       path: `/repos/${repository}/releases/${release.id}`,

--- a/scripts/sync-github-release-notes.test.mjs
+++ b/scripts/sync-github-release-notes.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  escapeMarkdownHtmlTags,
   findPreviousReleaseTag,
   syncGeneratedReleaseNotes,
   tagNameForPackage,
@@ -37,6 +38,23 @@ test('findPreviousReleaseTag picks the previous release for the same package', (
   );
 });
 
+test('escapeMarkdownHtmlTags preserves component names in generated notes', () => {
+  assert.equal(
+    escapeMarkdownHtmlTags(
+      [
+        '* feat(runtime): support <Teleport> component by @sentomk',
+        '* feat(runtime): support `<KeepAlive>` component by @jynxbt',
+        '* feat: support <style scoped> in Vue SFCs by @Huxpro',
+      ].join('\n'),
+    ),
+    [
+      '* feat(runtime): support &lt;Teleport&gt; component by @sentomk',
+      '* feat(runtime): support `<KeepAlive>` component by @jynxbt',
+      '* feat: support &lt;style scoped&gt; in Vue SFCs by @Huxpro',
+    ].join('\n'),
+  );
+});
+
 test('syncGeneratedReleaseNotes replaces release body with GitHub generated notes', async () => {
   const calls = [];
   const fetchImpl = (url, options = {}) => {
@@ -64,14 +82,14 @@ test('syncGeneratedReleaseNotes replaces release body with GitHub generated note
       });
       return jsonResponse({
         name: 'vue-lynx@0.4.0',
-        body: '## Minor Changes\n\n- feat: demo (#1) — @Huxpro',
+        body: '## Minor Changes\n\n- feat: support <Teleport> component (#1) — @Huxpro',
       });
     }
 
     if (url.endsWith('/releases/123')) {
       assert.equal(options.method, 'PATCH');
       assert.deepEqual(JSON.parse(options.body), {
-        body: '## Minor Changes\n\n- feat: demo (#1) — @Huxpro',
+        body: '## Minor Changes\n\n- feat: support &lt;Teleport&gt; component (#1) — @Huxpro',
       });
       return jsonResponse({ id: 123 });
     }


### PR DESCRIPTION
## Summary
- escape raw HTML-like tags in generated GitHub release notes before patching release bodies
- keep existing inline code spans unchanged
- adds coverage for <Teleport>, <style scoped>, and existing `<KeepAlive>` code spans

## Validation
- node --test scripts/sync-github-release-notes.test.mjs
- pnpm lint

Also re-ran the fixed sync script for the current 0.4.0 release set so existing GitHub Release pages now display <Teleport> correctly.