### PR TITLE
feat: add Vue Lynx talk deck

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
-        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+        version: 1.2.7(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.8(@swc/helpers@0.5.19))
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -45,7 +45,7 @@ importers:
         version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
-        version: 1.2.7(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -606,6 +606,19 @@ importers:
         specifier: ^5.0.0
         version: 5.9.3
 
+  slides:
+    dependencies:
+      '@lynx-js/web-core':
+        specifier: ^0.20.0
+        version: 0.20.2(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1)
+      '@lynx-js/web-elements':
+        specifier: ^0.12.0
+        version: 0.12.0(tslib@2.8.1)
+    devDependencies:
+      vite:
+        specifier: ^5.4.10
+        version: 5.4.21(@types/node@25.5.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)
+
   website:
     dependencies:
       '@douyinfe/semi-icons':
@@ -981,16 +994,34 @@ packages:
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
 
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.27.3':
     resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.3':
     resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.3':
@@ -999,16 +1030,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.3':
     resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.3':
     resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.3':
@@ -1017,10 +1066,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.3':
     resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.3':
@@ -1029,10 +1090,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.3':
     resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.3':
@@ -1041,10 +1114,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.3':
     resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.3':
@@ -1053,10 +1138,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.3':
     resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.3':
@@ -1065,16 +1162,34 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.3':
     resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.27.3':
     resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.27.3':
@@ -1089,6 +1204,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.27.3':
     resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
     engines: {node: '>=18'}
@@ -1099,6 +1220,12 @@ packages:
     resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.3':
@@ -1113,11 +1240,23 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.27.3':
     resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.27.3':
     resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
@@ -1125,10 +1264,22 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.3':
     resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.3':
@@ -3246,6 +3397,11 @@ packages:
 
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
@@ -5671,6 +5827,37 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6309,52 +6496,103 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.27.3':
     optional: true
 
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
   '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.27.3':
     optional: true
 
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
   '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.27.3':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.3':
     optional: true
 
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
   '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.27.3':
     optional: true
 
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
   '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.27.3':
     optional: true
 
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
   '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.3':
     optional: true
 
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
   '@esbuild/linux-riscv64@0.27.3':
     optional: true
 
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.27.3':
@@ -6363,10 +6601,16 @@ snapshots:
   '@esbuild/netbsd-arm64@0.27.3':
     optional: true
 
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/netbsd-x64@0.27.3':
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.3':
@@ -6375,13 +6619,25 @@ snapshots:
   '@esbuild/openharmony-arm64@0.27.3':
     optional: true
 
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
   '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.27.3':
     optional: true
 
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.27.3':
@@ -8815,6 +9071,32 @@ snapshots:
       acorn: 8.16.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.27.3:
     optionalDependencies:
@@ -11722,16 +12004,15 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@3.2.4(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
+  vite-node@3.2.4(@types/node@25.5.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 5.4.21(@types/node@25.5.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)
     transitivePeerDependencies:
       - '@types/node'
-      - jiti
       - less
       - lightningcss
       - sass
@@ -11740,8 +12021,18 @@ snapshots:
       - sugarss
       - supports-color
       - terser
-      - tsx
-      - yaml
+
+  vite@5.4.21(@types/node@25.5.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.8
+      rollup: 4.59.0
+    optionalDependencies:
+      '@types/node': 25.5.0
+      fsevents: 2.3.3
+      sass: 1.98.0
+      sass-embedded: 1.98.0
+      terser: 5.46.0
 
   vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
@@ -11784,7 +12075,7 @@ snapshots:
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-      vite-node: 3.2.4(@types/node@25.5.0)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite-node: 3.2.4(@types/node@25.5.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,4 +2,4 @@ packages:
   - packages/*
   - examples/*
   - website
-
+  - slides

--- a/slides/README.md
+++ b/slides/README.md
@@ -1,0 +1,81 @@
+# Vue Lynx — Talk Deck
+
+HTML slide deck for the Vue Lynx talk. Live `<lynx-view>` embeds render
+real Vue Lynx apps inline; design language mirrors `vue.lynxjs.org`.
+
+## Run
+
+```bash
+cd slides
+pnpm install
+pnpm dev
+# open http://localhost:4321
+```
+
+Vite serves example bundles via a symlink to `../website/docs/public/examples`.
+Run `cd ../website && pnpm prepare:docs` once if those bundles are missing.
+
+## Navigation
+
+| Key                       | Action                  |
+| ------------------------- | ----------------------- |
+| `→` `↓` `Space` `PageDown`| Next slide              |
+| `←` `↑` `PageUp`          | Previous slide          |
+| `Home`                    | First slide             |
+| `End`                     | Last slide              |
+| `f`                       | Toggle fullscreen       |
+| `o`                       | Toggle overview grid    |
+| `1`..`9`                  | Jump to slide N         |
+| `.`                       | Toggle dark mode        |
+| **`s`**                   | **Open speaker view**   |
+| `b`                       | Blackout audience screen|
+
+URL hash reflects the current slide (e.g. `#7`), so you can deep-link.
+
+## Speaker view (`s`)
+
+Press `s` on the main deck and a popup window opens at `/speaker.html`. It
+shows:
+
+- The **current slide** rendered live (left)
+- The **next slide** preview (right top)
+- **Speaker notes** for the current slide (right bottom)
+- An **elapsed talk timer** (auto-starts, with `Pause` / `Reset`)
+- **Wall-clock time** beside it
+
+The two windows sync via `BroadcastChannel('vue-lynx-deck')` — navigate in
+either window, both move. Arrow keys + `b` (blackout) + `.` (dark mode)
+work from the speaker view too.
+
+### Recommended setup
+
+1. Drag the main deck window onto the external display, press `f` to
+   fullscreen it.
+2. Press `s` — the speaker popup opens on the laptop screen.
+3. Drag it to your preferred position (it auto-sizes to ~85% of screen).
+4. Drive the talk from either side; the audience only ever sees the deck.
+
+### URL flags
+
+- `/?embed=1#3` — embed mode: strips chrome, jumps to slide 3, forbids
+  internal navigation. Used internally by the speaker iframes.
+
+## Writing speaker notes
+
+Add an `<aside class="notes">…</aside>` inside any `<section class="slide">`.
+HTML is allowed; the notes are automatically hidden in the audience view and
+piped to the speaker view through the BroadcastChannel.
+
+## Embedded demos
+
+`<vl-demo bundle="todomvc/dist/main.web.bundle">` mounts a real Vue Lynx
+app via `@lynx-js/web-core/client`. Each embed lazy-loads the runtime on
+first reveal so the opening slides stay snappy.
+
+## Files
+
+- `index.html` — every slide as a `<section>` (no framework)
+- `src/main.js` — slide navigation, `<vl-demo>` lazy loader
+- `src/styles.css` — design tokens + slide chrome
+- `src/meteors.js` — canvas meteors background, same recipe as the site
+- `public/examples` — symlink to the website's prebuilt example bundles

--- a/slides/index.html
+++ b/slides/index.html
@@ -1,0 +1,738 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <title>Vue Lynx — Unlock Native for Vue</title>
+  <meta name="theme-color" content="#42b883" />
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+</head>
+<body>
+
+<div class="deck">
+
+  <canvas class="meteors" aria-hidden="true"></canvas>
+
+  <!-- Chrome -->
+  <div class="chrome chrome--top">
+    <span class="chrome__dot"></span>
+    <span>Vue Lynx · pre-alpha</span>
+  </div>
+  <div class="chrome chrome--top-right">
+    <button class="dark-toggle" aria-label="Toggle dark mode" title="Press . to toggle">
+      theme · .
+    </button>
+  </div>
+  <div class="chrome chrome--bottom">
+    <span data-counter>01 / 17</span>
+  </div>
+  <div class="chrome chrome--bottom-right">
+    <a href="https://vue.lynxjs.org" target="_blank" rel="noreferrer">vue.lynxjs.org</a>
+  </div>
+
+  <div class="progress"><div class="progress__bar"></div></div>
+
+  <!-- ====================================================
+       Slide 1 — Cover
+       ==================================================== -->
+  <section class="slide cover">
+    <div class="cover__top">
+      <span class="badge">
+        <span class="badge__dot"></span>
+        Pre-Alpha · How I Vibed This in 2 Weeks
+      </span>
+      <div class="cover__title">
+        <div class="cover__title-line">
+          <span class="verb brand-text" data-cover-verb>Unlock</span>
+        </div>
+        <div class="cover__title-line">
+          <span class="pre">Native for </span><span class="brand-text">Vue</span>
+        </div>
+      </div>
+      <p class="cover__tagline">
+        Develop Lynx with the familiar Vue 3.
+      </p>
+    </div>
+    <div class="cover__bottom">
+      <span>vue-lynx · talk · 2026</span>
+      <div class="stack">
+        <span>Xuan "Huxpro" Huang</span>
+        <span>Lynx, ByteDance</span>
+      </div>
+    </div>
+    <aside class="notes">
+      <p><strong>Open:</strong> Vue Lynx — a Vue 3 framework for shipping native apps.</p>
+      <p>Pre-alpha. Built solo in two weeks. Today: show what's there, tell the story briefly, then talk about why Lynx is the platform that made this possible.</p>
+      <p><em>Press <kbd>s</kbd> any time to flip to / from this speaker view.</em></p>
+    </aside>
+  </section>
+
+  <!-- ====================================================
+       Slide 2 — Pitch (three pillars)
+       ==================================================== -->
+  <section class="slide pitch">
+    <div class="pitch__head">
+      <span class="eyebrow">I · The Pitch</span>
+      <h2 class="h-section">
+        Apps <em style="font-family:var(--serif);font-weight:400">upgrading</em>
+        from web to native.
+      </h2>
+      <p class="lead">
+        Same Vue codebase. Real native UI. Three things shift the moment you
+        cross the bridge.
+      </p>
+    </div>
+    <div class="pillars">
+      <div class="pillar">
+        <span class="pillar__num">i.</span>
+        <h3 class="pillar__title">Speed</h3>
+        <p class="pillar__copy">
+          Native rendering, native layout, native scrolling. No DOM, no
+          reflow tax. Cold start measured in milliseconds, not seconds.
+        </p>
+      </div>
+      <div class="pillar">
+        <span class="pillar__num">ii.</span>
+        <h3 class="pillar__title">Experience</h3>
+        <p class="pillar__copy">
+          Silky 60fps gestures via Main-Thread Script. Native list
+          virtualization. Inputs and keyboard that feel like the OS, because
+          they <em>are</em> the OS.
+        </p>
+      </div>
+      <div class="pillar">
+        <span class="pillar__num">iii.</span>
+        <h3 class="pillar__title">Capabilities</h3>
+        <p class="pillar__copy">
+          Camera, sensors, deep links, native modals. Anything the platform
+          exposes is one element away &mdash; without leaving your
+          <code>&lt;template&gt;</code>.
+        </p>
+      </div>
+    </div>
+    <aside class="notes">
+      <p><strong>Frame:</strong> Vue Lynx isn't a port — it's a category shift. Same codebase, three things change once you cross the bridge.</p>
+      <ul>
+        <li><strong>Speed</strong> — native rendering, no DOM tax</li>
+        <li><strong>Experience</strong> — gestures and scroll at 60fps via main-thread script</li>
+        <li><strong>Capabilities</strong> — every native API the platform exposes</li>
+      </ul>
+      <p>Don't dwell — these become the three demo slides next. Just plant the structure.</p>
+    </aside>
+  </section>
+
+  <!-- ====================================================
+       Slide 3 — Speed (TodoMVC live demo)
+       ==================================================== -->
+  <section class="slide demo">
+    <div class="demo__body">
+      <span class="eyebrow">i · Speed</span>
+      <h2 class="demo__title">
+        The classic <span class="brand-text">TodoMVC</span>, redrawn natively.
+      </h2>
+      <p class="demo__copy">
+        Same Composition API you'd write for the web &mdash; reactive state,
+        <code>v-model</code>, computed totals. The runtime ships Vue's
+        reactivity to the background thread, and Lynx paints natively on
+        the main one. Tap latency stays under one frame.
+      </p>
+      <div class="demo__meta">
+        <span class="chip chip--brand">Composition API</span>
+        <span class="chip">v-model</span>
+        <span class="chip">native &lt;input&gt;</span>
+        <span class="chip">scroll-view</span>
+      </div>
+    </div>
+    <div class="demo__stage">
+      <div class="phone">
+        <div class="phone__inner">
+          <vl-demo bundle="todomvc/dist/main.web.bundle"></vl-demo>
+        </div>
+      </div>
+    </div>
+    <aside class="notes">
+      <p><strong>Speed.</strong> This is TodoMVC. Same Composition API, same <code>v-model</code>, same computed totals you'd write for the web.</p>
+      <p>What's different: the input is a <em>native</em> input. The scroll is a <em>native</em> scroll-view. There's no DOM, no reflow tax, no virtual-list polyfill. Cold start is measured in <em>milliseconds</em>.</p>
+      <p><strong>Do live:</strong> tap a few todos, mark them complete. Show the input field — single-frame latency.</p>
+    </aside>
+  </section>
+
+  <!-- ====================================================
+       Slide 4 — Experience: Waterfall Gallery
+       ==================================================== -->
+  <section class="slide demo demo--reverse">
+    <div class="demo__stage">
+      <div class="phone">
+        <div class="phone__inner">
+          <vl-demo bundle="gallery/dist/GalleryComplete.web.bundle"></vl-demo>
+        </div>
+      </div>
+    </div>
+    <div class="demo__body">
+      <span class="eyebrow">ii · Experience</span>
+      <h2 class="demo__title">
+        A two-column <span class="brand-text">waterfall</span> that scrolls
+        like the OS does.
+      </h2>
+      <p class="demo__copy">
+        Backed by the native <code>&lt;list&gt;</code> element &mdash; not a
+        virtual one. Cells recycle, images stream, the scroll thread never
+        waits on JavaScript. The custom scrollbar is driven by a Main-Thread
+        Script that bypasses BG entirely.
+      </p>
+      <div class="demo__meta">
+        <span class="chip chip--brand">native &lt;list&gt;</span>
+        <span class="chip">MTS scrollbar</span>
+        <span class="chip">image streaming</span>
+      </div>
+    </div>
+    <aside class="notes">
+      <p><strong>Experience, part one.</strong> A two-column waterfall, scrolling like the OS does it — because it <em>is</em> the OS scrolling.</p>
+      <p>Backed by the real native <code>&lt;list&gt;</code> element. Cells recycle, images stream, the scroll thread <strong>never</strong> blocks on JavaScript.</p>
+      <p>The custom scrollbar on the side is a Main-Thread Script — runs synchronously with the scroll, bypassing the background thread.</p>
+      <p><strong>Do live:</strong> drag-scroll fast. Show the scrollbar following without lag.</p>
+    </aside>
+  </section>
+
+  <!-- ====================================================
+       Slide 5 — Experience: Swiper + MTS
+       ==================================================== -->
+  <section class="slide demo">
+    <div class="demo__body">
+      <span class="eyebrow">ii · Experience</span>
+      <h2 class="demo__title">
+        Touch handlers on the <span class="brand-text">UI thread</span>.
+      </h2>
+      <p class="demo__copy">
+        A carousel that follows your finger pixel-for-pixel, indicator
+        snapping in real time. Drag events run synchronously on Lynx's
+        main thread via Main-Thread Script &mdash; never round-tripping
+        through Vue's reactivity tick.
+      </p>
+      <div class="demo__meta">
+        <span class="chip chip--brand">Main-Thread Script</span>
+        <span class="chip">runOnBackground</span>
+        <span class="chip">no JS bridge</span>
+      </div>
+      <p class="kicker" style="margin-top:8px">
+        Zero-latency gestures without leaving Vue.
+      </p>
+    </div>
+    <div class="demo__stage">
+      <div class="phone">
+        <div class="phone__inner">
+          <vl-demo bundle="swiper/dist/Swiper.web.bundle"></vl-demo>
+        </div>
+      </div>
+    </div>
+    <aside class="notes">
+      <p><strong>Experience, part two.</strong> A carousel where the swipe handler runs on the <strong>UI thread</strong>, not Vue's reactivity tick.</p>
+      <p>This is <em>Main-Thread Script</em> — handlers compiled out of Vue code and registered on the native side. Drag the card: it follows your finger pixel-for-pixel. Indicator updates synchronously.</p>
+      <p>Same API surface as ReactLynx's MTS. We borrowed the directive shape; a more Vue-idiomatic <code>&lt;script main-thread setup&gt;</code> is open work.</p>
+      <p><strong>Do live:</strong> drag slowly to show the indicator tracking. Then flick to show snap.</p>
+    </aside>
+  </section>
+
+  <!-- ====================================================
+       Slide 6 — Capabilities (Transition demo)
+       ==================================================== -->
+  <section class="slide demo demo--reverse">
+    <div class="demo__stage">
+      <div class="phone">
+        <div class="phone__inner">
+          <vl-demo bundle="transition/dist/transition.web.bundle"></vl-demo>
+        </div>
+      </div>
+    </div>
+    <div class="demo__body">
+      <span class="eyebrow">iii · Capabilities</span>
+      <h2 class="demo__title">
+        Every Vue primitive you know &mdash;
+        <span class="brand-text">on native.</span>
+      </h2>
+      <p class="demo__copy">
+        Composition API, SFCs, slots, provide/inject. Suspense for async
+        components. Transition and TransitionGroup powered by CSS animations
+        on the native compositor. Pinia, Vue Router, TanStack Query, Tailwind.
+      </p>
+      <div class="demo__meta">
+        <span class="chip chip--brand">&lt;Transition&gt;</span>
+        <span class="chip">&lt;Suspense&gt;</span>
+        <span class="chip">Pinia</span>
+        <span class="chip">Vue Router</span>
+        <span class="chip">Tailwind</span>
+        <span class="chip">Vue Query</span>
+      </div>
+    </div>
+    <aside class="notes">
+      <p><strong>Capabilities.</strong> This is the part that makes Vue developers double-take.</p>
+      <p>The Vue you already know — <em>all of it</em> — runs here. Composition API. SFCs. Slots. provide/inject. Suspense for async components. <code>&lt;Transition&gt;</code> and <code>&lt;TransitionGroup&gt;</code>, powered by CSS animations on the native compositor.</p>
+      <p>And the ecosystem comes with: Pinia, Vue Router, TanStack Query, Tailwind. The demo on the phone is the Transition primitive, animating natively.</p>
+    </aside>
+  </section>
+
+  <!-- ====================================================
+       Slide 7 — Showcase strip
+       ==================================================== -->
+  <section class="slide gallery">
+    <div class="gallery__head">
+      <div class="stack-y gap-md">
+        <span class="eyebrow">The Gallery</span>
+        <h2 class="h-section">
+          One renderer, <span class="brand-text">an ecosystem</span> of apps.
+        </h2>
+      </div>
+      <p class="lead" style="max-width:36ch;text-align:right">
+        Twenty-plus example apps in the repo today &mdash; each one running
+        natively, each one tappable on the web.
+      </p>
+    </div>
+    <div class="gallery__strip">
+      <div class="gallery__item">
+        <div class="phone">
+          <div class="phone__inner">
+            <vl-demo bundle="hackernews-tailwind/dist/main.web.bundle"></vl-demo>
+          </div>
+        </div>
+        <div class="gallery__caption">
+          <b>HackerNews</b>real-world Vue + Router + Query
+        </div>
+      </div>
+      <div class="gallery__item">
+        <div class="phone">
+          <div class="phone__inner">
+            <vl-demo bundle="gallery/dist/GalleryAutoScroll.web.bundle"></vl-demo>
+          </div>
+        </div>
+        <div class="gallery__caption">
+          <b>Auto-scroll Gallery</b>continuous native list
+        </div>
+      </div>
+      <div class="gallery__item">
+        <div class="phone">
+          <div class="phone__inner">
+            <vl-demo bundle="swiper/dist/SwiperMTS.web.bundle"></vl-demo>
+          </div>
+        </div>
+        <div class="gallery__caption">
+          <b>MTS Swiper</b>UI-thread gestures
+        </div>
+      </div>
+      <div class="gallery__item">
+        <div class="phone">
+          <div class="phone__inner">
+            <vl-demo bundle="7guis/dist/circle-drawer.web.bundle"></vl-demo>
+          </div>
+        </div>
+        <div class="gallery__caption">
+          <b>7GUIs · Circle Drawer</b>undo, redo, dialogs
+        </div>
+      </div>
+    </div>
+    <aside class="notes">
+      <p><strong>Twenty-plus apps in the repo today.</strong> A real Vue HackerNews client (with Router and Query). Auto-scrolling native list. Main-thread-script swiper. 7GUIs benchmarks including the circle-drawer with undo/redo + dialogs.</p>
+      <p>Each one runs natively <em>and</em> in the browser via Lynx for Web — that's literally how this deck is embedding them right now. No iframe to localhost, no native sim — actual Vue Lynx, running.</p>
+      <p>This is a transition slide — move to the story once you've let them look.</p>
+    </aside>
+  </section>
+
+  <!-- ====================================================
+       Slide 8 — Divider: Story
+       ==================================================== -->
+  <section class="slide divider">
+    <span class="eyebrow">Chapter II</span>
+    <div class="divider__row">
+      <span class="divider__num numeral--brand">II</span>
+      <h2 class="divider__title">
+        The story of <br/>Vue Lynx.
+      </h2>
+    </div>
+    <p class="divider__tag">
+      Two weeks of nights and weekends. One person, one Max plan, one
+      stubborn architectural bet. The kind of project that wasn't supposed
+      to be possible by yourself.
+    </p>
+    <aside class="notes">
+      <p><strong>Pivot.</strong> Quick story slide — keep it tight, the deck spends most time on what's built, not how.</p>
+      <p>Setup line: "Briefly, how this got built — because the answer is short, and the technique generalizes."</p>
+    </aside>
+  </section>
+
+  <!-- ====================================================
+       Slide 9 — Story timeline + the bill
+       ==================================================== -->
+  <section class="slide story">
+    <div class="story__head">
+      <span class="eyebrow">3/01 &rarr; 3/23</span>
+      <h2 class="h-section">
+        160 commits. 21 active days. One repo.
+      </h2>
+      <p class="lead">
+        Vue's mature Custom Renderer API was the foundation. The
+        Lynx team's dual-thread architecture was the constraint. Claude
+        was the harness. Together &mdash; a working Vue runtime on native.
+      </p>
+    </div>
+
+    <div class="timeline">
+      <div class="tl-item">
+        <span class="tl-item__week">Weekend · 3/01&ndash;3/03</span>
+        <h3 class="tl-item__title">Dual-thread MVP</h3>
+        <p class="tl-item__copy">
+          Vue runtime on BG, ops buffer to Main, ShadowElement tree.
+          By Monday morning: TodoMVC working.
+        </p>
+      </div>
+      <div class="tl-item">
+        <span class="tl-item__week">Week 1 · 3/04&ndash;3/09</span>
+        <h3 class="tl-item__title">MTS &amp; demos</h3>
+        <p class="tl-item__copy">
+          Main-Thread Script, Gallery, Swiper. Cross-thread APIs:
+          <code>runOnBackground</code>, NodesRef, template refs.
+        </p>
+      </div>
+      <div class="tl-item">
+        <span class="tl-item__week">Week 2 · 3/10&ndash;3/16</span>
+        <h3 class="tl-item__title">Toolchain &amp; website</h3>
+        <p class="tl-item__copy">
+          Layer-based dual-bundle plugin. Independent repo. Rspress site +
+          publish pipeline. 9 example apps in a single 22h session.
+        </p>
+      </div>
+      <div class="tl-item">
+        <span class="tl-item__week">Final · 3/17&ndash;3/23</span>
+        <h3 class="tl-item__title">Polish &amp; HackerNews</h3>
+        <p class="tl-item__copy">
+          Transition, Vue Query, Tailwind. HackerNews port for
+          differential evaluation. Bilingual docs overnight by agent.
+        </p>
+      </div>
+    </div>
+
+    <div class="story__bill">
+      <div class="bill__cell">
+        <span class="label">commits</span>
+        <span class="value">160</span>
+      </div>
+      <div class="bill__cell">
+        <span class="label">human hours</span>
+        <span class="value">123<small>h</small></span>
+      </div>
+      <div class="bill__cell">
+        <span class="label">upstream tests pass</span>
+        <span class="value">852<small>/ 949</small></span>
+      </div>
+      <div class="bill__cell">
+        <span class="label">example apps</span>
+        <span class="value">20<small>+</small></span>
+      </div>
+    </div>
+    <aside class="notes">
+      <p><strong>Three foundations:</strong></p>
+      <ul>
+        <li><strong>Vue</strong> has a mature Custom Renderer API — that did the heavy lifting</li>
+        <li><strong>Lynx</strong> ships a dual-threaded architecture — that's what made the native-feel possible</li>
+        <li><strong>Agentic dev</strong> with Claude as the harness — that compressed the calendar</li>
+      </ul>
+      <p>Concrete signal: 852 of 949 upstream Vue tests pass. The skiplist is documented, every failure accounted for.</p>
+      <p>Don't dive into harness engineering — that's a different talk. Pivot: "the foundation underneath made this possible at all."</p>
+    </aside>
+  </section>
+
+  <!-- ====================================================
+       Slide 10 — Divider: Lynx Platform
+       ==================================================== -->
+  <section class="slide divider">
+    <span class="eyebrow">Chapter III</span>
+    <div class="divider__row">
+      <span class="divider__num numeral--brand">III</span>
+      <h2 class="divider__title">
+        The Lynx<br/>platform itself.
+      </h2>
+    </div>
+    <p class="divider__tag">
+      None of this would matter if the floor underneath wasn't built right.
+      Vue Lynx exists because Lynx is two things at once: web-friendly on
+      the surface, architecturally serious underneath.
+    </p>
+    <aside class="notes">
+      <p><strong>Setup for the Lynx pitch.</strong> Frame: "Vue Lynx is only as good as the platform it sits on. Let me tell you why Lynx is the platform."</p>
+      <p>Two-part argument coming up: web-friendly surface, performant core. Don't pre-empt.</p>
+    </aside>
+  </section>
+
+  <!-- ====================================================
+       Slide 11 — Web-friendly
+       ==================================================== -->
+  <section class="slide web">
+    <div class="web__body">
+      <span class="eyebrow">a · Web-friendly</span>
+      <h2 class="h-section">
+        The code you'd write <em style="font-family:var(--serif);font-weight:400">anyway</em>.
+      </h2>
+      <ul class="web__list">
+        <li><span><b>SFCs, templates, CSS.</b> The same .vue file. Class selectors and CSS variables that just work.</span></li>
+        <li><span><b>HTML-shaped tags.</b> <code>&lt;view&gt;</code>, <code>&lt;text&gt;</code>, <code>&lt;image&gt;</code>, <code>&lt;list&gt;</code> &mdash; the mental model is one swap away.</span></li>
+        <li><span><b>Renders on the web too.</b> Every example in the deck is running through Lynx for Web right now.</span></li>
+      </ul>
+    </div>
+
+    <div class="codeframe">
+      <div class="codeframe__head">
+        <span class="dots"><span></span><span></span><span></span></span>
+        <span>HelloWorld.vue</span>
+      </div>
+<pre><span class="code-tag">&lt;script setup&gt;</span>
+<span class="code-key">import</span> { ref, computed } <span class="code-key">from</span> <span class="code-str">'vue'</span>
+
+<span class="code-key">const</span> count <span class="code-key">=</span> <span class="code-fn">ref</span>(<span class="code-str">0</span>)
+<span class="code-key">const</span> doubled <span class="code-key">=</span> <span class="code-fn">computed</span>(() <span class="code-key">=&gt;</span> count.value <span class="code-key">*</span> <span class="code-str">2</span>)
+<span class="code-tag">&lt;/script&gt;</span>
+
+<span class="code-tag">&lt;template&gt;</span>
+  <span class="code-tag">&lt;view</span> <span class="code-attr">class</span>=<span class="code-str">"card"</span><span class="code-tag">&gt;</span>
+    <span class="code-tag">&lt;text</span> <span class="code-attr">class</span>=<span class="code-str">"title"</span><span class="code-tag">&gt;</span>Hello, Lynx<span class="code-tag">&lt;/text&gt;</span>
+    <span class="code-tag">&lt;text</span> <span class="code-attr">@tap</span>=<span class="code-str">"count++"</span><span class="code-tag">&gt;</span>
+      Tapped {{ count }} · doubled {{ doubled }}
+    <span class="code-tag">&lt;/text&gt;</span>
+  <span class="code-tag">&lt;/view&gt;</span>
+<span class="code-tag">&lt;/template&gt;</span>
+
+<span class="code-tag">&lt;style scoped&gt;</span>
+<span class="code-com">/* same CSS you write today */</span>
+.card { padding: <span class="code-str">24px</span>; border-radius: <span class="code-str">16px</span>; }
+.title { font-size: <span class="code-str">28px</span>; font-weight: <span class="code-str">600</span>; }
+<span class="code-tag">&lt;/style&gt;</span></pre>
+    </div>
+    <aside class="notes">
+      <p><strong>Web-friendly is a feature, not an accident.</strong></p>
+      <p>SFCs, templates, scoped CSS — all the same. The element vocabulary is HTML-shaped: <code>&lt;view&gt;</code> for <code>&lt;div&gt;</code>, <code>&lt;text&gt;</code> for <code>&lt;p&gt;</code>/<code>&lt;span&gt;</code>, <code>&lt;image&gt;</code> for <code>&lt;img&gt;</code>, plus <code>&lt;list&gt;</code> when you need virtualization.</p>
+      <p>Important: the same bundle renders on the web via Lynx for Web — that's how every demo in this deck is running right now.</p>
+      <p>Next slide pivots: "and it's serious underneath" → dual thread.</p>
+    </aside>
+  </section>
+
+  <!-- ====================================================
+       Slide 12 — Architecturally performing (dual thread)
+       ==================================================== -->
+  <section class="slide arch">
+    <div class="arch__head">
+      <span class="eyebrow">b · Architecturally performing</span>
+      <h2 class="h-section">
+        Two threads, by design.
+      </h2>
+      <p class="lead">
+        Lynx splits your app across a dedicated <em>background</em> thread
+        for framework work and a <em>main</em> thread that owns the UI.
+        Vue Lynx puts the whole reactivity system on one, and lets the
+        other stay free for layout, scrolling, and gesture response.
+      </p>
+    </div>
+    <div class="arch__diagram">
+      <div class="thread thread--bg">
+        <span class="thread__label">
+          <span style="width:8px;height:8px;border-radius:50%;background:var(--vue-green);"></span>
+          Background thread
+        </span>
+        <h3 class="thread__title">Vue 3 runtime &amp; your code</h3>
+        <ul class="thread__list">
+          <li>reactivity, lifecycle</li>
+          <li>component tree diff</li>
+          <li>event handlers</li>
+          <li>data fetching</li>
+          <li>flat ops &rarr;</li>
+        </ul>
+      </div>
+      <div class="thread thread--main">
+        <span class="thread__label">
+          <span style="width:8px;height:8px;border-radius:50%;background:var(--brand-teal);"></span>
+          Main (UI) thread
+        </span>
+        <h3 class="thread__title">Native elements &amp; render</h3>
+        <ul class="thread__list">
+          <li>&larr; ops interpreter</li>
+          <li>layout &amp; paint</li>
+          <li>gestures &amp; scrolling</li>
+          <li>Main-Thread Script handlers</li>
+          <li>events &rarr;</li>
+        </ul>
+      </div>
+    </div>
+    <p class="arch__caption">
+      One bundle, two layers, no JS bridge round-trip on the hot path.
+    </p>
+    <aside class="notes">
+      <p><strong>The architectural punchline.</strong></p>
+      <p>Two threads, both fully programmable in your bundle. Vue runtime — reactivity, diff, lifecycle, handlers — lives on the <strong>background</strong>. Native layout, paint, gestures, scroll live on the <strong>main</strong> thread.</p>
+      <p>They talk via a flat <em>ops</em> buffer, batched per Vue tick. <strong>No JS bridge round-trip on the hot path.</strong> That's why gestures stay 60fps even while reactivity does its job.</p>
+      <p>For people from RN-land: this is the part that's different. RN's bridge sits between you and the UI. Lynx doesn't have a bridge — both threads <em>are</em> your bundle.</p>
+    </aside>
+  </section>
+
+  <!-- ====================================================
+       Slide 13 — Vue + Lynx = Vue Native
+       ==================================================== -->
+  <section class="slide combine">
+    <div class="combine__tile">
+      <svg viewBox="0 0 261.76 226.69" aria-label="Vue logo">
+        <path d="M161.096.001l-30.225 52.351L100.647.001H0l130.877 226.688L261.749.001z" fill="#42b883" />
+        <path d="M161.096.001l-30.225 52.351L100.647.001H52.346l78.526 136.01L209.398.001z" fill="#35495e" />
+      </svg>
+      <span class="combine__name">Vue 3</span>
+    </div>
+    <span class="combine__op">&times;</span>
+    <div class="combine__tile">
+      <svg viewBox="0 0 33 33" aria-label="Lynx logo">
+        <path fill="#00ddff" d="M 15.5,0.5 C 16.5,0.5 17.5,0.5 18.5,0.5C 18.5,4.83333 18.5,9.16667 18.5,13.5C 21.5,13.5 24.5,13.5 27.5,13.5C 24.516,20.1221 20.516,26.1221 15.5,31.5C 14.2801,31.1131 13.6135,30.2798 13.5,29C 14.3942,25.2238 14.7275,21.3905 14.5,17.5C 11.5,17.5 8.5,17.5 5.5,17.5C 5.35055,16.448 5.51722,15.448 6,14.5C 9.43419,9.94886 12.6009,5.28219 15.5,0.5 Z" />
+      </svg>
+      <span class="combine__name">Lynx</span>
+    </div>
+    <span class="combine__op">=</span>
+    <div class="combine__result">
+      <span class="result-label">A new path</span>
+      <h2 class="result-text">
+        Vue, <br/><span class="brand-text">on native.</span>
+      </h2>
+    </div>
+    <aside class="notes">
+      <p><strong>The headline.</strong> Vue × Lynx = Vue on native.</p>
+      <p>Hold the moment briefly — let the equation land. Then transition: "And we'd love your help making this a thing."</p>
+    </aside>
+  </section>
+
+  <!-- ====================================================
+       Slide 14 — Divider: Close
+       ==================================================== -->
+  <section class="slide divider">
+    <span class="eyebrow">Chapter IV</span>
+    <div class="divider__row">
+      <span class="divider__num numeral--brand">IV</span>
+      <h2 class="divider__title">
+        And we'd love<br/>your help.
+      </h2>
+    </div>
+    <p class="divider__tag">
+      Vue Lynx is pre-alpha. The architecture is solid; Vue's API surface
+      is large. What ships next depends on who shows up.
+    </p>
+    <aside class="notes">
+      <p><strong>Tone shift to ask.</strong> Set up that the project is real but needs the community.</p>
+      <p>Reinforce: architecture is solid (we showed it), but Vue's surface area is huge and the ecosystem is vast.</p>
+    </aside>
+  </section>
+
+  <!-- ====================================================
+       Slide 15 — The Ask
+       ==================================================== -->
+  <section class="slide cta">
+    <span class="eyebrow">The ask</span>
+    <h2 class="cta__title">
+      Native shouldn't be a different <span class="brand-text">team</span>.
+    </h2>
+    <p class="cta__sub">
+      Vue developers should ship native apps as naturally as they ship for
+      the web today. The foundation is laid. The path is clear. The
+      ecosystem we already know &mdash; Pinia, Router, Query, Tailwind &mdash;
+      runs here.
+    </p>
+    <div style="display:flex;gap:48px;margin-top:24px;flex-wrap:wrap">
+      <div class="stack-y gap-sm">
+        <span class="eyebrow" style="margin-bottom:8px">What's there</span>
+        <ul class="web__list">
+          <li><b>Composition API &amp; SFCs</b></li>
+          <li><b>Transition, Suspense, slots</b></li>
+          <li><b>Pinia, Router, Query, Tailwind</b></li>
+          <li><b>Main-Thread Script</b></li>
+        </ul>
+      </div>
+      <div class="stack-y gap-sm">
+        <span class="eyebrow" style="margin-bottom:8px">What's open</span>
+        <ul class="web__list">
+          <li><b>KeepAlive, Teleport</b></li>
+          <li><code>&lt;script main-thread setup&gt;</code></li>
+          <li><b>Vue DevTools integration</b></li>
+          <li><b>The ecosystem you'd port</b></li>
+        </ul>
+      </div>
+    </div>
+    <aside class="notes">
+      <p><strong>The ask, expanded.</strong> What's there is real. What's open is where help matters.</p>
+      <p>Left column = what works today, ready for production exploration. Right column = where contributors can move the needle.</p>
+      <p>Land on: <em>"native shouldn't be a different team"</em> — that's the line you want them to remember.</p>
+    </aside>
+  </section>
+
+  <!-- ====================================================
+       Slide 16 — Try today
+       ==================================================== -->
+  <section class="slide cta">
+    <span class="eyebrow">Try it tonight</span>
+    <h2 class="cta__title">
+      One <span class="brand-text">npm create</span>, and you're shipping
+      native.
+    </h2>
+
+    <div class="cta__commandbox" data-copy="npm create vue-lynx@latest" style="cursor:pointer">
+      <div class="cmd">
+        <span class="prompt">$</span>
+        <span>npm create vue-lynx@latest</span>
+      </div>
+      <div class="cta__divider"></div>
+      <div class="agent">for Agent</div>
+    </div>
+
+    <div class="cta__links">
+      <a class="cta__link cta__link--brand"
+         href="https://vue.lynxjs.org/guide/quick-start"
+         target="_blank" rel="noreferrer">
+        Quick Start &rarr;
+      </a>
+      <a class="cta__link"
+         href="https://github.com/Huxpro/vue-lynx"
+         target="_blank" rel="noreferrer">
+        github.com/Huxpro/vue-lynx
+      </a>
+      <a class="cta__link"
+         href="https://lynxjs.org"
+         target="_blank" rel="noreferrer">
+        lynxjs.org
+      </a>
+      <a class="cta__link"
+         href="https://vue.lynxjs.org/guide/introduction"
+         target="_blank" rel="noreferrer">
+        Read the intro
+      </a>
+    </div>
+    <aside class="notes">
+      <p><strong>The call to action.</strong> One command — <code>npm create vue-lynx@latest</code>.</p>
+      <p>Repo, docs, intro all linked. The "for Agent" button copies a prompt the agent can use to bootstrap a new project — for the AI-pilled.</p>
+      <p>Promise: "Tonight, on the bus home, you can have a Vue app running on an iPhone."</p>
+    </aside>
+  </section>
+
+  <!-- ====================================================
+       Slide 17 — Thank you
+       ==================================================== -->
+  <section class="slide thankyou">
+    <span class="eyebrow">Fin.</span>
+    <h1><span class="brand-text">Thank</span> you.</h1>
+    <p class="sig">
+      Questions, PRs, opinions &mdash; all welcome.
+    </p>
+    <div class="handles">
+      <a href="https://x.com/Huxpro" target="_blank" rel="noreferrer">@Huxpro</a>
+      <a href="https://github.com/Huxpro/vue-lynx" target="_blank" rel="noreferrer">huxpro/vue-lynx</a>
+      <a href="https://vue.lynxjs.org" target="_blank" rel="noreferrer">vue.lynxjs.org</a>
+    </div>
+    <aside class="notes">
+      <p><strong>Close.</strong> Thank them. Invite questions. Stay on this slide for Q&amp;A.</p>
+      <p>If asked "is this production?" — pre-alpha, but the architecture is solid and the surface that's there is well-tested.</p>
+      <p>If asked "what about Android?" — Lynx is cross-platform, the same bundle runs on both.</p>
+    </aside>
+  </section>
+
+</div>
+
+<script type="module" src="/src/main.js"></script>
+</body>
+</html>

--- a/slides/package.json
+++ b/slides/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "vue-lynx-slides",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Talk deck for Vue Lynx, with live <lynx-view> embeds",
+  "scripts": {
+    "dev": "vite --host 0.0.0.0 --port 4321",
+    "build": "vite build",
+    "preview": "vite preview --host 0.0.0.0 --port 4321"
+  },
+  "dependencies": {
+    "@lynx-js/web-core": "^0.20.0",
+    "@lynx-js/web-elements": "^0.12.0"
+  },
+  "devDependencies": {
+    "vite": "^5.4.10"
+  }
+}

--- a/slides/public/favicon.svg
+++ b/slides/public/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#42b883"/>
+      <stop offset="0.5" stop-color="#34d399"/>
+      <stop offset="1" stop-color="#00ddff"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#g)"/>
+  <path d="M40 14h-8l-3 5.5L26 14h-8l14 24 14-24h-6z" fill="white" opacity="0.95"/>
+</svg>

--- a/slides/speaker.html
+++ b/slides/speaker.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Speaker · Vue Lynx</title>
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+</head>
+<body>
+  <main class="sv">
+
+    <header class="sv-top">
+      <div class="sv-id">
+        <span class="sv-dot"></span>
+        <span>Speaker view</span>
+      </div>
+      <div class="sv-counter">
+        <span data-slide-now>01</span>
+        <span class="sv-sep">/</span>
+        <span data-slide-total>--</span>
+      </div>
+      <div class="sv-clocks">
+        <div class="sv-clock" data-elapsed>00:00</div>
+        <div class="sv-clock sv-clock--alt" data-clock>--:--</div>
+      </div>
+    </header>
+
+    <section class="sv-grid">
+      <div class="sv-stage sv-stage--current">
+        <div class="sv-stage__head">
+          <span class="sv-stage__label">Now</span>
+          <span class="sv-stage__title" data-now-title>—</span>
+        </div>
+        <div class="sv-stage__frame">
+          <iframe data-frame="now" title="Current slide" loading="eager"></iframe>
+        </div>
+      </div>
+
+      <div class="sv-side">
+        <div class="sv-stage sv-stage--next">
+          <div class="sv-stage__head">
+            <span class="sv-stage__label">Next</span>
+            <span class="sv-stage__title" data-next-title>—</span>
+          </div>
+          <div class="sv-stage__frame">
+            <iframe data-frame="next" title="Next slide" loading="eager"></iframe>
+          </div>
+        </div>
+
+        <div class="sv-notes">
+          <div class="sv-notes__head">
+            <span class="sv-notes__label">Speaker notes</span>
+          </div>
+          <div class="sv-notes__body" data-notes>
+            <p class="sv-notes__empty">No notes for this slide.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <footer class="sv-bottom">
+      <div class="sv-controls">
+        <button class="sv-btn" data-nav="prev" title="← / ↑ / PageUp">‹ Prev</button>
+        <button class="sv-btn sv-btn--primary" data-nav="next" title="→ / ↓ / Space / PageDown">Next ›</button>
+        <span class="sv-sep">·</span>
+        <button class="sv-btn" data-timer="toggle" title="Pause / resume timer">Pause</button>
+        <button class="sv-btn" data-timer="reset" title="Reset timer">Reset</button>
+        <span class="sv-sep">·</span>
+        <button class="sv-btn" data-blackout title="Fade audience screen to black (b)">Blackout (b)</button>
+      </div>
+      <div class="sv-hints">
+        ←/→ navigate · <kbd>s</kbd> from main deck toggles this view ·
+        <kbd>.</kbd> dark mode · <kbd>b</kbd> blackout · <kbd>r</kbd> reset timer ·
+        <kbd>f</kbd> fullscreen
+      </div>
+    </footer>
+  </main>
+
+  <script type="module" src="/src/speaker.js"></script>
+</body>
+</html>

--- a/slides/src/main.js
+++ b/slides/src/main.js
@@ -1,0 +1,510 @@
+import './styles.css';
+import { mountMeteors } from './meteors.js';
+
+// =========================================================
+// URL flags — ?embed=1 locks the deck to a single slide and
+// strips all chrome so the speaker view can iframe it.
+// =========================================================
+const params = new URLSearchParams(location.search);
+const embedMode = params.has('embed');
+if (embedMode) {
+  document.documentElement.classList.add('is-embed');
+}
+
+// =========================================================
+// Lynx runtime — lazy, single-flight
+// =========================================================
+let lynxRuntimeReady = null;
+function ensureLynxRuntime() {
+  if (!lynxRuntimeReady) {
+    lynxRuntimeReady = import('@lynx-js/web-core/client');
+  }
+  return lynxRuntimeReady;
+}
+
+// Rewrite the webpack publicPath baked into the bundle at build time so image
+// URLs resolve against the bundle location, not the (unreachable) dev-machine
+// address that was captured when the example was built. Both spacing variants
+// occur across bundles: `.p="x"` and `.p = "x"`.
+const WEBPACK_PUBLIC_PATH_RE = /\.p\s*=\s*\\"[^"]*\\"/g;
+
+// Shared group keeps multiple lynx-views on a single worker
+const LYNX_GROUP_ID = 7;
+
+// =========================================================
+// <vl-demo bundle="todomvc/dist/main.web.bundle">
+// =========================================================
+class VlDemo extends HTMLElement {
+  static get observedAttributes() { return ['bundle']; }
+
+  constructor() {
+    super();
+    this._mounted = false;
+    this._loadStarted = false;
+  }
+
+  connectedCallback() {
+    if (this._mounted) return;
+    this._mounted = true;
+    if (embedMode) {
+      // Speaker preview: skip the live demo, show a calm placeholder.
+      this.innerHTML = `
+        <div class="vl-demo__loading vl-demo__loading--embed">
+          <div class="vl-demo__bullet"></div>
+          <div>Live on audience screen</div>
+        </div>
+      `;
+      this.dataset.ready = 'embed';
+      return;
+    }
+    this.innerHTML = `
+      <div class="vl-demo__loading">
+        <div class="spinner"></div>
+        <div>Loading Lynx for Web</div>
+      </div>
+    `;
+  }
+
+  attributeChangedCallback() {
+    if (this._loadStarted) this.load();
+  }
+
+  /** Begin loading the runtime + bundle. Called by the deck on slide reveal. */
+  async load() {
+    if (this._loadStarted) return;
+    this._loadStarted = true;
+
+    const bundle = this.getAttribute('bundle');
+    if (!bundle) return;
+    const url = `/examples/${bundle}`;
+
+    try {
+      await ensureLynxRuntime();
+
+      const view = document.createElement('lynx-view');
+      view.setAttribute('lynx-group-id', String(LYNX_GROUP_ID));
+      view.setAttribute('transform-vh', '');
+      view.setAttribute('transform-vw', '');
+
+      view.customTemplateLoader = async (templateUrl) => {
+        const res = await fetch(templateUrl);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const text = await res.text();
+        const baseUrl = templateUrl.substring(0, templateUrl.lastIndexOf('/') + 1);
+        const rewritten = text.replace(
+          WEBPACK_PUBLIC_PATH_RE,
+          `.p=\\"${baseUrl}\\"`,
+        );
+        const template = JSON.parse(rewritten);
+
+        if (template.lepusCode?.root) {
+          const root = template.lepusCode.root;
+          if (
+            typeof root === 'string' &&
+            root.includes('__webpack_require__') &&
+            !root.includes('function __webpack_require__')
+          ) {
+            template.lepusCode.root =
+              `var __webpack_require__={p:"${baseUrl}"};` + root;
+          }
+        }
+        return template;
+      };
+
+      this.insertBefore(view, this.firstChild);
+
+      const t0 = performance.now();
+      const markReady = () => {
+        this.dataset.ready = 'true';
+      };
+
+      const pollShadow = () => {
+        const sr = view.shadowRoot;
+        if (sr) {
+          if (sr.childElementCount > 0) {
+            markReady();
+            return;
+          }
+          const mo = new MutationObserver(() => {
+            if (sr.childElementCount > 0) {
+              mo.disconnect();
+              markReady();
+            }
+          });
+          mo.observe(sr, { childList: true, subtree: true });
+        } else if (performance.now() - t0 < 5000) {
+          requestAnimationFrame(pollShadow);
+        }
+      };
+
+      view.url = url;
+      pollShadow();
+
+      const updateDims = () => {
+        const r = this.getBoundingClientRect();
+        view.browserConfig = {
+          pixelWidth: Math.round(r.width * window.devicePixelRatio),
+          pixelHeight: Math.round(r.height * window.devicePixelRatio),
+        };
+      };
+      requestAnimationFrame(updateDims);
+      const ro = new ResizeObserver(updateDims);
+      ro.observe(this);
+    } catch (err) {
+      console.error('[demo] load failed', err);
+      const loading = this.querySelector('.vl-demo__loading');
+      if (loading) {
+        loading.innerHTML = `<div style="color:#ff8a8a;text-align:center;">
+          Failed to load demo<br><small style="opacity:.6">${err.message ?? err}</small>
+        </div>`;
+      }
+    }
+  }
+}
+
+customElements.define('vl-demo', VlDemo);
+
+// =========================================================
+// Deck navigation
+// =========================================================
+const deck = document.querySelector('.deck');
+const slides = Array.from(document.querySelectorAll('.slide'));
+const progressBar = document.querySelector('.progress__bar');
+const counter = document.querySelector('[data-counter]');
+
+let current = 0;
+let speakerWindow = null;
+let blackedOut = false;
+
+// =========================================================
+// Slide metadata — title + sanitized notes — shared with the
+// speaker view via BroadcastChannel so it can render notes
+// without parsing the live DOM.
+// =========================================================
+const slideMeta = slides.map((slide) => {
+  // Title heuristic: first big heading, or eyebrow as fallback.
+  const titleEl = slide.querySelector(
+    '.h-cover, .h-section, .demo__title, .divider__title, .cta__title, .combine__result .result-text, .thankyou h1',
+  );
+  const eyebrowEl = slide.querySelector('.eyebrow');
+  const title = (titleEl?.textContent || eyebrowEl?.textContent || '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 80);
+
+  const notesEl = slide.querySelector('aside.notes');
+  const notes = notesEl ? notesEl.innerHTML : '';
+
+  return { title, notes };
+});
+
+function setSlide(index, opts = {}) {
+  current = Math.max(0, Math.min(slides.length - 1, index));
+  slides.forEach((s, i) => {
+    s.classList.toggle('is-active', i === current);
+    s.classList.toggle('is-prev', i < current);
+  });
+  if (progressBar) {
+    progressBar.style.width = `${((current + 1) / slides.length) * 100}%`;
+  }
+  if (counter) {
+    counter.textContent = String(current + 1).padStart(2, '0') +
+      ' / ' + String(slides.length).padStart(2, '0');
+  }
+  if (!opts.skipHash) {
+    history.replaceState(null, '', `#${current + 1}`);
+  }
+  preloadDemosNear(current);
+
+  if (!opts.fromChannel) {
+    broadcastState();
+  }
+}
+
+function preloadDemosNear(index) {
+  // Embed iframes are speaker previews — no need to spin up Lynx workers there.
+  // It would also steal keyboard focus from the speaker's outer window.
+  if (embedMode) return;
+  for (const offset of [0, 1]) {
+    const slide = slides[index + offset];
+    if (!slide) continue;
+    slide.querySelectorAll('vl-demo').forEach((d) => d.load?.());
+  }
+}
+
+function next() { setSlide(current + 1); }
+function prev() { setSlide(current - 1); }
+function first() { setSlide(0); }
+function last() { setSlide(slides.length - 1); }
+
+// =========================================================
+// BroadcastChannel — speaker <-> deck sync.
+// We use this in BOTH the main deck and the embed iframes so
+// that "go to slide N" arrives in the right window.
+// =========================================================
+const channel = new BroadcastChannel('vue-lynx-deck');
+
+function broadcastState() {
+  if (embedMode) return;
+  channel.postMessage({
+    type: 'state',
+    index: current,
+    total: slides.length,
+    slides: slideMeta,
+  });
+}
+
+// BroadcastChannel: only the main deck (non-embed) reacts to nav/state requests.
+// Embed iframes ignore it entirely — they're driven by direct postMessage from
+// the speaker window, which targets a specific iframe instead of broadcasting.
+if (!embedMode) {
+  channel.addEventListener('message', (ev) => {
+    const msg = ev.data;
+    if (!msg || typeof msg !== 'object') return;
+    switch (msg.type) {
+      case 'request-state':
+        broadcastState();
+        break;
+      case 'nav':
+        if (msg.dir === 'next') next();
+        else if (msg.dir === 'prev') prev();
+        else if (msg.dir === 'first') first();
+        else if (msg.dir === 'last') last();
+        else if (msg.dir === 'goto' && typeof msg.index === 'number') setSlide(msg.index);
+        break;
+      case 'theme-toggle':
+        document.documentElement.classList.toggle('dark');
+        break;
+      case 'blackout':
+        applyBlackout(!!msg.on);
+        break;
+      case 'speaker-closed':
+        speakerWindow = null;
+        break;
+    }
+  });
+}
+
+// Embed iframes navigate via window.postMessage from the speaker (per-iframe targeting).
+// Also listen for hashchange as a safety net.
+if (embedMode) {
+  window.addEventListener('message', (ev) => {
+    if (ev.origin !== location.origin) return;
+    const msg = ev.data;
+    if (!msg || msg.type !== 'go') return;
+    if (typeof msg.index === 'number' && msg.index !== current) {
+      setSlide(msg.index, { fromChannel: true });
+    }
+  });
+
+  window.addEventListener('hashchange', () => {
+    const hash = Number.parseInt(location.hash.replace('#', ''), 10);
+    if (!Number.isNaN(hash) && hash >= 1 && hash <= slides.length) {
+      const idx = hash - 1;
+      if (idx !== current) setSlide(idx, { skipHash: true, fromChannel: true });
+    }
+  });
+}
+
+// =========================================================
+// Speaker window helpers
+// =========================================================
+function openSpeakerWindow() {
+  if (speakerWindow && !speakerWindow.closed) {
+    speakerWindow.focus();
+    return;
+  }
+  const w = Math.min(1400, Math.round(screen.availWidth * 0.85));
+  const h = Math.min(900, Math.round(screen.availHeight * 0.85));
+  speakerWindow = window.open(
+    '/speaker.html',
+    'vue-lynx-speaker',
+    `popup,width=${w},height=${h}`,
+  );
+  // First sync — give the popup a tick to register its channel listener
+  setTimeout(broadcastState, 250);
+}
+
+function applyBlackout(on) {
+  blackedOut = on;
+  document.body.classList.toggle('is-blackout', on);
+}
+
+// =========================================================
+// Keyboard
+// =========================================================
+// In embed mode the deck is read-only — the iframe is just a preview surface
+// for the speaker view. Any local navigation would desync the speaker, then get
+// stomped on the next heartbeat ("advances then reverts" bug).
+if (!embedMode) {
+  document.addEventListener('keydown', (e) => {
+    if (e.target.matches?.('input, textarea, [contenteditable]')) return;
+
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+      case 'PageDown':
+      case ' ':
+        e.preventDefault(); next(); break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+      case 'PageUp':
+        e.preventDefault(); prev(); break;
+      case 'Home': e.preventDefault(); first(); break;
+      case 'End': e.preventDefault(); last(); break;
+      case 'f': case 'F': toggleFullscreen(); break;
+      case 'o': case 'O': deck.classList.toggle('overview'); break;
+      case '.':
+        document.documentElement.classList.toggle('dark');
+        channel.postMessage({ type: 'theme-toggle-mirror' });
+        break;
+      case 's': case 'S':
+        e.preventDefault();
+        openSpeakerWindow();
+        break;
+      case 'b': case 'B':
+        applyBlackout(!blackedOut);
+        channel.postMessage({ type: 'blackout', on: blackedOut });
+        break;
+      default:
+        if (/^[1-9]$/.test(e.key)) {
+          setSlide(Number(e.key) - 1);
+        }
+    }
+  });
+}
+
+function toggleFullscreen() {
+  if (document.fullscreenElement) {
+    document.exitFullscreen();
+  } else {
+    document.documentElement.requestFullscreen?.();
+  }
+}
+
+// Click in overview mode jumps to slide
+deck.addEventListener('click', (e) => {
+  if (!deck.classList.contains('overview')) return;
+  const slide = e.target.closest('.slide');
+  if (!slide) return;
+  const idx = slides.indexOf(slide);
+  if (idx >= 0) {
+    deck.classList.remove('overview');
+    setSlide(idx);
+  }
+});
+
+// Mouse wheel / touch swipe — disabled in embed mode (the iframes
+// should never navigate themselves; the speaker is the controller).
+if (!embedMode) {
+  let wheelLock = false;
+  deck.addEventListener('wheel', (e) => {
+    if (deck.classList.contains('overview')) return;
+    if (wheelLock) return;
+    const threshold = 30;
+    if (Math.abs(e.deltaY) < threshold && Math.abs(e.deltaX) < threshold) return;
+    wheelLock = true;
+    setTimeout(() => (wheelLock = false), 600);
+    if (e.deltaY > 0 || e.deltaX > 0) next();
+    else prev();
+  }, { passive: true });
+
+  let touchStart = null;
+  deck.addEventListener('touchstart', (e) => {
+    touchStart = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+  }, { passive: true });
+  deck.addEventListener('touchend', (e) => {
+    if (!touchStart) return;
+    const dx = (e.changedTouches[0].clientX - touchStart.x);
+    const dy = (e.changedTouches[0].clientY - touchStart.y);
+    if (Math.abs(dx) > 50 && Math.abs(dx) > Math.abs(dy)) {
+      dx < 0 ? next() : prev();
+    } else if (Math.abs(dy) > 50) {
+      dy < 0 ? next() : prev();
+    }
+    touchStart = null;
+  }, { passive: true });
+}
+
+// =========================================================
+// Dark mode toggle button
+// =========================================================
+document.querySelector('.dark-toggle')?.addEventListener('click', () => {
+  document.documentElement.classList.toggle('dark');
+});
+
+// =========================================================
+// Boot
+// =========================================================
+const startIndex = (() => {
+  const hash = Number.parseInt(location.hash.replace('#', ''), 10);
+  if (!Number.isNaN(hash) && hash >= 1 && hash <= slides.length) {
+    return hash - 1;
+  }
+  return 0;
+})();
+setSlide(startIndex, { skipHash: true });
+
+// Re-broadcast every few seconds in case the speaker connects late
+if (!embedMode) {
+  setInterval(broadcastState, 4000);
+  // Tell other tabs we just woke up — they'll resync.
+  channel.postMessage({ type: 'request-state' });
+}
+
+const canvas = document.querySelector('.meteors');
+if (canvas) mountMeteors(canvas, { gridSize: 120, meteorCount: 3 });
+
+// =========================================================
+// Cycling cover verb — "Unlock", "Vibe", "Render", "Ship"
+// =========================================================
+const verbs = ['Unlock', 'Vibe', 'Render', 'Ship'];
+const verbEl = document.querySelector('[data-cover-verb]');
+if (verbEl) {
+  let i = 0;
+  let text = verbs[0];
+  let deleting = false;
+  let paused = false;
+
+  const tick = () => {
+    const word = verbs[i];
+    if (!deleting && text === word) {
+      if (!paused) { paused = true; setTimeout(tick, 1500); return; }
+      paused = false; deleting = true;
+      setTimeout(tick, 120);
+    } else if (deleting) {
+      text = word.substring(0, text.length - 1);
+      verbEl.textContent = text;
+      if (text === '') {
+        deleting = false;
+        i = (i + 1) % verbs.length;
+        setTimeout(tick, 180);
+      } else setTimeout(tick, 80);
+    } else {
+      text = verbs[i].substring(0, text.length + 1);
+      verbEl.textContent = text;
+      setTimeout(tick, 160);
+    }
+  };
+  setTimeout(tick, 1500);
+}
+
+// Copy buttons
+document.querySelectorAll('[data-copy]').forEach((el) => {
+  el.addEventListener('click', () => {
+    const text = el.dataset.copy || el.textContent;
+    navigator.clipboard.writeText(text);
+    const old = el.textContent;
+    el.textContent = 'copied!';
+    setTimeout(() => { el.textContent = old; }, 1200);
+  });
+});
+
+// Tell the world we're closing too (so the speaker can grey out if needed)
+window.addEventListener('beforeunload', () => {
+  try {
+    channel.postMessage({ type: 'deck-closed' });
+  } catch {
+    // The channel may already be closed during page teardown.
+  }
+});

--- a/slides/src/meteors.js
+++ b/slides/src/meteors.js
@@ -1,0 +1,154 @@
+/**
+ * Meteors background — same recipe as website/theme,
+ * but with theme-aware brand-color sourcing.
+ */
+
+const DIR = { UP: 0, RIGHT: 1, DOWN: 2, LEFT: 3 };
+
+class Meteor {
+  constructor(gridSize, canvas) {
+    this.gridSize = gridSize;
+    this.canvas = canvas;
+    this.reset();
+  }
+
+  reset() {
+    this.direction = Math.floor(Math.random() * 4);
+    this.speed = 2 + Math.random() * 3;
+    this.length = this.gridSize * (1 + Math.random() * 2);
+    this.opacity = 0.55 + Math.random() * 0.35;
+
+    const middle = (size) => {
+      const margin = size * 0.2;
+      return margin + Math.random() * (size * 0.6);
+    };
+
+    switch (this.direction) {
+      case DIR.UP:
+        this.x =
+          Math.floor(middle(this.canvas.width) / this.gridSize) * this.gridSize;
+        this.y = this.canvas.height;
+        break;
+      case DIR.RIGHT:
+        this.x = 0;
+        this.y =
+          Math.floor(middle(this.canvas.height) / this.gridSize) *
+          this.gridSize;
+        break;
+      case DIR.DOWN:
+        this.x =
+          Math.floor(middle(this.canvas.width) / this.gridSize) * this.gridSize;
+        this.y = 0;
+        break;
+      case DIR.LEFT:
+        this.x = this.canvas.width;
+        this.y =
+          Math.floor(middle(this.canvas.height) / this.gridSize) *
+          this.gridSize;
+        break;
+    }
+  }
+
+  update() {
+    switch (this.direction) {
+      case DIR.UP:
+        this.y -= this.speed;
+        if (this.y + this.length < 0) this.reset();
+        break;
+      case DIR.RIGHT:
+        this.x += this.speed;
+        if (this.x > this.canvas.width) this.reset();
+        break;
+      case DIR.DOWN:
+        this.y += this.speed;
+        if (this.y > this.canvas.height) this.reset();
+        break;
+      case DIR.LEFT:
+        this.x -= this.speed;
+        if (this.x + this.length < 0) this.reset();
+        break;
+    }
+  }
+
+  draw(ctx) {
+    let endX = this.x;
+    let endY = this.y;
+    switch (this.direction) {
+      case DIR.UP: endY = this.y + this.length; break;
+      case DIR.RIGHT: endX = this.x - this.length; break;
+      case DIR.DOWN: endY = this.y - this.length; break;
+      case DIR.LEFT: endX = this.x + this.length; break;
+    }
+    const gradient = ctx.createLinearGradient(this.x, this.y, endX, endY);
+    gradient.addColorStop(0, `rgba(66, 184, 131, ${this.opacity})`);
+    gradient.addColorStop(0.02, `rgba(66, 184, 131, ${this.opacity * 0.8})`);
+    gradient.addColorStop(0.05, `rgba(0, 221, 255, ${this.opacity * 0.6})`);
+    gradient.addColorStop(1, 'rgba(0, 221, 255, 0)');
+    ctx.beginPath();
+    ctx.strokeStyle = gradient;
+    ctx.lineWidth = 2;
+    ctx.moveTo(this.x, this.y);
+    ctx.lineTo(endX, endY);
+    ctx.stroke();
+  }
+}
+
+export function mountMeteors(canvas, { gridSize = 120, meteorCount = 3 } = {}) {
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return () => undefined;
+
+  const dpr = Math.min(window.devicePixelRatio || 1, 2);
+  const resize = () => {
+    canvas.width = window.innerWidth * dpr;
+    canvas.height = window.innerHeight * dpr;
+    canvas.style.width = `${window.innerWidth}px`;
+    canvas.style.height = `${window.innerHeight}px`;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  };
+  resize();
+  window.addEventListener('resize', resize);
+
+  const meteors = Array.from(
+    { length: meteorCount },
+    () =>
+      new Meteor(gridSize, {
+        get width() { return canvas.width / dpr; },
+        get height() { return canvas.height / dpr; },
+      }),
+  );
+
+  let raf;
+  const tick = () => {
+    const w = canvas.width / dpr;
+    const h = canvas.height / dpr;
+    ctx.clearRect(0, 0, w, h);
+
+    // grid
+    const gridStroke = document.documentElement.classList.contains('dark')
+      ? 'rgba(255, 255, 255, 0.05)'
+      : 'rgba(15, 18, 22, 0.06)';
+    ctx.strokeStyle = gridStroke;
+    ctx.lineWidth = 1;
+    for (let x = 0; x < w; x += gridSize) {
+      ctx.beginPath();
+      ctx.moveTo(x, 0);
+      ctx.lineTo(x, h);
+      ctx.stroke();
+    }
+    for (let y = 0; y < h; y += gridSize) {
+      ctx.beginPath();
+      ctx.moveTo(0, y);
+      ctx.lineTo(w, y);
+      ctx.stroke();
+    }
+
+    meteors.forEach((m) => { m.update(); m.draw(ctx); });
+    raf = requestAnimationFrame(tick);
+  };
+  tick();
+
+  return () => {
+    cancelAnimationFrame(raf);
+    window.removeEventListener('resize', resize);
+  };
+}

--- a/slides/src/speaker.css
+++ b/slides/src/speaker.css
@@ -1,0 +1,286 @@
+/* Speaker view — uses the same design tokens as the main deck */
+@import './styles.css';
+
+:root.dark {
+  color-scheme: dark;
+}
+
+html, body {
+  background: var(--paper);
+  color: var(--ink);
+  margin: 0;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.sv {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  height: 100vh;
+  gap: 12px;
+  padding: 14px 18px;
+  font-family: var(--display);
+}
+
+/* ===== Top bar ===== */
+.sv-top {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 16px;
+  padding: 4px 6px;
+}
+
+.sv-id {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.sv-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--vue-green);
+  box-shadow: 0 0 12px rgba(66, 184, 131, 0.6);
+  animation: sv-pulse 2.4s infinite;
+}
+@keyframes sv-pulse {
+  0%, 100% { opacity: 0.4; transform: scale(0.9); }
+  50% { opacity: 1; transform: scale(1.1); }
+}
+
+.sv-counter {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 8px;
+  font-family: var(--mono);
+  font-size: 18px;
+  font-weight: 500;
+  color: var(--ink);
+  justify-self: center;
+}
+.sv-counter .sv-sep {
+  color: var(--ink-mute);
+  font-weight: 400;
+}
+
+.sv-clocks {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 18px;
+  justify-self: end;
+  font-family: var(--mono);
+}
+.sv-clock {
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+  font-variant-numeric: tabular-nums;
+  transition: color 0.2s ease;
+}
+.sv-clock[data-paused="true"] {
+  color: var(--ink-mute);
+  text-decoration: line-through;
+  text-decoration-color: var(--ink-faint);
+}
+.sv-clock--alt {
+  color: var(--ink-mute);
+  font-weight: 400;
+  font-size: 18px;
+}
+
+/* ===== Main grid: current slide + side column ===== */
+.sv-grid {
+  display: grid;
+  grid-template-columns: 1.6fr 1fr;
+  gap: 16px;
+  min-height: 0;
+}
+
+.sv-side {
+  display: grid;
+  grid-template-rows: 1fr 1.4fr;
+  gap: 16px;
+  min-height: 0;
+}
+
+.sv-stage,
+.sv-notes {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  background: var(--paper-elev);
+  overflow: hidden;
+  min-height: 0;
+}
+
+.sv-stage__head,
+.sv-notes__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--line-soft);
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  background: var(--paper);
+}
+
+.sv-stage__label {
+  color: var(--vue-green);
+  font-weight: 600;
+}
+.sv-stage--next .sv-stage__label {
+  color: var(--brand-teal);
+}
+
+.sv-stage__title,
+.sv-notes__label {
+  font-family: var(--display);
+  font-size: 13px;
+  text-transform: none;
+  letter-spacing: -0.005em;
+  color: var(--ink);
+  font-weight: 500;
+  max-width: 70%;
+  text-align: right;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sv-stage__frame {
+  flex: 1;
+  position: relative;
+  background: var(--paper);
+  min-height: 0;
+}
+.sv-stage__frame iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  display: block;
+}
+
+.sv-notes__body {
+  flex: 1;
+  overflow: auto;
+  padding: 18px 22px;
+  font-size: 16px;
+  line-height: 1.55;
+  color: var(--ink);
+}
+.sv-notes__body p { margin: 0 0 12px; }
+.sv-notes__body p:last-child { margin-bottom: 0; }
+.sv-notes__body ul { margin: 0 0 12px; padding-left: 20px; }
+.sv-notes__body li { margin-bottom: 4px; }
+.sv-notes__body strong { color: var(--ink); font-weight: 600; }
+.sv-notes__body em {
+  font-family: var(--serif);
+  font-style: italic;
+  color: var(--ink-soft);
+}
+.sv-notes__body code {
+  font-family: var(--mono);
+  font-size: 0.9em;
+  padding: 1px 6px;
+  border-radius: 5px;
+  background: rgba(15, 18, 22, 0.06);
+  color: var(--vue-green);
+}
+:root.dark .sv-notes__body code {
+  background: rgba(255, 255, 255, 0.06);
+}
+.sv-notes__body kbd {
+  font-family: var(--mono);
+  font-size: 0.85em;
+  padding: 2px 7px;
+  border-radius: 5px;
+  border: 1px solid var(--line);
+  background: var(--paper);
+  color: var(--ink);
+  box-shadow: 0 1px 0 var(--line);
+}
+.sv-notes__empty {
+  color: var(--ink-mute);
+  font-style: italic;
+}
+
+/* ===== Bottom bar ===== */
+.sv-bottom {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 6px 8px 2px;
+}
+
+.sv-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sv-btn {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: var(--paper-elev);
+  color: var(--ink);
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s, background 0.15s, transform 0.15s;
+}
+.sv-btn:hover {
+  border-color: var(--vue-green);
+  color: var(--vue-green);
+}
+.sv-btn:active { transform: translateY(1px); }
+.sv-btn--primary {
+  background: var(--vue-green);
+  color: #fff;
+  border-color: transparent;
+}
+.sv-btn--primary:hover {
+  background: var(--vue-dark);
+  color: #fff;
+}
+
+.sv-hints {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--ink-mute);
+}
+.sv-hints kbd {
+  font-family: inherit;
+  padding: 1px 6px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  background: var(--paper);
+  color: var(--ink);
+}
+
+/* When the audience screen is blacked out, dim the speaker preview to match */
+.sv-blackout-on .sv-stage--current { opacity: 0.4; }
+
+/* Compact layout on smaller speaker windows */
+@media (max-width: 1100px) {
+  .sv-grid { grid-template-columns: 1fr; grid-template-rows: 1.4fr 1fr; }
+  .sv-side { grid-template-rows: 1fr 1fr; grid-template-columns: 1fr 1.4fr; display: grid; }
+}

--- a/slides/src/speaker.js
+++ b/slides/src/speaker.js
@@ -1,0 +1,260 @@
+import './speaker.css';
+
+const CHANNEL_NAME = 'vue-lynx-deck';
+const channel = new BroadcastChannel(CHANNEL_NAME);
+
+// =========================================================
+// DOM refs
+// =========================================================
+const frameNow = document.querySelector('iframe[data-frame="now"]');
+const frameNext = document.querySelector('iframe[data-frame="next"]');
+const titleNow = document.querySelector('[data-now-title]');
+const titleNext = document.querySelector('[data-next-title]');
+const notesEl = document.querySelector('[data-notes]');
+const slideNowEl = document.querySelector('[data-slide-now]');
+const slideTotalEl = document.querySelector('[data-slide-total]');
+const elapsedEl = document.querySelector('[data-elapsed]');
+const clockEl = document.querySelector('[data-clock]');
+
+// =========================================================
+// State
+// =========================================================
+let current = 0;
+let total = 17; // updated as soon as deck reports
+let slideMeta = []; // [{index, title, notes}]
+let blackedOut = false;
+
+// =========================================================
+// Frame URL builder
+// =========================================================
+function frameSrcFor(index) {
+  return `/?embed=1#${index + 1}`;
+}
+
+/**
+ * Drive an iframe to a target slide.
+ *
+ * - First load: assign src (cold boot the iframe).
+ * - Subsequent: post a `go` message directly to its contentWindow.
+ *   We deliberately do NOT reassign src for hash-only changes — that does
+ *   not reliably reload the iframe across browsers, and the iframe's
+ *   main.js only reads the hash once on boot.
+ *
+ * Direct postMessage gives us per-iframe targeting; using BroadcastChannel
+ * here would navigate both Now and Next at once.
+ */
+function setFrameTo(frame, index) {
+  if (!frame) return;
+  if (index < 0 || index >= total) {
+    if (frame.src !== 'about:blank') frame.src = 'about:blank';
+    frame.dataset.slide = '';
+    return;
+  }
+  const isFirstLoad = !frame.src || frame.src === 'about:blank' || !frame.dataset.slide;
+  if (isFirstLoad) {
+    frame.src = frameSrcFor(index);
+    frame.dataset.slide = String(index);
+    return;
+  }
+  const currentIdx = Number(frame.dataset.slide);
+  if (currentIdx === index) return; // already there
+  frame.dataset.slide = String(index);
+  const sendGo = () => {
+    try {
+      frame.contentWindow?.postMessage({ type: 'go', index }, location.origin);
+    } catch {
+      // Hard fallback — cold reload the iframe.
+      frame.src = frameSrcFor(index);
+    }
+  };
+  // If the iframe doc isn't reachable yet, wait for load.
+  if (frame.contentWindow && frame.contentDocument?.readyState === 'complete') {
+    sendGo();
+  } else {
+    frame.addEventListener('load', sendGo, { once: true });
+  }
+}
+
+// =========================================================
+// Render
+// =========================================================
+function render() {
+  if (slideNowEl) slideNowEl.textContent = String(current + 1).padStart(2, '0');
+  if (slideTotalEl) slideTotalEl.textContent = String(total).padStart(2, '0');
+
+  setFrameTo(frameNow, current);
+  setFrameTo(frameNext, current + 1);
+
+  const meta = slideMeta[current] || {};
+  if (titleNow) titleNow.textContent = meta.title || '';
+  const nextMeta = slideMeta[current + 1] || {};
+  if (titleNext) {
+    titleNext.textContent = current + 1 >= total ? '— end of deck —' : (nextMeta.title || '');
+  }
+
+  if (notesEl) {
+    if (meta.notes?.trim()) {
+      notesEl.innerHTML = meta.notes;
+    } else {
+      notesEl.innerHTML = '<p class="sv-notes__empty">No notes for this slide.</p>';
+    }
+  }
+}
+
+// =========================================================
+// Channel — listen for state from the main deck
+// =========================================================
+channel.addEventListener('message', (ev) => {
+  const msg = ev.data;
+  if (!msg || typeof msg !== 'object') return;
+  if (msg.type === 'state') {
+    current = msg.index;
+    total = msg.total;
+    if (Array.isArray(msg.slides)) slideMeta = msg.slides;
+    render();
+  }
+});
+
+// Ask the main deck to broadcast its current state so we sync on open.
+channel.postMessage({ type: 'request-state' });
+
+// =========================================================
+// Navigation buttons → send commands to deck
+// =========================================================
+document.querySelectorAll('[data-nav]').forEach((btn) => {
+  btn.addEventListener('click', () => {
+    channel.postMessage({ type: 'nav', dir: btn.dataset.nav });
+  });
+});
+
+// Keyboard — same as main deck
+document.addEventListener('keydown', (e) => {
+  if (e.target.matches?.('input, textarea, [contenteditable]')) return;
+  switch (e.key) {
+    case 'ArrowRight': case 'ArrowDown': case 'PageDown': case ' ':
+      e.preventDefault();
+      channel.postMessage({ type: 'nav', dir: 'next' });
+      break;
+    case 'ArrowLeft': case 'ArrowUp': case 'PageUp':
+      e.preventDefault();
+      channel.postMessage({ type: 'nav', dir: 'prev' });
+      break;
+    case 'Home':
+      e.preventDefault();
+      channel.postMessage({ type: 'nav', dir: 'first' });
+      break;
+    case 'End':
+      e.preventDefault();
+      channel.postMessage({ type: 'nav', dir: 'last' });
+      break;
+    case 'f': case 'F':
+      toggleFullscreen();
+      break;
+    case '.':
+      document.documentElement.classList.toggle('dark');
+      channel.postMessage({ type: 'theme-toggle' });
+      break;
+    case 'r': case 'R':
+      resetTimer();
+      break;
+    case 'b': case 'B':
+      toggleBlackout();
+      break;
+    default:
+      if (/^[1-9]$/.test(e.key)) {
+        channel.postMessage({ type: 'nav', dir: 'goto', index: Number(e.key) - 1 });
+      }
+  }
+});
+
+function toggleFullscreen() {
+  if (document.fullscreenElement) document.exitFullscreen();
+  else document.documentElement.requestFullscreen?.();
+}
+
+// =========================================================
+// Timer
+// =========================================================
+let startedAt = Date.now();
+let pausedAccum = 0;
+let pausedAt = null;
+
+function tickTimer() {
+  // Elapsed (paused-aware)
+  const baseline = pausedAt ?? Date.now();
+  const elapsedMs = (baseline - startedAt) - pausedAccum;
+  const s = Math.max(0, Math.floor(elapsedMs / 1000));
+  const hh = Math.floor(s / 3600);
+  const mm = Math.floor((s % 3600) / 60);
+  const ss = s % 60;
+  const fmt = hh
+    ? `${hh}:${String(mm).padStart(2, '0')}:${String(ss).padStart(2, '0')}`
+    : `${String(mm).padStart(2, '0')}:${String(ss).padStart(2, '0')}`;
+  if (elapsedEl) {
+    elapsedEl.textContent = fmt;
+    elapsedEl.dataset.paused = pausedAt ? 'true' : 'false';
+  }
+
+  // Wall clock
+  if (clockEl) {
+    const now = new Date();
+    clockEl.textContent =
+      String(now.getHours()).padStart(2, '0') + ':' +
+      String(now.getMinutes()).padStart(2, '0');
+  }
+}
+
+function startTimerLoop() {
+  tickTimer();
+  setInterval(tickTimer, 1000);
+}
+
+function resetTimer() {
+  startedAt = Date.now();
+  pausedAccum = 0;
+  pausedAt = null;
+  tickTimer();
+  const btn = document.querySelector('[data-timer="toggle"]');
+  if (btn) btn.textContent = 'Pause';
+}
+
+function toggleTimer() {
+  const btn = document.querySelector('[data-timer="toggle"]');
+  if (pausedAt) {
+    // resume
+    pausedAccum += Date.now() - pausedAt;
+    pausedAt = null;
+    if (btn) btn.textContent = 'Pause';
+  } else {
+    pausedAt = Date.now();
+    if (btn) btn.textContent = 'Resume';
+  }
+  tickTimer();
+}
+
+document.querySelector('[data-timer="toggle"]')?.addEventListener('click', toggleTimer);
+document.querySelector('[data-timer="reset"]')?.addEventListener('click', resetTimer);
+startTimerLoop();
+
+// =========================================================
+// Blackout — broadcast to main deck
+// =========================================================
+function toggleBlackout() {
+  blackedOut = !blackedOut;
+  channel.postMessage({ type: 'blackout', on: blackedOut });
+  document.body.classList.toggle('sv-blackout-on', blackedOut);
+  const btn = document.querySelector('[data-blackout]');
+  if (btn) btn.textContent = blackedOut ? 'Restore (b)' : 'Blackout (b)';
+}
+document.querySelector('[data-blackout]')?.addEventListener('click', toggleBlackout);
+
+// =========================================================
+// Close cleanly
+// =========================================================
+window.addEventListener('beforeunload', () => {
+  channel.postMessage({ type: 'speaker-closed' });
+  channel.close();
+});
+
+// First paint
+render();

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -1,0 +1,1450 @@
+/* ===========================================================
+   Vue Lynx — Talk Deck
+   Design language inherited from vue.lynxjs.org:
+   Vue green #42b883, brand teal #00ddff, bridge emerald #34d399.
+   ----------------------------------------------------------- */
+
+@import url('https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700;800&family=Geist+Mono:wght@400;500&family=Instrument+Serif:ital@0;1&display=swap');
+
+:root {
+  /* Brand */
+  --vue-green: #42b883;
+  --vue-dark: #35495e;
+  --brand-emerald: #34d399;
+  --brand-teal: #00ddff;
+  --brand-gradient: linear-gradient(
+    270deg,
+    var(--vue-green),
+    var(--brand-emerald),
+    var(--brand-teal),
+    var(--brand-emerald),
+    var(--vue-green)
+  );
+
+  /* Surfaces */
+  --ink: #0f1216;
+  --ink-soft: rgba(15, 18, 22, 0.72);
+  --ink-mute: rgba(15, 18, 22, 0.52);
+  --ink-faint: rgba(15, 18, 22, 0.18);
+  --paper: #f7f8fa;
+  --paper-elev: rgba(255, 255, 255, 0.62);
+  --line: rgba(15, 18, 22, 0.10);
+  --line-soft: rgba(15, 18, 22, 0.06);
+
+  /* Type */
+  --display: 'Geist', -apple-system, 'Segoe UI', sans-serif;
+  --serif: 'Instrument Serif', 'Cormorant Garamond', Georgia, serif;
+  --mono: 'Geist Mono', 'JetBrains Mono', ui-monospace, monospace;
+
+  /* Layout */
+  --slide-pad-x: clamp(56px, 6vw, 120px);
+  --slide-pad-y: clamp(40px, 5vh, 80px);
+  --radius: 18px;
+  --radius-lg: 28px;
+  --shadow-sm: 0 1px 2px rgba(15, 18, 22, 0.04), 0 8px 24px -12px rgba(15, 18, 22, 0.10);
+  --shadow-lg: 0 30px 80px -40px rgba(15, 18, 22, 0.30), 0 8px 32px -16px rgba(15, 18, 22, 0.18);
+}
+
+:root.dark {
+  --ink: #f4f5f7;
+  --ink-soft: rgba(244, 245, 247, 0.72);
+  --ink-mute: rgba(244, 245, 247, 0.52);
+  --ink-faint: rgba(244, 245, 247, 0.18);
+  --paper: #0a0c10;
+  --paper-elev: rgba(255, 255, 255, 0.04);
+  --line: rgba(244, 245, 247, 0.10);
+  --line-soft: rgba(244, 245, 247, 0.06);
+  --vue-green: #5dd5a8;
+  --brand-emerald: #34d399;
+  --brand-teal: #3deae7;
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3), 0 8px 24px -12px rgba(0, 0, 0, 0.6);
+  --shadow-lg: 0 30px 80px -40px rgba(0, 0, 0, 0.9), 0 8px 32px -16px rgba(0, 0, 0, 0.6);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  background: var(--paper);
+  color: var(--ink);
+  font-family: var(--display);
+  font-feature-settings: 'ss01', 'ss02', 'cv11';
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  overflow: hidden;
+  height: 100vh;
+  width: 100vw;
+}
+
+/* =========================================================
+   Deck shell
+   ========================================================= */
+.deck {
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.meteors {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  opacity: 0.85;
+  mask-image: linear-gradient(to bottom, black 0%, black 60%, transparent 100%);
+}
+
+.slide {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: var(--slide-pad-y) var(--slide-pad-x);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.45s cubic-bezier(0.2, 0.7, 0.2, 1),
+              transform 0.55s cubic-bezier(0.2, 0.7, 0.2, 1);
+  transform: translateY(20px);
+  z-index: 1;
+}
+
+.slide.is-active {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+  z-index: 2;
+}
+
+.slide.is-prev {
+  transform: translateY(-20px);
+}
+
+/* =========================================================
+   Slide chrome (corner labels, page numbers)
+   ========================================================= */
+.chrome {
+  position: fixed;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  z-index: 100;
+  pointer-events: none;
+  user-select: none;
+}
+
+.chrome a {
+  pointer-events: auto;
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px solid var(--ink-faint);
+  padding-bottom: 2px;
+  transition: color 0.2s, border-color 0.2s;
+}
+.chrome a:hover {
+  color: var(--vue-green);
+  border-color: var(--vue-green);
+}
+
+.chrome--top { top: 28px; left: 28px; }
+.chrome--top-right {
+  top: 28px;
+  right: 28px;
+  pointer-events: auto;
+}
+.chrome--bottom { bottom: 28px; left: 28px; }
+.chrome--bottom-right { bottom: 28px; right: 28px; }
+
+.chrome__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--vue-green);
+  box-shadow: 0 0 12px rgba(66, 184, 131, 0.5);
+  animation: pulse 2.4s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 0.4; transform: scale(0.9); }
+  50% { opacity: 1; transform: scale(1.1); }
+}
+
+.dark-toggle {
+  appearance: none;
+  background: transparent;
+  border: 1px solid var(--line);
+  color: var(--ink-mute);
+  padding: 6px 10px;
+  border-radius: 999px;
+  font: inherit;
+  cursor: pointer;
+  transition: border-color 0.2s, color 0.2s, background 0.2s;
+}
+.dark-toggle:hover {
+  border-color: var(--vue-green);
+  color: var(--vue-green);
+}
+
+/* =========================================================
+   Section numerals (editorial serif italic)
+   ========================================================= */
+.numeral {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: clamp(72px, 11vw, 180px);
+  line-height: 0.95;
+  letter-spacing: -0.04em;
+  color: var(--ink);
+  display: inline-block;
+}
+
+.numeral--brand {
+  background: var(--brand-gradient);
+  background-size: 200% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: gradientMove 9s linear infinite;
+}
+
+.eyebrow {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.eyebrow::before {
+  content: '';
+  width: 24px;
+  height: 1px;
+  background: var(--vue-green);
+}
+
+/* =========================================================
+   Typography scale
+   ========================================================= */
+h1, h2, h3, p { margin: 0; }
+
+.h-cover {
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: clamp(54px, 8vw, 128px);
+  line-height: 0.94;
+  letter-spacing: -0.035em;
+  max-width: 18ch;
+}
+
+.h-section {
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: clamp(40px, 5vw, 72px);
+  line-height: 1.05;
+  letter-spacing: -0.025em;
+  max-width: 32ch;
+}
+
+.h-card {
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: clamp(20px, 1.6vw, 26px);
+  line-height: 1.2;
+  letter-spacing: -0.015em;
+}
+
+.lead {
+  font-size: clamp(18px, 1.6vw, 24px);
+  line-height: 1.5;
+  color: var(--ink-soft);
+  max-width: 56ch;
+  font-weight: 400;
+}
+
+.kicker {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: clamp(28px, 3vw, 44px);
+  line-height: 1.2;
+  color: var(--ink-soft);
+  font-weight: 400;
+  max-width: 28ch;
+}
+
+.brand-text {
+  background: var(--brand-gradient);
+  background-size: 200% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: gradientMove 6s linear infinite;
+}
+
+@keyframes gradientMove {
+  0% { background-position: 0% 50%; }
+  100% { background-position: -200% 50%; }
+}
+
+/* =========================================================
+   Cover slide
+   ========================================================= */
+.cover {
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.cover__top {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+
+.cover__title {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.cover__title-line {
+  font-family: var(--display);
+  font-weight: 500;
+  font-size: clamp(78px, 11vw, 188px);
+  line-height: 0.92;
+  letter-spacing: -0.045em;
+}
+
+.cover__title-line .pre {
+  color: var(--ink);
+  font-weight: 500;
+}
+
+.cover__title-line .verb {
+  display: inline-block;
+  border-right: 4px solid transparent;
+  margin-right: -4px;
+  animation: caret 1s cubic-bezier(1, 0, 0, 1) infinite;
+}
+
+@keyframes caret {
+  0%, 49% {
+    border-image: linear-gradient(
+      to bottom, var(--vue-green), var(--brand-emerald), var(--brand-teal)
+    ) 1;
+  }
+  50%, 100% {
+    border-image: linear-gradient(to bottom, transparent, transparent) 1;
+  }
+}
+
+.cover__tagline {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: clamp(28px, 3vw, 44px);
+  color: var(--ink-soft);
+  max-width: 32ch;
+  margin-top: 12px;
+}
+
+.cover__bottom {
+  width: 100%;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--ink-mute);
+}
+
+.cover__bottom .stack {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  text-align: right;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  height: 36px;
+  padding: 0 18px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: var(--paper-elev);
+  backdrop-filter: blur(20px);
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+.badge__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--vue-green);
+  box-shadow: 0 0 8px rgba(66, 184, 131, 0.6);
+}
+
+/* =========================================================
+   Pitch slide — three pillars
+   ========================================================= */
+.pitch {
+  gap: clamp(28px, 4vh, 56px);
+  justify-content: center;
+}
+
+.pitch__head {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  max-width: 32ch;
+}
+
+.pillars {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: clamp(16px, 2vw, 28px);
+}
+
+.pillar {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: clamp(20px, 2vw, 32px);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper-elev);
+  backdrop-filter: blur(20px);
+  position: relative;
+  overflow: hidden;
+  transition: transform 0.4s ease, border-color 0.4s ease;
+}
+
+.pillar::after {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: var(--radius);
+  padding: 1px;
+  background: var(--brand-gradient);
+  background-size: 200% 100%;
+  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  mask-composite: exclude;
+  -webkit-mask-composite: xor;
+  opacity: 0;
+  transition: opacity 0.4s ease;
+  animation: gradientMove 4s linear infinite;
+  pointer-events: none;
+}
+
+.pillar:hover::after { opacity: 1; }
+.pillar:hover { transform: translateY(-4px); }
+
+.pillar__num {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 32px;
+  color: var(--vue-green);
+  line-height: 1;
+}
+
+.pillar__title {
+  font-size: clamp(22px, 2.2vw, 34px);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.05;
+}
+
+.pillar__copy {
+  color: var(--ink-soft);
+  font-size: clamp(14px, 1.05vw, 16px);
+  line-height: 1.55;
+}
+
+/* =========================================================
+   Demo slides — phone frame around <lynx-view>
+   ========================================================= */
+.demo {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: clamp(40px, 6vw, 96px);
+  align-items: center;
+}
+
+.demo--reverse { grid-template-columns: 1fr 1.2fr; }
+.demo--reverse .demo__body { order: 2; }
+
+.demo__body {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+  max-width: 44ch;
+}
+
+.demo__title {
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: clamp(36px, 4vw, 58px);
+  line-height: 1.05;
+  letter-spacing: -0.025em;
+}
+
+.demo__copy {
+  color: var(--ink-soft);
+  font-size: clamp(16px, 1.2vw, 19px);
+  line-height: 1.55;
+  font-weight: 400;
+}
+
+.demo__meta {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 28px;
+  padding: 0 12px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: var(--paper-elev);
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.chip--brand {
+  border-color: rgba(66, 184, 131, 0.4);
+  color: var(--vue-green);
+}
+
+.demo__stage {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+/* Phone frame — matches the website's mobile-show-frame recipe */
+.phone {
+  --phone-w: clamp(280px, 28vw, 360px);
+  --phone-h: calc(var(--phone-w) * (590 / 270));
+  width: var(--phone-w);
+  height: var(--phone-h);
+  padding: 6px;
+  background: linear-gradient(160deg, #2a2a2a 0%, #1a1a1a 100%);
+  border-radius: 32px;
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.10),
+    0 30px 80px rgba(0, 0, 0, 0.35),
+    inset 0 1px 0 rgba(255, 255, 255, 0.10);
+  box-sizing: border-box;
+  position: relative;
+}
+
+.phone::before {
+  content: '';
+  position: absolute;
+  top: 6px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 86px;
+  height: 22px;
+  background: #1a1a1a;
+  border-radius: 0 0 14px 14px;
+  z-index: 3;
+}
+
+.phone__inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  border-radius: 26px;
+  overflow: hidden;
+  background: #0a0c10;
+}
+
+.phone__inner > vl-demo,
+.phone__inner > .phone__placeholder {
+  position: absolute;
+  inset: 0;
+}
+
+.phone__placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ink-mute);
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+/* lynx-view container inside <vl-demo> */
+vl-demo {
+  display: block;
+  width: 100%;
+  height: 100%;
+  position: relative;
+}
+
+vl-demo lynx-view {
+  display: block;
+  width: 100%;
+  height: 100%;
+  container-type: size;
+  --rpx-unit: calc(100cqw / 750);
+  --vh-unit: 1cqh;
+  --vw-unit: 1cqw;
+}
+
+vl-demo .vl-demo__loading {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  color: rgba(255, 255, 255, 0.55);
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  background: #0a0c10;
+  transition: opacity 0.3s ease;
+  z-index: 2;
+}
+
+vl-demo[data-ready="true"] .vl-demo__loading {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.spinner {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.12);
+  border-top-color: var(--brand-teal);
+  animation: spin 0.9s linear infinite;
+}
+
+@keyframes spin { to { transform: rotate(360deg); } }
+
+.vl-demo__loading--embed { color: rgba(255, 255, 255, 0.45); }
+.vl-demo__bullet {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--brand-teal);
+  box-shadow: 0 0 10px rgba(0, 221, 255, 0.6);
+  animation: spkr-pulse 2.4s infinite;
+}
+@keyframes spkr-pulse {
+  0%, 100% { opacity: 0.4; transform: scale(0.9); }
+  50% { opacity: 1; transform: scale(1.2); }
+}
+
+/* =========================================================
+   Showcase grid — multiple phones
+   ========================================================= */
+.gallery {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 32px;
+}
+
+.gallery__head {
+  width: 100%;
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 28px;
+}
+
+.gallery__strip {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: clamp(16px, 2vw, 28px);
+  align-items: end;
+}
+
+.gallery__item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+}
+
+.gallery__item .phone {
+  --phone-w: clamp(180px, 16vw, 220px);
+}
+
+.gallery__caption {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  text-align: center;
+}
+
+.gallery__caption b {
+  color: var(--ink);
+  font-weight: 600;
+  display: block;
+  letter-spacing: -0.01em;
+  font-family: var(--display);
+  font-size: 15px;
+  text-transform: none;
+  margin-bottom: 2px;
+}
+
+/* =========================================================
+   Section divider slides
+   ========================================================= */
+.divider {
+  align-items: flex-start;
+  justify-content: center;
+  gap: 24px;
+}
+
+.divider__row {
+  display: flex;
+  align-items: flex-end;
+  gap: clamp(24px, 4vw, 56px);
+  max-width: 100%;
+}
+
+.divider__num {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: clamp(160px, 22vw, 320px);
+  line-height: 0.85;
+  letter-spacing: -0.05em;
+  color: var(--ink);
+  flex-shrink: 0;
+}
+
+.divider__num.numeral--brand {
+  background: var(--brand-gradient);
+  background-size: 200% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: gradientMove 9s linear infinite;
+}
+
+.divider__title {
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: clamp(48px, 6vw, 96px);
+  line-height: 0.95;
+  letter-spacing: -0.035em;
+  max-width: 16ch;
+  padding-bottom: clamp(20px, 2vw, 32px);
+}
+
+.divider__tag {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: clamp(20px, 1.8vw, 28px);
+  color: var(--ink-mute);
+  max-width: 40ch;
+  font-weight: 400;
+}
+
+/* =========================================================
+   Story timeline
+   ========================================================= */
+.story {
+  gap: clamp(28px, 4vh, 48px);
+}
+
+.story__head {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 56ch;
+}
+
+.timeline {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: clamp(16px, 2vw, 32px);
+  position: relative;
+  padding-top: 28px;
+}
+
+.timeline::before {
+  content: '';
+  position: absolute;
+  top: 14px;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(
+    to right,
+    transparent,
+    var(--line) 20%,
+    var(--line) 80%,
+    transparent
+  );
+}
+
+.tl-item {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  position: relative;
+  padding-top: 24px;
+}
+
+.tl-item::before {
+  content: '';
+  position: absolute;
+  top: -14px;
+  left: 0;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--paper);
+  border: 2px solid var(--vue-green);
+}
+
+.tl-item__week {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vue-green);
+}
+
+.tl-item__title {
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: clamp(18px, 1.6vw, 22px);
+  letter-spacing: -0.01em;
+  line-height: 1.2;
+}
+
+.tl-item__copy {
+  font-size: 14px;
+  color: var(--ink-soft);
+  line-height: 1.5;
+}
+
+.story__bill {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1px;
+  background: var(--line);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  overflow: hidden;
+  margin-top: 8px;
+}
+
+.bill__cell {
+  background: var(--paper);
+  padding: 18px 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.bill__cell .label {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+
+.bill__cell .value {
+  font-family: var(--display);
+  font-size: clamp(22px, 2.5vw, 32px);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.bill__cell .value small {
+  font-size: 13px;
+  color: var(--ink-mute);
+  font-weight: 400;
+}
+
+/* =========================================================
+   Architecture diagram (dual thread)
+   ========================================================= */
+.arch {
+  gap: clamp(28px, 4vh, 48px);
+}
+
+.arch__head {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 56ch;
+}
+
+.arch__diagram {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: clamp(20px, 3vw, 56px);
+  align-items: stretch;
+  position: relative;
+}
+
+.thread {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 28px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper-elev);
+  backdrop-filter: blur(20px);
+  min-height: 220px;
+}
+
+.thread__label {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--vue-green);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.thread--main .thread__label { color: var(--brand-teal); }
+
+.thread__title {
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: clamp(22px, 2.2vw, 30px);
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+}
+
+.thread__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: var(--ink-soft);
+  font-size: 15px;
+  font-family: var(--mono);
+  letter-spacing: -0.005em;
+}
+
+.thread__list li::before {
+  content: '·  ';
+  color: var(--vue-green);
+}
+
+.thread--main .thread__list li::before { color: var(--brand-teal); }
+
+.arch__bridge {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.arch__bridge svg {
+  width: clamp(40px, 6vw, 80px);
+  height: auto;
+  opacity: 0.5;
+}
+
+.arch__caption {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  text-align: center;
+}
+
+/* =========================================================
+   Web-friendly slide (code block + bullets)
+   ========================================================= */
+.web {
+  display: grid;
+  grid-template-columns: 1fr 1.1fr;
+  gap: clamp(40px, 5vw, 80px);
+  align-items: center;
+}
+
+.web__body {
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+  max-width: 36ch;
+}
+
+.web__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.web__list li {
+  display: flex;
+  gap: 14px;
+  align-items: flex-start;
+  font-size: clamp(15px, 1.15vw, 18px);
+  color: var(--ink-soft);
+  line-height: 1.5;
+}
+
+.web__list li b {
+  color: var(--ink);
+  font-weight: 600;
+}
+
+.web__list li::before {
+  content: '';
+  margin-top: 9px;
+  width: 18px;
+  height: 1px;
+  flex-shrink: 0;
+  background: var(--vue-green);
+}
+
+.codeframe {
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper-elev);
+  backdrop-filter: blur(20px);
+  overflow: hidden;
+  font-family: var(--mono);
+  font-size: 13px;
+  line-height: 1.65;
+  box-shadow: var(--shadow-sm);
+}
+
+.codeframe__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 18px;
+  border-bottom: 1px solid var(--line-soft);
+  color: var(--ink-mute);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.codeframe__head .dots {
+  display: flex;
+  gap: 5px;
+}
+.codeframe__head .dots span {
+  width: 9px; height: 9px; border-radius: 50%;
+  background: var(--line);
+}
+
+.codeframe pre {
+  margin: 0;
+  padding: 20px 22px;
+  overflow: auto;
+  color: var(--ink);
+  white-space: pre;
+}
+
+.code-tag { color: #5dd5a8; }
+.code-attr { color: #b39ddb; }
+.code-str { color: #f9a8b8; }
+.code-key { color: #ffd58a; }
+.code-com { color: var(--ink-mute); font-style: italic; }
+.code-fn { color: #00ddff; }
+
+/* =========================================================
+   Combine slide — Vue + Lynx = Vue Native
+   ========================================================= */
+.combine {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr auto 1.4fr;
+  align-items: center;
+  gap: clamp(24px, 4vw, 56px);
+}
+
+.combine__tile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 14px;
+  padding: 28px;
+}
+
+.combine__tile svg {
+  width: 96px;
+  height: 96px;
+}
+
+.combine__name {
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: clamp(22px, 2vw, 32px);
+  letter-spacing: -0.02em;
+}
+
+.combine__op {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: clamp(56px, 7vw, 96px);
+  color: var(--ink-mute);
+  line-height: 1;
+}
+
+.combine__result {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.combine__result .result-label {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+
+.combine__result .result-text {
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: clamp(40px, 5.5vw, 80px);
+  line-height: 0.98;
+  letter-spacing: -0.03em;
+}
+
+/* =========================================================
+   CTA / close
+   ========================================================= */
+.cta {
+  align-items: flex-start;
+  gap: 28px;
+  justify-content: center;
+}
+
+.cta__title {
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: clamp(56px, 7vw, 116px);
+  line-height: 0.94;
+  letter-spacing: -0.035em;
+  max-width: 18ch;
+}
+
+.cta__sub {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: clamp(24px, 2.4vw, 38px);
+  color: var(--ink-soft);
+  font-weight: 400;
+  max-width: 36ch;
+}
+
+.cta__commandbox {
+  display: inline-flex;
+  align-items: stretch;
+  background: rgba(15, 18, 22, 0.04);
+  border-radius: 16px;
+  padding: 6px;
+  border: 1px solid var(--line);
+  box-shadow: var(--shadow-sm);
+  max-width: 560px;
+}
+
+:root.dark .cta__commandbox {
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.cta__commandbox .cmd {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 22px;
+  font-family: var(--mono);
+  font-size: 16px;
+  color: var(--ink);
+}
+
+.cta__commandbox .cmd .prompt {
+  color: var(--vue-green);
+  font-weight: 600;
+}
+
+.cta__divider {
+  width: 1px;
+  background: var(--line);
+  margin: 8px 6px;
+}
+
+.cta__commandbox .agent {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 22px;
+  border-radius: 12px;
+  font-family: var(--mono);
+  font-size: 14px;
+  font-weight: 500;
+  position: relative;
+  overflow: hidden;
+  color: var(--ink);
+}
+
+.cta__commandbox .agent::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1px;
+  background: var(--brand-gradient);
+  background-size: 300% 300%;
+  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  mask-composite: exclude;
+  -webkit-mask-composite: xor;
+  animation: gradientMove 4s ease infinite;
+  opacity: 0.6;
+}
+
+.cta__links {
+  display: flex;
+  gap: 18px;
+  flex-wrap: wrap;
+  margin-top: 16px;
+}
+
+.cta__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  font-family: var(--mono);
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  color: var(--ink-soft);
+  text-decoration: none;
+  transition: border-color 0.2s, color 0.2s, transform 0.2s;
+}
+.cta__link:hover {
+  border-color: var(--vue-green);
+  color: var(--vue-green);
+  transform: translateY(-1px);
+}
+.cta__link--brand {
+  background: var(--vue-green);
+  color: #fff;
+  border-color: transparent;
+}
+.cta__link--brand:hover {
+  background: var(--vue-dark);
+  color: #fff;
+}
+
+/* Thank you */
+.thankyou {
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 24px;
+}
+
+.thankyou h1 {
+  font-family: var(--display);
+  font-weight: 500;
+  font-size: clamp(96px, 14vw, 220px);
+  line-height: 0.9;
+  letter-spacing: -0.045em;
+}
+
+.thankyou .sig {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: clamp(20px, 2vw, 32px);
+  color: var(--ink-soft);
+}
+
+.thankyou .handles {
+  display: flex;
+  gap: 28px;
+  font-family: var(--mono);
+  font-size: 14px;
+  color: var(--ink-mute);
+}
+.thankyou .handles a {
+  color: inherit;
+  text-decoration: none;
+  border-bottom: 1px solid var(--line);
+  padding-bottom: 2px;
+  transition: color 0.2s, border-color 0.2s;
+}
+.thankyou .handles a:hover {
+  color: var(--vue-green);
+  border-color: var(--vue-green);
+}
+
+/* =========================================================
+   Overview grid (press 'o')
+   ========================================================= */
+.deck.overview .meteors { opacity: 0.2; }
+.deck.overview .chrome { opacity: 0.3; }
+
+.deck.overview .slide {
+  position: relative;
+  inset: auto;
+  opacity: 1 !important;
+  transform: scale(0.18) !important;
+  pointer-events: auto;
+  transition: transform 0.3s ease;
+  width: 100vw;
+  height: 100vh;
+  flex: 0 0 100vw;
+}
+
+.deck.overview {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  grid-auto-rows: 1fr;
+  gap: 8px;
+  padding: 32px;
+  overflow: auto;
+  height: 100vh;
+  position: static;
+}
+
+.deck.overview .slide {
+  transform-origin: top left;
+  width: 25vw !important;
+  height: 25vh !important;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  overflow: hidden;
+  cursor: pointer;
+}
+
+.deck.overview .slide.is-active {
+  border-color: var(--vue-green);
+  box-shadow: 0 0 0 2px var(--vue-green);
+}
+
+.deck.overview .slide > * {
+  transform: scale(0.25);
+  transform-origin: top left;
+  width: 400%;
+  height: 400%;
+}
+
+/* =========================================================
+   Speaker notes — hidden in the audience deck, surfaced by
+   the speaker view via DOM read.
+   ========================================================= */
+.notes {
+  display: none;
+}
+
+/* =========================================================
+   Embed mode (?embed=1) — used inside speaker view iframes.
+   Hides all presenter chrome; the slide becomes pure content.
+   ========================================================= */
+.is-embed .chrome,
+.is-embed .progress,
+.is-embed .meteors {
+  display: none !important;
+}
+.is-embed body,
+.is-embed .deck {
+  background: var(--paper);
+}
+.is-embed .slide {
+  transition: none;
+}
+
+/* =========================================================
+   Blackout — speaker can fade the audience screen to black.
+   ========================================================= */
+body.is-blackout::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: #000;
+  z-index: 9999;
+  pointer-events: none;
+  animation: blackoutFade 0.25s ease-out;
+}
+@keyframes blackoutFade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* =========================================================
+   Progress bar
+   ========================================================= */
+.progress {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: var(--line-soft);
+  z-index: 50;
+}
+.progress__bar {
+  height: 100%;
+  background: var(--brand-gradient);
+  background-size: 200% 100%;
+  width: 0%;
+  transition: width 0.3s ease;
+  animation: gradientMove 6s linear infinite;
+}
+
+/* Subtle helpers */
+.spacer-sm { height: 12px; }
+.spacer-md { height: 24px; }
+.spacer-lg { height: 48px; }
+
+.stack-y { display: flex; flex-direction: column; }
+.stack-x { display: flex; align-items: center; }
+.gap-sm { gap: 8px; }
+.gap-md { gap: 16px; }
+.gap-lg { gap: 32px; }

--- a/slides/vite.config.js
+++ b/slides/vite.config.js
@@ -1,0 +1,66 @@
+import { defineConfig } from 'vite';
+import path from 'node:path';
+import fs from 'node:fs';
+
+const examplesSource = path.resolve(__dirname, '../website/docs/public/examples');
+const examplesDest = path.resolve(__dirname, 'public/examples');
+// pnpm hoists workspace deps into the repo-root .pnpm/ store; the lynx runtime
+// fetches its wasm + worker bundles from there at runtime, so we need to whitelist it.
+const workspaceRoot = path.resolve(__dirname, '..');
+
+// Ensure examples are reachable from /examples at dev + build time.
+function ensureExamplesSymlink() {
+  if (!fs.existsSync(examplesSource)) return;
+  try {
+    const stat = fs.lstatSync(examplesDest);
+    if (stat.isSymbolicLink() || stat.isDirectory()) return;
+  } catch {
+    // not present
+  }
+  try {
+    fs.mkdirSync(path.dirname(examplesDest), { recursive: true });
+    const relativeTarget = path.relative(path.dirname(examplesDest), examplesSource);
+    fs.symlinkSync(relativeTarget, examplesDest, 'dir');
+  } catch (err) {
+    console.warn('[slides] could not symlink examples:', err.message);
+  }
+}
+ensureExamplesSymlink();
+
+export default defineConfig({
+  // web-core ships top-level await — needs ES2022+
+  esbuild: { target: 'es2022' },
+  build: {
+    target: 'es2022',
+    outDir: 'dist',
+    emptyOutDir: true,
+    rollupOptions: {
+      input: {
+        main: path.resolve(__dirname, 'index.html'),
+        speaker: path.resolve(__dirname, 'speaker.html'),
+      },
+    },
+  },
+  optimizeDeps: {
+    esbuildOptions: { target: 'es2022' },
+    // The Lynx runtime fetches its WASM via `new URL('../../binary/.../client_bg.wasm', import.meta.url)`.
+    // Pre-bundling rewrites `import.meta.url` to point at node_modules/.vite/deps/chunk-X.js,
+    // and the relative `binary/` path no longer resolves. Excluding keeps the original ESM tree
+    // intact so the wasm + worker-companion JS files are served correctly.
+    exclude: ['@lynx-js/web-core', '@lynx-js/web-elements'],
+  },
+  assetsInclude: ['**/*.wasm'],
+  // web-core's worker uses code splitting, which requires an ES module worker.
+  worker: {
+    format: 'es',
+  },
+  server: {
+    fs: {
+      allow: [path.resolve(__dirname), examplesSource, workspaceRoot],
+    },
+    watch: {
+      // Don't watch the symlinked example bundles — they make HMR pointless
+      ignored: ['**/public/examples/**'],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- add a standalone HTML/Vite talk deck for Vue Lynx
- embed live Vue Lynx web demos with lazy runtime loading
- add a synchronized speaker view with notes, previews, timer, navigation, theme, and blackout controls
- register the private `slides` workspace and its dependencies

## Why

The talk deck previously lived as untracked local work in the main checkout. Moving it into a dedicated workspace makes it reproducible, reviewable, and isolated from regular repository development.

## Validation

- `pnpm test` — 12 files, 104 tests passed
- `pnpm --dir slides build`
- `pnpm exec biome check slides/src slides/vite.config.js`
- `git diff --cached --check`

The Vite config uses ES module workers because `@lynx-js/web-core` workers use code splitting, which is incompatible with the default IIFE worker output during production builds.
