### PR TITLE
fix(types): re-export Vue type names and drop legacy Volar plugin entries

### DIFF
--- a/.changeset/types-reexport-and-volar-v1-drop.md
+++ b/.changeset/types-reexport-and-volar-v1-drop.md
@@ -2,7 +2,7 @@
 "vue-lynx": patch
 ---
 
-fix(types): re-export Vue core type aliases and drop stale Volar 1.x plugin entry
+fix(types): re-export Vue core type aliases and drop stale Volar plugin entries
 
 - Re-export `Ref`, `ComputedRef`, `WritableComputedRef`, `ShallowRef`, `UnwrapRef`, `UnwrapNestedRefs`, `MaybeRef`, `MaybeRefOrGetter`, `Reactive`, `DeepReadonly`, `VNode`, `VNodeRef`, `VNodeChild`, `DefineComponent`, `FunctionalComponent`, `ComponentInternalInstance`, `SetupContext`, `Plugin`, `Directive`, `InjectionKey`, `PropType`, `ExtractPropTypes`, `EmitsOptions`, `SlotsType`, `WatchOptions`, `WatchHandle`, `WatchStopHandle` from `vue-lynx` so consumers that alias `vue → vue-lynx` for types pick them up.
-- Drop the `version: 1` Volar plugin entry (for Vue Language Tools ≤ 1.8.27, EOL 2023). Modern Vue Language Tools warns on the v1 handler on every run.
+- Drop the legacy Volar plugin handlers for Vue Language Tools ≤ 1.8.27 (EOL 2023) and ≤ 2.0.13 (Feb 2024). Only the modern `>= 2.0.14` handler remains; the legacy `version: 1` handler triggered a warning on every run, and the middle handler was strictly subsumed by the modern one.

--- a/.changeset/types-reexport-and-volar-v1-drop.md
+++ b/.changeset/types-reexport-and-volar-v1-drop.md
@@ -1,0 +1,8 @@
+---
+"vue-lynx": patch
+---
+
+fix(types): re-export Vue core type aliases and drop stale Volar 1.x plugin entry
+
+- Re-export `Ref`, `ComputedRef`, `WritableComputedRef`, `ShallowRef`, `UnwrapRef`, `UnwrapNestedRefs`, `MaybeRef`, `MaybeRefOrGetter`, `Reactive`, `DeepReadonly`, `VNode`, `VNodeRef`, `VNodeChild`, `DefineComponent`, `FunctionalComponent`, `ComponentInternalInstance`, `SetupContext`, `Plugin`, `Directive`, `InjectionKey`, `PropType`, `ExtractPropTypes`, `EmitsOptions`, `SlotsType`, `WatchOptions`, `WatchHandle`, `WatchStopHandle` from `vue-lynx` so consumers that alias `vue → vue-lynx` for types pick them up.
+- Drop the `version: 1` Volar plugin entry (for Vue Language Tools ≤ 1.8.27, EOL 2023). Modern Vue Language Tools warns on the v1 handler on every run.

--- a/packages/vue-lynx/runtime/src/index.ts
+++ b/packages/vue-lynx/runtime/src/index.ts
@@ -23,9 +23,35 @@ import {
 import type {
   App,
   Component,
+  ComponentInternalInstance,
   ComponentPublicInstance,
+  ComputedRef,
+  DeepReadonly,
+  DefineComponent,
+  Directive,
+  EmitsOptions,
+  ExtractPropTypes,
+  FunctionalComponent,
+  InjectionKey,
+  MaybeRef,
+  MaybeRefOrGetter,
   ObjectDirective,
+  Plugin,
+  PropType,
+  Reactive,
+  Ref,
+  SetupContext,
+  ShallowRef,
+  SlotsType,
+  UnwrapNestedRefs,
+  UnwrapRef,
   VNode,
+  VNodeChild,
+  VNodeRef,
+  WatchHandle,
+  WatchOptions,
+  WatchStopHandle,
+  WritableComputedRef,
 } from '@vue/runtime-core';
 
 import { runOnMainThread } from './cross-thread.js';
@@ -48,7 +74,38 @@ import { transformToWorklet } from './transform-to-worklet.js';
 import { Transition } from './Transition.js';
 import { TransitionGroup } from './TransitionGroup.js';
 
-export type { App, Component, ComponentPublicInstance };
+export type {
+  App,
+  Component,
+  ComponentInternalInstance,
+  ComponentPublicInstance,
+  ComputedRef,
+  DeepReadonly,
+  DefineComponent,
+  Directive,
+  EmitsOptions,
+  ExtractPropTypes,
+  FunctionalComponent,
+  InjectionKey,
+  MaybeRef,
+  MaybeRefOrGetter,
+  Plugin,
+  PropType,
+  Reactive,
+  Ref,
+  SetupContext,
+  ShallowRef,
+  SlotsType,
+  UnwrapNestedRefs,
+  UnwrapRef,
+  VNode,
+  VNodeChild,
+  VNodeRef,
+  WatchHandle,
+  WatchOptions,
+  WatchStopHandle,
+  WritableComputedRef,
+};
 
 const _renderer = createRenderer<ShadowElement, ShadowElement>(nodeOps);
 const _createApp = _renderer.createApp;

--- a/packages/vue-lynx/types/src/volar-plugin.cjs
+++ b/packages/vue-lynx/types/src/volar-plugin.cjs
@@ -53,12 +53,7 @@ function lynxModifierTransform(node, context) {
 }
 
 const plugins = [
-    // <= 2.0.13
-    ({ vueCompilerOptions }) => {
-        vueCompilerOptions.nativeTags = nativeTags;
-        return { version: 2 };
-    },
-    // >= 2.0.14
+    // Vue Language Tools >= 2.0.14 (Feb 2024)
     () => {
         return {
             version: 2,

--- a/packages/vue-lynx/types/src/volar-plugin.cjs
+++ b/packages/vue-lynx/types/src/volar-plugin.cjs
@@ -53,11 +53,6 @@ function lynxModifierTransform(node, context) {
 }
 
 const plugins = [
-    // <= 1.8.27
-    ({ vueCompilerOptions }) => {
-        vueCompilerOptions.nativeTags = nativeTags;
-        return { version: 1 };
-    },
     // <= 2.0.13
     ({ vueCompilerOptions }) => {
         vueCompilerOptions.nativeTags = nativeTags;


### PR DESCRIPTION
## Summary

Two small fixes bundled together. Both unblock downstream libraries (e.g. a Reka-style headless UI kit for Lynx) that consume `vue-lynx` types directly.

### 1. Re-export Vue core type aliases from `vue-lynx`

`runtime/src/index.ts` re-exports ~79 runtime values from `@vue/runtime-core` but only 3 type aliases (`App`, `Component`, `ComponentPublicInstance`). Consumers that alias `vue → vue-lynx` for types (a common pattern when building libraries that target both web Vue and vue-lynx) currently can't pull `Ref`, `ComputedRef`, `PropType`, `VNode`, `Plugin`, `Directive`, etc.

Added explicit type re-exports for:

- Refs / reactivity: `Ref`, `ComputedRef`, `WritableComputedRef`, `ShallowRef`, `UnwrapRef`, `UnwrapNestedRefs`, `MaybeRef`, `MaybeRefOrGetter`, `Reactive`, `DeepReadonly`
- VNodes / components: `VNode`, `VNodeRef`, `VNodeChild`, `DefineComponent`, `FunctionalComponent`, `ComponentInternalInstance`, `SetupContext`
- App / plugins / directives: `Plugin`, `Directive`, `InjectionKey`
- Props / emits / slots: `PropType`, `ExtractPropTypes`, `EmitsOptions`, `SlotsType`
- Watch: `WatchOptions`, `WatchHandle`, `WatchStopHandle`

Kept the explicit-list style already used in the file (consistent with `isolatedDeclarations: true`).

### 2. Drop legacy Volar plugin handlers; keep only the modern one

`types/src/volar-plugin.cjs` previously shipped three handlers. Two are removed:

- **`version: 1` handler** — targeted Vue Language Tools `<= 1.8.27` (EOL 2023). Modern VLT (3.x) prints a warning on the v1 handler every run.
- **Middle `version: 2` handler** — targeted VLT `<= 2.0.13` (Feb 2024). It set `nativeTags` via the deprecated `vueCompilerOptions.nativeTags` field; the modern handler already does this via `resolveTemplateCompilerOptions` AND adds the `lynxModifierTransform` node transform, so it's a strict superset.

Result: a single handler for VLT `>= 2.0.14`. vue-lynx is 0.x greenfield and the repo pins no VLT version (templates/examples/lockfile all delegate to the user's editor extension), so any consumer installing today gets a supported version.

## Test plan

- [x] `pnpm --filter vue-lynx-runtime build` — runtime builds, `dist/index.d.ts` contains all new type re-exports
- [x] `pnpm --filter vue-lynx-types build` — types pkg builds, `dist/volar-plugin.cjs` contains only the single modern handler
- [x] `tsc -p packages/vue-lynx/types/tsconfig.type-tests.json --noEmit` — type tests pass
- [ ] Verify downstream library can import the newly re-exported type names from `vue-lynx`