### PR TITLE
chore: gitignore generated .rslib build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+.rslib/
 *.tsbuildinfo
 .rspeedy/
 packages/upstream-tests/core/


### PR DESCRIPTION
## Summary

Ignores `.rslib/`, which is generated during package builds and should not be linted or committed.

- Mirrors the existing `dist/` ignore behaviour.
- Lets `biome check .` skip generated declaration intermediates via `vcs.useIgnoreFile: true`.
- No source changes.

## Verification

- CI green except the repo-side Vercel authorization status.
