### PR TITLE
fix(plugin): follow aliased/tsconfig-path imports into the MT worklet graph

### DIFF
--- a/.changeset/mt-worklet-loader-resolve-imports.md
+++ b/.changeset/mt-worklet-loader-resolve-imports.md
@@ -1,0 +1,5 @@
+---
+"vue-lynx": patch
+---
+
+Fix MT worklet loader dropping non-relative imports from the module graph. Aliased, tsconfig-path, and package worklets are now resolved and followed, so they no longer fail at runtime. Imports inside comments and string/template literals are ignored when following the worklet graph. Adds opt-in `includeWorkletPackages` to follow worklet imports into named `node_modules` packages.

--- a/packages/testing-library/src/__tests__/worklet-loader-imports.test.ts
+++ b/packages/testing-library/src/__tests__/worklet-loader-imports.test.ts
@@ -90,6 +90,32 @@ describe('extractImportSpecifiers', () => {
     expect(specs.some(s => s.includes('type=template'))).toBe(false);
     expect(specs.some(s => s.includes('type=style'))).toBe(false);
   });
+
+  it('ignores imports inside line and block comments', () => {
+    const specs = extractImportSpecifiers(`
+      import { real } from './real.js';
+      // import fake from './fake-line.vue';
+      /**
+       * Usage:
+       *   import App from './App.vue';
+       *   import { createApp } from 'vue-lynx';
+       */
+      import { other } from './other.js';
+    `);
+    expect(specs).toContain('./real.js');
+    expect(specs).toContain('./other.js');
+    expect(specs).not.toContain('./fake-line.vue');
+    expect(specs).not.toContain('./App.vue');
+    expect(specs).not.toContain('vue-lynx');
+  });
+
+  it('does not treat comment delimiters inside string literals as comments', () => {
+    const specs = extractImportSpecifiers(`
+      const url = "https://example.com/* not a comment */";
+      import { real } from './real.js';
+    `);
+    expect(specs).toContain('./real.js');
+  });
 });
 
 describe('extractLocalImports', () => {

--- a/packages/testing-library/src/__tests__/worklet-loader-imports.test.ts
+++ b/packages/testing-library/src/__tests__/worklet-loader-imports.test.ts
@@ -72,49 +72,126 @@ describe('isWorkletPackage', () => {
 });
 
 describe('extractImportSpecifiers', () => {
-  it('keeps relative and non-relative, drops shared + vue template/style', () => {
-    const specs = extractImportSpecifiers(`
-      import { a } from './rel.js';
-      import { b } from '@/alias';
-      import { c } from 'pkg';
-      import { d } from './shared.js' with { runtime: 'shared' };
-      import s from './App.vue?vue&type=script&setup=true&lang.ts';
-      import t from './App.vue?vue&type=template&id=abc';
-      import y from './App.vue?vue&type=style&index=0&id=abc&lang.css';
-    `);
-    expect(specs).toContain('./rel.js');
-    expect(specs).toContain('@/alias');
-    expect(specs).toContain('pkg');
-    expect(specs).not.toContain('./shared.js');
-    expect(specs.some(s => s.includes('type=script'))).toBe(true);
-    expect(specs.some(s => s.includes('type=template'))).toBe(false);
-    expect(specs.some(s => s.includes('type=style'))).toBe(false);
-  });
+  // One parametrized table over input *shapes*. `include` = substrings that
+  // must appear in at least one returned specifier; `exclude` = substrings
+  // that must appear in none. This is the fragile surface (the regex parser),
+  // and both real incidents on this loader originated here — dropped edges,
+  // then the JSDoc-import bug — so variants live here rather than in the
+  // resolution policy tests below.
+  const cases: Array<{
+    name: string;
+    source: string;
+    include?: string[];
+    exclude?: string[];
+  }> = [
+    {
+      name: 'relative import',
+      source: `import { a } from './rel.js';`,
+      include: ['./rel.js'],
+    },
+    {
+      name: 'aliased / non-relative import',
+      source: `import { b } from '@/alias';`,
+      include: ['@/alias'],
+    },
+    {
+      name: 'bare package import',
+      source: `import { c } from 'pkg';`,
+      include: ['pkg'],
+    },
+    {
+      name: 'double-quoted specifier',
+      source: `import x from "./dq.js";`,
+      include: ['./dq.js'],
+    },
+    {
+      name: 'bare side-effect import',
+      source: `import './side-effect.js';`,
+      include: ['./side-effect.js'],
+    },
+    {
+      name: 're-export keyed on `from` (export … from)',
+      source: `export { x } from './reexport.js';`,
+      include: ['./reexport.js'],
+    },
+    {
+      name: 're-export star (export * from)',
+      source: `export * from './star.js';`,
+      include: ['./star.js'],
+    },
+    {
+      name: "single-line `with { runtime: 'shared' }` is dropped",
+      source: `import { d } from './shared.js' with { runtime: 'shared' };`,
+      exclude: ['./shared.js'],
+    },
+    {
+      // #1 — extractSharedImports is multiline-aware; SWC may reformat the
+      // attribute onto the next line. If this leaked through, the shared
+      // module would be followed as a plain local import and have its exports
+      // stripped, defeating `shared`.
+      name: "multiline `with { runtime: 'shared' }` is dropped",
+      source: `import { d } from './shared.js'\n  with { runtime: 'shared' };`,
+      exclude: ['./shared.js'],
+    },
+    {
+      // #4 — any attribute import is dropped, not only runtime:'shared'.
+      name: "other attribute imports (with { type: 'json' }) are dropped",
+      source: `import data from './data.json' with { type: 'json' };`,
+      exclude: ['./data.json'],
+    },
+    {
+      name: 'import inside a line comment is ignored',
+      source: `// import fake from './fake-line.vue';\nimport { real } from './real.js';`,
+      include: ['./real.js'],
+      exclude: ['./fake-line.vue'],
+    },
+    {
+      name: 'imports inside a JSDoc/block comment are ignored',
+      source: `/**\n * import App from './App.vue';\n * import { createApp } from 'vue-lynx';\n */\nimport { real } from './real.js';`,
+      include: ['./real.js'],
+      exclude: ['./App.vue', 'vue-lynx'],
+    },
+    {
+      name: 'comment delimiters inside a string literal are not comments',
+      source: `const url = "https://example.com/* not a comment */";\nimport { real } from './real.js';`,
+      include: ['./real.js'],
+    },
+    {
+      // #2 — import-like text inside a string literal must not be followed
+      // (a worklet building a code string, an embedded snippet, …). Same
+      // failure class as the JSDoc bug, different trigger.
+      name: 'import-like text inside a string literal is not followed',
+      source: `const code = "import App from './fake.vue'";\nimport { real } from './real.js';`,
+      include: ['./real.js'],
+      exclude: ['./fake.vue'],
+    },
+    {
+      // #2 — same, but inside a template literal (GraphQL/SQL/codegen).
+      name: 'import-like text inside a template literal is not followed',
+      source: 'const tpl = `import X from \'./tpl-fake.js\'`;\nimport { real } from \'./real.js\';',
+      include: ['./real.js'],
+      exclude: ['./tpl-fake.js'],
+    },
+    {
+      name: 'vue script sub-module kept, template/style dropped',
+      source: `
+        import s from './App.vue?vue&type=script&setup=true&lang.ts';
+        import t from './App.vue?vue&type=template&id=abc';
+        import y from './App.vue?vue&type=style&index=0&id=abc&lang.css';
+      `,
+      include: ['type=script'],
+      exclude: ['type=template', 'type=style'],
+    },
+  ];
 
-  it('ignores imports inside line and block comments', () => {
-    const specs = extractImportSpecifiers(`
-      import { real } from './real.js';
-      // import fake from './fake-line.vue';
-      /**
-       * Usage:
-       *   import App from './App.vue';
-       *   import { createApp } from 'vue-lynx';
-       */
-      import { other } from './other.js';
-    `);
-    expect(specs).toContain('./real.js');
-    expect(specs).toContain('./other.js');
-    expect(specs).not.toContain('./fake-line.vue');
-    expect(specs).not.toContain('./App.vue');
-    expect(specs).not.toContain('vue-lynx');
-  });
-
-  it('does not treat comment delimiters inside string literals as comments', () => {
-    const specs = extractImportSpecifiers(`
-      const url = "https://example.com/* not a comment */";
-      import { real } from './real.js';
-    `);
-    expect(specs).toContain('./real.js');
+  it.each(cases)('$name', ({ source, include = [], exclude = [] }) => {
+    const specs = extractImportSpecifiers(source);
+    for (const inc of include) {
+      expect(specs.some(s => s.includes(inc))).toBe(true);
+    }
+    for (const exc of exclude) {
+      expect(specs.some(s => s.includes(exc))).toBe(false);
+    }
   });
 });
 
@@ -241,6 +318,28 @@ describe('extractLocalImports', () => {
     const resolve = resolverFrom({ lodash: '/p/node_modules/lodash/i.js' });
     expect(await extractLocalImports(`import 'lodash';`, resolve)).toBe('');
   });
+
+  // The emitted side-effect block is what actually breaks the build when a
+  // spurious edge slips through, so pin the regressions at this level too.
+  it.each([
+    {
+      name: "multiline shared import is never re-emitted",
+      source: `import { x } from './shared.js'\n  with { runtime: 'shared' };`,
+      absent: './shared.js',
+    },
+    {
+      name: 'import-like text in a string literal is never re-emitted',
+      source: `const code = "import App from './fake.vue'";`,
+      absent: './fake.vue',
+    },
+    {
+      name: 'import-like text in a template literal is never re-emitted',
+      source: 'const tpl = `import X from \'./tpl-fake.js\'`;',
+      absent: './tpl-fake.js',
+    },
+  ])('does not emit a bogus edge: $name', async ({ source, absent }) => {
+    expect(await extractLocalImports(source, noResolve)).not.toContain(absent);
+  });
 });
 
 // --- End-to-end through the actual loader (default export) -----------------
@@ -333,5 +432,13 @@ describe('worklet-loader-mt (end-to-end)', () => {
       includeWorkletPackages: ['@org/motion'],
     });
     expect(followed).toContain(`import '@org/motion';`);
+  });
+
+  it('skips a non-relative import the resolver rejects (does not fail)', async () => {
+    // No `resolve` map → getResolve rejects for `@/missing`; the loader's
+    // try/catch maps that to null and drops the edge instead of throwing.
+    const src = `import { gone } from '@/missing';\nexport const x = gone;`;
+    const out = await runLoaderMT(src, { resourcePath: '/project/src/App.ts' });
+    expect(out).not.toContain('@/missing');
   });
 });

--- a/packages/testing-library/src/__tests__/worklet-loader-imports.test.ts
+++ b/packages/testing-library/src/__tests__/worklet-loader-imports.test.ts
@@ -30,6 +30,7 @@ import {
   extractLocalImports,
   isUnderNodeModules,
   isWorkletPackage,
+  packageNameFromNodeModulesPath,
 } from '../../../vue-lynx/plugin/src/loaders/worklet-utils.js';
 
 /** Resolve specifiers from a fixed map; anything unlisted is unresolvable. */
@@ -68,6 +69,46 @@ describe('isWorkletPackage', () => {
 
   it('empty allowlist matches nothing', () => {
     expect(isWorkletPackage('anything', [])).toBe(false);
+  });
+});
+
+describe('packageNameFromNodeModulesPath', () => {
+  it('extracts scoped and unscoped package names (posix + win32)', () => {
+    expect(packageNameFromNodeModulesPath('/proj/node_modules/lodash/index.js'))
+      .toBe('lodash');
+    expect(
+      packageNameFromNodeModulesPath('/proj/node_modules/@my-org/foo/dist/index.js'),
+    ).toBe('@my-org/foo');
+    expect(
+      packageNameFromNodeModulesPath('C:\\proj\\node_modules\\@my-org\\foo\\i.js'),
+    ).toBe('@my-org/foo');
+  });
+
+  it('uses the last node_modules segment (nested deps + pnpm layout)', () => {
+    expect(
+      packageNameFromNodeModulesPath('/proj/node_modules/a/node_modules/b/i.js'),
+    ).toBe('b');
+    expect(
+      packageNameFromNodeModulesPath(
+        '/proj/node_modules/.pnpm/@my-org+foo@1.0.0/node_modules/@my-org/foo/dist/i.js',
+      ),
+    ).toBe('@my-org/foo');
+  });
+
+  it('returns null when not under node_modules', () => {
+    expect(packageNameFromNodeModulesPath('/proj/src/gesture.ts')).toBe(null);
+  });
+
+  // The path-derived package name feeds the same allowlist matcher used for
+  // import specifiers, so a RegExp pattern matches at both checkpoints.
+  it('a path-derived name matches the same RegExp allowlist as a specifier', () => {
+    const allowlist = [/^@my-org\//];
+    const path = '/proj/node_modules/@my-org/foo/dist/index.js';
+    const pkgName = packageNameFromNodeModulesPath(path);
+    expect(pkgName).not.toBe(null);
+    expect(isWorkletPackage(pkgName!, allowlist)).toBe(true);
+    // and the original specifier matches too — one stable input at both ends
+    expect(isWorkletPackage('@my-org/foo', allowlist)).toBe(true);
   });
 });
 

--- a/packages/testing-library/src/__tests__/worklet-loader-imports.test.ts
+++ b/packages/testing-library/src/__tests__/worklet-loader-imports.test.ts
@@ -99,8 +99,6 @@ describe('packageNameFromNodeModulesPath', () => {
     expect(packageNameFromNodeModulesPath('/proj/src/gesture.ts')).toBe(null);
   });
 
-  // The path-derived package name feeds the same allowlist matcher used for
-  // import specifiers, so a RegExp pattern matches at both checkpoints.
   it('a path-derived name matches the same RegExp allowlist as a specifier', () => {
     const allowlist = [/^@my-org\//];
     const path = '/proj/node_modules/@my-org/foo/dist/index.js';
@@ -476,10 +474,8 @@ describe('worklet-loader-mt (end-to-end)', () => {
   });
 
   it('follows a bare npm import matched by a RegExp allowlist entry', async () => {
-    // Guards the prior bug end-to-end: a RegExp like /^@org\// must match the
-    // package even though the resolver returns an absolute node_modules path.
-    // String-allowlist tests above would pass even if RegExp handling broke,
-    // so this exercises the RegExp path through the real loader.
+    // The string-allowlist tests above pass even if RegExp handling breaks, so
+    // exercise a RegExp through the real loader (resolver returns an abs path).
     const src = `import { animate } from '@org/motion';\nexport const x = animate;`;
     const resolve = { '@org/motion': '/project/node_modules/@org/motion/dist/index.js' };
 

--- a/packages/testing-library/src/__tests__/worklet-loader-imports.test.ts
+++ b/packages/testing-library/src/__tests__/worklet-loader-imports.test.ts
@@ -475,6 +475,29 @@ describe('worklet-loader-mt (end-to-end)', () => {
     expect(followed).toContain(`import '@org/motion';`);
   });
 
+  it('follows a bare npm import matched by a RegExp allowlist entry', async () => {
+    // Guards the prior bug end-to-end: a RegExp like /^@org\// must match the
+    // package even though the resolver returns an absolute node_modules path.
+    // String-allowlist tests above would pass even if RegExp handling broke,
+    // so this exercises the RegExp path through the real loader.
+    const src = `import { animate } from '@org/motion';\nexport const x = animate;`;
+    const resolve = { '@org/motion': '/project/node_modules/@org/motion/dist/index.js' };
+
+    const followed = await runLoaderMT(src, {
+      resourcePath: '/project/src/App.ts',
+      resolve,
+      includeWorkletPackages: [/^@org\//],
+    });
+    expect(followed).toContain(`import '@org/motion';`);
+
+    const dropped = await runLoaderMT(src, {
+      resourcePath: '/project/src/App.ts',
+      resolve,
+      includeWorkletPackages: [/^@other\//],
+    });
+    expect(dropped).not.toContain('@org/motion');
+  });
+
   it('skips a non-relative import the resolver rejects (does not fail)', async () => {
     // No `resolve` map → getResolve rejects for `@/missing`; the loader's
     // try/catch maps that to null and drops the edge instead of throwing.

--- a/packages/testing-library/src/__tests__/worklet-loader-imports.test.ts
+++ b/packages/testing-library/src/__tests__/worklet-loader-imports.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Tests for the MT worklet loader's import follower.
+ *
+ * `extractLocalImports` decides the entire MT dependency graph. If it ever
+ * silently regresses, every `'main thread'` worklet reached through that
+ * import disappears from the MT bundle with no build error — animations
+ * just stop working and the runtime throws a confusing
+ * `cannot read property 'bind' of undefined` deep inside worklet-runtime.
+ *
+ * The loader resolves each non-relative specifier and follows it when it
+ * points at project/aliased source (outside `node_modules`); imports
+ * resolving into `node_modules` are followed only when allowlisted via
+ * `includeWorkletPackages`. These tests pin those invariants:
+ *   - Relative imports are always followed (no regression)
+ *   - Aliased / tsconfig-path imports resolving to project source ARE followed
+ *   - Bare package imports are dropped by default, followed when allowlisted
+ *   - Unresolvable specifiers are skipped, not fatal
+ *   - The original specifier is re-emitted verbatim (downstream re-resolves)
+ *   - `with { runtime: 'shared' }` and vue template/style sub-modules are skipped
+ *   - End-to-end: an aliased worklet module's `registerWorkletInternal`
+ *     reaches the MT output, and the importer re-emits the aliased edge
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import workletLoaderMT from '../../../vue-lynx/plugin/src/loaders/worklet-loader-mt.js';
+import type { ResolveImport } from '../../../vue-lynx/plugin/src/loaders/worklet-utils.js';
+import {
+  extractImportSpecifiers,
+  extractLocalImports,
+  isUnderNodeModules,
+  isWorkletPackage,
+} from '../../../vue-lynx/plugin/src/loaders/worklet-utils.js';
+
+/** Resolve specifiers from a fixed map; anything unlisted is unresolvable. */
+function resolverFrom(map: Record<string, string>): ResolveImport {
+  return async (specifier) => map[specifier] ?? null;
+}
+
+describe('isUnderNodeModules', () => {
+  it('detects node_modules paths (posix + win32)', () => {
+    expect(isUnderNodeModules('/proj/node_modules/lodash/index.js')).toBe(true);
+    expect(isUnderNodeModules('C:\\proj\\node_modules\\pkg\\i.js')).toBe(true);
+  });
+
+  it('returns false for project source', () => {
+    expect(isUnderNodeModules('/proj/src/gesture.ts')).toBe(false);
+    // a file literally named node_modules.ts is not a node_modules tree
+    expect(isUnderNodeModules('/proj/src/node_modules.ts')).toBe(false);
+  });
+});
+
+describe('isWorkletPackage', () => {
+  it('exact and package-root prefix match', () => {
+    expect(isWorkletPackage('@org/motion', ['@org/motion'])).toBe(true);
+    expect(isWorkletPackage('@org/motion/sub', ['@org/motion'])).toBe(true);
+  });
+
+  it('does NOT match same-prefix-different-package', () => {
+    expect(isWorkletPackage('@org/motion-x', ['@org/motion'])).toBe(false);
+    expect(isWorkletPackage('motion', ['mo'])).toBe(false);
+  });
+
+  it('RegExp is tested against the full specifier', () => {
+    expect(isWorkletPackage('@my-org/lynx-anim', [/^@my-org\//])).toBe(true);
+    expect(isWorkletPackage('lodash', [/^@my-org\//])).toBe(false);
+  });
+
+  it('empty allowlist matches nothing', () => {
+    expect(isWorkletPackage('anything', [])).toBe(false);
+  });
+});
+
+describe('extractImportSpecifiers', () => {
+  it('keeps relative and non-relative, drops shared + vue template/style', () => {
+    const specs = extractImportSpecifiers(`
+      import { a } from './rel.js';
+      import { b } from '@/alias';
+      import { c } from 'pkg';
+      import { d } from './shared.js' with { runtime: 'shared' };
+      import s from './App.vue?vue&type=script&setup=true&lang.ts';
+      import t from './App.vue?vue&type=template&id=abc';
+      import y from './App.vue?vue&type=style&index=0&id=abc&lang.css';
+    `);
+    expect(specs).toContain('./rel.js');
+    expect(specs).toContain('@/alias');
+    expect(specs).toContain('pkg');
+    expect(specs).not.toContain('./shared.js');
+    expect(specs.some(s => s.includes('type=script'))).toBe(true);
+    expect(specs.some(s => s.includes('type=template'))).toBe(false);
+    expect(specs.some(s => s.includes('type=style'))).toBe(false);
+  });
+});
+
+describe('extractLocalImports', () => {
+  const noResolve = resolverFrom({});
+
+  it('always follows relative imports (no resolution needed)', async () => {
+    const out = await extractLocalImports(
+      `
+      import { foo } from './rel.js';
+      import bar from '../sibling.js';
+    `,
+      noResolve,
+    );
+    expect(out).toContain(`import './rel.js'`);
+    expect(out).toContain(`import '../sibling.js'`);
+  });
+
+  it('follows aliased / tsconfig-path imports resolving to project source', async () => {
+    const resolve = resolverFrom({
+      '@/gesture': '/project/src/gesture.ts',
+      '#components/box': '/project/src/components/box.ts',
+      '~/utils': '/project/src/utils/index.ts',
+    });
+    const out = await extractLocalImports(
+      `
+      import { useGesture } from '@/gesture';
+      import Box from '#components/box';
+      import { x } from '~/utils';
+    `,
+      resolve,
+    );
+    // re-emitted verbatim — downstream re-resolves with its own alias config
+    expect(out).toContain(`import '@/gesture';`);
+    expect(out).toContain(`import '#components/box';`);
+    expect(out).toContain(`import '~/utils';`);
+  });
+
+  it('drops bare package imports resolving into node_modules by default', async () => {
+    const resolve = resolverFrom({
+      '@org/motion': '/project/node_modules/@org/motion/dist/index.js',
+      lodash: '/project/node_modules/lodash/index.js',
+    });
+    const out = await extractLocalImports(
+      `
+      import { foo } from './rel.js';
+      import { animate } from '@org/motion';
+      import lodash from 'lodash';
+    `,
+      resolve,
+    );
+    expect(out).toContain(`import './rel.js'`);
+    expect(out).not.toContain('@org/motion');
+    expect(out).not.toContain('lodash');
+  });
+
+  it('follows node_modules imports that are allowlisted', async () => {
+    const resolve = resolverFrom({
+      '@org/motion': '/project/node_modules/@org/motion/dist/index.js',
+      '@org/motion/sub': '/project/node_modules/@org/motion/dist/sub.js',
+      lodash: '/project/node_modules/lodash/index.js',
+    });
+    const out = await extractLocalImports(
+      `
+      import { animate } from '@org/motion';
+      import s from '@org/motion/sub';
+      import unrelated from 'lodash';
+    `,
+      resolve,
+      ['@org/motion'],
+    );
+    expect(out).toContain(`import '@org/motion';`);
+    expect(out).toContain(`import '@org/motion/sub';`);
+    expect(out).not.toContain('lodash');
+  });
+
+  it('skips unresolvable specifiers without throwing', async () => {
+    const out = await extractLocalImports(
+      `
+      import { foo } from './rel.js';
+      import { nope } from 'totally-missing-pkg';
+    `,
+      noResolve,
+    );
+    expect(out).toContain(`import './rel.js'`);
+    expect(out).not.toContain('totally-missing-pkg');
+  });
+
+  it("skips imports with `with { runtime: 'shared' }`", async () => {
+    const out = await extractLocalImports(
+      `import { x } from './shared.js' with { runtime: 'shared' };`,
+      noResolve,
+    );
+    expect(out).not.toContain(`import './shared.js'`);
+  });
+
+  it('keeps vue script sub-modules, drops template/style', async () => {
+    const out = await extractLocalImports(
+      `
+      import script from './App.vue?vue&type=script&setup=true&lang.ts';
+      import template from './App.vue?vue&type=template&id=abc';
+      import style from './App.vue?vue&type=style&index=0&id=abc&lang.css';
+    `,
+      noResolve,
+    );
+    expect(out).toContain('type=script');
+    expect(out).not.toContain('type=template');
+    expect(out).not.toContain('type=style');
+  });
+
+  it('deduplicates repeated specifiers', async () => {
+    const out = await extractLocalImports(
+      `
+      import a from './shared.js';
+      import b from './shared.js';
+    `,
+      noResolve,
+    );
+    expect(out.match(/'\.\/shared\.js'/g)?.length).toBe(1);
+  });
+
+  it('returns empty string when nothing is followed', async () => {
+    expect(await extractLocalImports('const x = 1;', noResolve)).toBe('');
+    const resolve = resolverFrom({ lodash: '/p/node_modules/lodash/i.js' });
+    expect(await extractLocalImports(`import 'lodash';`, resolve)).toBe('');
+  });
+});
+
+// --- End-to-end through the actual loader (default export) -----------------
+
+interface RunOptions {
+  resourcePath?: string;
+  resourceQuery?: string;
+  resolve?: Record<string, string>;
+  includeWorkletPackages?: ReadonlyArray<string | RegExp>;
+}
+
+/** Drive the async loader with a minimal mock LoaderContext. */
+function runLoaderMT(source: string, opts: RunOptions = {}): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const ctx = {
+      cacheable() {},
+      async() {
+        return (err: Error | null, result?: string) =>
+          err ? reject(err) : resolve(result ?? '');
+      },
+      getOptions() {
+        return { includeWorkletPackages: opts.includeWorkletPackages };
+      },
+      getResolve() {
+        return (_context: string, request: string) => {
+          const resolved = opts.resolve?.[request];
+          return resolved == null
+            ? Promise.reject(new Error(`cannot resolve ${request}`))
+            : Promise.resolve(resolved);
+        };
+      },
+      context: '/project/src',
+      rootContext: '/project',
+      resourcePath: opts.resourcePath ?? '/project/src/mod.ts',
+      resourceQuery: opts.resourceQuery ?? '',
+      emitError() {},
+    };
+    const loader = workletLoaderMT as unknown as (
+      this: typeof ctx,
+      source: string,
+    ) => void;
+    loader.call(ctx, source);
+  });
+}
+
+describe('worklet-loader-mt (end-to-end)', () => {
+  // A module that DEFINES a 'main thread' worklet (the aliased dependency).
+  const gestureModule = `
+    export const onScroll = (event: { detail?: { scrollTop?: number } }) => {
+      'main thread'
+      const y = event.detail?.scrollTop ?? 0
+      return y
+    }
+  `;
+
+  // An importer that reaches the worklet module through a path alias.
+  const importerModule = `
+    import { onScroll } from '@/gesture';
+    export const handler = onScroll;
+  `;
+
+  it("extracts the worklet's registerWorkletInternal into MT output", async () => {
+    const out = await runLoaderMT(gestureModule, {
+      resourcePath: '/project/src/gesture.ts',
+    });
+    expect(out).toContain('registerWorkletInternal');
+  });
+
+  it('re-emits an aliased import edge so MT reaches the worklet module', async () => {
+    const out = await runLoaderMT(importerModule, {
+      resourcePath: '/project/src/App.ts',
+      resolve: { '@/gesture': '/project/src/gesture.ts' },
+    });
+    expect(out).toContain(`import '@/gesture';`);
+  });
+
+  it('does NOT follow a bare npm import unless allowlisted', async () => {
+    const src = `import { animate } from '@org/motion';\nexport const x = animate;`;
+    const resolve = { '@org/motion': '/project/node_modules/@org/motion/index.js' };
+
+    const dropped = await runLoaderMT(src, {
+      resourcePath: '/project/src/App.ts',
+      resolve,
+    });
+    expect(dropped).not.toContain('@org/motion');
+
+    const followed = await runLoaderMT(src, {
+      resourcePath: '/project/src/App.ts',
+      resolve,
+      includeWorkletPackages: ['@org/motion'],
+    });
+    expect(followed).toContain(`import '@org/motion';`);
+  });
+});

--- a/packages/testing-library/src/__tests__/worklet-loader-imports.test.ts
+++ b/packages/testing-library/src/__tests__/worklet-loader-imports.test.ts
@@ -31,6 +31,7 @@ import {
   isUnderNodeModules,
   isWorkletPackage,
   packageNameFromNodeModulesPath,
+  packageRootFromSpecifier,
 } from '../../../vue-lynx/plugin/src/loaders/worklet-utils.js';
 
 /** Resolve specifiers from a fixed map; anything unlisted is unresolvable. */
@@ -51,10 +52,25 @@ describe('isUnderNodeModules', () => {
   });
 });
 
+describe('packageRootFromSpecifier', () => {
+  it('reduces scoped and unscoped specifiers to the package root', () => {
+    expect(packageRootFromSpecifier('@my-org/foo/dist/x')).toBe('@my-org/foo');
+    expect(packageRootFromSpecifier('@my-org/foo')).toBe('@my-org/foo');
+    expect(packageRootFromSpecifier('lodash/fp')).toBe('lodash');
+    expect(packageRootFromSpecifier('lodash')).toBe('lodash');
+  });
+
+  it('returns null for input with no usable package segment', () => {
+    expect(packageRootFromSpecifier('')).toBe(null);
+    expect(packageRootFromSpecifier('@scope')).toBe(null);
+  });
+});
+
 describe('isWorkletPackage', () => {
-  it('exact and package-root prefix match', () => {
+  // Inputs are already reduced to a package root (see packageRootFromSpecifier),
+  // so matching is exact for strings and a direct test for RegExp.
+  it('matches a root exactly', () => {
     expect(isWorkletPackage('@org/motion', ['@org/motion'])).toBe(true);
-    expect(isWorkletPackage('@org/motion/sub', ['@org/motion'])).toBe(true);
   });
 
   it('does NOT match same-prefix-different-package', () => {
@@ -62,7 +78,7 @@ describe('isWorkletPackage', () => {
     expect(isWorkletPackage('motion', ['mo'])).toBe(false);
   });
 
-  it('RegExp is tested against the full specifier', () => {
+  it('RegExp is tested against the package root', () => {
     expect(isWorkletPackage('@my-org/lynx-anim', [/^@my-org\//])).toBe(true);
     expect(isWorkletPackage('lodash', [/^@my-org\//])).toBe(false);
   });
@@ -492,6 +508,23 @@ describe('worklet-loader-mt (end-to-end)', () => {
       includeWorkletPackages: [/^@other\//],
     });
     expect(dropped).not.toContain('@org/motion');
+  });
+
+  it('follows a SUBPATH import of an allowlisted package (root reduction)', async () => {
+    // The specifier carries a subpath but the allowlist names the package root;
+    // checkpoint A must reduce the specifier to its root before matching, the
+    // same way the loader exclude reduces the resolved path.
+    const src = `import { animate } from '@org/motion/extras';\nexport const x = animate;`;
+    const resolve = {
+      '@org/motion/extras': '/project/node_modules/@org/motion/extras/index.js',
+    };
+
+    const followed = await runLoaderMT(src, {
+      resourcePath: '/project/src/App.ts',
+      resolve,
+      includeWorkletPackages: ['@org/motion'],
+    });
+    expect(followed).toContain(`import '@org/motion/extras';`);
   });
 
   it('skips a non-relative import the resolver rejects (does not fail)', async () => {

--- a/packages/testing-library/src/__tests__/worklet-loader-imports.test.ts
+++ b/packages/testing-library/src/__tests__/worklet-loader-imports.test.ts
@@ -83,6 +83,17 @@ describe('isWorkletPackage', () => {
     expect(isWorkletPackage('lodash', [/^@my-org\//])).toBe(false);
   });
 
+  it.each([/^@my-org\//g, /^@my-org\//y])(
+    'treats stateful pattern %s as stateless',
+    (pattern) => {
+      pattern.lastIndex = 2;
+
+      expect(isWorkletPackage('@my-org/lynx-anim', [pattern])).toBe(true);
+      expect(isWorkletPackage('@my-org/lynx-anim', [pattern])).toBe(true);
+      expect(pattern.lastIndex).toBe(2);
+    },
+  );
+
   it('empty allowlist matches nothing', () => {
     expect(isWorkletPackage('anything', [])).toBe(false);
   });

--- a/packages/vue-lynx/plugin/src/entry.ts
+++ b/packages/vue-lynx/plugin/src/entry.ts
@@ -204,6 +204,7 @@ export interface ApplyEntryOptions {
   customCSSInheritanceList?: string[];
   enableCSSInlineVariables?: boolean;
   debugInfoOutside?: boolean;
+  includeWorkletPackages?: ReadonlyArray<string | RegExp>;
 }
 
 export function applyEntry(
@@ -285,6 +286,30 @@ export function applyEntry(
     return rspackConfig;
   });
 
+  // Worklet packages: opt-in bare specifiers whose `'main thread'` worklets
+  // must reach the MT bundle even though they install under `node_modules`.
+  const includeWorkletPackages = opts.includeWorkletPackages ?? [];
+
+  // `node_modules` exclude with a carve-out for allowlisted worklet packages.
+  // When a consumer installs e.g. `@vue-lynx/motion-mini` as a real dep, the
+  // resolved path lives under `node_modules`; without this carve-out the
+  // worklet transforms would skip it and its `'main thread'` registrations
+  // would never reach the MT bundle. pnpm workspace symlinks resolve to
+  // realpaths under `packages/` and never hit this branch.
+  const nodeModulesExcludeWithAllowlist = (resource: string): boolean => {
+    if (!/node_modules/.test(resource)) return false;
+    if (includeWorkletPackages.length === 0) return true;
+    const norm = resource.replace(/\\/g, '/');
+    for (const p of includeWorkletPackages) {
+      if (p instanceof RegExp) {
+        if (p.test(norm)) return false;
+      } else if (norm.includes('/node_modules/' + p + '/')) {
+        return false;
+      }
+    }
+    return true;
+  };
+
   // Worklet loader (BG layer): runs SWC JS-target transform on BG-layer
   // .js/.ts/.vue files to replace 'main thread' functions with context objects.
   api.modifyBundlerChain((chain, { environment }) => {
@@ -298,7 +323,7 @@ export function applyEntry(
       .rule('vue:worklet')
       .issuerLayer(LAYERS.BACKGROUND)
       .test(/\.(?:[cm]?[jt]sx?|vue)$/)
-      .exclude.add(/node_modules/).end()
+      .exclude.add(nodeModulesExcludeWithAllowlist).end()
       .use('worklet-loader')
       .loader(path.resolve(_dirname, './loaders/worklet-loader'))
       .end();
@@ -343,6 +368,7 @@ export function applyEntry(
       .test(/\.vue$/)
       .use('worklet-loader-mt')
       .loader(path.resolve(_dirname, './loaders/worklet-loader-mt'))
+      .options({ includeWorkletPackages })
       .end();
 
     // JS/TS on MT: LEPUS worklet transform (extract registerWorkletInternal calls).
@@ -353,7 +379,7 @@ export function applyEntry(
       .issuerLayer(LAYERS.MAIN_THREAD)
       .test(/\.[cm]?[jt]sx?$/)
       .exclude
-      .add(/node_modules/)
+      .add(nodeModulesExcludeWithAllowlist)
       .add(mainThreadPkgDir);
     if (vueInternalPkgDir) {
       workletMtExclude.add(vueInternalPkgDir);
@@ -361,6 +387,7 @@ export function applyEntry(
     workletMtExclude.end()
       .use('worklet-loader-mt')
       .loader(path.resolve(_dirname, './loaders/worklet-loader-mt'))
+      .options({ includeWorkletPackages })
       .end();
   });
 

--- a/packages/vue-lynx/plugin/src/entry.ts
+++ b/packages/vue-lynx/plugin/src/entry.ts
@@ -16,6 +16,10 @@ import {
 } from '@lynx-js/template-webpack-plugin';
 
 import { LAYERS } from './layers.js';
+import {
+  isWorkletPackage,
+  packageNameFromNodeModulesPath,
+} from './loaders/worklet-utils.js';
 import { vueScopeStripCSSPlugin } from './plugins/vue-scope-strip-css-plugin.js';
 import { VueScopedCSSIdPlugin } from './plugins/vue-scoped-cssid-plugin.js';
 
@@ -296,18 +300,19 @@ export function applyEntry(
   // worklet transforms would skip it and its `'main thread'` registrations
   // would never reach the MT bundle. pnpm workspace symlinks resolve to
   // realpaths under `packages/` and never hit this branch.
+  //
+  // The allowlist is matched against the package NAME derived from the resolved
+  // path — never the raw path — so it shares the exact matching model used when
+  // following import specifiers (see `isWorkletPackage`). Without this, a
+  // RegExp like `/^@my-org\//` would match the specifier `@my-org/foo` but
+  // never the path `…/node_modules/@my-org/foo/dist/index.js`, silently
+  // dropping the package here.
   const nodeModulesExcludeWithAllowlist = (resource: string): boolean => {
     if (!/node_modules/.test(resource)) return false;
     if (includeWorkletPackages.length === 0) return true;
-    const norm = resource.replace(/\\/g, '/');
-    for (const p of includeWorkletPackages) {
-      if (p instanceof RegExp) {
-        if (p.test(norm)) return false;
-      } else if (norm.includes('/node_modules/' + p + '/')) {
-        return false;
-      }
-    }
-    return true;
+    const pkgName = packageNameFromNodeModulesPath(resource);
+    if (pkgName === null) return true;
+    return !isWorkletPackage(pkgName, includeWorkletPackages);
   };
 
   // Worklet loader (BG layer): runs SWC JS-target transform on BG-layer

--- a/packages/vue-lynx/plugin/src/entry.ts
+++ b/packages/vue-lynx/plugin/src/entry.ts
@@ -301,12 +301,9 @@ export function applyEntry(
   // would never reach the MT bundle. pnpm workspace symlinks resolve to
   // realpaths under `packages/` and never hit this branch.
   //
-  // The allowlist is matched against the package NAME derived from the resolved
-  // path — never the raw path — so it shares the exact matching model used when
-  // following import specifiers (see `isWorkletPackage`). Without this, a
-  // RegExp like `/^@my-org\//` would match the specifier `@my-org/foo` but
-  // never the path `…/node_modules/@my-org/foo/dist/index.js`, silently
-  // dropping the package here.
+  // Match the allowlist against the package NAME (not the raw path) so it shares
+  // the matching model used when following import specifiers — see
+  // `isWorkletPackage`.
   const nodeModulesExcludeWithAllowlist = (resource: string): boolean => {
     if (!/node_modules/.test(resource)) return false;
     if (includeWorkletPackages.length === 0) return true;

--- a/packages/vue-lynx/plugin/src/index.ts
+++ b/packages/vue-lynx/plugin/src/index.ts
@@ -126,6 +126,12 @@ export interface PluginVueLynxOptions {
    *     `'@vue-lynx/motion-mini/dist/foo'`, but NOT
    *     `'@vue-lynx/motion-mini-x'`.
    *
+   * Patterns are matched against the package specifier/name (e.g.
+   * `'@my-org/foo'`) at every checkpoint — never the resolved filesystem
+   * path — so a RegExp like `/^@my-org\//` matches consistently whether the
+   * package is followed as an import or carved out of the `node_modules`
+   * loader exclude.
+   *
    * @example
    * ```ts
    * pluginVueLynx({

--- a/packages/vue-lynx/plugin/src/index.ts
+++ b/packages/vue-lynx/plugin/src/index.ts
@@ -109,6 +109,33 @@ export interface PluginVueLynxOptions {
    * @deprecated Will default to `false` in the next major version.
    */
   autoPixelUnit?: boolean;
+
+  /**
+   * Allowlist of bare-import specifiers whose `'main thread'` worklets
+   * should be reached by the MT bundler.
+   *
+   * The worklet loader follows relative imports (`./foo`, `../bar`) and
+   * resolves non-relative imports: path aliases and tsconfig `paths` that
+   * point at project source (outside `node_modules`) are followed
+   * automatically. Imports resolving INTO `node_modules` are dropped by
+   * default — list the package names (or RegExps matching them) here to
+   * follow worklets shipped as a published/installed package.
+   *
+   * Strings match exactly OR as a package-root prefix:
+   *   - `'@vue-lynx/motion-mini'` matches itself and any subpath like
+   *     `'@vue-lynx/motion-mini/dist/foo'`, but NOT
+   *     `'@vue-lynx/motion-mini-x'`.
+   *
+   * @example
+   * ```ts
+   * pluginVueLynx({
+   *   includeWorkletPackages: ['@vue-lynx/motion-mini', /^@my-org\/lynx-/],
+   * })
+   * ```
+   *
+   * @defaultValue []
+   */
+  includeWorkletPackages?: ReadonlyArray<string | RegExp>;
 }
 
 /**
@@ -132,6 +159,7 @@ export function pluginVueLynx(
     enableCSSInlineVariables = false,
     debugInfoOutside = true,
     autoPixelUnit = true,
+    includeWorkletPackages = [],
   } = options;
 
   return [
@@ -260,6 +288,7 @@ export function pluginVueLynx(
           customCSSInheritanceList,
           enableCSSInlineVariables,
           debugInfoOutside,
+          includeWorkletPackages,
         });
       },
     },

--- a/packages/vue-lynx/plugin/src/index.ts
+++ b/packages/vue-lynx/plugin/src/index.ts
@@ -126,11 +126,9 @@ export interface PluginVueLynxOptions {
    *     `'@vue-lynx/motion-mini/dist/foo'`, but NOT
    *     `'@vue-lynx/motion-mini-x'`.
    *
-   * Patterns are matched against the package specifier/name (e.g.
-   * `'@my-org/foo'`) at every checkpoint — never the resolved filesystem
-   * path — so a RegExp like `/^@my-org\//` matches consistently whether the
-   * package is followed as an import or carved out of the `node_modules`
-   * loader exclude.
+   * Patterns match the package specifier/name (e.g. `'@my-org/foo'`), never the
+   * resolved filesystem path, so a RegExp like `/^@my-org\//` matches whether
+   * the package is reached as an import or carved out of the loader exclude.
    *
    * @example
    * ```ts

--- a/packages/vue-lynx/plugin/src/index.ts
+++ b/packages/vue-lynx/plugin/src/index.ts
@@ -121,14 +121,13 @@ export interface PluginVueLynxOptions {
    * default — list the package names (or RegExps matching them) here to
    * follow worklets shipped as a published/installed package.
    *
-   * Strings match exactly OR as a package-root prefix:
-   *   - `'@vue-lynx/motion-mini'` matches itself and any subpath like
-   *     `'@vue-lynx/motion-mini/dist/foo'`, but NOT
-   *     `'@vue-lynx/motion-mini-x'`.
-   *
-   * Patterns match the package specifier/name (e.g. `'@my-org/foo'`), never the
-   * resolved filesystem path, so a RegExp like `/^@my-org\//` matches whether
-   * the package is reached as an import or carved out of the loader exclude.
+   * Both checkpoints reduce their input to the package root before matching,
+   * so a pattern always matches the package name (e.g. `'@my-org/foo'`), never
+   * a subpath or the resolved filesystem path:
+   *   - strings match the root exactly — `'@vue-lynx/motion-mini'` covers the
+   *     package and all its subpath imports, but NOT `'@vue-lynx/motion-mini-x'`;
+   *   - a RegExp like `/^@my-org\//` matches whether the package is reached as
+   *     an import or carved out of the `node_modules` loader exclude.
    *
    * @example
    * ```ts

--- a/packages/vue-lynx/plugin/src/loaders/worklet-loader-mt.ts
+++ b/packages/vue-lynx/plugin/src/loaders/worklet-loader-mt.ts
@@ -106,35 +106,13 @@ async function transformModule(
       return (localImports ? localImports + '\n' : '') + 'export default {};';
     }
 
-    const resourcePath = ctx.resourcePath;
-    const lepusResult = transformReactLynxSync(source, {
-      pluginName: 'vue:worklet-mt',
-      filename: resourcePath,
-      sourcemap: false,
-      cssScope: false,
-      shake: false,
-      compat: false,
-      refresh: false,
-      defineDCE: false,
-      directiveDCE: false,
-      worklet: {
-        target: 'LEPUS',
-        filename: resourcePath,
-        runtimePkg: 'vue-lynx',
-      },
-    });
-
-    if (lepusResult.errors.length > 0) {
-      for (const err of lepusResult.errors) {
-        ctx.emitError(
-          new Error(`[worklet-loader-mt] LEPUS transform: ${err.text}`),
-        );
-      }
+    const lepusCode = runLepusTransform(ctx, source);
+    if (lepusCode === null) {
       return (localImports ? localImports + '\n' : '') + 'export default {};';
     }
 
-    const registrations = extractRegistrations(lepusResult.code);
-    const sharedImports = extractSharedImports(lepusResult.code);
+    const registrations = extractRegistrations(lepusCode);
+    const sharedImports = extractSharedImports(lepusCode);
     const parts = [sharedImports, localImports, registrations, 'export default {};'].filter(
       Boolean,
     );
@@ -162,12 +140,31 @@ async function transformModule(
     return sharedImports + (localImports ? '\n' + localImports : '');
   }
 
-  const resourcePath = ctx.resourcePath;
-  const filename = resourcePath;
+  const lepusCode = runLepusTransform(ctx, source);
+  if (lepusCode === null) return localImports;
 
-  const lepusResult = transformReactLynxSync(source, {
+  // Extract shared imports from the LEPUS output (SWC preserves them)
+  const sharedImports = extractSharedImports(lepusCode);
+
+  // Return shared imports + local imports (for dep graph) + extracted registrations
+  const registrations = extractRegistrations(lepusCode);
+  const parts = [sharedImports, localImports, registrations].filter(Boolean);
+  return parts.join('\n');
+}
+
+/**
+ * Run the LEPUS worklet transform on a module and surface any transform
+ * errors via `ctx.emitError`. Returns the transformed code, or `null` when
+ * the transform failed — callers fall back to their own minimal output.
+ */
+function runLepusTransform(
+  ctx: Rspack.LoaderContext<WorkletLoaderMTOptions>,
+  source: string,
+): string | null {
+  const resourcePath = ctx.resourcePath;
+  const result = transformReactLynxSync(source, {
     pluginName: 'vue:worklet-mt',
-    filename,
+    filename: resourcePath,
     sourcemap: false,
     cssScope: false,
     shake: false,
@@ -177,25 +174,19 @@ async function transformModule(
     directiveDCE: false,
     worklet: {
       target: 'LEPUS',
-      filename,
+      filename: resourcePath,
       runtimePkg: 'vue-lynx',
     },
   });
 
-  if (lepusResult.errors.length > 0) {
-    for (const err of lepusResult.errors) {
+  if (result.errors.length > 0) {
+    for (const err of result.errors) {
       ctx.emitError(
         new Error(`[worklet-loader-mt] LEPUS transform: ${err.text}`),
       );
     }
-    return localImports;
+    return null;
   }
 
-  // Extract shared imports from the LEPUS output (SWC preserves them)
-  const sharedImports = extractSharedImports(lepusResult.code);
-
-  // Return shared imports + local imports (for dep graph) + extracted registrations
-  const registrations = extractRegistrations(lepusResult.code);
-  const parts = [sharedImports, localImports, registrations].filter(Boolean);
-  return parts.join('\n');
+  return result.code;
 }

--- a/packages/vue-lynx/plugin/src/loaders/worklet-loader-mt.ts
+++ b/packages/vue-lynx/plugin/src/loaders/worklet-loader-mt.ts
@@ -30,14 +30,60 @@ import type { Rspack } from '@rsbuild/core';
 
 import { transformReactLynxSync } from '@lynx-js/react/transform';
 
+import type { ResolveImport } from './worklet-utils.js';
 import { extractLocalImports, extractRegistrations, extractSharedImports } from './worklet-utils.js';
 
-export default function workletLoaderMT(
-  this: Rspack.LoaderContext,
-  source: string,
-): string {
-  this.cacheable(true);
+export interface WorkletLoaderMTOptions {
+  /**
+   * Allowlist of bare-import specifiers whose `'main thread'` worklets must
+   * be followed into the MT module graph even though they resolve into
+   * `node_modules`. Imports resolving to project/aliased source (outside
+   * `node_modules`) are always followed and do not need to be listed.
+   */
+  includeWorkletPackages?: ReadonlyArray<string | RegExp>;
+}
 
+export default function workletLoaderMT(
+  this: Rspack.LoaderContext<WorkletLoaderMTOptions>,
+  source: string,
+): void {
+  // Resolution requires an async loader (`this.async()`); the loader output
+  // stays a pure function of (source, resolve config), so caching is sound.
+  this.cacheable(true);
+  const callback = this.async();
+
+  const includeWorkletPackages = this.getOptions()?.includeWorkletPackages ?? [];
+
+  // Resolve specifiers exactly as the importing module would (honours the
+  // bundler's alias + tsconfig `paths`). Unresolvable specifiers resolve to
+  // `null` so the caller can skip them instead of failing the build.
+  // `getResolve` returns a union (callback form | promise form); select the
+  // promise form so we can await it.
+  const resolver = this.getResolve({}) as (
+    context: string,
+    request: string,
+  ) => Promise<string | false | undefined>;
+  const context = this.context ?? this.rootContext;
+  const resolveImport: ResolveImport = async (specifier) => {
+    try {
+      return (await resolver(context, specifier)) || null;
+    } catch {
+      return null;
+    }
+  };
+
+  transformModule(this, source, resolveImport, includeWorkletPackages).then(
+    (result) => callback(null, result),
+    (err) => callback(err instanceof Error ? err : new Error(String(err))),
+  );
+}
+
+async function transformModule(
+  ctx: Rspack.LoaderContext<WorkletLoaderMTOptions>,
+  source: string,
+  resolveImport: ResolveImport,
+  includeWorkletPackages: ReadonlyArray<string | RegExp>,
+): Promise<string> {
   // Vue script sub-modules: the inline match resource proxy re-exports
   // `export { default } from "...inline..."`. If we strip exports entirely,
   // the proxy fails with ESModulesLinkingError. Instead, emit local imports
@@ -45,10 +91,14 @@ export default function workletLoaderMT(
   // connector's side-effect import means the proxy's exports are unused
   // and will be tree-shaken.
   if (
-    this.resourceQuery?.includes('vue')
-    && this.resourceQuery?.includes('type=script')
+    ctx.resourceQuery?.includes('vue')
+    && ctx.resourceQuery?.includes('type=script')
   ) {
-    const localImports = extractLocalImports(source);
+    const localImports = await extractLocalImports(
+      source,
+      resolveImport,
+      includeWorkletPackages,
+    );
 
     if (
       !source.includes('\'main thread\'') && !source.includes('"main thread"')
@@ -56,7 +106,7 @@ export default function workletLoaderMT(
       return (localImports ? localImports + '\n' : '') + 'export default {};';
     }
 
-    const resourcePath = this.resourcePath;
+    const resourcePath = ctx.resourcePath;
     const lepusResult = transformReactLynxSync(source, {
       pluginName: 'vue:worklet-mt',
       filename: resourcePath,
@@ -76,7 +126,7 @@ export default function workletLoaderMT(
 
     if (lepusResult.errors.length > 0) {
       for (const err of lepusResult.errors) {
-        this.emitError(
+        ctx.emitError(
           new Error(`[worklet-loader-mt] LEPUS transform: ${err.text}`),
         );
       }
@@ -94,9 +144,13 @@ export default function workletLoaderMT(
   // Regular .js/.ts files (not vue sub-modules):
   // Strip everything except local imports, shared imports, and registrations.
 
-  // Preserve local (relative-path) imports so webpack follows the dependency
-  // graph to sub-modules that may contain worklet registrations.
-  const localImports = extractLocalImports(source);
+  // Preserve local imports so webpack follows the dependency graph to
+  // sub-modules that may contain worklet registrations.
+  const localImports = await extractLocalImports(
+    source,
+    resolveImport,
+    includeWorkletPackages,
+  );
 
   // Quick check: skip LEPUS transform for files without 'main thread' directive
   // (but still extract shared imports from source since they don't need LEPUS)
@@ -108,7 +162,7 @@ export default function workletLoaderMT(
     return sharedImports + (localImports ? '\n' + localImports : '');
   }
 
-  const resourcePath = this.resourcePath;
+  const resourcePath = ctx.resourcePath;
   const filename = resourcePath;
 
   const lepusResult = transformReactLynxSync(source, {
@@ -130,7 +184,7 @@ export default function workletLoaderMT(
 
   if (lepusResult.errors.length > 0) {
     for (const err of lepusResult.errors) {
-      this.emitError(
+      ctx.emitError(
         new Error(`[worklet-loader-mt] LEPUS transform: ${err.text}`),
       );
     }

--- a/packages/vue-lynx/plugin/src/loaders/worklet-utils.ts
+++ b/packages/vue-lynx/plugin/src/loaders/worklet-utils.ts
@@ -47,6 +47,20 @@ export function isWorkletPackage(
 }
 
 /**
+ * Remove line (`//…`) and block (`/* … *\/`) comments from JS/TS source,
+ * leaving string and template literals untouched so delimiters appearing
+ * inside them are not treated as comment starts.
+ *
+ * @internal Exported for tests.
+ */
+export function stripComments(source: string): string {
+  return source.replace(
+    /("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|`(?:\\.|[^`\\])*`)|\/\/[^\n]*|\/\*[\s\S]*?\*\//g,
+    (_match, literal) => (literal ? literal : ''),
+  );
+}
+
+/**
  * Parse the import specifiers of a module that the MT graph may need to
  * follow.
  *
@@ -63,6 +77,13 @@ export function isWorkletPackage(
  */
 export function extractImportSpecifiers(source: string): string[] {
   const specifiers = new Set<string>();
+
+  // Strip comments first so JSDoc/example snippets like `* import App from
+  // './App.vue';` are not mistaken for real import edges (re-emitting them
+  // would inject unresolvable imports and fail the build). String and
+  // template literals are preserved so `//` or `/*` inside them is left
+  // intact.
+  source = stripComments(source);
 
   // Match the `from` clause of any import (relative OR non-relative), but
   // skip lines carrying a `with {` attribute (shared-runtime imports).
@@ -160,6 +181,7 @@ export function extractSharedImports(source: string): string {
   const re = /import\s+(.+?)\s+from\s+(['"])([^'"]+)\2\s*with\s*\{[\s\S]*?runtime:\s*['"]shared['"][\s\S]*?\}\s*;?/g;
   const imports: string[] = [];
   let match;
+  source = stripComments(source);
   while ((match = re.exec(source)) !== null) {
     const specifiers = match[1]!;
     const quote = match[2]!;

--- a/packages/vue-lynx/plugin/src/loaders/worklet-utils.ts
+++ b/packages/vue-lynx/plugin/src/loaders/worklet-utils.ts
@@ -154,10 +154,8 @@ export function tokenizeLiterals(source: string): {
 export function extractImportSpecifiers(source: string): string[] {
   const specifiers = new Set<string>();
 
-  // Mask string/template literals (and drop comments) before scanning, so
-  // neither JSDoc example imports nor import-like text inside a string or
-  // template literal is mistaken for a real import edge — re-emitting either
-  // would inject an unresolvable import and fail the build.
+  // Mask literals / drop comments before scanning (see tokenizeLiterals) so
+  // import-like text inside them is never followed as a real edge.
   const { code, literals } = tokenizeLiterals(source);
   const unquote = (lit: string) => lit.slice(1, -1);
 
@@ -202,15 +200,8 @@ export function extractImportSpecifiers(source: string): string[] {
  * may not contain `'main thread'` directives themselves, but they import
  * `.vue`/`.ts` files that do.
  *
- * Which imports are followed:
- *   - Relative imports (`./foo`, `../bar`) — always (original behaviour).
- *   - Non-relative imports (path aliases, tsconfig `paths`, `@/…`, `~/…`,
- *     bare packages) — resolved via `resolveImport`. Followed when they
- *     resolve to project/aliased source OUTSIDE `node_modules`, so internal
- *     aliases are no longer silently dropped.
- *   - Imports resolving INTO `node_modules` — followed only when they match
- *     the `includeWorkletPackages` allowlist, letting a published package
- *     ship MT worklets to consumers.
+ * The follow policy (relative always, non-relative by resolved location,
+ * `node_modules` only when allowlisted) is applied inline below.
  *
  * Unresolvable specifiers are skipped (never fail the build). The original
  * specifier string is re-emitted verbatim so the downstream bundler resolves

--- a/packages/vue-lynx/plugin/src/loaders/worklet-utils.ts
+++ b/packages/vue-lynx/plugin/src/loaders/worklet-utils.ts
@@ -15,18 +15,13 @@ export function isUnderNodeModules(resolvedPath: string): boolean {
 }
 
 /**
- * Extract the package name (`name` or `@scope/name`) from a resolved path that
- * lives under `node_modules`, or `null` when the path is not under
- * `node_modules`.
+ * Extract the package name (`name` or `@scope/name`) from a resolved path under
+ * `node_modules`, or `null` when the path is not under `node_modules`. Lets a
+ * resolved path be matched against the allowlist as a package specifier (see
+ * {@link isWorkletPackage}).
  *
  * Uses the LAST `node_modules` segment so nested deps and pnpm's
- * `…/.pnpm/<pkg>@<v>/node_modules/<pkg>/…` layout both resolve to the real
- * package name.
- *
- * This is the bridge that lets a resolved filesystem path be matched against
- * the SAME `includeWorkletPackages` allowlist as an original import specifier
- * (see {@link isWorkletPackage}): both checkpoints match a package specifier
- * rather than mixing specifier and absolute-path inputs.
+ * `…/.pnpm/<pkg>@<v>/node_modules/<pkg>/…` layout both resolve correctly.
  */
 export function packageNameFromNodeModulesPath(
   resolvedPath: string,
@@ -65,11 +60,9 @@ function specifierMatchesPattern(
 /**
  * Whether `specifier` is covered by the `includeWorkletPackages` allowlist.
  *
- * This is the single matching model used at BOTH worklet checkpoints: when
- * following import specifiers ({@link extractLocalImports}) and when deciding
- * the `node_modules` loader carve-out in the plugin. The latter feeds the
- * package name derived via {@link packageNameFromNodeModulesPath}, so both
- * checkpoints match a package specifier — never a raw filesystem path.
+ * The single matcher used at both checkpoints — following import specifiers
+ * ({@link extractLocalImports}) and the plugin's `node_modules` loader carve-out
+ * — so both always match a package specifier, never a raw filesystem path.
  *
  * @internal Exported for tests.
  */

--- a/packages/vue-lynx/plugin/src/loaders/worklet-utils.ts
+++ b/packages/vue-lynx/plugin/src/loaders/worklet-utils.ts
@@ -3,34 +3,72 @@
 // LICENSE file in the root directory of this source tree.
 
 /**
- * Extract import statements that reference relative (local) paths.
- *
- * Converts named/default/namespace imports to side-effect-only imports
- * (`import './foo'`) to preserve webpack's dependency graph without
- * executing user code or pulling in external packages.
- *
- * This is critical for the MT layer: entry files like `index.ts` may not
- * contain `'main thread'` directives themselves, but they import `.vue`
- * or `.ts` files that do. Without preserving these edges, webpack never
- * reaches the files with worklet registrations.
- *
- * Vue sub-module imports (`?vue&type=template`, `?vue&type=style`) are
- * filtered out — only `?vue&type=script` imports are preserved. Template
- * and style sub-modules would pull in Vue runtime/CSS processing on the
- * MT layer, which is unnecessary and harmful.
- *
- * Imports with `with { runtime: 'shared' }` are also skipped — these are
- * handled separately by `extractSharedImports()`.
+ * Resolve a specifier to an absolute path. Returns `null` when the
+ * specifier cannot be resolved (the import is then skipped rather than
+ * failing the build).
  */
-export function extractLocalImports(source: string): string {
+export type ResolveImport = (specifier: string) => Promise<string | null>;
+
+/** Whether a resolved absolute path lives inside a `node_modules` tree. */
+export function isUnderNodeModules(resolvedPath: string): boolean {
+  return /[/\\]node_modules[/\\]/.test(resolvedPath);
+}
+
+/**
+ * Match a bare-import specifier against a single allowlist pattern.
+ *
+ * Strings match exactly OR as a package-root prefix:
+ *   - `@vue-lynx/motion-mini` matches `@vue-lynx/motion-mini` and
+ *     `@vue-lynx/motion-mini/sub/path`, but NOT `@vue-lynx/motion-mini-x`.
+ * RegExp patterns are tested against the full specifier.
+ */
+function specifierMatchesPattern(
+  specifier: string,
+  pattern: string | RegExp,
+): boolean {
+  if (pattern instanceof RegExp) return pattern.test(specifier);
+  if (specifier === pattern) return true;
+  return specifier.startsWith(pattern + '/');
+}
+
+/**
+ * Whether `specifier` is covered by the `includeWorkletPackages` allowlist.
+ *
+ * @internal Exported for tests.
+ */
+export function isWorkletPackage(
+  specifier: string,
+  allowlist: ReadonlyArray<string | RegExp>,
+): boolean {
+  for (const p of allowlist) {
+    if (specifierMatchesPattern(specifier, p)) return true;
+  }
+  return false;
+}
+
+/**
+ * Parse the import specifiers of a module that the MT graph may need to
+ * follow.
+ *
+ * Returns deduplicated specifiers (relative AND non-relative) after
+ * dropping:
+ *   - `with { runtime: 'shared' }` imports (handled by
+ *     {@link extractSharedImports}), and
+ *   - vue template/style sub-modules (`?vue&type=template|style`) — only
+ *     `?vue&type=script` sub-modules are kept, since template/style would
+ *     pull Vue runtime / CSS processing onto the MT layer.
+ *
+ * Classification of non-relative specifiers (alias vs package) is left to
+ * the caller, which resolves them — see {@link extractLocalImports}.
+ */
+export function extractImportSpecifiers(source: string): string[] {
   const specifiers = new Set<string>();
 
-  // Match 'from' clause with relative specifier: from './foo' or from "../bar"
-  // but skip lines that contain `with {` (shared runtime imports).
-  const fromRe = /from\s+['"](\.[^'"]+)['"]/g;
+  // Match the `from` clause of any import (relative OR non-relative), but
+  // skip lines carrying a `with {` attribute (shared-runtime imports).
+  const fromRe = /from\s+['"]([^'"]+)['"]/g;
   let match;
   while ((match = fromRe.exec(source)) !== null) {
-    // Check if this import has `with {` attribute (shared runtime import)
     const lineStart = source.lastIndexOf('\n', match.index) + 1;
     const lineEnd = source.indexOf('\n', match.index);
     const line = source.slice(lineStart, lineEnd === -1 ? undefined : lineEnd);
@@ -38,24 +76,70 @@ export function extractLocalImports(source: string): string {
     specifiers.add(match[1]!);
   }
 
-  // Match bare side-effect imports: import './foo' or import "../bar"
-  const bareRe = /import\s+['"](\.[^'"]+)['"]/g;
+  // Match bare side-effect imports: import './foo' or import 'pkg'.
+  const bareRe = /import\s+['"]([^'"]+)['"]/g;
   while ((match = bareRe.exec(source)) !== null) {
     specifiers.add(match[1]!);
   }
 
-  if (specifiers.size === 0) return '';
+  return [...specifiers].filter(s => {
+    if (!s.includes('?vue')) return true;
+    return s.includes('type=script');
+  });
+}
 
-  return [...specifiers]
-    // Filter out vue template/style sub-module imports — they pull in
-    // Vue runtime / CSS processing which is unnecessary on the MT layer.
-    // Only keep script sub-modules (and non-vue imports).
-    .filter(s => {
-      if (!s.includes('?vue')) return true;
-      return s.includes('type=script');
-    })
-    .map(s => `import '${s}';`)
-    .join('\n');
+/**
+ * Build the side-effect import block that preserves webpack's MT dependency
+ * graph for a processed module.
+ *
+ * Converts each followed import to a side-effect-only import
+ * (`import './foo'`) so webpack reaches sub-modules that contain worklet
+ * registrations without executing user code or pulling in unrelated
+ * packages. This is critical for the MT layer: entry files like `index.ts`
+ * may not contain `'main thread'` directives themselves, but they import
+ * `.vue`/`.ts` files that do.
+ *
+ * Which imports are followed:
+ *   - Relative imports (`./foo`, `../bar`) — always (original behaviour).
+ *   - Non-relative imports (path aliases, tsconfig `paths`, `@/…`, `~/…`,
+ *     bare packages) — resolved via `resolveImport`. Followed when they
+ *     resolve to project/aliased source OUTSIDE `node_modules`, so internal
+ *     aliases are no longer silently dropped.
+ *   - Imports resolving INTO `node_modules` — followed only when they match
+ *     the `includeWorkletPackages` allowlist, letting a published package
+ *     ship MT worklets to consumers.
+ *
+ * Unresolvable specifiers are skipped (never fail the build). The original
+ * specifier string is re-emitted verbatim so the downstream bundler resolves
+ * it again with its own alias/paths config.
+ */
+export async function extractLocalImports(
+  source: string,
+  resolveImport: ResolveImport,
+  includeWorkletPackages: ReadonlyArray<string | RegExp> = [],
+): Promise<string> {
+  const kept: string[] = [];
+
+  for (const spec of extractImportSpecifiers(source)) {
+    // Relative imports are always followed — no resolution needed.
+    if (spec.startsWith('.')) {
+      kept.push(spec);
+      continue;
+    }
+
+    // Non-relative: resolve to decide whether it's project/aliased source
+    // (follow) or an external package (follow only when allowlisted).
+    const resolved = await resolveImport(spec);
+    if (resolved === null) continue; // unresolvable → skip, don't fail build
+    if (!isUnderNodeModules(resolved)) {
+      kept.push(spec);
+      continue;
+    }
+    if (isWorkletPackage(spec, includeWorkletPackages)) kept.push(spec);
+  }
+
+  if (kept.length === 0) return '';
+  return kept.map(s => `import '${s}';`).join('\n');
 }
 
 /**

--- a/packages/vue-lynx/plugin/src/loaders/worklet-utils.ts
+++ b/packages/vue-lynx/plugin/src/loaders/worklet-utils.ts
@@ -47,6 +47,16 @@ export function isWorkletPackage(
 }
 
 /**
+ * Matches a string/template literal (capture group 1) OR a line/block comment
+ * (no capture group). Used only with {@link String.prototype.replace}, which
+ * resets a global regex's `lastIndex` after each call, so this single shared
+ * instance is safe to reuse across {@link stripComments} and
+ * {@link tokenizeLiterals}.
+ */
+const LITERAL_OR_COMMENT_RE =
+  /("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|`(?:\\.|[^`\\])*`)|\/\/[^\n]*|\/\*[\s\S]*?\*\//g;
+
+/**
  * Remove line (`//…`) and block (`/* … *\/`) comments from JS/TS source,
  * leaving string and template literals untouched so delimiters appearing
  * inside them are not treated as comment starts.
@@ -55,7 +65,7 @@ export function isWorkletPackage(
  */
 export function stripComments(source: string): string {
   return source.replace(
-    /("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|`(?:\\.|[^`\\])*`)|\/\/[^\n]*|\/\*[\s\S]*?\*\//g,
+    LITERAL_OR_COMMENT_RE,
     (_match, literal) => (literal ? literal : ''),
   );
 }
@@ -84,7 +94,7 @@ export function tokenizeLiterals(source: string): {
 } {
   const literals: string[] = [];
   const code = source.replace(
-    /("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|`(?:\\.|[^`\\])*`)|\/\/[^\n]*|\/\*[\s\S]*?\*\//g,
+    LITERAL_OR_COMMENT_RE,
     (_match, literal) => {
       if (literal === undefined) return ''; // comment → drop
       literals.push(literal);

--- a/packages/vue-lynx/plugin/src/loaders/worklet-utils.ts
+++ b/packages/vue-lynx/plugin/src/loaders/worklet-utils.ts
@@ -61,13 +61,49 @@ export function stripComments(source: string): string {
 }
 
 /**
+ * Replace every string/template literal with an indexed placeholder
+ * (`\u0000N\u0000`) and drop comments, returning the rewritten code plus the
+ * captured literals.
+ *
+ * Unlike {@link stripComments} (which preserves literal *contents*), this
+ * masks them, so import-like text *inside* a string or template literal — a
+ * worklet that builds a code string containing `from 'x'`, a GraphQL/SQL
+ * template, etc. — is never mistaken for a real import edge. Nested literals
+ * collapse into the outermost placeholder, so `from 'x'` inside a template
+ * is hidden along with it.
+ *
+ * Known limitation: regex literals are not tokenized, so a regex whose raw
+ * text contains `//` can still confuse comment handling. This is rare in
+ * worklet entry modules and intentionally left to a real tokenizer.
+ *
+ * @internal Exported for tests.
+ */
+export function tokenizeLiterals(source: string): {
+  code: string;
+  literals: string[];
+} {
+  const literals: string[] = [];
+  const code = source.replace(
+    /("(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|`(?:\\.|[^`\\])*`)|\/\/[^\n]*|\/\*[\s\S]*?\*\//g,
+    (_match, literal) => {
+      if (literal === undefined) return ''; // comment → drop
+      literals.push(literal);
+      return `\u0000${literals.length - 1}\u0000`;
+    },
+  );
+  return { code, literals };
+}
+
+/**
  * Parse the import specifiers of a module that the MT graph may need to
  * follow.
  *
  * Returns deduplicated specifiers (relative AND non-relative) after
  * dropping:
- *   - `with { runtime: 'shared' }` imports (handled by
- *     {@link extractSharedImports}), and
+ *   - attribute imports (`… with { … }`, e.g. `runtime: 'shared'`) — shared
+ *     imports are handled by {@link extractSharedImports}; other attributes
+ *     (`type: 'json'`, …) carry no worklet registrations, so neither is
+ *     followed, and
  *   - vue template/style sub-modules (`?vue&type=template|style`) — only
  *     `?vue&type=script` sub-modules are kept, since template/style would
  *     pull Vue runtime / CSS processing onto the MT layer.
@@ -78,29 +114,35 @@ export function stripComments(source: string): string {
 export function extractImportSpecifiers(source: string): string[] {
   const specifiers = new Set<string>();
 
-  // Strip comments first so JSDoc/example snippets like `* import App from
-  // './App.vue';` are not mistaken for real import edges (re-emitting them
-  // would inject unresolvable imports and fail the build). String and
-  // template literals are preserved so `//` or `/*` inside them is left
-  // intact.
-  source = stripComments(source);
+  // Mask string/template literals (and drop comments) before scanning, so
+  // neither JSDoc example imports nor import-like text inside a string or
+  // template literal is mistaken for a real import edge — re-emitting either
+  // would inject an unresolvable import and fail the build.
+  const { code, literals } = tokenizeLiterals(source);
+  const unquote = (lit: string) => lit.slice(1, -1);
 
-  // Match the `from` clause of any import (relative OR non-relative), but
-  // skip lines carrying a `with {` attribute (shared-runtime imports).
-  const fromRe = /from\s+['"]([^'"]+)['"]/g;
+  // An import attribute always follows the specifier with only whitespace
+  // between, so a lookahead from the end of the match catches it regardless
+  // of line breaks (SWC may reformat `with { runtime: 'shared' }` onto the
+  // next line). This keeps us in lockstep with extractSharedImports, which
+  // is multiline-aware — without it a reformatted shared import would leak
+  // through here and be followed as a plain local import.
+  const attribAhead = /^\s*with\s*\{/;
+
+  // Match the `from` clause of any import (relative OR non-relative), and any
+  // re-export (`export … from`), keying on `from` + a masked specifier.
+  const fromRe = /from\s+\u0000(\d+)\u0000/g;
   let match;
-  while ((match = fromRe.exec(source)) !== null) {
-    const lineStart = source.lastIndexOf('\n', match.index) + 1;
-    const lineEnd = source.indexOf('\n', match.index);
-    const line = source.slice(lineStart, lineEnd === -1 ? undefined : lineEnd);
-    if (/with\s*\{/.test(line)) continue;
-    specifiers.add(match[1]!);
+  while ((match = fromRe.exec(code)) !== null) {
+    if (attribAhead.test(code.slice(fromRe.lastIndex))) continue;
+    specifiers.add(unquote(literals[Number(match[1])]!));
   }
 
   // Match bare side-effect imports: import './foo' or import 'pkg'.
-  const bareRe = /import\s+['"]([^'"]+)['"]/g;
-  while ((match = bareRe.exec(source)) !== null) {
-    specifiers.add(match[1]!);
+  const bareRe = /import\s+\u0000(\d+)\u0000/g;
+  while ((match = bareRe.exec(code)) !== null) {
+    if (attribAhead.test(code.slice(bareRe.lastIndex))) continue;
+    specifiers.add(unquote(literals[Number(match[1])]!));
   }
 
   return [...specifiers].filter(s => {

--- a/packages/vue-lynx/plugin/src/loaders/worklet-utils.ts
+++ b/packages/vue-lynx/plugin/src/loaders/worklet-utils.ts
@@ -15,6 +15,37 @@ export function isUnderNodeModules(resolvedPath: string): boolean {
 }
 
 /**
+ * Extract the package name (`name` or `@scope/name`) from a resolved path that
+ * lives under `node_modules`, or `null` when the path is not under
+ * `node_modules`.
+ *
+ * Uses the LAST `node_modules` segment so nested deps and pnpm's
+ * `…/.pnpm/<pkg>@<v>/node_modules/<pkg>/…` layout both resolve to the real
+ * package name.
+ *
+ * This is the bridge that lets a resolved filesystem path be matched against
+ * the SAME `includeWorkletPackages` allowlist as an original import specifier
+ * (see {@link isWorkletPackage}): both checkpoints match a package specifier
+ * rather than mixing specifier and absolute-path inputs.
+ */
+export function packageNameFromNodeModulesPath(
+  resolvedPath: string,
+): string | null {
+  const norm = resolvedPath.replace(/\\/g, '/');
+  const marker = '/node_modules/';
+  const idx = norm.lastIndexOf(marker);
+  if (idx === -1) return null;
+  const segments = norm.slice(idx + marker.length).split('/');
+  const first = segments[0];
+  if (!first) return null;
+  if (first.startsWith('@')) {
+    const second = segments[1];
+    return second ? `${first}/${second}` : null;
+  }
+  return first;
+}
+
+/**
  * Match a bare-import specifier against a single allowlist pattern.
  *
  * Strings match exactly OR as a package-root prefix:
@@ -33,6 +64,12 @@ function specifierMatchesPattern(
 
 /**
  * Whether `specifier` is covered by the `includeWorkletPackages` allowlist.
+ *
+ * This is the single matching model used at BOTH worklet checkpoints: when
+ * following import specifiers ({@link extractLocalImports}) and when deciding
+ * the `node_modules` loader carve-out in the plugin. The latter feeds the
+ * package name derived via {@link packageNameFromNodeModulesPath}, so both
+ * checkpoints match a package specifier — never a raw filesystem path.
  *
  * @internal Exported for tests.
  */

--- a/packages/vue-lynx/plugin/src/loaders/worklet-utils.ts
+++ b/packages/vue-lynx/plugin/src/loaders/worklet-utils.ts
@@ -15,22 +15,19 @@ export function isUnderNodeModules(resolvedPath: string): boolean {
 }
 
 /**
- * Extract the package name (`name` or `@scope/name`) from a resolved path under
- * `node_modules`, or `null` when the path is not under `node_modules`. Lets a
- * resolved path be matched against the allowlist as a package specifier (see
- * {@link isWorkletPackage}).
+ * Reduce an import specifier to its package root: `@scope/name` or `name`,
+ * dropping any subpath. Returns `null` for input with no usable package
+ * segment (empty, or a bare `@scope` with no name).
  *
- * Uses the LAST `node_modules` segment so nested deps and pnpm's
- * `…/.pnpm/<pkg>@<v>/node_modules/<pkg>/…` layout both resolve correctly.
+ *   - `@my-org/foo/dist/x` → `@my-org/foo`
+ *   - `lodash/fp`          → `lodash`
+ *
+ * This is the canonical "package root" both worklet checkpoints reduce to
+ * before matching the allowlist, so a specifier and a resolved path always
+ * compare as the same input (see {@link isWorkletPackage}).
  */
-export function packageNameFromNodeModulesPath(
-  resolvedPath: string,
-): string | null {
-  const norm = resolvedPath.replace(/\\/g, '/');
-  const marker = '/node_modules/';
-  const idx = norm.lastIndexOf(marker);
-  if (idx === -1) return null;
-  const segments = norm.slice(idx + marker.length).split('/');
+export function packageRootFromSpecifier(specifier: string): string | null {
+  const segments = specifier.split('/');
   const first = segments[0];
   if (!first) return null;
   if (first.startsWith('@')) {
@@ -41,37 +38,55 @@ export function packageNameFromNodeModulesPath(
 }
 
 /**
- * Match a bare-import specifier against a single allowlist pattern.
+ * Extract the package root from a resolved path under `node_modules`, or `null`
+ * when the path is not under `node_modules`.
  *
- * Strings match exactly OR as a package-root prefix:
- *   - `@vue-lynx/motion-mini` matches `@vue-lynx/motion-mini` and
- *     `@vue-lynx/motion-mini/sub/path`, but NOT `@vue-lynx/motion-mini-x`.
- * RegExp patterns are tested against the full specifier.
+ * Uses the LAST `node_modules` segment so nested deps and pnpm's
+ * `…/.pnpm/<pkg>@<v>/node_modules/<pkg>/…` layout both resolve correctly, then
+ * reduces the remainder via {@link packageRootFromSpecifier}.
  */
-function specifierMatchesPattern(
-  specifier: string,
-  pattern: string | RegExp,
-): boolean {
-  if (pattern instanceof RegExp) return pattern.test(specifier);
-  if (specifier === pattern) return true;
-  return specifier.startsWith(pattern + '/');
+export function packageNameFromNodeModulesPath(
+  resolvedPath: string,
+): string | null {
+  const norm = resolvedPath.replace(/\\/g, '/');
+  const marker = '/node_modules/';
+  const idx = norm.lastIndexOf(marker);
+  if (idx === -1) return null;
+  return packageRootFromSpecifier(norm.slice(idx + marker.length));
 }
 
 /**
- * Whether `specifier` is covered by the `includeWorkletPackages` allowlist.
+ * Match a package root against a single allowlist pattern. Inputs are already
+ * reduced to a package root (see {@link packageRootFromSpecifier}), so:
+ *   - strings match exactly (`@org/motion` ≠ `@org/motion-x`), and
+ *   - RegExp patterns are tested against the root (`/^@org\//` matches
+ *     `@org/motion`).
+ */
+function matchesPattern(
+  packageRoot: string,
+  pattern: string | RegExp,
+): boolean {
+  return pattern instanceof RegExp
+    ? pattern.test(packageRoot)
+    : packageRoot === pattern;
+}
+
+/**
+ * Whether a package root is covered by the `includeWorkletPackages` allowlist.
  *
  * The single matcher used at both checkpoints — following import specifiers
  * ({@link extractLocalImports}) and the plugin's `node_modules` loader carve-out
- * — so both always match a package specifier, never a raw filesystem path.
+ * — both of which reduce their input to a package root first, so a specifier
+ * and a resolved path always compare as the same thing.
  *
  * @internal Exported for tests.
  */
 export function isWorkletPackage(
-  specifier: string,
+  packageRoot: string,
   allowlist: ReadonlyArray<string | RegExp>,
 ): boolean {
   for (const p of allowlist) {
-    if (specifierMatchesPattern(specifier, p)) return true;
+    if (matchesPattern(packageRoot, p)) return true;
   }
   return false;
 }
@@ -229,7 +244,11 @@ export async function extractLocalImports(
       kept.push(spec);
       continue;
     }
-    if (isWorkletPackage(spec, includeWorkletPackages)) kept.push(spec);
+    // Match the allowlist against the package ROOT (same input the plugin's
+    // loader carve-out derives from the resolved path), so a specifier and a
+    // path always compare as the same thing.
+    const root = packageRootFromSpecifier(spec);
+    if (root && isWorkletPackage(root, includeWorkletPackages)) kept.push(spec);
   }
 
   if (kept.length === 0) return '';

--- a/packages/vue-lynx/plugin/src/loaders/worklet-utils.ts
+++ b/packages/vue-lynx/plugin/src/loaders/worklet-utils.ts
@@ -67,7 +67,7 @@ function matchesPattern(
   pattern: string | RegExp,
 ): boolean {
   return pattern instanceof RegExp
-    ? pattern.test(packageRoot)
+    ? new RegExp(pattern.source, pattern.flags).test(packageRoot)
     : packageRoot === pattern;
 }
 


### PR DESCRIPTION
Fixes #191.

## Summary

MT worklets imported through aliases, tsconfig paths, or package specifiers were dropped from the main-thread graph, so their registrations never ran.

- Makes `worklet-loader-mt` async and resolves non-relative imports with `this.getResolve(...)`.
- Follows project/aliased source outside `node_modules` and re-emits the original specifier for bundler resolution.
- Adds opt-in `includeWorkletPackages` (string or `RegExp`) for packages that intentionally ship MT worklets.
- Keeps relative imports and shared/runtime/vue sub-module skips unchanged.

## Allowlist matching (addresses review)

Both decision points now reduce their input to a package root before matching, so a specifier and a resolved path always compare as the same thing.

- `packageRootFromSpecifier` reduces an import specifier (`@org/foo/dist/x` → `@org/foo`).
- `packageNameFromNodeModulesPath` reduces a resolved path (`…/node_modules/@org/foo/dist/index.js` → `@org/foo`), using the last `node_modules` segment so nested deps and pnpm layouts resolve.
- Both feed the single `isWorkletPackage` matcher, so `/^@org\//` matches at the follow checkpoint AND the loader carve-out — no more silent misses for `RegExp` users.

## Safety

- Unresolvable specifiers are skipped instead of failing the build.
- Imports inside comments and string/template literals are masked before extraction, so doc examples and code-building worklets aren't followed as real edges.
- Backward compatible: this only adds followed graph edges.

## Verification

- `worklet-loader-imports.test.ts`: 46 tests, including a path-vs-specifier RegExp parity test and end-to-end RegExp/subpath cases through the real loader.
- Full testing-library suite green in CI; plugin build passes; Biome clean.
