### PR TITLE
fix: export mergeModels compiler helper for defineModel + defineProps

### DIFF
--- a/.changeset/merge-models-export.md
+++ b/.changeset/merge-models-export.md
@@ -1,0 +1,7 @@
+---
+"vue-lynx": patch
+---
+
+fix: export `mergeModels` compiler runtime helper
+
+Vue 3.4+'s SFC compiler emits `import { mergeModels } from 'vue'` when `defineModel()` is used alongside an explicit `defineProps()` or `defineEmits()` call. `mergeModels` was missing from vue-lynx's re-exports, which caused an `ESModulesLinkingError` at build time. The helper is now re-exported so this `defineModel()` usage pattern works out of the box.

--- a/packages/testing-library/src/__tests__/define-model.test.ts
+++ b/packages/testing-library/src/__tests__/define-model.test.ts
@@ -1,0 +1,75 @@
+/**
+ * defineModel tests — verify that the mergeModels compiler helper is exported
+ * and that defineModel works alongside explicit defineProps / defineEmits.
+ *
+ * Regression coverage for https://github.com/Huxpro/vue-lynx/issues/186
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  h,
+  defineComponent,
+  ref,
+  nextTick,
+  mergeModels,
+  useModel,
+} from 'vue-lynx';
+import { render, fireEvent } from '../index.js';
+
+describe('defineModel', () => {
+  it('exports mergeModels helper', () => {
+    expect(typeof mergeModels).toBe('function');
+  });
+
+  it('mergeModels merges array and object model declarations', () => {
+    // Simulates what the Vue 3.4+ compiler generates when defineModel()
+    // is used together with defineProps({ extra: String }).
+    const merged = mergeModels(
+      { extra: { type: String } },
+      { modelValue: {} },
+    );
+    expect(merged).toHaveProperty('extra');
+    expect(merged).toHaveProperty('modelValue');
+  });
+
+  it('component using useModel alongside extra props renders correctly', async () => {
+    // This mirrors compiled output of:
+    //   defineProps({ label: String })
+    //   const model = defineModel<string>()
+    const Child = defineComponent({
+      props: mergeModels(
+        { label: { type: String, default: '' } },
+        { modelValue: {}, 'modelValue:modifiers': {} },
+      ),
+      emits: ['update:modelValue'],
+      setup(props) {
+        const model = useModel(props, 'modelValue');
+        return () =>
+          h('view', null, [
+            h('text', null, `${props.label}:${model.value}`),
+          ]);
+      },
+    });
+
+    const value = ref('hello');
+    const Parent = defineComponent({
+      setup() {
+        return () =>
+          h(Child, {
+            label: 'field',
+            modelValue: value.value,
+            'onUpdate:modelValue': (v: string) => {
+              value.value = v;
+            },
+          });
+      },
+    });
+
+    const { container } = render(Parent);
+    await nextTick();
+    await nextTick();
+
+    const text = container.querySelector('text');
+    expect(text?.textContent).toBe('field:hello');
+  });
+});

--- a/packages/vue-lynx/runtime/src/index.ts
+++ b/packages/vue-lynx/runtime/src/index.ts
@@ -819,6 +819,8 @@ export { useCssVars } from './use-css-vars.js';
 /** @hidden */ export { withMemo } from '@vue/runtime-core';
 /** @hidden */ export { isMemoSame } from '@vue/runtime-core';
 /** @hidden */ export { guardReactiveProps } from '@vue/runtime-core';
+// @ts-expect-error mergeModels is exported at runtime but missing from Vue's .d.ts
+/** @hidden */ export { mergeModels } from '@vue/runtime-core';
 // @ts-expect-error withAsyncContext is exported at runtime but missing from Vue's .d.ts
 /** @hidden */ export { withAsyncContext } from '@vue/runtime-core';
 /** @hidden */ export { Text } from '@vue/runtime-core';


### PR DESCRIPTION
## Summary

- Re-export `mergeModels` from `@vue/runtime-core` as a compiler helper in `vue-lynx`'s runtime entry
- Add regression tests covering the export and a component using `mergeModels` + `useModel`

Fixes #186

## Context

Vue 3.4+ compiler emits `import { mergeModels as _mergeModels } from 'vue'` when `defineModel()` is used together with explicit `defineProps` or `defineEmits`. Since `vue-lynx` selectively re-exports Vue internals (rather than using a blanket `export *`), `mergeModels` was missing, causing:

```
ESModulesLinkingError: export 'mergeModels' (imported as '_mergeModels') was not found in 'vue'
```

The fix follows the existing pattern for compiler helpers that are exported at runtime but missing from Vue's `.d.ts` (same as `withAsyncContext`).

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes (104/104 tests, including 3 new)
- [x] `pnpm lint` passes
- [x] New `define-model.test.ts` verifies: export exists, merge behavior works, component renders with `mergeModels` + `useModel`