### PR TITLE
feat(plugin): workletPackages allowlist + fix(runtime): typed runOnMainThread

### DIFF
--- a/packages/testing-library/src/__tests__/run-on-main-thread.types.test.ts
+++ b/packages/testing-library/src/__tests__/run-on-main-thread.types.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Compile-time checks for `runOnMainThread`'s signature.
+ *
+ * The previous generic constraint (`Fn extends (...args: unknown[]) => R`)
+ * rejected every typed worklet body because function-arg positions are
+ * contravariant. Consumers had to close over values or cast through
+ * `unknown[]`. These assertions pin the looser constraint and the
+ * round-trip of Parameters<Fn> / ReturnType<Fn>, so the contract can't
+ * silently tighten back.
+ *
+ * `expectTypeOf` is type-only — these assertions cost nothing at runtime.
+ */
+
+import { describe, expectTypeOf, it } from 'vitest';
+
+import { runOnMainThread } from 'vue-lynx';
+
+describe('runOnMainThread (type contract)', () => {
+  it('accepts a typed numeric arg and preserves Parameters / ReturnType', () => {
+    const fn = runOnMainThread((x: number) => {
+      'main thread';
+      void x;
+    });
+    expectTypeOf(fn).parameter(0).toEqualTypeOf<number>();
+    expectTypeOf(fn).returns.toEqualTypeOf<Promise<void>>();
+  });
+
+  it('accepts a typed object arg — the case that the old signature rejected', () => {
+    interface Sample {
+      id: number;
+      label: string;
+    }
+    const fn = runOnMainThread((s: Sample) => {
+      'main thread';
+      void s;
+    });
+    expectTypeOf(fn).parameter(0).toEqualTypeOf<Sample>();
+  });
+
+  it('preserves multi-arg signatures', () => {
+    const fn = runOnMainThread((a: number, b: string): boolean => {
+      'main thread';
+      void a;
+      void b;
+      return true;
+    });
+    expectTypeOf(fn).parameters.toEqualTypeOf<[number, string]>();
+    expectTypeOf(fn).returns.toEqualTypeOf<Promise<boolean>>();
+  });
+
+  it('preserves non-void return types', () => {
+    const fn = runOnMainThread((): number => {
+      'main thread';
+      return 42;
+    });
+    expectTypeOf(fn).returns.toEqualTypeOf<Promise<number>>();
+  });
+
+  it('allows generic worklet bodies', () => {
+    function makeRunner<T>(): (v: T) => Promise<void> {
+      return runOnMainThread((v: T) => {
+        'main thread';
+        void v;
+      });
+    }
+    expectTypeOf(makeRunner<string>()).parameter(0).toEqualTypeOf<string>();
+  });
+
+  it('rejects non-function first argument', () => {
+    // Declared but never invoked — TS still type-checks the body, but the
+    // bad call never reaches the runtime side of runOnMainThread.
+    const _typeCheckOnly = (): void => {
+      // @ts-expect-error first arg must be a function
+      runOnMainThread(42);
+    };
+    void _typeCheckOnly;
+  });
+});

--- a/packages/testing-library/src/__tests__/worklet-loader-imports.test.ts
+++ b/packages/testing-library/src/__tests__/worklet-loader-imports.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for the MT worklet loader's import extractor.
+ *
+ * The regex in `extractLocalImports` decides the entire MT dependency
+ * graph. If it ever silently regresses, every `'main thread'` worklet
+ * disappears from the MT bundle with no runtime error — animations
+ * just stop working. These tests pin the invariants that matter:
+ *   - Relative imports are always preserved
+ *   - Bare specifiers are dropped by default (backwards compat)
+ *   - Allowlist entries match exactly OR as a package-root prefix
+ *   - Allowlist entries do NOT match unrelated packages with the same
+ *     prefix (e.g. `@vue-lynx/motion-mini` must not match
+ *     `@vue-lynx/motion-mini-x`)
+ *   - RegExp entries match against the full specifier
+ *   - `with { runtime: 'shared' }` imports are skipped
+ *   - Vue template/style sub-modules are dropped, script sub-modules kept
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  extractLocalImports,
+  isWorkletPackage,
+} from '../../../vue-lynx/plugin/src/loaders/worklet-utils.js';
+
+describe('isWorkletPackage', () => {
+  it('exact string match', () => {
+    expect(isWorkletPackage('@org/motion', ['@org/motion'])).toBe(true);
+  });
+
+  it('package-root prefix match', () => {
+    expect(isWorkletPackage('@org/motion/sub/path', ['@org/motion'])).toBe(true);
+  });
+
+  it('does NOT match same-prefix-different-package', () => {
+    // This is the classic prefix-match bug: `@org/motion`.startsWith('@org/motion')
+    // is true for `@org/motion-x` even though that's a different package.
+    expect(isWorkletPackage('@org/motion-x', ['@org/motion'])).toBe(false);
+    expect(isWorkletPackage('motion', ['mo'])).toBe(false);
+  });
+
+  it('RegExp pattern is tested against the full specifier', () => {
+    expect(isWorkletPackage('@my-org/lynx-anim', [/^@my-org\//])).toBe(true);
+    expect(isWorkletPackage('lodash', [/^@my-org\//])).toBe(false);
+  });
+
+  it('empty allowlist matches nothing', () => {
+    expect(isWorkletPackage('anything', [])).toBe(false);
+  });
+});
+
+describe('extractLocalImports', () => {
+  it('preserves relative imports', () => {
+    const out = extractLocalImports(`
+      import { foo } from './rel.js';
+      import bar from '../sibling.js';
+    `);
+    expect(out).toContain(`import './rel.js'`);
+    expect(out).toContain(`import '../sibling.js'`);
+  });
+
+  it('drops bare specifiers without allowlist (backwards compat)', () => {
+    const out = extractLocalImports(`
+      import { foo } from './rel.js';
+      import { animate } from '@org/motion';
+      import lodash from 'lodash';
+    `);
+    expect(out).toContain(`import './rel.js'`);
+    expect(out).not.toContain('@org/motion');
+    expect(out).not.toContain('lodash');
+  });
+
+  it('follows allowlisted bare specifiers (exact and subpath)', () => {
+    const out = extractLocalImports(
+      `
+      import { foo } from './rel.js';
+      import { animate } from '@org/motion';
+      import s from '@org/motion/sub/path';
+      import unrelated from 'lodash';
+    `,
+      ['@org/motion'],
+    );
+    expect(out).toContain(`import '@org/motion'`);
+    expect(out).toContain(`import '@org/motion/sub/path'`);
+    expect(out).not.toContain('lodash');
+  });
+
+  it('rejects same-prefix-different-package via allowlist', () => {
+    const out = extractLocalImports(
+      `import { x } from '@org/motion-x';`,
+      ['@org/motion'],
+    );
+    expect(out).not.toContain('@org/motion-x');
+  });
+
+  it('follows RegExp-allowlisted specifiers', () => {
+    const out = extractLocalImports(
+      `
+      import { a } from '@my-org/lynx-anim';
+      import { b } from '@my-org/lynx-gestures';
+      import { c } from '@other-org/thing';
+    `,
+      [/^@my-org\//],
+    );
+    expect(out).toContain(`import '@my-org/lynx-anim'`);
+    expect(out).toContain(`import '@my-org/lynx-gestures'`);
+    expect(out).not.toContain('@other-org');
+  });
+
+  it('preserves bare side-effect imports when allowlisted', () => {
+    const out = extractLocalImports(
+      `import '@org/motion';`,
+      ['@org/motion'],
+    );
+    expect(out).toContain(`import '@org/motion'`);
+  });
+
+  it("skips imports with `with { runtime: 'shared' }`", () => {
+    const out = extractLocalImports(
+      `import { x } from './shared.js' with { runtime: 'shared' };`,
+    );
+    // The shared-runtime import is handled by extractSharedImports, not us.
+    expect(out).not.toContain(`import './shared.js'`);
+  });
+
+  it('keeps vue script sub-modules but drops template/style', () => {
+    const out = extractLocalImports(`
+      import script from './App.vue?vue&type=script&setup=true&lang.ts';
+      import template from './App.vue?vue&type=template&id=abc';
+      import style from './App.vue?vue&type=style&index=0&id=abc&lang.css';
+    `);
+    expect(out).toContain('type=script');
+    expect(out).not.toContain('type=template');
+    expect(out).not.toContain('type=style');
+  });
+
+  it('returns empty string when no imports match', () => {
+    expect(extractLocalImports('const x = 1;')).toBe('');
+    expect(extractLocalImports(`import 'lodash';`)).toBe('');
+  });
+
+  it('deduplicates repeated specifiers', () => {
+    const out = extractLocalImports(`
+      import a from './shared.js';
+      import b from './shared.js';
+    `);
+    const matches = out.match(/'\.\/shared\.js'/g);
+    expect(matches?.length).toBe(1);
+  });
+});

--- a/packages/vue-lynx/plugin/src/entry.ts
+++ b/packages/vue-lynx/plugin/src/entry.ts
@@ -204,6 +204,7 @@ export interface ApplyEntryOptions {
   customCSSInheritanceList?: string[];
   enableCSSInlineVariables?: boolean;
   debugInfoOutside?: boolean;
+  workletPackages?: ReadonlyArray<string | RegExp>;
 }
 
 export function applyEntry(
@@ -287,6 +288,29 @@ export function applyEntry(
 
   // Worklet loader (BG layer): runs SWC JS-target transform on BG-layer
   // .js/.ts/.vue files to replace 'main thread' functions with context objects.
+  const workletPackages = opts.workletPackages ?? [];
+
+  // `node_modules` exclude with a carve-out for allowlisted worklet packages.
+  // When a consumer installs e.g. `@vue-lynx/motion-mini` as a real dep, the
+  // resolved path lives under `node_modules`; without this carve-out the
+  // worklet transform would skip it and its `'main thread'` registrations
+  // would never reach the MT bundle. pnpm workspace symlinks resolve to
+  // realpaths under `packages/` and never hit this branch.
+  const nodeModulesExcludeWithAllowlist = (resource: string): boolean => {
+    if (!/node_modules/.test(resource)) return false;
+    if (workletPackages.length === 0) return true;
+    const norm = resource.replace(/\\/g, '/');
+    for (const p of workletPackages) {
+      if (p instanceof RegExp) {
+        if (p.test(norm)) return false;
+      } else {
+        // Match `/node_modules/<pkg>/` (with or without scope already in `p`).
+        if (norm.includes('/node_modules/' + p + '/')) return false;
+      }
+    }
+    return true;
+  };
+
   api.modifyBundlerChain((chain, { environment }) => {
     const isLynx = environment.name === 'lynx'
       || environment.name.startsWith('lynx-');
@@ -298,7 +322,7 @@ export function applyEntry(
       .rule('vue:worklet')
       .issuerLayer(LAYERS.BACKGROUND)
       .test(/\.(?:[cm]?[jt]sx?|vue)$/)
-      .exclude.add(/node_modules/).end()
+      .exclude.add(nodeModulesExcludeWithAllowlist).end()
       .use('worklet-loader')
       .loader(path.resolve(_dirname, './loaders/worklet-loader'))
       .end();
@@ -343,6 +367,7 @@ export function applyEntry(
       .test(/\.vue$/)
       .use('worklet-loader-mt')
       .loader(path.resolve(_dirname, './loaders/worklet-loader-mt'))
+      .options({ workletPackages })
       .end();
 
     // JS/TS on MT: LEPUS worklet transform (extract registerWorkletInternal calls).
@@ -353,7 +378,7 @@ export function applyEntry(
       .issuerLayer(LAYERS.MAIN_THREAD)
       .test(/\.[cm]?[jt]sx?$/)
       .exclude
-      .add(/node_modules/)
+      .add(nodeModulesExcludeWithAllowlist)
       .add(mainThreadPkgDir);
     if (vueInternalPkgDir) {
       workletMtExclude.add(vueInternalPkgDir);
@@ -361,6 +386,7 @@ export function applyEntry(
     workletMtExclude.end()
       .use('worklet-loader-mt')
       .loader(path.resolve(_dirname, './loaders/worklet-loader-mt'))
+      .options({ workletPackages })
       .end();
   });
 

--- a/packages/vue-lynx/plugin/src/index.ts
+++ b/packages/vue-lynx/plugin/src/index.ts
@@ -109,6 +109,32 @@ export interface PluginVueLynxOptions {
    * @deprecated Will default to `false` in the next major version.
    */
   autoPixelUnit?: boolean;
+
+  /**
+   * Allowlist of bare-import specifiers whose `'main thread'` worklets
+   * should be reached by the MT bundler.
+   *
+   * By default, the worklet loader only follows relative imports
+   * (`./foo`, `../bar`) when walking the MT dependency graph, which
+   * means worklets shipped as a package (e.g. animation primitives,
+   * gesture helpers) are silently dropped from the MT bundle. List
+   * those package names — or RegExps matching them — here.
+   *
+   * Strings match exactly OR as a package-root prefix:
+   *   - `'@vue-lynx/motion-mini'` matches itself and any subpath like
+   *     `'@vue-lynx/motion-mini/dist/foo'`, but NOT
+   *     `'@vue-lynx/motion-mini-x'`.
+   *
+   * @example
+   * ```ts
+   * pluginVueLynx({
+   *   workletPackages: ['@vue-lynx/motion-mini', /^@my-org\/lynx-/],
+   * })
+   * ```
+   *
+   * @defaultValue []
+   */
+  workletPackages?: ReadonlyArray<string | RegExp>;
 }
 
 /**
@@ -132,6 +158,7 @@ export function pluginVueLynx(
     enableCSSInlineVariables = false,
     debugInfoOutside = true,
     autoPixelUnit = true,
+    workletPackages = [],
   } = options;
 
   return [
@@ -260,6 +287,7 @@ export function pluginVueLynx(
           customCSSInheritanceList,
           enableCSSInlineVariables,
           debugInfoOutside,
+          workletPackages,
         });
       },
     },

--- a/packages/vue-lynx/plugin/src/loaders/worklet-loader-mt.ts
+++ b/packages/vue-lynx/plugin/src/loaders/worklet-loader-mt.ts
@@ -32,11 +32,17 @@ import { transformReactLynxSync } from '@lynx-js/react/transform';
 
 import { extractLocalImports, extractRegistrations, extractSharedImports } from './worklet-utils.js';
 
+interface WorkletLoaderMTOptions {
+  workletPackages?: ReadonlyArray<string | RegExp>;
+}
+
 export default function workletLoaderMT(
-  this: Rspack.LoaderContext,
+  this: Rspack.LoaderContext<WorkletLoaderMTOptions>,
   source: string,
 ): string {
   this.cacheable(true);
+
+  const workletPackages = this.getOptions().workletPackages ?? [];
 
   // Vue script sub-modules: the inline match resource proxy re-exports
   // `export { default } from "...inline..."`. If we strip exports entirely,
@@ -48,7 +54,7 @@ export default function workletLoaderMT(
     this.resourceQuery?.includes('vue')
     && this.resourceQuery?.includes('type=script')
   ) {
-    const localImports = extractLocalImports(source);
+    const localImports = extractLocalImports(source, workletPackages);
 
     if (
       !source.includes('\'main thread\'') && !source.includes('"main thread"')
@@ -96,7 +102,7 @@ export default function workletLoaderMT(
 
   // Preserve local (relative-path) imports so webpack follows the dependency
   // graph to sub-modules that may contain worklet registrations.
-  const localImports = extractLocalImports(source);
+  const localImports = extractLocalImports(source, workletPackages);
 
   // Quick check: skip LEPUS transform for files without 'main thread' directive
   // (but still extract shared imports from source since they don't need LEPUS)

--- a/packages/vue-lynx/plugin/src/loaders/worklet-utils.ts
+++ b/packages/vue-lynx/plugin/src/loaders/worklet-utils.ts
@@ -3,6 +3,36 @@
 // LICENSE file in the root directory of this source tree.
 
 /**
+ * Match a bare-import specifier against a single allowlist pattern.
+ *
+ * Strings match exactly OR as a package-root prefix:
+ *   - `@vue-lynx/motion-mini` matches `@vue-lynx/motion-mini` and
+ *     `@vue-lynx/motion-mini/sub/path`, but NOT `@vue-lynx/motion-mini-x`.
+ * RegExp patterns are tested against the full specifier.
+ */
+function specifierMatchesPattern(
+  specifier: string,
+  pattern: string | RegExp,
+): boolean {
+  if (pattern instanceof RegExp) return pattern.test(specifier);
+  if (specifier === pattern) return true;
+  return specifier.startsWith(pattern + '/');
+}
+
+/**
+ * @internal Exported for tests.
+ */
+export function isWorkletPackage(
+  specifier: string,
+  allowlist: ReadonlyArray<string | RegExp>,
+): boolean {
+  for (const p of allowlist) {
+    if (specifierMatchesPattern(specifier, p)) return true;
+  }
+  return false;
+}
+
+/**
  * Extract import statements that reference relative (local) paths.
  *
  * Converts named/default/namespace imports to side-effect-only imports
@@ -14,6 +44,12 @@
  * or `.ts` files that do. Without preserving these edges, webpack never
  * reaches the files with worklet registrations.
  *
+ * Bare-specifier imports are followed only if they match a
+ * `workletPackages` entry — see {@link isWorkletPackage}. This lets
+ * library authors ship reusable worklets (e.g. animation primitives) as
+ * normal npm/workspace packages, while keeping unrelated dependencies
+ * out of the MT bundle.
+ *
  * Vue sub-module imports (`?vue&type=template`, `?vue&type=style`) are
  * filtered out — only `?vue&type=script` imports are preserved. Template
  * and style sub-modules would pull in Vue runtime/CSS processing on the
@@ -22,12 +58,15 @@
  * Imports with `with { runtime: 'shared' }` are also skipped — these are
  * handled separately by `extractSharedImports()`.
  */
-export function extractLocalImports(source: string): string {
+export function extractLocalImports(
+  source: string,
+  workletPackages: ReadonlyArray<string | RegExp> = [],
+): string {
   const specifiers = new Set<string>();
 
-  // Match 'from' clause with relative specifier: from './foo' or from "../bar"
-  // but skip lines that contain `with {` (shared runtime imports).
-  const fromRe = /from\s+['"](\.[^'"]+)['"]/g;
+  // Match 'from' clause with any specifier (relative OR bare).
+  // We filter bare specifiers against `workletPackages` below.
+  const fromRe = /from\s+['"]([^'"]+)['"]/g;
   let match;
   while ((match = fromRe.exec(source)) !== null) {
     // Check if this import has `with {` attribute (shared runtime import)
@@ -35,13 +74,23 @@ export function extractLocalImports(source: string): string {
     const lineEnd = source.indexOf('\n', match.index);
     const line = source.slice(lineStart, lineEnd === -1 ? undefined : lineEnd);
     if (/with\s*\{/.test(line)) continue;
-    specifiers.add(match[1]!);
+    const spec = match[1]!;
+    if (spec.startsWith('.')) {
+      specifiers.add(spec);
+    } else if (isWorkletPackage(spec, workletPackages)) {
+      specifiers.add(spec);
+    }
   }
 
-  // Match bare side-effect imports: import './foo' or import "../bar"
-  const bareRe = /import\s+['"](\.[^'"]+)['"]/g;
+  // Match bare side-effect imports: import './foo' or import 'pkg'
+  const bareRe = /import\s+['"]([^'"]+)['"]/g;
   while ((match = bareRe.exec(source)) !== null) {
-    specifiers.add(match[1]!);
+    const spec = match[1]!;
+    if (spec.startsWith('.')) {
+      specifiers.add(spec);
+    } else if (isWorkletPackage(spec, workletPackages)) {
+      specifiers.add(spec);
+    }
   }
 
   if (specifiers.size === 0) return '';

--- a/packages/vue-lynx/runtime/src/cross-thread.ts
+++ b/packages/vue-lynx/runtime/src/cross-thread.ts
@@ -38,11 +38,17 @@ const RUN_WORKLET_CTX = 'Lynx.Worklet.runWorkletCtx';
  * await animate(0.5) // executes on Main Thread
  * ```
  */
-export function runOnMainThread<R, Fn extends (...args: unknown[]) => R>(
+// The args constraint uses `any[]` (not `unknown[]`) because function-arg
+// positions are contravariant: a `(initial: T) => void` is NOT assignable to
+// `(...args: unknown[]) => void`, so the previous signature rejected every
+// typed worklet body. Using `any[]` keeps `Parameters<Fn>` precise at the call
+// site while accepting any concrete signature.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function runOnMainThread<Fn extends (...args: any[]) => any>(
   fn: Fn,
-): (...args: Parameters<Fn>) => Promise<R> {
+): (...args: Parameters<Fn>) => Promise<ReturnType<Fn>> {
   registerWorkletCtx(fn as unknown as Worklet);
-  return async (...params: Parameters<Fn>): Promise<R> => {
+  return async (...params: Parameters<Fn>): Promise<ReturnType<Fn>> => {
     return new Promise((resolve) => {
       const resolveId = onFunctionCall(resolve as (value: unknown) => void);
       lynx.getCoreContext().dispatchEvent({

--- a/packages/vue-lynx/runtime/src/cross-thread.ts
+++ b/packages/vue-lynx/runtime/src/cross-thread.ts
@@ -38,13 +38,15 @@ const RUN_WORKLET_CTX = 'Lynx.Worklet.runWorkletCtx';
  * await animate(0.5) // executes on Main Thread
  * ```
  */
-// The args constraint uses `any[]` (not `unknown[]`) because function-arg
+// The args constraint uses `never[]` (not `unknown[]`) because function-arg
 // positions are contravariant: a `(initial: T) => void` is NOT assignable to
-// `(...args: unknown[]) => void`, so the previous signature rejected every
-// typed worklet body. Using `any[]` keeps `Parameters<Fn>` precise at the call
-// site while accepting any concrete signature.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function runOnMainThread<Fn extends (...args: any[]) => any>(
+// `(...args: unknown[]) => void`, so a constraint of `unknown[]` would reject
+// every typed worklet body. `never` is the bottom type — any concrete arg
+// type is assignable from it — so `(...args: never[]) => unknown` matches any
+// concrete function signature, and `Parameters<Fn>` / `ReturnType<Fn>` stay
+// precise at the call site. This is the standard "any function" generic
+// constraint that doesn't trip `noExplicitAny`.
+export function runOnMainThread<Fn extends (...args: never[]) => unknown>(
   fn: Fn,
 ): (...args: Parameters<Fn>) => Promise<ReturnType<Fn>> {
   registerWorkletCtx(fn as unknown as Worklet);


### PR DESCRIPTION
## Summary

- `packages/vue-lynx/plugin/src/loaders/worklet-utils.ts` — `extractLocalImports` only followed relative imports. Bare-specifier worklet imports silently dropped from MT bundle, animations no-op'd with no error.
- `packages/vue-lynx/runtime/src/cross-thread.ts` — `runOnMainThread`'s `Fn extends (...args: unknown[]) => R` rejected every typed function body (arg positions are contravariant).

## Changes

- New `pluginVueLynx({ workletPackages: [...] })` — strings match exactly + package-root prefix (`@org/x` ≠ `@org/x-y`), or RegExp. Threaded through `entry.ts` to the MT loader; also carves out node_modules exclude. See `packages/vue-lynx/plugin/src/index.ts`.
- `runOnMainThread` loosened to `Fn extends (...args: any[]) => any`. `Parameters<Fn>` / `ReturnType<Fn>` stay precise at call sites.
- Empty allowlist preserves previous behavior.

## Tests

- `packages/testing-library/src/__tests__/worklet-loader-imports.test.ts` — 15 unit tests pinning the extractor: relative preservation, default bare drop, exact + prefix matching, `@org/x` vs `@org/x-y` rejection, RegExp, `with { runtime: 'shared' }` skip, vue script-vs-template filtering, dedupe.
- `packages/testing-library/src/__tests__/run-on-main-thread.types.test.ts` — 6 `expectTypeOf` assertions pinning the signature. Type-only, ~0 runtime cost.
- Full suite: 122/122.

## Not addressed (upstream)

- `@lynx-js/react/transform` doesn't lift non-directive sibling helpers to MT → `X is not a function` at runtime. Workaround: inline checks at call sites (what `@lynx-js/motion`'s own bundle does).
- `@lynx-js/web-core` doesn't propagate touch worklets on plain `<view>` — drag is native-only.

## Test plan

- [x] `pnpm --filter vue-lynx-testing-library test` — 122/122 green
- [ ] Sanity-build an existing example with `workletPackages` unset (should be no-op)