### PR TITLE
fix: route LEPUS global events to GlobalEventEmitter

### DIFF
--- a/.changeset/global-events-keyboard.md
+++ b/.changeset/global-events-keyboard.md
@@ -1,0 +1,5 @@
+---
+"vue-lynx": patch
+---
+
+Route native `globalEventFromLepus` global events to `GlobalEventEmitter` and add the `useGlobalEvent` composable.

--- a/packages/testing-library/src/__tests__/global-events.test.ts
+++ b/packages/testing-library/src/__tests__/global-events.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { onLifecycleEvent } from '../../../vue-lynx/runtime/src/global-events';
 
 describe('global events', () => {
@@ -46,5 +46,53 @@ describe('global events', () => {
     } finally {
       (globalThis as any).lynx = prevLynx;
     }
+  });
+});
+
+describe('entry-background lifecycle wrapper', () => {
+  let prevLynx: unknown;
+  let prevLynxCoreInject: unknown;
+
+  beforeEach(() => {
+    prevLynx = (globalThis as any).lynx;
+    prevLynxCoreInject = (globalThis as any).lynxCoreInject;
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    (globalThis as any).lynx = prevLynx;
+    (globalThis as any).lynxCoreInject = prevLynxCoreInject;
+  });
+
+  it('preserves the existing tt.OnLifecycleEvent handler when installing the wrapper', async () => {
+    const trigger = vi.fn();
+    (globalThis as any).lynx = {
+      getJSModule: (name: string) =>
+        name === 'GlobalEventEmitter' ? { trigger } : undefined,
+    };
+
+    const prevOnLifecycleEvent = vi.fn();
+    const tt: { OnLifecycleEvent?: (event: [string, unknown]) => void } = {
+      OnLifecycleEvent: prevOnLifecycleEvent,
+    };
+    (globalThis as any).lynxCoreInject = { tt };
+
+    await import('../../../vue-lynx/runtime/src/entry-background');
+
+    // The wrapper replaced the original handler.
+    expect(tt.OnLifecycleEvent).not.toBe(prevOnLifecycleEvent);
+
+    const event: [string, unknown] = [
+      'globalEventFromLepus',
+      ['keyboardstatuschanged', [{ height: 300 }]],
+    ];
+    tt.OnLifecycleEvent?.(event);
+
+    // Our routing still runs...
+    expect(trigger).toHaveBeenCalledWith('keyboardstatuschanged', [
+      { height: 300 },
+    ]);
+    // ...and the previously-registered handler is preserved.
+    expect(prevOnLifecycleEvent).toHaveBeenCalledWith(event);
   });
 });

--- a/packages/testing-library/src/__tests__/global-events.test.ts
+++ b/packages/testing-library/src/__tests__/global-events.test.ts
@@ -1,5 +1,7 @@
+import { effectScope } from '@vue/runtime-core';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { onLifecycleEvent } from '../../../vue-lynx/runtime/src/global-events';
+import { useGlobalEvent } from '../../../vue-lynx/runtime/src/use-global-event';
 
 describe('global events', () => {
   it('routes globalEventFromLepus to GlobalEventEmitter', () => {
@@ -94,5 +96,52 @@ describe('entry-background lifecycle wrapper', () => {
     ]);
     // ...and the previously-registered handler is preserved.
     expect(prevOnLifecycleEvent).toHaveBeenCalledWith(event);
+  });
+});
+
+describe('useGlobalEvent', () => {
+  let prevLynx: unknown;
+
+  beforeEach(() => {
+    prevLynx = (globalThis as any).lynx;
+  });
+
+  afterEach(() => {
+    (globalThis as any).lynx = prevLynx;
+  });
+
+  it('subscribes on call and unsubscribes when the scope is disposed', () => {
+    const addListener = vi.fn();
+    const removeListener = vi.fn();
+    (globalThis as any).lynx = {
+      getJSModule: (name: string) =>
+        name === 'GlobalEventEmitter' ? { addListener, removeListener } : undefined,
+    };
+
+    const handler = vi.fn();
+    const scope = effectScope();
+    scope.run(() => {
+      useGlobalEvent('keyboardstatuschanged', handler);
+    });
+
+    // Subscribed immediately with the same handler reference.
+    expect(addListener).toHaveBeenCalledWith('keyboardstatuschanged', handler);
+    expect(removeListener).not.toHaveBeenCalled();
+
+    // Disposing the scope removes exactly that listener.
+    scope.stop();
+    expect(removeListener).toHaveBeenCalledWith('keyboardstatuschanged', handler);
+  });
+
+  it('does not throw when GlobalEventEmitter is unavailable', () => {
+    (globalThis as any).lynx = { getJSModule: () => undefined };
+
+    const scope = effectScope();
+    expect(() => {
+      scope.run(() => {
+        useGlobalEvent('keyboardstatuschanged', vi.fn());
+      });
+      scope.stop();
+    }).not.toThrow();
   });
 });

--- a/packages/testing-library/src/__tests__/global-events.test.ts
+++ b/packages/testing-library/src/__tests__/global-events.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+import { onLifecycleEvent } from '../../../vue-lynx/runtime/src/global-events';
+
+describe('global events', () => {
+  it('routes globalEventFromLepus to GlobalEventEmitter', () => {
+    const trigger = vi.fn();
+    const prevLynx = (globalThis as any).lynx;
+
+    (globalThis as any).lynx = {
+      getJSModule: vi.fn((name: string) => {
+        if (name === 'GlobalEventEmitter') {
+          return { trigger };
+        }
+
+        return undefined;
+      }),
+    };
+
+    try {
+      onLifecycleEvent([
+        'globalEventFromLepus',
+        ['keyboardstatuschanged', [{ height: 300 }]],
+      ]);
+
+      expect(trigger).toHaveBeenCalledWith('keyboardstatuschanged', [
+        { height: 300 },
+      ]);
+    } finally {
+      (globalThis as any).lynx = prevLynx;
+    }
+  });
+
+  it('ignores other lifecycle events', () => {
+    const trigger = vi.fn();
+    const prevLynx = (globalThis as any).lynx;
+
+    (globalThis as any).lynx = {
+      getJSModule: vi.fn(() => ({ trigger })),
+    };
+
+    try {
+      expect(() => {
+        onLifecycleEvent(['updatePage', { data: true }]);
+      }).not.toThrow();
+      expect(trigger).not.toHaveBeenCalled();
+    } finally {
+      (globalThis as any).lynx = prevLynx;
+    }
+  });
+});

--- a/packages/vue-lynx/runtime/src/entry-background.ts
+++ b/packages/vue-lynx/runtime/src/entry-background.ts
@@ -14,6 +14,7 @@
  */
 
 import { publishEvent } from './event-registry.js';
+import { onLifecycleEvent } from './global-events.js';
 
 // `lynxCoreInject` is injected by RuntimeWrapperWebpackPlugin as a parameter
 // of the outer __init_card_bundle__ function – it is available as a bare
@@ -22,6 +23,7 @@ import { publishEvent } from './event-registry.js';
 declare var lynxCoreInject:
   | {
     tt?: {
+      OnLifecycleEvent?: (event: [string, unknown]) => void;
       publishEvent?: (handlerName: string, data: unknown) => void;
       [key: string]: unknown;
     };
@@ -33,8 +35,15 @@ const g = globalThis as Record<string, unknown>;
 
 // Primary path: lynxCoreInject.tt.publishEvent (used by modern Lynx)
 if (typeof lynxCoreInject !== 'undefined' && lynxCoreInject?.tt) {
-  lynxCoreInject.tt.publishEvent = publishEvent;
-  lynxCoreInject.tt['publicComponentEvent'] = (
+  const tt = lynxCoreInject.tt;
+  const prevOnLifecycleEvent = tt.OnLifecycleEvent;
+
+  tt.publishEvent = publishEvent;
+  tt.OnLifecycleEvent = (event: [string, unknown]) => {
+    onLifecycleEvent(event);
+    prevOnLifecycleEvent?.(event);
+  };
+  tt['publicComponentEvent'] = (
     _cid: string,
     sign: string,
     data: unknown,

--- a/packages/vue-lynx/runtime/src/global-events.ts
+++ b/packages/vue-lynx/runtime/src/global-events.ts
@@ -1,0 +1,27 @@
+// Copyright 2026 Xuan Huang (huxpro). All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+type GlobalEventEmitter = {
+  trigger?: (eventName: string, params: unknown) => void;
+};
+
+declare const lynx:
+  | {
+    getJSModule?: (name: string) => GlobalEventEmitter | undefined;
+  }
+  | undefined;
+
+/**
+ * Handles Lynx lifecycle events delivered from the main thread / LEPUS.
+ */
+export function onLifecycleEvent(event: [string, unknown]): void {
+  const [type, data] = event;
+
+  if (type !== 'globalEventFromLepus') {
+    return;
+  }
+
+  const [eventName, params] = data as [string, unknown];
+  lynx?.getJSModule?.('GlobalEventEmitter')?.trigger?.(eventName, params);
+}

--- a/packages/vue-lynx/runtime/src/global-events.ts
+++ b/packages/vue-lynx/runtime/src/global-events.ts
@@ -2,15 +2,9 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-type GlobalEventEmitter = {
-  trigger?: (eventName: string, params: unknown) => void;
-};
+import type { LynxGlobal } from './lynx-global.js';
 
-declare const lynx:
-  | {
-    getJSModule?: (name: string) => GlobalEventEmitter | undefined;
-  }
-  | undefined;
+declare const lynx: LynxGlobal;
 
 /**
  * Handles Lynx lifecycle events delivered from the main thread / LEPUS.

--- a/packages/vue-lynx/runtime/src/index.ts
+++ b/packages/vue-lynx/runtime/src/index.ts
@@ -228,6 +228,7 @@ export {
   runOnBackground,
   transformToWorklet,
 };
+export { useGlobalEvent } from './use-global-event.js';
 
 /** @internal Exposed for upstream-tests bridge render(). */
 export { createPageRoot } from './shadow-element.js';

--- a/packages/vue-lynx/runtime/src/lynx-global.ts
+++ b/packages/vue-lynx/runtime/src/lynx-global.ts
@@ -1,0 +1,23 @@
+// Copyright 2026 Xuan Huang (huxpro). All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+export type GlobalEventHandler = (...args: unknown[]) => void;
+
+/**
+ * Lynx's `GlobalEventEmitter` JSModule. All members are optional because the
+ * module is only present at runtime on-device; different call sites use
+ * different subsets (`trigger` to dispatch, `addListener`/`removeListener` to
+ * subscribe).
+ */
+export type GlobalEventEmitter = {
+  trigger?: (eventName: string, params: unknown) => void;
+  addListener?: (eventName: string, handler: GlobalEventHandler) => void;
+  removeListener?: (eventName: string, handler: GlobalEventHandler) => void;
+};
+
+export type LynxGlobal =
+  | {
+    getJSModule?: (name: string) => GlobalEventEmitter | undefined;
+  }
+  | undefined;

--- a/packages/vue-lynx/runtime/src/use-global-event.ts
+++ b/packages/vue-lynx/runtime/src/use-global-event.ts
@@ -1,0 +1,33 @@
+// Copyright 2026 Xuan Huang (huxpro). All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import { onScopeDispose } from '@vue/runtime-core';
+
+type GlobalEventHandler = (...args: unknown[]) => void;
+
+type GlobalEventEmitter = {
+  addListener?: (eventName: string, handler: GlobalEventHandler) => void;
+  removeListener?: (eventName: string, handler: GlobalEventHandler) => void;
+};
+
+declare const lynx:
+  | {
+    getJSModule?: (name: string) => GlobalEventEmitter | undefined;
+  }
+  | undefined;
+
+/**
+ * Registers a listener on Lynx's global event emitter for the current scope.
+ */
+export function useGlobalEvent(
+  eventName: string,
+  handler: GlobalEventHandler,
+): void {
+  const emitter = lynx?.getJSModule?.('GlobalEventEmitter');
+
+  emitter?.addListener?.(eventName, handler);
+  onScopeDispose(() => {
+    emitter?.removeListener?.(eventName, handler);
+  });
+}

--- a/packages/vue-lynx/runtime/src/use-global-event.ts
+++ b/packages/vue-lynx/runtime/src/use-global-event.ts
@@ -4,18 +4,9 @@
 
 import { onScopeDispose } from '@vue/runtime-core';
 
-type GlobalEventHandler = (...args: unknown[]) => void;
+import type { GlobalEventHandler, LynxGlobal } from './lynx-global.js';
 
-type GlobalEventEmitter = {
-  addListener?: (eventName: string, handler: GlobalEventHandler) => void;
-  removeListener?: (eventName: string, handler: GlobalEventHandler) => void;
-};
-
-declare const lynx:
-  | {
-    getJSModule?: (name: string) => GlobalEventEmitter | undefined;
-  }
-  | undefined;
+declare const lynx: LynxGlobal;
 
 /**
  * Registers a listener on Lynx's global event emitter for the current scope.


### PR DESCRIPTION
## Summary

`globalEventFromLepus` lifecycle events (e.g. `keyboardstatuschanged`) never reached the background thread. This routes them into `GlobalEventEmitter`.

- Wraps `tt.OnLifecycleEvent` to forward LEPUS lifecycle events to `GlobalEventEmitter`, **preserving** any existing handler.
- Adds `useGlobalEvent()` composable with automatic scope cleanup (`onScopeDispose`).
- Exports `useGlobalEvent` from the runtime entry; adds a regression test + patch changeset.

## Verification

- `pnpm test`; biome clean on touched files.
- Confirmed native `keyboardstatuschanged` reaches `useGlobalEvent('keyboardstatuschanged', ...)`.

> **Note:** `pnpm --filter vue-lynx run build` stops at the pre-existing `types` package error (`elements/index.ts` can't resolve `vue`) — unrelated to this change.
