### PR TITLE
feat(ai-chat): polish native chat interactions

### DIFF
--- a/docs/superpowers/plans/2026-07-14-chat-send-motion-web-fallback.md
+++ b/docs/superpowers/plans/2026-07-14-chat-send-motion-web-fallback.md
@@ -1,0 +1,104 @@
+# Chat Send Motion and Web Fallback Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver a measured Native send animation, reliable Native composer clearing, and conventional bottom-follow behavior on Web.
+
+**Architecture:** Put platform and motion arithmetic in `chat-viewport.ts`, keep renderer-owned input synchronization inside `PromptBox`, and let `ChatPage` orchestrate the resulting platform-specific behavior. Native preserves top anchoring; Web bypasses it and uses the existing scroll-view `scrollTo` UI method.
+
+**Tech Stack:** Vue 3, Vue Lynx, Lynx UI methods, CSS keyframes, Vitest.
+
+---
+
+### Task 1: Platform and motion policy
+
+**Files:**
+- Modify: `examples/ai-chat/src/lib/chat-viewport.ts`
+- Modify: `examples/ai-chat/tests/chat-viewport.test.ts`
+
+- [x] **Step 1: Write failing policy tests**
+
+Add assertions that `turnScrollMode('web')` returns `bottom`, Native returns `anchor`, and `calculateMessageLaunchDistance` returns a clamped positive distance from viewport, composer, keyboard, and bubble measurements.
+
+- [x] **Step 2: Run the targeted test and verify RED**
+
+Run `pnpm --filter @vue-lynx-example/ai-chat test -- tests/chat-viewport.test.ts` and expect missing-export failures.
+
+- [x] **Step 3: Implement the pure helpers**
+
+Add typed `turnScrollMode(platform)` and `calculateMessageLaunchDistance(metrics)` exports. Clamp Native distance to 44–420 px and return zero for Web.
+
+- [x] **Step 4: Run the targeted test and verify GREEN**
+
+Run the same command and expect all viewport tests to pass.
+
+### Task 2: Native composer reset
+
+**Files:**
+- Modify: `examples/ai-chat/src/components/chat/PromptBox.vue`
+- Modify: `examples/ai-chat/src/pages/ChatPage.vue`
+- Modify: `examples/ai-chat/tests/chat-motion.test.ts`
+
+- [x] **Step 1: Write a failing reset wiring test**
+
+Require `PromptBox` to import `setNativeInputValue` and watch a reset key after rendering. Require `handleSubmit` to clear `input.value` and increment that key.
+
+- [x] **Step 2: Run the targeted test and verify RED**
+
+Run `pnpm --filter @vue-lynx-example/ai-chat test -- tests/chat-motion.test.ts` and expect the new reset assertions to fail.
+
+- [x] **Step 3: Implement reset ownership**
+
+Pass an incrementing reset key into `PromptBox`. A post-flush child watcher invokes `setNativeInputValue(inputRef.value, '')` only on Native, after the cleared model has committed.
+
+- [x] **Step 4: Run the targeted test and verify GREEN**
+
+Run the same command and expect all chat motion tests to pass.
+
+### Task 3: Measured Native launch and Web bottom follow
+
+**Files:**
+- Modify: `examples/ai-chat/src/pages/ChatPage.vue`
+- Modify: `examples/ai-chat/src/App.css`
+- Modify: `examples/ai-chat/tests/chat-motion.test.ts`
+
+- [x] **Step 1: Write failing orchestration and CSS tests**
+
+Require Web turns to bypass `anchoredMessageId`, call `scrollToBottom`, and omit anchored spacer height. Require the user entrance to use `--user-message-launch-distance`, a 400–460 ms duration, and an assistant delay of at least 200 ms.
+
+- [x] **Step 2: Run the targeted test and verify RED**
+
+Run `pnpm --filter @vue-lynx-example/ai-chat test -- tests/chat-motion.test.ts` and expect the platform/motion assertions to fail.
+
+- [x] **Step 3: Implement the orchestration**
+
+Read `SystemInfo.platform`, calculate the measured Native launch style after message layout, preserve Native `scrollMessageToTop`, and route Web sends to `scrollToBottom(true)`. Pass no anchored turn height to Web spacer calculation.
+
+- [x] **Step 4: Strengthen the signature animation**
+
+Animate the complete user-message unit from the measured translation with a spring-like scale and opacity change over 500 ms. Delay assistant content 360 ms and keep reduced-motion overrides intact.
+
+- [x] **Step 5: Run targeted tests and verify GREEN**
+
+Run the viewport and chat-motion test files together and expect both suites to pass.
+
+### Task 4: Full verification and publish
+
+**Files:**
+- Verify all scoped source, test, spec, and plan files.
+
+- [x] **Step 1: Run automated verification**
+
+Run the complete AI chat Vitest suite, lint, and a cache-clean production build.
+
+- [x] **Step 2: Verify Web behavior**
+
+Open the Web preview at a mobile viewport, use a long chat, send a message, and assert both the cleared composer and bottom-visible new message.
+
+- [x] **Step 3: Verify Native behavior**
+
+Open the fresh bundle in LynxExplorer on iPhone 17 iOS 26, establish the first turn, then send the second message from the bottom composer. Capture evidence that the complete message unit visibly launches and the Native textarea becomes empty.
+
+- [x] **Step 4: Commit and push**
+
+Stage only scoped files, commit once verification is green, push `codex/native-chat-ux`, and confirm the existing PR is updated.

--- a/docs/superpowers/plans/2026-07-14-chat-send-motion-web-fallback.md
+++ b/docs/superpowers/plans/2026-07-14-chat-send-motion-web-fallback.md
@@ -64,7 +64,7 @@ Run the same command and expect all chat motion tests to pass.
 
 - [x] **Step 1: Write failing orchestration and CSS tests**
 
-Require Web turns to bypass `anchoredMessageId`, call `scrollToBottom`, and omit anchored spacer height. Require the user entrance to use `--user-message-launch-distance`, a 400–460 ms duration, and an assistant delay of at least 200 ms.
+Require Web turns to bypass `anchoredMessageId`, call `scrollToBottom`, and omit anchored spacer height. Require the user entrance to use `--user-message-launch-distance`, a 500 ms duration, and an assistant delay of at least 200 ms.
 
 - [x] **Step 2: Run the targeted test and verify RED**
 
@@ -72,11 +72,11 @@ Run `pnpm --filter @vue-lynx-example/ai-chat test -- tests/chat-motion.test.ts` 
 
 - [x] **Step 3: Implement the orchestration**
 
-Read `SystemInfo.platform`, calculate the measured Native launch style after message layout, preserve Native `scrollMessageToTop`, and route Web sends to `scrollToBottom(true)`. Pass no anchored turn height to Web spacer calculation.
+Read `SystemInfo.platform`, calculate the measured Native launch style after message layout, preserve Native `scrollMessageToTop`, and route Web sends and streaming mutations through the observed `scroll-top` attribute. Pass no anchored turn height to Web spacer calculation.
 
 - [x] **Step 4: Strengthen the signature animation**
 
-Animate the complete user-message unit from the measured translation with a spring-like scale and opacity change over 500 ms. Delay assistant content 360 ms and keep reduced-motion overrides intact.
+Animate the complete user-message unit from the measured translation with a monotonic ease-out scale and opacity change over 500 ms. Do not overshoot the target. Delay assistant content 360 ms and keep reduced-motion overrides intact.
 
 - [x] **Step 5: Run targeted tests and verify GREEN**
 

--- a/docs/superpowers/specs/2026-07-14-chat-send-motion-web-fallback-design.md
+++ b/docs/superpowers/specs/2026-07-14-chat-send-motion-web-fallback-design.md
@@ -7,7 +7,7 @@ Make a newly sent message feel visibly connected to the composer on Native, clea
 ## Platform behavior
 
 - Native keeps the existing anchored-turn layout. A newly submitted user bubble launches upward with a measured translation based on the viewport, composer, keyboard, and bubble heights. The assistant reveal waits until the user launch is substantially complete.
-- Web does not use the Native top-anchor spacer or `scrollIntoView`. It uses the conventional chat behavior: after a send and during followed streaming updates, the message list scrolls to the bottom.
+- Web does not use the Native top-anchor spacer or `scrollIntoView`. Lynx Web does not dispatch `contentsizechanged`, and its Background Thread UI-method bridge does not move this scroll view reliably, so followed message mutations toggle the Web element's observed `scroll-top` attribute. This keeps the list at the bottom after a send and throughout streaming.
 - Reduced-motion mode preserves the final layout and reduces all entrance animations to one millisecond.
 
 ## Input synchronization
@@ -16,7 +16,7 @@ Make a newly sent message feel visibly connected to the composer on Native, clea
 
 ## Motion calculation
 
-The launch distance is computed in a pure helper so it is testable. It approximates the distance between the bubble's anchored top position and the visible composer edge, clamps the result to a useful range, and returns zero for Web. `ChatPage` stores the measured bubble height and exposes the result as the `--user-message-launch-distance` custom property on the animated bubble.
+The launch distance is computed in a pure helper so it is testable. It approximates the distance between the bubble's anchored top position and the visible composer edge, clamps the result to a useful range, and returns zero for Web. `ChatPage` stores the measured bubble height and exposes the result as the `--user-message-launch-distance` custom property on the animated bubble. The transform follows a single monotonic ease-out path to the target; it deliberately has no overshoot or rebound.
 
 ## Verification
 

--- a/docs/superpowers/specs/2026-07-14-chat-send-motion-web-fallback-design.md
+++ b/docs/superpowers/specs/2026-07-14-chat-send-motion-web-fallback-design.md
@@ -1,0 +1,25 @@
+# Chat Send Motion and Web Fallback Design
+
+## Goal
+
+Make a newly sent message feel visibly connected to the composer on Native, clear the Native composer reliably after submission, and keep new content visible on Web by following the bottom of the conversation.
+
+## Platform behavior
+
+- Native keeps the existing anchored-turn layout. A newly submitted user bubble launches upward with a measured translation based on the viewport, composer, keyboard, and bubble heights. The assistant reveal waits until the user launch is substantially complete.
+- Web does not use the Native top-anchor spacer or `scrollIntoView`. It uses the conventional chat behavior: after a send and during followed streaming updates, the message list scrolls to the bottom.
+- Reduced-motion mode preserves the final layout and reduces all entrance animations to one millisecond.
+
+## Input synchronization
+
+`PromptBox` continues emitting `v-model` updates. After accepting a submission, `ChatPage` clears the Vue model and increments a reset key. A post-flush watcher owned by `PromptBox` observes that key and resets the Native built-in textarea through its `setValue` UI method. Keeping the Native reset inside the child avoids cross-component ref timing and preserves keyboard focus without remounting the textarea.
+
+## Motion calculation
+
+The launch distance is computed in a pure helper so it is testable. It approximates the distance between the bubble's anchored top position and the visible composer edge, clamps the result to a useful range, and returns zero for Web. `ChatPage` stores the measured bubble height and exposes the result as the `--user-message-launch-distance` custom property on the animated bubble.
+
+## Verification
+
+- Vitest covers platform strategy, launch-distance bounds, Native input reset wiring, and stronger staggered motion.
+- Web verification uses a long conversation and proves the newly sent message becomes visible at the bottom.
+- Native verification uses LynxExplorer on iPhone 17 with iOS 26. It first establishes an existing conversation, then sends a second message from the bottom-docked composer and proves both the launch and the empty Native textarea.

--- a/examples/ai-chat/src/App.css
+++ b/examples/ai-chat/src/App.css
@@ -157,15 +157,19 @@
   animation: shimmer-pulse 1.6s ease-in-out infinite;
 }
 
-/* Chat motion is restrained and state-driven. The message bubble is the one
-   signature transition; streamed blocks only use a short reveal so layout
-   remains readable while content is arriving. */
+/* The user bubble is the signature transition: Native supplies a measured
+   distance from the composer while Web uses a zero-distance fade. Streamed
+   blocks stay quiet so the launch remains the focus. */
+.user-message-pending {
+  opacity: 0;
+}
+
 .user-message-enter {
-  animation: user-message-enter 260ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation: user-message-enter 500ms cubic-bezier(0.25, 0.46, 0.45, 0.94) both;
 }
 
 .assistant-turn-enter {
-  animation: assistant-turn-enter 240ms cubic-bezier(0.25, 1, 0.5, 1) 150ms both;
+  animation: assistant-turn-enter 240ms cubic-bezier(0.25, 1, 0.5, 1) 360ms both;
 }
 
 .stream-block-enter {
@@ -181,11 +185,19 @@
 }
 
 @keyframes user-message-enter {
-  from {
-    opacity: 0;
-    transform: translateY(12px) scale(0.985);
+  0% {
+    opacity: 0.5;
+    transform: translateY(var(--user-message-launch-distance)) scale(0.95);
   }
-  to {
+  70% {
+    opacity: 1;
+    transform: translateY(-7px) scale(1.01);
+  }
+  86% {
+    opacity: 1;
+    transform: translateY(3px) scale(0.997);
+  }
+  100% {
     opacity: 1;
     transform: translateY(0px) scale(1);
   }

--- a/examples/ai-chat/src/App.css
+++ b/examples/ai-chat/src/App.css
@@ -157,6 +157,98 @@
   animation: shimmer-pulse 1.6s ease-in-out infinite;
 }
 
+/* Chat motion is restrained and state-driven. The message bubble is the one
+   signature transition; streamed blocks only use a short reveal so layout
+   remains readable while content is arriving. */
+.user-message-enter {
+  animation: user-message-enter 260ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+.assistant-turn-enter {
+  animation: assistant-turn-enter 240ms cubic-bezier(0.25, 1, 0.5, 1) 150ms both;
+}
+
+.stream-block-enter {
+  animation: stream-block-enter 220ms cubic-bezier(0.25, 1, 0.5, 1) both;
+}
+
+.message-part-enter {
+  animation: message-part-enter 220ms cubic-bezier(0.25, 1, 0.5, 1) both;
+}
+
+.submit-icon-enter {
+  animation: submit-icon-enter 160ms cubic-bezier(0.22, 1, 0.36, 1) both;
+}
+
+@keyframes user-message-enter {
+  from {
+    opacity: 0;
+    transform: translateY(12px) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0px) scale(1);
+  }
+}
+
+@keyframes assistant-turn-enter {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0px);
+  }
+}
+
+@keyframes stream-block-enter {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0px);
+  }
+}
+
+@keyframes message-part-enter {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0px);
+  }
+}
+
+@keyframes submit-icon-enter {
+  from {
+    opacity: 0.35;
+    transform: scale(0.72) rotate(-18deg);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) rotate(0deg);
+  }
+}
+
+/* Lynx's CSS parser does not expose media queries. The host preference is
+   mapped to this runtime class by useReducedMotion instead. */
+.motion-reduced .user-message-enter,
+.motion-reduced .assistant-turn-enter,
+.motion-reduced .stream-block-enter,
+.motion-reduced .message-part-enter,
+.motion-reduced .submit-icon-enter,
+.motion-reduced .shimmer-pulse,
+.motion-reduced .spin {
+  animation-duration: 1ms;
+  animation-delay: 0ms;
+  animation-iteration-count: 1;
+}
+
 @keyframes shimmer-pulse {
   0% {
     opacity: 1;

--- a/examples/ai-chat/src/App.css
+++ b/examples/ai-chat/src/App.css
@@ -165,7 +165,7 @@
 }
 
 .user-message-enter {
-  animation: user-message-enter 500ms cubic-bezier(0.25, 0.46, 0.45, 0.94) both;
+  animation: user-message-enter 500ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
 .assistant-turn-enter {
@@ -185,19 +185,11 @@
 }
 
 @keyframes user-message-enter {
-  0% {
+  from {
     opacity: 0.5;
     transform: translateY(var(--user-message-launch-distance)) scale(0.95);
   }
-  70% {
-    opacity: 1;
-    transform: translateY(-7px) scale(1.01);
-  }
-  86% {
-    opacity: 1;
-    transform: translateY(3px) scale(0.997);
-  }
-  100% {
+  to {
     opacity: 1;
     transform: translateY(0px) scale(1);
   }

--- a/examples/ai-chat/src/App.vue
+++ b/examples/ai-chat/src/App.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-import { computed, onMounted } from 'vue-lynx';
+import { computed, nextTick, onMounted, useTemplateRef, watch } from 'vue-lynx';
+import type { ShadowElement } from 'vue-lynx';
 
 import './App.css';
 import OverlayHost from './components/overlay/OverlayHost.vue';
@@ -7,6 +8,7 @@ import Sidebar from './components/Sidebar.vue';
 import Toaster from './components/ui/Toaster.vue';
 import { useChats } from './composables/useChats';
 import { useOverlay } from './composables/useOverlay';
+import { useReducedMotion } from './composables/useReducedMotion';
 import { useSession } from './composables/useSession';
 import { useTheme } from './composables/useTheme';
 import { useSidebarDrawer, useViewport } from './composables/useViewport';
@@ -22,8 +24,15 @@ const { fetchSession } = useSession();
 const { stack } = useOverlay();
 const { isMobile } = useViewport();
 const { sidebarOpen, close: closeSidebar } = useSidebarDrawer();
+const reducedMotion = useReducedMotion();
+const drawerRef = useTemplateRef<ShadowElement>('drawerRef');
+const DRAWER_EASING = 'cubic-bezier(0.25, 1, 0.5, 1)';
 
 const themeClass = computed(() => `theme-${colorMode.value}`);
+const rootClass = computed(() => [
+  themeClass.value,
+  reducedMotion.value ? 'motion-reduced' : '',
+]);
 
 // Translucent overlay backdrops don't composite on the Lynx web platform
 // (opaque backgrounds paint, alpha ones don't) — so modals dim the app by
@@ -34,6 +43,21 @@ function handleSidebarShowChange(show: boolean) {
   if (!show) closeSidebar();
 }
 
+async function syncDrawerSurface(open: boolean) {
+  // Lynx UI's Sheet keeps horizontal movement on the main thread. Vue's
+  // background style diff does not reliably update a previously translated
+  // native surface, so use the native UI method for the same direct mutation.
+  await nextTick();
+  drawerRef.value
+    ?.setNativeProps({
+      transform: open ? 'translateX(0px)' : 'translateX(-288px)',
+      transition: reducedMotion.value ? 'none' : `transform 240ms ${DRAWER_EASING}`,
+    })
+    .exec();
+}
+
+watch(sidebarOpen, (open) => void syncDrawerSurface(open));
+
 onMounted(async () => {
   await fetchSession();
   await fetchChats();
@@ -41,7 +65,7 @@ onMounted(async () => {
 </script>
 
 <template>
-  <view class="root w-full h-full bg-page font-sans" :class="themeClass" :style="rootStyle">
+  <view class="root w-full h-full bg-page font-sans" :class="rootClass" :style="rootStyle">
     <view
       class="flex flex-row flex-1 h-full app-content"
       :style="{ opacity: dimmed ? '0.4' : '1' }"
@@ -68,10 +92,11 @@ onMounted(async () => {
     <!-- Keep only the moving surface mounted so its transform can animate. -->
     <view
       v-if="isMobile"
+      ref="drawerRef"
       class="absolute top-0 bottom-0 left-0 drawer-panel shadow-lg"
       :event-through="false"
       :style="{
-        transform: sidebarOpen ? 'translateX(0px)' : 'translateX(-288px)',
+        transform: 'translateX(-288px)',
       }"
     >
       <Sidebar drawer />
@@ -94,7 +119,6 @@ onMounted(async () => {
   z-index: 40;
   width: 288px;
   background-color: var(--ui-bg-sidebar);
-  transition: transform 240ms cubic-bezier(0.25, 1, 0.5, 1);
 }
 .drawer-backdrop {
   z-index: 30;

--- a/examples/ai-chat/src/components/Navbar.vue
+++ b/examples/ai-chat/src/components/Navbar.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
+import { computed } from 'vue-lynx';
 import { useRouter } from 'vue-router';
 
 import { useColorMode } from '../composables/useColorMode';
 import { useSidebarDrawer, useViewport } from '../composables/useViewport';
 import Icon from './ui/Icon.vue';
+import MotionPressable from './ui/MotionPressable.vue';
 
 /**
  * Port of app/components/Navbar.vue (UDashboardNavbar): title slot on the
@@ -14,31 +16,61 @@ const router = useRouter();
 const { colorMode, toggle } = useColorMode();
 const { isMobile } = useViewport();
 const { toggle: toggleSidebar } = useSidebarDrawer();
+const SystemInfo = (globalThis as { SystemInfo?: { platform?: string } }).SystemInfo;
+const isIOS = SystemInfo?.platform === 'iOS';
+const hostProps =
+  typeof lynx === 'undefined'
+    ? undefined
+    : (lynx.__globalProps as { fullscreen?: boolean | string; safeAreaTop?: number } | undefined);
+const isFullscreen = hostProps?.fullscreen === true || hostProps?.fullscreen === 'true';
+const safeAreaTop = isFullscreen && isIOS ? Math.max(0, Number(hostProps?.safeAreaTop) || 0) : 0;
+const navbarStyle = computed(() => ({
+  // A full-screen LynxView includes the status-bar area. Use the inset supplied
+  // by the host so embedded views, landscape, and non-notched devices stay at 0.
+  paddingTop: isMobile.value && safeAreaTop > 0 ? `${safeAreaTop}px` : undefined,
+  height: isMobile.value ? `${48 + safeAreaTop}px` : '48px',
+}));
 </script>
 
 <template>
-  <view class="flex flex-row items-center justify-between px-4 h-12 shrink-0">
+  <view
+    class="flex flex-row items-center justify-between px-4 h-12 shrink-0"
+    :style="navbarStyle"
+  >
     <view class="flex flex-row items-center min-w-0 flex-1 gap-1">
-      <view v-if="isMobile" class="p-2 rounded-md" @tap="toggleSidebar()">
+      <MotionPressable
+        v-if="isMobile"
+        class="p-2 rounded-md"
+        accessibility-label="Open navigation"
+        @tap="toggleSidebar()"
+      >
         <Icon name="i-lucide-menu" tone="muted" :size="20" />
-      </view>
+      </MotionPressable>
       <slot name="title" />
     </view>
 
     <view class="flex flex-row items-center gap-1">
       <slot />
 
-      <view class="p-2 rounded-md" @tap="toggle">
+      <MotionPressable
+        class="p-2 rounded-md"
+        :accessibility-label="colorMode === 'dark' ? 'Use light mode' : 'Use dark mode'"
+        @tap="toggle"
+      >
         <Icon
           :name="colorMode === 'dark' ? 'i-lucide-moon' : 'i-lucide-sun'"
           tone="muted"
           :size="18"
         />
-      </view>
+      </MotionPressable>
 
-      <view class="p-2 rounded-md" @tap="router.push('/')">
+      <MotionPressable
+        class="p-2 rounded-md"
+        accessibility-label="New chat"
+        @tap="router.push('/')"
+      >
         <Icon name="i-lucide-circle-plus" tone="muted" :size="18" />
-      </view>
+      </MotionPressable>
     </view>
   </view>
 </template>

--- a/examples/ai-chat/src/components/Sidebar.vue
+++ b/examples/ai-chat/src/components/Sidebar.vue
@@ -10,6 +10,7 @@ import { useSidebarDrawer } from '../composables/useViewport';
 import Logo from './Logo.vue';
 import UserMenu from './UserMenu.vue';
 import Icon from './ui/Icon.vue';
+import MotionPressable from './ui/MotionPressable.vue';
 import UButton from './ui/UButton.vue';
 
 /**
@@ -85,12 +86,22 @@ function openChat(id: string) {
         <Logo :size="32" />
         <text class="text-xl font-bold text-highlighted">Chat</text>
       </view>
-      <view v-if="drawer" class="p-1.5 rounded-md" @tap="closeDrawer()">
+      <MotionPressable
+        v-if="drawer"
+        class="p-1.5 rounded-md"
+        accessibility-label="Close navigation"
+        @tap="closeDrawer()"
+      >
         <Icon name="i-lucide-x" tone="muted" :size="20" />
-      </view>
-      <view v-else class="p-1.5 rounded-md" @tap="collapsed = !collapsed">
+      </MotionPressable>
+      <MotionPressable
+        v-else
+        class="p-1.5 rounded-md"
+        accessibility-label="Toggle sidebar"
+        @tap="collapsed = !collapsed"
+      >
         <Icon name="i-lucide-panel-left" tone="muted" :size="20" />
-      </view>
+      </MotionPressable>
     </view>
 
     <!-- primary nav -->

--- a/examples/ai-chat/src/components/chat/MarkdownView.vue
+++ b/examples/ai-chat/src/components/chat/MarkdownView.vue
@@ -27,6 +27,13 @@ function tableStyle(columns: number) {
   return { width: `${Math.max(320, columns * 160)}px` };
 }
 
+function streamBlockStyle(index: number) {
+  return {
+    marginTop: index > 0 ? '16px' : '0px',
+    animationDelay: props.streaming ? `${Math.min(index, 3) * 28}ms` : '0ms',
+  };
+}
+
 const HEADING_CLASSES: Record<number, string> = {
   1: 'text-2xl font-bold text-highlighted',
   2: 'text-xl font-bold text-highlighted',
@@ -50,7 +57,8 @@ const HEADING_CLASSES: Record<number, string> = {
     <view
       v-for="(block, bi) in blocks"
       :key="bi"
-      :style="bi > 0 ? { marginTop: '16px' } : undefined"
+      :class="streaming ? 'stream-block-enter' : ''"
+      :style="streamBlockStyle(bi)"
     >
       <!-- paragraph / heading / quote share the inline renderer -->
       <text

--- a/examples/ai-chat/src/components/chat/PromptBox.vue
+++ b/examples/ai-chat/src/components/chat/PromptBox.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
-import { computed, useTemplateRef } from 'vue-lynx';
+import { computed, useTemplateRef, watch } from 'vue-lynx';
 import type { ShadowElement } from 'vue-lynx';
 
+import { setNativeInputValue } from '../../composables/useNativeInputValue';
 import { inputEventValue } from '../../lib/input-event';
 import type { ChatStatus } from '../../types/ai';
 import ModelSelect from '../ModelSelect.vue';
@@ -20,6 +21,7 @@ const props = withDefaults(
     status?: ChatStatus;
     disabled?: boolean;
     placeholder?: string;
+    resetKey?: number;
   }>(),
   { status: 'ready', placeholder: 'Type your message here...' },
 );
@@ -63,6 +65,14 @@ function blurInput() {
 function focusInput() {
   invokeInput('focus');
 }
+
+watch(
+  () => props.resetKey,
+  () => {
+    if (!isWeb && inputRef.value) setNativeInputValue(inputRef.value, '');
+  },
+  { flush: 'post' },
+);
 
 defineExpose({ blur: blurInput, focus: focusInput });
 </script>

--- a/examples/ai-chat/src/components/chat/PromptBox.vue
+++ b/examples/ai-chat/src/components/chat/PromptBox.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
-import { computed } from 'vue-lynx';
+import { computed, useTemplateRef } from 'vue-lynx';
+import type { ShadowElement } from 'vue-lynx';
 
 import { inputEventValue } from '../../lib/input-event';
 import type { ChatStatus } from '../../types/ai';
 import ModelSelect from '../ModelSelect.vue';
 import Icon from '../ui/Icon.vue';
+import MotionPressable from '../ui/MotionPressable.vue';
 
 /**
  * Port of UChatPrompt + UChatPromptSubmit: textarea with a footer row
@@ -17,7 +19,6 @@ const props = withDefaults(
     modelValue: string;
     status?: ChatStatus;
     disabled?: boolean;
-    error?: string | null;
     placeholder?: string;
   }>(),
   { status: 'ready', placeholder: 'Type your message here...' },
@@ -32,6 +33,7 @@ const emit = defineEmits<{
 }>();
 
 const isWeb = (globalThis as { SystemInfo?: { platform?: string } }).SystemInfo?.platform === 'web';
+const inputRef = useTemplateRef<ShadowElement>('inputRef');
 
 const submitState = computed(() => {
   if (props.status === 'submitted' || props.status === 'streaming') return 'stop';
@@ -49,17 +51,26 @@ function onSubmitTap() {
   else if (submitState.value === 'reload') emit('reload');
   else if (props.modelValue.trim()) emit('submit');
 }
+
+function invokeInput(method: 'focus' | 'blur') {
+  inputRef.value?.invoke({ method }).exec();
+}
+
+function blurInput() {
+  invokeInput('blur');
+}
+
+function focusInput() {
+  invokeInput('focus');
+}
+
+defineExpose({ blur: blurInput, focus: focusInput });
 </script>
 
 <template>
   <view
     class="flex flex-col rounded-lg prompt-surface border border-default px-1.5 pt-1.5 pb-1.5 shadow-sm"
   >
-    <view v-if="error" class="flex flex-row items-center gap-2 px-2.5 pt-1.5 pb-1">
-      <Icon name="i-lucide-alert-circle" tone="error" :size="16" />
-      <text class="text-sm text-error flex-1" text-maxline="2">{{ error }}</text>
-    </view>
-
     <slot name="header" />
 
     <view class="prompt-input-stack">
@@ -71,6 +82,7 @@ function onSubmitTap() {
            emits Lynx-shaped input events; Native uses the built-in tag. -->
       <view v-if="isWeb" class="prompt-input-web px-2.5 py-2">
         <x-textarea
+          ref="inputRef"
           :value="modelValue"
           :placeholder="placeholder"
           :maxlines="5"
@@ -85,6 +97,7 @@ function onSubmitTap() {
       </view>
       <textarea
         v-else
+        ref="inputRef"
         :value="modelValue"
         :placeholder="placeholder"
         :maxlines="5"
@@ -100,19 +113,27 @@ function onSubmitTap() {
 
     <view class="flex flex-row items-center justify-between px-1 pt-1">
       <view class="flex flex-row items-center gap-1">
-        <view class="p-1.5 rounded-md" @tap="emit('attach')">
+        <MotionPressable
+          class="p-1.5 rounded-md"
+          accessibility-label="Attach file"
+          @tap="emit('attach')"
+        >
           <Icon name="i-lucide-paperclip" tone="muted" :size="16" />
-        </view>
+        </MotionPressable>
 
         <ModelSelect />
       </view>
 
-      <view
+      <MotionPressable
         class="rounded-full p-1.5 bg-inverted items-center justify-center"
         :class="disabled ? 'opacity-50' : ''"
+        :disabled="disabled"
+        :accessibility-label="submitState === 'stop' ? 'Stop response' : submitState === 'reload' ? 'Retry response' : 'Send message'"
         @tap="onSubmitTap"
       >
         <Icon
+          :key="submitState"
+          class="submit-icon-enter"
           :name="
             submitState === 'stop'
               ? 'i-lucide-square'
@@ -123,7 +144,7 @@ function onSubmitTap() {
           tone="inverted"
           :size="16"
         />
-      </view>
+      </MotionPressable>
     </view>
   </view>
 </template>

--- a/examples/ai-chat/src/components/chat/PromptBox.vue
+++ b/examples/ai-chat/src/components/chat/PromptBox.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue-lynx';
 
+import { inputEventValue } from '../../lib/input-event';
 import type { ChatStatus } from '../../types/ai';
 import ModelSelect from '../ModelSelect.vue';
 import Icon from '../ui/Icon.vue';
@@ -30,14 +31,16 @@ const emit = defineEmits<{
   attach: [];
 }>();
 
+const isWeb = (globalThis as { SystemInfo?: { platform?: string } }).SystemInfo?.platform === 'web';
+
 const submitState = computed(() => {
   if (props.status === 'submitted' || props.status === 'streaming') return 'stop';
   if (props.status === 'error') return 'reload';
   return 'send';
 });
 
-function onInput(e: { detail?: { value?: string } }) {
-  emit('update:modelValue', e.detail?.value ?? '');
+function onInput(event: { detail?: unknown; target?: unknown }) {
+  emit('update:modelValue', inputEventValue(event));
 }
 
 function onSubmitTap() {
@@ -49,7 +52,9 @@ function onSubmitTap() {
 </script>
 
 <template>
-  <view class="flex flex-col rounded-lg prompt-surface border border-default px-1.5 pt-1.5 pb-1.5 shadow-sm">
+  <view
+    class="flex flex-col rounded-lg prompt-surface border border-default px-1.5 pt-1.5 pb-1.5 shadow-sm"
+  >
     <view v-if="error" class="flex flex-row items-center gap-2 px-2.5 pt-1.5 pb-1">
       <Icon name="i-lucide-alert-circle" tone="error" :size="16" />
       <text class="text-sm text-error flex-1" text-maxline="2">{{ error }}</text>
@@ -57,16 +62,41 @@ function onSubmitTap() {
 
     <slot name="header" />
 
-    <!-- Lynx has no auto-growing textarea on the web platform (tag unmapped
-         in web-core); a single-line input adapts the original's textarea. -->
-    <input
-      :value="modelValue"
-      :placeholder="placeholder"
-      confirm-type="send"
-      class="prompt-input text-base text-highlighted px-2.5 py-2"
-      @input="onInput"
-      @confirm="onSubmitTap"
-    />
+    <view class="prompt-input-stack">
+      <!-- The mirror participates in layout on both renderers. The textarea
+           overlays it, so wrapped text grows the composer without measuring
+           text through the background thread. -->
+      <text class="prompt-input-mirror text-base px-2.5 py-2">{{ modelValue || ' ' }}</text>
+      <!-- Web core currently maps `x-textarea` to the custom element that
+           emits Lynx-shaped input events; Native uses the built-in tag. -->
+      <view v-if="isWeb" class="prompt-input-web px-2.5 py-2">
+        <x-textarea
+          :value="modelValue"
+          :placeholder="placeholder"
+          :maxlines="5"
+          :maxlength="4000"
+          :bounces="false"
+          :enable-scroll-bar="false"
+          confirm-type="send"
+          class="prompt-input-web-control text-base text-highlighted"
+          @input="onInput"
+          @confirm="onSubmitTap"
+        />
+      </view>
+      <textarea
+        v-else
+        :value="modelValue"
+        :placeholder="placeholder"
+        :maxlines="5"
+        :maxlength="4000"
+        :bounces="false"
+        :enable-scroll-bar="false"
+        confirm-type="send"
+        class="prompt-input text-base text-highlighted px-2.5 py-2"
+        @input="onInput"
+        @confirm="onSubmitTap"
+      />
+    </view>
 
     <view class="flex flex-row items-center justify-between px-1 pt-1">
       <view class="flex flex-row items-center gap-1">
@@ -83,7 +113,13 @@ function onSubmitTap() {
         @tap="onSubmitTap"
       >
         <Icon
-          :name="submitState === 'stop' ? 'i-lucide-square' : submitState === 'reload' ? 'i-lucide-rotate-cw' : 'i-lucide-arrow-up'"
+          :name="
+            submitState === 'stop'
+              ? 'i-lucide-square'
+              : submitState === 'reload'
+              ? 'i-lucide-rotate-cw'
+              : 'i-lucide-arrow-up'
+          "
           tone="inverted"
           :size="16"
         />
@@ -98,13 +134,55 @@ function onSubmitTap() {
      so the halfway blend is precomputed per theme */
   background-color: var(--ui-bg-elevated-half);
 }
-.prompt-input {
-  height: 40px;
+.prompt-input-stack {
+  position: relative;
+  width: 100%;
+  min-height: 40px;
+  max-height: 112px;
+  overflow: hidden;
+}
+.prompt-input-mirror {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 40px;
+  max-height: 112px;
+  overflow: hidden;
+  color: transparent;
+  line-height: 24px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.prompt-input-web {
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+}
+.prompt-input-web-control {
+  height: 100%;
   width: 100%;
   background-color: transparent;
   border: none;
   color: var(--ui-text-highlighted);
   caret-color: var(--ui-primary);
+  line-height: 24px;
+  --placeholder-color: var(--ui-text-dimmed);
+}
+.prompt-input {
+  box-sizing: border-box;
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  background-color: transparent;
+  border: none;
+  color: var(--ui-text-highlighted);
+  caret-color: var(--ui-primary);
+  line-height: 24px;
   --placeholder-color: var(--ui-text-dimmed);
 }
 </style>

--- a/examples/ai-chat/src/components/chat/message/MessageActions.vue
+++ b/examples/ai-chat/src/components/chat/message/MessageActions.vue
@@ -5,6 +5,7 @@ import { useToast } from '../../../composables/useToast';
 import type { UIMessage } from '../../../types/ai';
 import { getTextFromMessage, isFileUIPart } from '../../../types/ai';
 import Icon from '../../ui/Icon.vue';
+import MotionPressable from '../../ui/MotionPressable.vue';
 
 /**
  * Port of app/components/chat/message/MessageActions.vue. UTooltips are
@@ -62,32 +63,49 @@ async function copy() {
 
 <template>
   <template v-if="message.role === 'assistant' && !streaming">
-    <view class="p-1.5 rounded-md" @tap="copy">
+    <MotionPressable class="p-1.5 rounded-md" accessibility-label="Copy response" @tap="copy">
       <Icon
         :name="copied ? 'i-lucide-copy-check' : 'i-lucide-copy'"
         :tone="copied ? 'primary' : 'muted'"
         :size="16"
       />
-    </view>
+    </MotionPressable>
 
-    <view class="p-1.5 rounded-md" @tap="emit('vote', message, true)">
+    <MotionPressable
+      class="p-1.5 rounded-md"
+      accessibility-label="Helpful response"
+      @tap="emit('vote', message, true)"
+    >
       <Icon name="i-lucide-thumbs-up" :tone="vote === true ? 'success' : 'muted'" :size="16" />
-    </view>
+    </MotionPressable>
 
-    <view class="p-1.5 rounded-md" @tap="emit('vote', message, false)">
+    <MotionPressable
+      class="p-1.5 rounded-md"
+      accessibility-label="Unhelpful response"
+      @tap="emit('vote', message, false)"
+    >
       <Icon name="i-lucide-thumbs-down" :tone="vote === false ? 'error' : 'muted'" :size="16" />
-    </view>
+    </MotionPressable>
 
-    <view class="p-1.5 rounded-md" @tap="emit('regenerate', message)">
+    <MotionPressable
+      class="p-1.5 rounded-md"
+      accessibility-label="Regenerate response"
+      @tap="emit('regenerate', message)"
+    >
       <Icon name="i-lucide-rotate-cw" tone="muted" :size="16" />
-    </view>
+    </MotionPressable>
   </template>
 
   <template v-if="message.role === 'user' && !streaming && !editing">
     <text v-if="formattedDate" class="text-xs text-muted mr-1.5">{{ formattedDate }}</text>
 
-    <view v-if="!hasFiles" class="p-1.5 rounded-md" @tap="emit('edit', message)">
+    <MotionPressable
+      v-if="!hasFiles"
+      class="p-1.5 rounded-md"
+      accessibility-label="Edit message"
+      @tap="emit('edit', message)"
+    >
       <Icon name="i-lucide-pencil" tone="muted" :size="16" />
-    </view>
+    </MotionPressable>
   </template>
 </template>

--- a/examples/ai-chat/src/components/chat/message/MessageContent.vue
+++ b/examples/ai-chat/src/components/chat/message/MessageContent.vue
@@ -34,6 +34,11 @@ const emit = defineEmits<{
 const merged = computed(() => getMergedParts(props.message.parts));
 const sources = computed(() => collectSources(props.message.parts));
 const fileParts = computed(() => props.message.parts.filter(isFileUIPart));
+
+function partEntranceClass(part: UIMessage['parts'][number]) {
+  if (props.message.role !== 'assistant' || isTextUIPart(part) || !isPartStreaming(part)) return '';
+  return 'message-part-enter';
+}
 </script>
 
 <template>
@@ -56,6 +61,7 @@ const fileParts = computed(() => props.message.parts.filter(isFileUIPart));
     <view
       v-for="(part, index) in merged"
       :key="`${message.id}-${part.type}-${index}`"
+      :class="partEntranceClass(part)"
       :style="index > 0 || fileParts.length ? { marginTop: '12px' } : undefined"
     >
       <ReasoningPart

--- a/examples/ai-chat/src/components/chat/message/MessageEdit.vue
+++ b/examples/ai-chat/src/components/chat/message/MessageEdit.vue
@@ -19,7 +19,7 @@ const emit = defineEmits<{
 
 const editingText = ref(props.text);
 const inputRef = useTemplateRef<ShadowElement>('inputRef');
-useNativeInputValue(inputRef, () => editingText.value);
+const syncInitialValue = useNativeInputValue(inputRef, () => editingText.value);
 const canSave = computed(
   () => editingText.value.trim().length > 0 && editingText.value !== props.text,
 );
@@ -33,6 +33,7 @@ const canSave = computed(
       v-model="editingText"
       class="edit-input text-base text-highlighted"
       confirm-type="done"
+      @layoutchange="syncInitialValue"
       @confirm="canSave && emit('save', message, editingText)"
     />
 

--- a/examples/ai-chat/src/components/ui/MotionPressable.vue
+++ b/examples/ai-chat/src/components/ui/MotionPressable.vue
@@ -1,0 +1,80 @@
+<script setup lang="ts">
+/**
+ * Touch feedback is intentionally handled on Lynx's main thread. The tap
+ * still crosses to Vue's background thread for the actual application action,
+ * but the pressed state appears synchronously on Native.
+ */
+const props = withDefaults(
+  defineProps<{
+    disabled?: boolean;
+    accessibilityLabel?: string;
+  }>(),
+  { disabled: false },
+);
+
+const emit = defineEmits<{ tap: [] }>();
+
+interface MainThreadTouchEvent {
+  currentTarget?: {
+    setStyleProperty?(name: string, value: string): void;
+  };
+}
+
+const pressIn = (event: MainThreadTouchEvent) => {
+  'main thread';
+  const element = event.currentTarget;
+  const prefersReducedMotion = Boolean(
+    (lynx.__globalProps as { prefersReducedMotion?: boolean } | undefined)?.prefersReducedMotion,
+  );
+  if (prefersReducedMotion) {
+    element?.setStyleProperty?.('transition', 'none');
+    element?.setStyleProperty?.('transform', 'scale(1)');
+    element?.setStyleProperty?.('opacity', '0.72');
+    return;
+  }
+  element?.setStyleProperty?.(
+    'transition',
+    'transform 90ms cubic-bezier(0.25, 1, 0.5, 1), opacity 90ms linear',
+  );
+  element?.setStyleProperty?.('transform', 'scale(0.94)');
+  element?.setStyleProperty?.('opacity', '0.72');
+};
+
+const pressOut = (event: MainThreadTouchEvent) => {
+  'main thread';
+  const element = event.currentTarget;
+  const prefersReducedMotion = Boolean(
+    (lynx.__globalProps as { prefersReducedMotion?: boolean } | undefined)?.prefersReducedMotion,
+  );
+  if (prefersReducedMotion) {
+    element?.setStyleProperty?.('transition', 'none');
+    element?.setStyleProperty?.('transform', 'scale(1)');
+    element?.setStyleProperty?.('opacity', '1');
+    return;
+  }
+  element?.setStyleProperty?.(
+    'transition',
+    'transform 140ms cubic-bezier(0.22, 1, 0.36, 1), opacity 140ms linear',
+  );
+  element?.setStyleProperty?.('transform', 'scale(1)');
+  element?.setStyleProperty?.('opacity', '1');
+};
+
+function onTap() {
+  if (!props.disabled) emit('tap');
+}
+</script>
+
+<template>
+  <view
+    :main-thread-bindtouchstart="props.disabled ? undefined : pressIn"
+    :main-thread-bindtouchend="props.disabled ? undefined : pressOut"
+    :main-thread-bindtouchcancel="props.disabled ? undefined : pressOut"
+    :accessibility-element="true"
+    accessibility-trait="button"
+    :accessibility-label="accessibilityLabel"
+    @tap="onTap"
+  >
+    <slot />
+  </view>
+</template>

--- a/examples/ai-chat/src/components/ui/UButton.vue
+++ b/examples/ai-chat/src/components/ui/UButton.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue-lynx';
 
 import Icon from './Icon.vue';
+import MotionPressable from './MotionPressable.vue';
 
 /**
  * Lynx re-implementation of the UButton subset the template uses.
@@ -114,10 +115,15 @@ function onTap() {
 </script>
 
 <template>
-  <view :class="classes" @tap="onTap">
+  <MotionPressable
+    :class="classes"
+    :disabled="disabled"
+    :accessibility-label="label"
+    @tap="onTap"
+  >
     <Icon v-if="icon" :name="icon" :tone="iconTone" :size="iconSize" />
     <slot />
     <text v-if="label" :class="labelClass">{{ label }}</text>
     <Icon v-if="trailingIcon" :name="trailingIcon" :tone="iconTone" :size="iconSize" />
-  </view>
+  </MotionPressable>
 </template>

--- a/examples/ai-chat/src/composables/useKeyboardAvoidance.ts
+++ b/examples/ai-chat/src/composables/useKeyboardAvoidance.ts
@@ -4,14 +4,8 @@ const KEYBOARD_EVENT = 'keyboardstatuschanged';
 const EASING = 'cubic-bezier(0.25, 1, 0.5, 1)';
 
 export interface KeyboardEventEmitter {
-  addListener(
-    name: string,
-    listener: (status: unknown, height: unknown) => void,
-  ): void;
-  removeListener(
-    name: string,
-    listener: (status: unknown, height: unknown) => void,
-  ): void;
+  addListener(name: string, listener: (status: unknown, height: unknown) => void): void;
+  removeListener(name: string, listener: (status: unknown, height: unknown) => void): void;
 }
 
 export interface KeyboardAvoidanceTarget {
@@ -27,7 +21,9 @@ function keyboardHeight(status: unknown, height: unknown): number {
 export function bindKeyboardAvoidance(
   emitter: KeyboardEventEmitter,
   getTarget: () => KeyboardAvoidanceTarget | null,
+  onHeightChange?: (height: number, previousHeight: number) => void,
 ): () => void {
+  let previousHeight = 0;
   const listener = (status: unknown, height: unknown) => {
     const offset = keyboardHeight(status, height);
     getTarget()
@@ -36,6 +32,8 @@ export function bindKeyboardAvoidance(
         transition: `transform ${offset > 0 ? '0.3s' : '0.1s'} ${EASING}`,
       })
       .exec();
+    onHeightChange?.(offset, previousHeight);
+    previousHeight = offset;
   };
 
   emitter.addListener(KEYBOARD_EVENT, listener);
@@ -44,6 +42,7 @@ export function bindKeyboardAvoidance(
 
 export function useKeyboardAvoidance(
   target: Readonly<{ value: KeyboardAvoidanceTarget | null }>,
+  onHeightChange?: (height: number, previousHeight: number) => void,
 ): void {
   let cleanup: (() => void) | undefined;
 
@@ -51,7 +50,7 @@ export function useKeyboardAvoidance(
     if (typeof lynx === 'undefined') return;
     const emitter = lynx.getJSModule('GlobalEventEmitter') as KeyboardEventEmitter | undefined;
     if (!emitter) return;
-    cleanup = bindKeyboardAvoidance(emitter, () => target.value);
+    cleanup = bindKeyboardAvoidance(emitter, () => target.value, onHeightChange);
   });
 
   onUnmounted(() => cleanup?.());

--- a/examples/ai-chat/src/composables/useKeyboardAvoidance.ts
+++ b/examples/ai-chat/src/composables/useKeyboardAvoidance.ts
@@ -45,8 +45,11 @@ export function useKeyboardAvoidance(
   onHeightChange?: (height: number, previousHeight: number) => void,
 ): void {
   let cleanup: (() => void) | undefined;
+  const isWeb =
+    (globalThis as { SystemInfo?: { platform?: string } }).SystemInfo?.platform === 'web';
 
   onMounted(() => {
+    if (isWeb) return;
     if (typeof lynx === 'undefined') return;
     const emitter = lynx.getJSModule('GlobalEventEmitter') as KeyboardEventEmitter | undefined;
     if (!emitter) return;

--- a/examples/ai-chat/src/composables/useNativeInputValue.ts
+++ b/examples/ai-chat/src/composables/useNativeInputValue.ts
@@ -1,5 +1,3 @@
-import { nextTick, onMounted } from 'vue-lynx';
-
 export interface NativeInputTarget {
   invoke(options: {
     method: string;
@@ -16,14 +14,23 @@ export function setNativeInputValue(target: NativeInputTarget, value: string): v
     .exec();
 }
 
+export function createNativeInputValueSync(
+  target: Readonly<{ value: NativeInputTarget | null }>,
+  getValue: () => string,
+): () => void {
+  let synced = false;
+  return () => {
+    if (synced || !target.value) return;
+    setNativeInputValue(target.value, getValue());
+    synced = true;
+  };
+}
+
 export function useNativeInputValue(
   target: Readonly<{ value: NativeInputTarget | null }>,
   getValue: () => string,
-): void {
-  onMounted(async () => {
-    // Wait until the input creation op has reached the native tree before
-    // invoking its UI method. v-model continues to own subsequent updates.
-    await nextTick();
-    if (target.value) setNativeInputValue(target.value, getValue());
-  });
+): () => void {
+  // A conditional input can mount before its create op reaches the native
+  // tree. Its first layoutchange is the deterministic native-ready signal.
+  return createNativeInputValueSync(target, getValue);
 }

--- a/examples/ai-chat/src/composables/useReducedMotion.ts
+++ b/examples/ai-chat/src/composables/useReducedMotion.ts
@@ -1,0 +1,33 @@
+import { onScopeDispose, ref } from 'vue-lynx';
+
+interface MediaQueryListLike {
+  matches: boolean;
+  addEventListener?(type: 'change', listener: (event: { matches: boolean }) => void): void;
+  removeEventListener?(type: 'change', listener: (event: { matches: boolean }) => void): void;
+}
+
+/**
+ * Lynx Web runs Vue in a worker, so an embedding host passes its matchMedia
+ * result as globalProps.prefersReducedMotion. The direct matchMedia fallback
+ * also covers same-realm renderers and tests. Native keeps the restrained
+ * default until its host supplies the same global prop.
+ */
+export function useReducedMotion() {
+  const globalProps =
+    typeof lynx === 'undefined'
+      ? undefined
+      : (lynx.__globalProps as { prefersReducedMotion?: boolean } | undefined);
+  const matchMedia = (globalThis as {
+    matchMedia?: (query: string) => MediaQueryListLike;
+  }).matchMedia;
+  const query = matchMedia?.('(prefers-reduced-motion: reduce)');
+  const reduced = ref(globalProps?.prefersReducedMotion ?? query?.matches ?? false);
+  const onChange = (event: { matches: boolean }) => {
+    reduced.value = event.matches;
+  };
+
+  query?.addEventListener?.('change', onChange);
+  onScopeDispose(() => query?.removeEventListener?.('change', onChange));
+
+  return reduced;
+}

--- a/examples/ai-chat/src/lib/chat-viewport.ts
+++ b/examples/ai-chat/src/lib/chat-viewport.ts
@@ -1,5 +1,6 @@
 const DEFAULT_NEAR_BOTTOM_THRESHOLD = 72;
 const NEW_TURN_TOP_GAP = 16;
+const WEB_BOTTOM_OFFSET = 1_000_000;
 
 interface ScrollMetrics {
   scrollTop: number;
@@ -57,6 +58,10 @@ export function calculateBottomSpacer(metrics: BottomSpacerMetrics): number {
 
 export function turnScrollMode(platform?: string): 'anchor' | 'bottom' {
   return platform === 'web' ? 'bottom' : 'anchor';
+}
+
+export function nextWebBottomOffset(current: number): number {
+  return current === WEB_BOTTOM_OFFSET ? WEB_BOTTOM_OFFSET - 1 : WEB_BOTTOM_OFFSET;
 }
 
 export function calculateMessageLaunchDistance(metrics: MessageLaunchMetrics): number {

--- a/examples/ai-chat/src/lib/chat-viewport.ts
+++ b/examples/ai-chat/src/lib/chat-viewport.ts
@@ -1,0 +1,48 @@
+const DEFAULT_NEAR_BOTTOM_THRESHOLD = 72;
+const NEW_TURN_TOP_GAP = 16;
+
+interface ScrollMetrics {
+  scrollTop: number;
+  scrollHeight: number;
+  viewportHeight: number;
+}
+
+interface BottomSpacerMetrics {
+  composerHeight: number;
+  keyboardHeight: number;
+  viewportHeight: number;
+  anchoredTurnHeight?: number;
+}
+
+function positive(value: number): number {
+  return Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+export function bottomDistance(metrics: ScrollMetrics): number {
+  const scrollTop = Math.max(0, Number.isFinite(metrics.scrollTop) ? metrics.scrollTop : 0);
+  return Math.max(0, positive(metrics.scrollHeight) - positive(metrics.viewportHeight) - scrollTop);
+}
+
+export function isNearBottom(
+  metrics: ScrollMetrics,
+  threshold = DEFAULT_NEAR_BOTTOM_THRESHOLD,
+): boolean {
+  return bottomDistance(metrics) <= positive(threshold);
+}
+
+export function calculateBottomSpacer(metrics: BottomSpacerMetrics): number {
+  const composerHeight = positive(metrics.composerHeight);
+  const keyboardHeight = positive(metrics.keyboardHeight);
+  const obstruction = composerHeight + keyboardHeight;
+
+  if (metrics.anchoredTurnHeight === undefined) return obstruction;
+
+  const blankSpace = Math.max(
+    0,
+    positive(metrics.viewportHeight) -
+      obstruction -
+      positive(metrics.anchoredTurnHeight) -
+      NEW_TURN_TOP_GAP,
+  );
+  return obstruction + blankSpace;
+}

--- a/examples/ai-chat/src/lib/chat-viewport.ts
+++ b/examples/ai-chat/src/lib/chat-viewport.ts
@@ -14,6 +14,14 @@ interface BottomSpacerMetrics {
   anchoredTurnHeight?: number;
 }
 
+interface MessageLaunchMetrics {
+  platform?: string;
+  viewportHeight: number;
+  composerHeight: number;
+  keyboardHeight: number;
+  messageHeight: number;
+}
+
 function positive(value: number): number {
   return Number.isFinite(value) && value > 0 ? value : 0;
 }
@@ -45,4 +53,21 @@ export function calculateBottomSpacer(metrics: BottomSpacerMetrics): number {
       NEW_TURN_TOP_GAP,
   );
   return obstruction + blankSpace;
+}
+
+export function turnScrollMode(platform?: string): 'anchor' | 'bottom' {
+  return platform === 'web' ? 'bottom' : 'anchor';
+}
+
+export function calculateMessageLaunchDistance(metrics: MessageLaunchMetrics): number {
+  if (turnScrollMode(metrics.platform) === 'bottom') return 0;
+
+  const distance =
+    positive(metrics.viewportHeight) -
+    positive(metrics.composerHeight) -
+    positive(metrics.keyboardHeight) -
+    positive(metrics.messageHeight) -
+    NEW_TURN_TOP_GAP;
+
+  return Math.min(420, Math.max(44, distance));
 }

--- a/examples/ai-chat/src/lib/input-event.ts
+++ b/examples/ai-chat/src/lib/input-event.ts
@@ -1,0 +1,15 @@
+interface TextInputEventLike {
+  detail?: unknown;
+  target?: unknown;
+}
+
+function valueFrom(candidate: unknown): string | undefined {
+  if (typeof candidate === 'string') return candidate;
+  if (!candidate || typeof candidate !== 'object') return undefined;
+  const value = (candidate as { value?: unknown }).value;
+  return typeof value === 'string' ? value : undefined;
+}
+
+export function inputEventValue(event: TextInputEventLike): string {
+  return valueFrom(event.detail) ?? valueFrom(event.target) ?? '';
+}

--- a/examples/ai-chat/src/pages/ChatPage.vue
+++ b/examples/ai-chat/src/pages/ChatPage.vue
@@ -25,6 +25,7 @@ import {
   calculateBottomSpacer,
   calculateMessageLaunchDistance,
   isNearBottom,
+  nextWebBottomOffset,
   turnScrollMode,
 } from '../lib/chat-viewport';
 import type { UIMessage } from '../types/ai';
@@ -114,6 +115,7 @@ const pendingAnimatedUserMessageId = ref<string | null>(null);
 const userMessageLaunchDistance = ref(0);
 const anchoredTurnHeight = ref(0);
 const followsOutput = ref(true);
+const webScrollOffset = ref<number>();
 const messageHeights = new Map<string, number>();
 let scrollTop = 0;
 let scrollHeight = 0;
@@ -150,6 +152,12 @@ const { messages, status, error, sendMessage, regenerate, stop } = chat;
 onUnmounted(stop);
 
 async function scrollToBottom(smooth = false) {
+  if (turnMode === 'bottom') {
+    webScrollOffset.value = nextWebBottomOffset(webScrollOffset.value ?? 0);
+    await nextTick();
+    return;
+  }
+
   // nextTick waits for the main thread to apply pending ops so the
   // scroll-view ref is resolvable by selector.
   await nextTick();
@@ -208,7 +216,7 @@ function beginAnchoredTurn(message: UIMessage | undefined, animateUser: boolean)
     animatedUserMessageId.value = animateUser ? message.id : null;
     userMessageLaunchDistance.value = 0;
     updateAnchoredTurnHeight();
-    void scrollToBottom(true);
+    void scrollToBottom();
     return;
   }
 
@@ -323,6 +331,16 @@ watch(status, async (value) => {
     title.value = updated.label;
   }
 });
+
+if (turnMode === 'bottom') {
+  watch(
+    messages,
+    () => {
+      if (followsOutput.value) void scrollToBottom();
+    },
+    { deep: true, flush: 'post' },
+  );
+}
 
 onMounted(async () => {
   try {
@@ -510,6 +528,7 @@ const bottomSpacerHeight = computed(() =>
     <scroll-view
       ref="scrollRef"
       scroll-orientation="vertical"
+      :scroll-top="webScrollOffset"
       :bounces="false"
       :scroll-bar-enable="false"
       class="flex-1 min-h-0"

--- a/examples/ai-chat/src/pages/ChatPage.vue
+++ b/examples/ai-chat/src/pages/ChatPage.vue
@@ -21,7 +21,12 @@ import { useOverlay } from '../composables/useOverlay';
 import { useToast } from '../composables/useToast';
 import { useViewport } from '../composables/useViewport';
 import { apiFetch } from '../lib/api';
-import { calculateBottomSpacer, isNearBottom } from '../lib/chat-viewport';
+import {
+  calculateBottomSpacer,
+  calculateMessageLaunchDistance,
+  isNearBottom,
+  turnScrollMode,
+} from '../lib/chat-viewport';
 import type { UIMessage } from '../types/ai';
 
 /** Port of app/pages/chat/[id].vue. */
@@ -56,6 +61,7 @@ interface Vote {
 const votes = ref<Vote[]>([]);
 
 const input = ref('');
+const inputResetKey = ref(0);
 const editingMessageId = ref<string | null>(null);
 
 const { files, open, removeFile, clearFiles, uploading, uploadedFiles } = useAttachments();
@@ -91,9 +97,10 @@ interface TouchLikeEvent {
 
 const systemInfo = (
   globalThis as {
-    SystemInfo?: { pixelHeight?: number; pixelRatio?: number };
+    SystemInfo?: { pixelHeight?: number; pixelRatio?: number; platform?: string };
   }
 ).SystemInfo;
+const turnMode = turnScrollMode(systemInfo?.platform);
 const initialViewportHeight = Math.max(
   0,
   (systemInfo?.pixelHeight ?? 720) / (systemInfo?.pixelRatio || 1) - 56,
@@ -103,6 +110,8 @@ const composerHeight = ref(112);
 const keyboardHeight = ref(0);
 const anchoredMessageId = ref<string | null>(null);
 const animatedUserMessageId = ref<string | null>(null);
+const pendingAnimatedUserMessageId = ref<string | null>(null);
+const userMessageLaunchDistance = ref(0);
 const anchoredTurnHeight = ref(0);
 const followsOutput = ref(true);
 const messageHeights = new Map<string, number>();
@@ -191,11 +200,35 @@ function updateAnchoredTurnHeight() {
 
 function beginAnchoredTurn(message: UIMessage | undefined, animateUser: boolean) {
   if (!message || message.role !== 'user') return;
-  anchoredMessageId.value = message.id;
-  animatedUserMessageId.value = animateUser ? message.id : null;
   followsOutput.value = true;
+
+  if (turnMode === 'bottom') {
+    anchoredMessageId.value = null;
+    pendingAnimatedUserMessageId.value = null;
+    animatedUserMessageId.value = animateUser ? message.id : null;
+    userMessageLaunchDistance.value = 0;
+    updateAnchoredTurnHeight();
+    void scrollToBottom(true);
+    return;
+  }
+
+  anchoredMessageId.value = message.id;
+  pendingAnimatedUserMessageId.value = animateUser ? message.id : null;
+  animatedUserMessageId.value = null;
   updateAnchoredTurnHeight();
   void scrollMessageToTop(message.id);
+}
+
+function userMessageLaunchStyle(messageId: string) {
+  if (
+    messageId !== animatedUserMessageId.value &&
+    messageId !== pendingAnimatedUserMessageId.value
+  ) {
+    return undefined;
+  }
+  return {
+    '--user-message-launch-distance': `${userMessageLaunchDistance.value}px`,
+  };
 }
 
 function isAssistantForAnimatedTurn(message: UIMessage) {
@@ -262,9 +295,22 @@ function handleComposerLayout(event: LayoutEvent) {
 
 function handleMessageLayout(messageId: string, event: LayoutEvent) {
   const height = Number(event.detail?.height);
-  if (!Number.isFinite(height) || height <= 0 || messageHeights.get(messageId) === height) return;
-  messageHeights.set(messageId, height);
-  updateAnchoredTurnHeight();
+  if (!Number.isFinite(height) || height <= 0) return;
+  if (messageHeights.get(messageId) !== height) {
+    messageHeights.set(messageId, height);
+    updateAnchoredTurnHeight();
+  }
+  if (pendingAnimatedUserMessageId.value !== messageId) return;
+
+  userMessageLaunchDistance.value = calculateMessageLaunchDistance({
+    platform: systemInfo?.platform,
+    viewportHeight: viewportHeight.value,
+    composerHeight: composerHeight.value,
+    keyboardHeight: keyboardHeight.value,
+    messageHeight: height,
+  });
+  pendingAnimatedUserMessageId.value = null;
+  animatedUserMessageId.value = messageId;
 }
 
 // The title is generated server-side before streaming starts on the first
@@ -309,7 +355,7 @@ onMounted(async () => {
   }
 });
 
-async function handleSubmit() {
+function handleSubmit() {
   if (input.value.trim() && !uploading.value) {
     const generation = sendMessage({
       text: input.value,
@@ -317,6 +363,7 @@ async function handleSubmit() {
     });
     beginAnchoredTurn(messages.value[messages.value.length - 1], true);
     input.value = '';
+    inputResetKey.value += 1;
     clearFiles();
     void generation;
   }
@@ -437,7 +484,8 @@ const bottomSpacerHeight = computed(() =>
     composerHeight: isOwner.value ? composerHeight.value : 0,
     keyboardHeight: isOwner.value ? keyboardHeight.value : 0,
     viewportHeight: viewportHeight.value,
-    anchoredTurnHeight: anchoredMessageId.value ? anchoredTurnHeight.value : undefined,
+    anchoredTurnHeight:
+      turnMode === 'anchor' && anchoredMessageId.value ? anchoredTurnHeight.value : undefined,
   }),
 );
 </script>
@@ -483,20 +531,23 @@ const bottomSpacerHeight = computed(() =>
             class="flex flex-col"
             :class="[
               message.role === 'user' ? 'items-end' : 'items-start',
+              message.role === 'user' && message.id === animatedUserMessageId
+                ? 'user-message-enter'
+                : message.role === 'user' && message.id === pendingAnimatedUserMessageId
+                  ? 'user-message-pending'
+                  : '',
               isAssistantForAnimatedTurn(message) ? 'assistant-turn-enter' : '',
             ]"
+            :style="userMessageLaunchStyle(message.id)"
             @layoutchange="(event) => handleMessageLayout(message.id, event)"
           >
             <!-- user bubble / assistant full width -->
             <view
-              :class="[
+              :class="
                 message.role === 'user'
                   ? 'bg-elevated rounded-lg px-4 py-3 user-bubble'
-                  : 'w-full',
-                message.role === 'user' && message.id === animatedUserMessageId
-                  ? 'user-message-enter'
-                  : '',
-              ]"
+                  : 'w-full'
+              "
             >
               <MessageContent
                 :message="message"
@@ -564,6 +615,7 @@ const bottomSpacerHeight = computed(() =>
         <PromptBox
           ref="promptBoxRef"
           v-model="input"
+          :reset-key="inputResetKey"
           :status="status"
           :disabled="uploading"
           @submit="handleSubmit"

--- a/examples/ai-chat/src/pages/ChatPage.vue
+++ b/examples/ai-chat/src/pages/ChatPage.vue
@@ -11,6 +11,7 @@ import MessageContent from '../components/chat/message/MessageContent.vue';
 import PromptBox from '../components/chat/PromptBox.vue';
 import Navbar from '../components/Navbar.vue';
 import Icon from '../components/ui/Icon.vue';
+import MotionPressable from '../components/ui/MotionPressable.vue';
 import { useAttachments } from '../composables/useAttachments';
 import { useChat } from '../composables/useChat';
 import { useChats } from '../composables/useChats';
@@ -61,6 +62,11 @@ const { files, open, removeFile, clearFiles, uploading, uploadedFiles } = useAtt
 
 const scrollRef = useTemplateRef<ShadowElement>('scrollRef');
 const promptRef = useTemplateRef<ShadowElement>('promptRef');
+interface PromptBoxHandle {
+  blur(): void;
+  focus(): void;
+}
+const promptBoxRef = useTemplateRef<PromptBoxHandle>('promptBoxRef');
 
 interface LayoutEvent {
   detail?: { height?: number };
@@ -71,6 +77,16 @@ interface ScrollEvent {
     scrollTop?: number;
     scrollHeight?: number;
   };
+}
+
+interface TouchPoint {
+  clientY?: number;
+  pageY?: number;
+}
+
+interface TouchLikeEvent {
+  touches?: TouchPoint[];
+  detail?: { touches?: TouchPoint[] };
 }
 
 const systemInfo = (
@@ -86,11 +102,13 @@ const viewportHeight = ref(initialViewportHeight);
 const composerHeight = ref(112);
 const keyboardHeight = ref(0);
 const anchoredMessageId = ref<string | null>(null);
+const animatedUserMessageId = ref<string | null>(null);
 const anchoredTurnHeight = ref(0);
 const followsOutput = ref(true);
 const messageHeights = new Map<string, number>();
 let scrollTop = 0;
 let scrollHeight = 0;
+let scrollDragStartY: number | null = null;
 
 useKeyboardAvoidance(promptRef, (height) => {
   keyboardHeight.value = height;
@@ -113,7 +131,7 @@ const chat = useChat({
       description: message,
       icon: 'i-lucide-alert-circle',
       color: 'error',
-      duration: 0,
+      duration: 4000,
     });
   },
 });
@@ -171,12 +189,43 @@ function updateAnchoredTurnHeight() {
   anchoredTurnHeight.value = Math.max(84, height);
 }
 
-function beginAnchoredTurn(message: UIMessage | undefined) {
+function beginAnchoredTurn(message: UIMessage | undefined, animateUser: boolean) {
   if (!message || message.role !== 'user') return;
   anchoredMessageId.value = message.id;
+  animatedUserMessageId.value = animateUser ? message.id : null;
   followsOutput.value = true;
   updateAnchoredTurnHeight();
   void scrollMessageToTop(message.id);
+}
+
+function isAssistantForAnimatedTurn(message: UIMessage) {
+  const anchorId = animatedUserMessageId.value;
+  if (!anchorId || message.role !== 'assistant') return false;
+  const anchorIndex = messages.value.findIndex((item) => item.id === anchorId);
+  return anchorIndex >= 0 && messages.value[anchorIndex + 1]?.id === message.id;
+}
+
+function touchY(event: TouchLikeEvent) {
+  const point = event.touches?.[0] ?? event.detail?.touches?.[0];
+  const y = Number(point?.clientY ?? point?.pageY);
+  return Number.isFinite(y) ? y : null;
+}
+
+function handleScrollTouchStart(event: TouchLikeEvent) {
+  scrollDragStartY = touchY(event);
+}
+
+function handleScrollTouchMove(event: TouchLikeEvent) {
+  if (keyboardHeight.value <= 0 || scrollDragStartY === null) return;
+  const nextY = touchY(event);
+  if (nextY === null || Math.abs(nextY - scrollDragStartY) < 6) return;
+  scrollDragStartY = null;
+  followsOutput.value = false;
+  promptBoxRef.value?.blur();
+}
+
+function handleScrollTouchEnd() {
+  scrollDragStartY = null;
 }
 
 function handleScroll(event: ScrollEvent) {
@@ -253,7 +302,7 @@ onMounted(async () => {
   // Arriving from the home page with only the first user message: generate.
   if (data.value.isOwner && data.value.messages.length === 1) {
     const generation = regenerate();
-    beginAnchoredTurn(messages.value[0]);
+    beginAnchoredTurn(messages.value[0], true);
     void generation;
   } else {
     void scrollToBottom();
@@ -266,7 +315,7 @@ async function handleSubmit() {
       text: input.value,
       files: uploadedFiles.value.length > 0 ? uploadedFiles.value : undefined,
     });
-    beginAnchoredTurn(messages.value[messages.value.length - 1]);
+    beginAnchoredTurn(messages.value[messages.value.length - 1], true);
     input.value = '';
     clearFiles();
     void generation;
@@ -294,7 +343,7 @@ async function saveEdit(message: UIMessage, text: string) {
   }
   editingMessageId.value = null;
   const generation = sendMessage({ text, messageId: message.id });
-  beginAnchoredTurn(messages.value[messages.value.length - 1]);
+  beginAnchoredTurn(messages.value[messages.value.length - 1], true);
   void generation;
 }
 
@@ -313,13 +362,15 @@ async function regenerateMessage(message: UIMessage) {
     return;
   }
   const generation = regenerate({ messageId: message.id });
-  beginAnchoredTurn([...messages.value].reverse().find((item) => item.role === 'user'));
+  const userMessage = [...messages.value].reverse().find((item) => item.role === 'user');
+  beginAnchoredTurn(userMessage, false);
   void generation;
 }
 
 function handleRegenerate() {
   const generation = regenerate();
-  beginAnchoredTurn([...messages.value].reverse().find((message) => message.role === 'user'));
+  const userMessage = [...messages.value].reverse().find((message) => message.role === 'user');
+  beginAnchoredTurn(userMessage, false);
   void generation;
 }
 
@@ -375,6 +426,8 @@ const showIndicator = computed(
       lastMessage.value.parts.length === 0),
 );
 
+const showGenerationError = computed(() => status.value === 'error' && Boolean(error.value));
+
 watch(showIndicator, () => {
   void nextTick().then(updateAnchoredTurnHeight);
 });
@@ -409,10 +462,16 @@ const bottomSpacerHeight = computed(() =>
     <scroll-view
       ref="scrollRef"
       scroll-orientation="vertical"
+      :bounces="false"
+      :scroll-bar-enable="false"
       class="flex-1 min-h-0"
       @layoutchange="handleViewportLayout"
       @scroll="handleScroll"
       @contentsizechanged="handleContentSizeChanged"
+      @touchstart="handleScrollTouchStart"
+      @touchmove="handleScrollTouchMove"
+      @touchend="handleScrollTouchEnd"
+      @touchcancel="handleScrollTouchEnd"
     >
       <view class="flex flex-col pt-4 chat-container" :class="isMobile ? 'px-4' : 'px-6'">
         <view class="flex flex-col gap-6">
@@ -422,14 +481,22 @@ const bottomSpacerHeight = computed(() =>
             :key="message.id"
             :flatten="false"
             class="flex flex-col"
-            :class="message.role === 'user' ? 'items-end' : 'items-start'"
+            :class="[
+              message.role === 'user' ? 'items-end' : 'items-start',
+              isAssistantForAnimatedTurn(message) ? 'assistant-turn-enter' : '',
+            ]"
             @layoutchange="(event) => handleMessageLayout(message.id, event)"
           >
             <!-- user bubble / assistant full width -->
             <view
-              :class="
-                message.role === 'user' ? 'bg-elevated rounded-lg px-4 py-3 user-bubble' : 'w-full'
-              "
+              :class="[
+                message.role === 'user'
+                  ? 'bg-elevated rounded-lg px-4 py-3 user-bubble'
+                  : 'w-full',
+                message.role === 'user' && message.id === animatedUserMessageId
+                  ? 'user-message-enter'
+                  : '',
+              ]"
             >
               <MessageContent
                 :message="message"
@@ -454,9 +521,31 @@ const bottomSpacerHeight = computed(() =>
           </view>
 
           <!-- thinking indicator -->
-          <view v-if="showIndicator" class="flex flex-row items-center gap-1.5">
+          <view
+            v-if="showIndicator"
+            class="flex flex-row items-center gap-1.5"
+            :class="animatedUserMessageId ? 'assistant-turn-enter' : ''"
+          >
             <Indicator />
             <text class="text-sm text-muted shimmer-pulse">Thinking...</text>
+          </view>
+
+          <view
+            v-if="showGenerationError"
+            class="flex flex-row items-center gap-2 rounded-lg border border-default bg-muted px-3 py-2.5 generation-error"
+            :class="animatedUserMessageId ? 'assistant-turn-enter' : ''"
+          >
+            <Icon name="i-lucide-alert-circle" tone="error" :size="16" />
+            <text class="text-sm text-muted flex-1" text-maxline="2">
+              {{ error?.message || 'The response stopped unexpectedly.' }}
+            </text>
+            <MotionPressable
+              class="rounded-md bg-elevated px-2.5 py-1.5"
+              accessibility-label="Retry response"
+              @tap="handleRegenerate"
+            >
+              <text class="text-sm font-medium text-highlighted">Retry</text>
+            </MotionPressable>
           </view>
         </view>
 
@@ -473,9 +562,9 @@ const bottomSpacerHeight = computed(() =>
     >
       <view class="pb-4 pt-1 prompt-container" :class="isMobile ? 'px-4' : 'px-6'">
         <PromptBox
+          ref="promptBoxRef"
           v-model="input"
           :status="status"
-          :error="error?.message"
           :disabled="uploading"
           @submit="handleSubmit"
           @stop="stop()"

--- a/examples/ai-chat/src/pages/ChatPage.vue
+++ b/examples/ai-chat/src/pages/ChatPage.vue
@@ -20,6 +20,7 @@ import { useOverlay } from '../composables/useOverlay';
 import { useToast } from '../composables/useToast';
 import { useViewport } from '../composables/useViewport';
 import { apiFetch } from '../lib/api';
+import { calculateBottomSpacer, isNearBottom } from '../lib/chat-viewport';
 import type { UIMessage } from '../types/ai';
 
 /** Port of app/pages/chat/[id].vue. */
@@ -60,7 +61,41 @@ const { files, open, removeFile, clearFiles, uploading, uploadedFiles } = useAtt
 
 const scrollRef = useTemplateRef<ShadowElement>('scrollRef');
 const promptRef = useTemplateRef<ShadowElement>('promptRef');
-useKeyboardAvoidance(promptRef);
+
+interface LayoutEvent {
+  detail?: { height?: number };
+}
+
+interface ScrollEvent {
+  detail?: {
+    scrollTop?: number;
+    scrollHeight?: number;
+  };
+}
+
+const systemInfo = (
+  globalThis as {
+    SystemInfo?: { pixelHeight?: number; pixelRatio?: number };
+  }
+).SystemInfo;
+const initialViewportHeight = Math.max(
+  0,
+  (systemInfo?.pixelHeight ?? 720) / (systemInfo?.pixelRatio || 1) - 56,
+);
+const viewportHeight = ref(initialViewportHeight);
+const composerHeight = ref(112);
+const keyboardHeight = ref(0);
+const anchoredMessageId = ref<string | null>(null);
+const anchoredTurnHeight = ref(0);
+const followsOutput = ref(true);
+const messageHeights = new Map<string, number>();
+let scrollTop = 0;
+let scrollHeight = 0;
+
+useKeyboardAvoidance(promptRef, (height) => {
+  keyboardHeight.value = height;
+  if (followsOutput.value) void scrollToBottom();
+});
 
 const chat = useChat({
   id: chatId,
@@ -87,34 +122,101 @@ const { messages, status, error, sendMessage, regenerate, stop } = chat;
 
 onUnmounted(stop);
 
-async function scrollToBottom() {
+async function scrollToBottom(smooth = false) {
   // nextTick waits for the main thread to apply pending ops so the
   // scroll-view ref is resolvable by selector.
   await nextTick();
   scrollRef.value
     ?.invoke({
       method: 'scrollTo',
-      params: { offset: 1e6, smooth: false },
+      params: { offset: 1e6, smooth },
     })
     .exec();
 }
 
-// Auto-scroll while streaming (should-auto-scroll on UChatMessages).
-watch(
-  messages,
-  () => {
-    void scrollToBottom();
-  },
-  { deep: true, flush: 'post' },
-);
+async function scrollMessageToTop(messageId: string) {
+  await nextTick();
+  if (typeof lynx === 'undefined') return;
+  lynx
+    .createSelectorQuery()
+    .select(`#chat-message-${messageId}`)
+    .invoke({
+      method: 'scrollIntoView',
+      params: {
+        scrollIntoViewOptions: {
+          block: 'start',
+          inline: 'start',
+          behavior: 'smooth',
+        },
+      },
+    })
+    .exec();
+}
 
-// Re-pin after the stream settles: the last parts (e.g. source pills) can
-// land after the final in-stream scroll was applied.
-watch(status, (value) => {
-  if (value === 'ready') {
-    setTimeout(() => void scrollToBottom(), 180);
+function updateAnchoredTurnHeight() {
+  const anchorId = anchoredMessageId.value;
+  const anchorIndex = messages.value.findIndex((message) => message.id === anchorId);
+  if (!anchorId || anchorIndex < 0) {
+    anchoredTurnHeight.value = 0;
+    return;
   }
-});
+
+  const anchoredMessages = messages.value.slice(anchorIndex);
+  let height = anchoredMessages.reduce(
+    (total, message) => total + (messageHeights.get(message.id) ?? 0),
+    0,
+  );
+  height += Math.max(0, anchoredMessages.length - 1) * 24;
+  if (showIndicator.value) height += 48;
+  anchoredTurnHeight.value = Math.max(84, height);
+}
+
+function beginAnchoredTurn(message: UIMessage | undefined) {
+  if (!message || message.role !== 'user') return;
+  anchoredMessageId.value = message.id;
+  followsOutput.value = true;
+  updateAnchoredTurnHeight();
+  void scrollMessageToTop(message.id);
+}
+
+function handleScroll(event: ScrollEvent) {
+  const nextTop = Number(event.detail?.scrollTop);
+  const nextHeight = Number(event.detail?.scrollHeight);
+  if (Number.isFinite(nextTop)) scrollTop = nextTop;
+  if (Number.isFinite(nextHeight) && nextHeight >= 0) scrollHeight = nextHeight;
+  followsOutput.value = isNearBottom({
+    scrollTop,
+    scrollHeight,
+    viewportHeight: viewportHeight.value,
+  });
+}
+
+function handleContentSizeChanged(event: ScrollEvent) {
+  const nextHeight = Number(event.detail?.scrollHeight);
+  if (Number.isFinite(nextHeight) && nextHeight >= 0) scrollHeight = nextHeight;
+  if (followsOutput.value) void scrollToBottom();
+}
+
+function handleViewportLayout(event: LayoutEvent) {
+  const height = Number(event.detail?.height);
+  if (!Number.isFinite(height) || height <= 0 || height === viewportHeight.value) return;
+  viewportHeight.value = height;
+  if (followsOutput.value) void scrollToBottom();
+}
+
+function handleComposerLayout(event: LayoutEvent) {
+  const height = Number(event.detail?.height);
+  if (!Number.isFinite(height) || height <= 0 || height === composerHeight.value) return;
+  composerHeight.value = height;
+  if (followsOutput.value) void scrollToBottom();
+}
+
+function handleMessageLayout(messageId: string, event: LayoutEvent) {
+  const height = Number(event.detail?.height);
+  if (!Number.isFinite(height) || height <= 0 || messageHeights.get(messageId) === height) return;
+  messageHeights.set(messageId, height);
+  updateAnchoredTurnHeight();
+}
 
 // The title is generated server-side before streaming starts on the first
 // message; refresh the sidebar/title as soon as the response streams.
@@ -148,22 +250,26 @@ onMounted(async () => {
     }
   }
 
-  scrollToBottom();
-
   // Arriving from the home page with only the first user message: generate.
   if (data.value.isOwner && data.value.messages.length === 1) {
-    void regenerate();
+    const generation = regenerate();
+    beginAnchoredTurn(messages.value[0]);
+    void generation;
+  } else {
+    void scrollToBottom();
   }
 });
 
 async function handleSubmit() {
   if (input.value.trim() && !uploading.value) {
-    void sendMessage({
+    const generation = sendMessage({
       text: input.value,
       files: uploadedFiles.value.length > 0 ? uploadedFiles.value : undefined,
     });
+    beginAnchoredTurn(messages.value[messages.value.length - 1]);
     input.value = '';
     clearFiles();
+    void generation;
   }
 }
 
@@ -179,11 +285,17 @@ async function saveEdit(message: UIMessage, text: string) {
       body: { messageId: message.id, type: 'edit' },
     });
   } catch {
-    toast.add({ description: 'Failed to save edit.', icon: 'i-lucide-alert-circle', color: 'error' });
+    toast.add({
+      description: 'Failed to save edit.',
+      icon: 'i-lucide-alert-circle',
+      color: 'error',
+    });
     return;
   }
   editingMessageId.value = null;
-  void sendMessage({ text, messageId: message.id });
+  const generation = sendMessage({ text, messageId: message.id });
+  beginAnchoredTurn(messages.value[messages.value.length - 1]);
+  void generation;
 }
 
 async function regenerateMessage(message: UIMessage) {
@@ -193,10 +305,22 @@ async function regenerateMessage(message: UIMessage) {
       body: { messageId: message.id, type: 'regenerate' },
     });
   } catch {
-    toast.add({ description: 'Failed to regenerate.', icon: 'i-lucide-alert-circle', color: 'error' });
+    toast.add({
+      description: 'Failed to regenerate.',
+      icon: 'i-lucide-alert-circle',
+      color: 'error',
+    });
     return;
   }
-  void regenerate({ messageId: message.id });
+  const generation = regenerate({ messageId: message.id });
+  beginAnchoredTurn([...messages.value].reverse().find((item) => item.role === 'user'));
+  void generation;
+}
+
+function handleRegenerate() {
+  const generation = regenerate();
+  beginAnchoredTurn([...messages.value].reverse().find((message) => message.role === 'user'));
+  void generation;
 }
 
 function getVote(messageId: string): boolean | null {
@@ -250,6 +374,19 @@ const showIndicator = computed(
       lastMessage.value?.role === 'assistant' &&
       lastMessage.value.parts.length === 0),
 );
+
+watch(showIndicator, () => {
+  void nextTick().then(updateAnchoredTurnHeight);
+});
+
+const bottomSpacerHeight = computed(() =>
+  calculateBottomSpacer({
+    composerHeight: isOwner.value ? composerHeight.value : 0,
+    keyboardHeight: isOwner.value ? keyboardHeight.value : 0,
+    viewportHeight: viewportHeight.value,
+    anchoredTurnHeight: anchoredMessageId.value ? anchoredTurnHeight.value : undefined,
+  }),
+);
 </script>
 
 <template>
@@ -269,53 +406,71 @@ const showIndicator = computed(
       </view>
     </Navbar>
 
-    <scroll-view ref="scrollRef" scroll-orientation="vertical" class="flex-1 min-h-0">
-      <view class="flex flex-col gap-6 py-4 chat-container" :class="isMobile ? 'px-4' : 'px-6'">
-        <view
-          v-for="message in messages"
-          :key="message.id"
-          class="flex flex-col"
-          :class="message.role === 'user' ? 'items-end' : 'items-start'"
-        >
-          <!-- user bubble / assistant full width -->
+    <scroll-view
+      ref="scrollRef"
+      scroll-orientation="vertical"
+      class="flex-1 min-h-0"
+      @layoutchange="handleViewportLayout"
+      @scroll="handleScroll"
+      @contentsizechanged="handleContentSizeChanged"
+    >
+      <view class="flex flex-col pt-4 chat-container" :class="isMobile ? 'px-4' : 'px-6'">
+        <view class="flex flex-col gap-6">
           <view
-            :class="
-              message.role === 'user'
-                ? 'bg-elevated rounded-lg px-4 py-3 user-bubble'
-                : 'w-full'
-            "
+            v-for="message in messages"
+            :id="`chat-message-${message.id}`"
+            :key="message.id"
+            :flatten="false"
+            class="flex flex-col"
+            :class="message.role === 'user' ? 'items-end' : 'items-start'"
+            @layoutchange="(event) => handleMessageLayout(message.id, event)"
           >
-            <MessageContent
-              :message="message"
-              :editing="isOwner && editingMessageId === message.id"
-              @save="saveEdit"
-              @cancel-edit="editingMessageId = null"
-            />
+            <!-- user bubble / assistant full width -->
+            <view
+              :class="
+                message.role === 'user' ? 'bg-elevated rounded-lg px-4 py-3 user-bubble' : 'w-full'
+              "
+            >
+              <MessageContent
+                :message="message"
+                :editing="isOwner && editingMessageId === message.id"
+                @save="saveEdit"
+                @cancel-edit="editingMessageId = null"
+              />
+            </view>
+
+            <!-- actions -->
+            <view v-if="isOwner" class="flex flex-row items-center mt-1.5 actions-row">
+              <MessageActions
+                :message="message"
+                :streaming="status === 'streaming' && message.id === lastMessage?.id"
+                :editing="editingMessageId === message.id"
+                :vote="getVote(message.id)"
+                @vote="(m, up) => vote(m, up)"
+                @edit="startEdit"
+                @regenerate="regenerateMessage"
+              />
+            </view>
           </view>
 
-          <!-- actions -->
-          <view v-if="isOwner" class="flex flex-row items-center mt-1.5 actions-row">
-            <MessageActions
-              :message="message"
-              :streaming="status === 'streaming' && message.id === lastMessage?.id"
-              :editing="editingMessageId === message.id"
-              :vote="getVote(message.id)"
-              @vote="(m, up) => vote(m, up)"
-              @edit="startEdit"
-              @regenerate="regenerateMessage"
-            />
+          <!-- thinking indicator -->
+          <view v-if="showIndicator" class="flex flex-row items-center gap-1.5">
+            <Indicator />
+            <text class="text-sm text-muted shimmer-pulse">Thinking...</text>
           </view>
         </view>
 
-        <!-- thinking indicator -->
-        <view v-if="showIndicator" class="flex flex-row items-center gap-1.5">
-          <Indicator />
-          <text class="text-sm text-muted shimmer-pulse">Thinking...</text>
-        </view>
+        <view class="chat-bottom-spacer" :style="{ height: `${bottomSpacerHeight}px` }" />
       </view>
     </scroll-view>
 
-    <view v-if="isOwner" ref="promptRef" class="prompt-dock">
+    <view
+      v-if="isOwner"
+      ref="promptRef"
+      :flatten="false"
+      class="prompt-dock"
+      @layoutchange="handleComposerLayout"
+    >
       <view class="pb-4 pt-1 prompt-container" :class="isMobile ? 'px-4' : 'px-6'">
         <PromptBox
           v-model="input"
@@ -324,7 +479,7 @@ const showIndicator = computed(
           :disabled="uploading"
           @submit="handleSubmit"
           @stop="stop()"
-          @reload="regenerate()"
+          @reload="handleRegenerate"
           @attach="open"
         >
           <template v-if="files.length > 0" #header>
@@ -356,8 +511,9 @@ const showIndicator = computed(
 .chat-page {
   position: relative;
 }
-.chat-container {
-  padding-bottom: 128px;
+.chat-bottom-spacer {
+  width: 1px;
+  flex-shrink: 0;
 }
 .prompt-dock {
   position: absolute;

--- a/examples/ai-chat/tests/agent-spinner.test.ts
+++ b/examples/ai-chat/tests/agent-spinner.test.ts
@@ -86,7 +86,7 @@ describe('agent spinner', () => {
       'utf8',
     );
 
-    expect(chatPage).toContain("status.value === 'submitted'");
+    expect(chatPage).toMatch(/status\.value === ["']submitted["']/);
     expect(chatPage).toContain('lastMessage.value.parts.length === 0');
     expect(chatPage).toContain('<Indicator />');
     expect(chatPage).toContain('Thinking...');

--- a/examples/ai-chat/tests/chat-motion.test.ts
+++ b/examples/ai-chat/tests/chat-motion.test.ts
@@ -22,18 +22,26 @@ describe('native-first chat motion', () => {
     expect(chatPage).toMatch(
       /v-for="message in messages"[\s\S]*?:style="userMessageLaunchStyle\(message\.id\)"[\s\S]*?@layoutchange/,
     );
-    expect(css).toMatch(/\.user-message-enter\s*{[^}]*500ms/s);
+    expect(css).toMatch(
+      /\.user-message-enter\s*{[^}]*500ms cubic-bezier\(0\.22, 1, 0\.36, 1\)/s,
+    );
     expect(css).toContain('var(--user-message-launch-distance)');
     expect(css).toMatch(/\.assistant-turn-enter\s*{[^}]*240ms[^}]*360ms/s);
+    expect(css).not.toMatch(/@keyframes user-message-enter[\s\S]*?70%/);
+    expect(css).not.toMatch(/@keyframes user-message-enter[\s\S]*?86%/);
   });
 
   it('falls back to bottom-follow scrolling for Web turns', async () => {
     const chatPage = await source('src/pages/ChatPage.vue');
 
     expect(chatPage).toContain('turnScrollMode');
+    expect(chatPage).toContain('nextWebBottomOffset');
     expect(chatPage).toContain("turnMode === 'bottom'");
     expect(chatPage).toMatch(/turnMode === 'bottom'[\s\S]*?anchoredMessageId\.value = null/);
-    expect(chatPage).toMatch(/turnMode === 'bottom'[\s\S]*?scrollToBottom\(true\)/);
+    expect(chatPage).toMatch(/turnMode === 'bottom'[\s\S]*?webScrollOffset\.value/);
+    expect(chatPage).toMatch(/watch\(\s*messages,[\s\S]*?scrollToBottom\(\)/);
+    expect(chatPage).toContain("{ deep: true, flush: 'post' }");
+    expect(chatPage).toContain(':scroll-top="webScrollOffset"');
     expect(chatPage).toMatch(
       /anchoredTurnHeight:\s*turnMode === 'anchor'[\s\S]*?anchoredTurnHeight\.value[\s\S]*?: undefined/,
     );

--- a/examples/ai-chat/tests/chat-motion.test.ts
+++ b/examples/ai-chat/tests/chat-motion.test.ts
@@ -9,12 +9,34 @@ const source = (relativePath: string) =>
 describe('native-first chat motion', () => {
   it('orchestrates a newly submitted user bubble before the assistant reveal', async () => {
     const chatPage = await source('src/pages/ChatPage.vue');
+    const css = await source('src/App.css');
 
     expect(chatPage).toContain('animatedUserMessageId');
+    expect(chatPage).toContain('pendingAnimatedUserMessageId');
+    expect(chatPage).toContain('calculateMessageLaunchDistance');
+    expect(chatPage).toContain("'--user-message-launch-distance'");
     expect(chatPage).toContain("'user-message-enter'");
     expect(chatPage).toContain("'assistant-turn-enter'");
     expect(chatPage).toMatch(/beginAnchoredTurn\([^)]*,\s*true\)/);
     expect(chatPage).toMatch(/beginAnchoredTurn\([^)]*,\s*false\)/);
+    expect(chatPage).toMatch(
+      /v-for="message in messages"[\s\S]*?:style="userMessageLaunchStyle\(message\.id\)"[\s\S]*?@layoutchange/,
+    );
+    expect(css).toMatch(/\.user-message-enter\s*{[^}]*500ms/s);
+    expect(css).toContain('var(--user-message-launch-distance)');
+    expect(css).toMatch(/\.assistant-turn-enter\s*{[^}]*240ms[^}]*360ms/s);
+  });
+
+  it('falls back to bottom-follow scrolling for Web turns', async () => {
+    const chatPage = await source('src/pages/ChatPage.vue');
+
+    expect(chatPage).toContain('turnScrollMode');
+    expect(chatPage).toContain("turnMode === 'bottom'");
+    expect(chatPage).toMatch(/turnMode === 'bottom'[\s\S]*?anchoredMessageId\.value = null/);
+    expect(chatPage).toMatch(/turnMode === 'bottom'[\s\S]*?scrollToBottom\(true\)/);
+    expect(chatPage).toMatch(
+      /anchoredTurnHeight:\s*turnMode === 'anchor'[\s\S]*?anchoredTurnHeight\.value[\s\S]*?: undefined/,
+    );
   });
 
   it('reveals streamed semantic blocks without replaying loaded history', async () => {
@@ -77,6 +99,21 @@ describe('native-first chat motion', () => {
     expect(chatPage).toContain('promptBoxRef.value?.blur()');
     expect(chatPage).toContain(':bounces="false"');
     expect(chatPage).toContain(':scroll-bar-enable="false"');
+  });
+
+  it('clears both Vue and the Native textarea value after accepting a send', async () => {
+    const prompt = await source('src/components/chat/PromptBox.vue');
+    const chatPage = await source('src/pages/ChatPage.vue');
+
+    expect(prompt).toContain("import { setNativeInputValue } from '../../composables/useNativeInputValue'");
+    expect(prompt).toContain('resetKey?: number');
+    expect(prompt).toMatch(/watch\(\s*\(\) => props\.resetKey/);
+    expect(prompt).toContain("{ flush: 'post' }");
+    expect(prompt).toContain("setNativeInputValue(inputRef.value, '')");
+    expect(prompt).toContain('defineExpose({ blur: blurInput, focus: focusInput })');
+    expect(chatPage).toContain('const inputResetKey = ref(0)');
+    expect(chatPage).toMatch(/input\.value = '';\s*inputResetKey\.value \+= 1;/);
+    expect(chatPage).toContain(':reset-key="inputResetKey"');
   });
 
   it('provides reduced-motion fallbacks for every chat entrance animation', async () => {

--- a/examples/ai-chat/tests/chat-motion.test.ts
+++ b/examples/ai-chat/tests/chat-motion.test.ts
@@ -1,0 +1,98 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const source = (relativePath: string) =>
+  readFile(path.resolve(import.meta.dirname, '..', relativePath), 'utf8').catch(() => '');
+
+describe('native-first chat motion', () => {
+  it('orchestrates a newly submitted user bubble before the assistant reveal', async () => {
+    const chatPage = await source('src/pages/ChatPage.vue');
+
+    expect(chatPage).toContain('animatedUserMessageId');
+    expect(chatPage).toContain("'user-message-enter'");
+    expect(chatPage).toContain("'assistant-turn-enter'");
+    expect(chatPage).toMatch(/beginAnchoredTurn\([^)]*,\s*true\)/);
+    expect(chatPage).toMatch(/beginAnchoredTurn\([^)]*,\s*false\)/);
+  });
+
+  it('reveals streamed semantic blocks without replaying loaded history', async () => {
+    const markdown = await source('src/components/chat/MarkdownView.vue');
+    const content = await source('src/components/chat/message/MessageContent.vue');
+
+    expect(markdown).toContain("streaming ? 'stream-block-enter' : ''");
+    expect(markdown).toContain('streamBlockStyle(bi)');
+    expect(content).toContain('message-part-enter');
+    expect(content).toContain('isTextUIPart(part)');
+  });
+
+  it('runs touch feedback synchronously on the main thread', async () => {
+    const pressable = await source('src/components/ui/MotionPressable.vue');
+    const button = await source('src/components/ui/UButton.vue');
+    const actions = await source('src/components/chat/message/MessageActions.vue');
+    const navbar = await source('src/components/Navbar.vue');
+
+    expect(pressable).toContain("'main thread'");
+    expect(pressable).toContain('main-thread-bindtouchstart');
+    expect(pressable).toContain('main-thread-bindtouchend');
+    expect(pressable).toContain(
+      ':main-thread-bindtouchstart="props.disabled ? undefined : pressIn"',
+    );
+    expect(pressable).toContain('prefersReducedMotion');
+    expect(pressable).toContain("setStyleProperty?.('transition', 'none')");
+    expect(pressable).toContain("setStyleProperty?.('transform'");
+    expect(button).toContain('<MotionPressable');
+    expect(actions).toContain('<MotionPressable');
+    expect(navbar).toContain('<MotionPressable');
+    expect(navbar).toContain('accessibility-label="Open navigation"');
+  });
+
+  it('morphs the composer action and offers an inline retry on failure', async () => {
+    const prompt = await source('src/components/chat/PromptBox.vue');
+    const chatPage = await source('src/pages/ChatPage.vue');
+
+    expect(prompt).toContain(':key="submitState"');
+    expect(prompt).toContain('submit-icon-enter');
+    expect(chatPage).toContain('generation-error');
+    expect(chatPage).toContain('Retry');
+    expect(prompt).not.toContain('v-if="error"');
+    expect(chatPage).not.toContain(':error="error?.message"');
+  });
+
+  it('uses the full-screen host safe-area inset instead of a device constant', async () => {
+    const navbar = await source('src/components/Navbar.vue');
+
+    expect(navbar).toContain('safeAreaTop');
+    expect(navbar).toContain('fullscreen');
+    expect(navbar).not.toContain("paddingTop: isMobile.value && isIOS ? '48px'");
+  });
+
+  it('dismisses the keyboard from a user drag without disabling Web scrolling', async () => {
+    const prompt = await source('src/components/chat/PromptBox.vue');
+    const chatPage = await source('src/pages/ChatPage.vue');
+
+    expect(prompt).toContain('defineExpose({ blur: blurInput, focus: focusInput })');
+    expect(chatPage).toContain('@touchstart="handleScrollTouchStart"');
+    expect(chatPage).toContain('promptBoxRef.value?.blur()');
+    expect(chatPage).toContain(':bounces="false"');
+    expect(chatPage).toContain(':scroll-bar-enable="false"');
+  });
+
+  it('provides reduced-motion fallbacks for every chat entrance animation', async () => {
+    const css = await source('src/App.css');
+    const app = await source('src/App.vue');
+    const reducedMotion = await source('src/composables/useReducedMotion.ts');
+
+    expect(css).toContain('.motion-reduced');
+    expect(app).toContain('useReducedMotion');
+    expect(app).toContain("reducedMotion.value ? 'motion-reduced' : ''");
+    expect(reducedMotion).toContain('prefersReducedMotion');
+    expect(reducedMotion).toContain("matchMedia?.('(prefers-reduced-motion: reduce)')");
+    expect(css).toContain('.user-message-enter');
+    expect(css).toContain('.assistant-turn-enter');
+    expect(css).toContain('.stream-block-enter');
+    expect(css).toContain('.message-part-enter');
+    expect(css).toContain('.submit-icon-enter');
+  });
+});

--- a/examples/ai-chat/tests/chat-viewport.test.ts
+++ b/examples/ai-chat/tests/chat-viewport.test.ts
@@ -5,6 +5,7 @@ import {
   calculateBottomSpacer,
   calculateMessageLaunchDistance,
   isNearBottom,
+  nextWebBottomOffset,
   turnScrollMode,
 } from '../src/lib/chat-viewport';
 
@@ -68,6 +69,16 @@ describe('chat viewport geometry', () => {
     expect(turnScrollMode('web')).toBe('bottom');
     expect(turnScrollMode('iOS')).toBe('anchor');
     expect(turnScrollMode('Android')).toBe('anchor');
+  });
+
+  it('changes the Web bottom offset on every request so the observed attribute fires', () => {
+    const first = nextWebBottomOffset(0);
+    const second = nextWebBottomOffset(first);
+    const third = nextWebBottomOffset(second);
+
+    expect(first).toBe(1_000_000);
+    expect(second).toBe(999_999);
+    expect(third).toBe(1_000_000);
   });
 
   it('measures a visible Native launch from the composer toward the anchored turn', () => {

--- a/examples/ai-chat/tests/chat-viewport.test.ts
+++ b/examples/ai-chat/tests/chat-viewport.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { bottomDistance, calculateBottomSpacer, isNearBottom } from '../src/lib/chat-viewport';
+import {
+  bottomDistance,
+  calculateBottomSpacer,
+  calculateMessageLaunchDistance,
+  isNearBottom,
+  turnScrollMode,
+} from '../src/lib/chat-viewport';
 
 describe('chat viewport geometry', () => {
   it('treats the user as near the bottom within a small tolerance', () => {
@@ -56,5 +62,50 @@ describe('chat viewport geometry', () => {
         anchoredTurnHeight: 640,
       }),
     ).toBe(404);
+  });
+
+  it('uses conventional bottom-follow scrolling on Web and top anchoring on Native', () => {
+    expect(turnScrollMode('web')).toBe('bottom');
+    expect(turnScrollMode('iOS')).toBe('anchor');
+    expect(turnScrollMode('Android')).toBe('anchor');
+  });
+
+  it('measures a visible Native launch from the composer toward the anchored turn', () => {
+    expect(
+      calculateMessageLaunchDistance({
+        platform: 'iOS',
+        viewportHeight: 760,
+        composerHeight: 112,
+        keyboardHeight: 300,
+        messageHeight: 72,
+      }),
+    ).toBe(260);
+    expect(
+      calculateMessageLaunchDistance({
+        platform: 'iOS',
+        viewportHeight: 1200,
+        composerHeight: 80,
+        keyboardHeight: 0,
+        messageHeight: 40,
+      }),
+    ).toBe(420);
+    expect(
+      calculateMessageLaunchDistance({
+        platform: 'Android',
+        viewportHeight: 240,
+        composerHeight: 160,
+        keyboardHeight: 80,
+        messageHeight: 72,
+      }),
+    ).toBe(44);
+    expect(
+      calculateMessageLaunchDistance({
+        platform: 'web',
+        viewportHeight: 760,
+        composerHeight: 112,
+        keyboardHeight: 0,
+        messageHeight: 72,
+      }),
+    ).toBe(0);
   });
 });

--- a/examples/ai-chat/tests/chat-viewport.test.ts
+++ b/examples/ai-chat/tests/chat-viewport.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { bottomDistance, calculateBottomSpacer, isNearBottom } from '../src/lib/chat-viewport';
+
+describe('chat viewport geometry', () => {
+  it('treats the user as near the bottom within a small tolerance', () => {
+    const metrics = { scrollTop: 508, scrollHeight: 1200, viewportHeight: 640 };
+
+    expect(bottomDistance(metrics)).toBe(52);
+    expect(isNearBottom(metrics)).toBe(true);
+    expect(isNearBottom({ ...metrics, scrollTop: 400 })).toBe(false);
+  });
+
+  it('clamps bounce and undersized-content distances to zero', () => {
+    expect(bottomDistance({ scrollTop: -20, scrollHeight: 500, viewportHeight: 640 })).toBe(0);
+    expect(
+      bottomDistance({
+        scrollTop: 600,
+        scrollHeight: 1200,
+        viewportHeight: 640,
+      }),
+    ).toBe(0);
+  });
+
+  it('uses the measured composer height as the normal bottom spacer', () => {
+    expect(
+      calculateBottomSpacer({
+        composerHeight: 116,
+        keyboardHeight: 0,
+        viewportHeight: 640,
+      }),
+    ).toBe(116);
+  });
+
+  it('shrinks intentional blank space while the keyboard or answer consumes it', () => {
+    const closed = calculateBottomSpacer({
+      composerHeight: 104,
+      keyboardHeight: 0,
+      viewportHeight: 700,
+      anchoredTurnHeight: 84,
+    });
+    const opened = calculateBottomSpacer({
+      composerHeight: 104,
+      keyboardHeight: 300,
+      viewportHeight: 700,
+      anchoredTurnHeight: 84,
+    });
+
+    expect(closed).toBe(600);
+    expect(opened).toBe(600);
+    expect(
+      calculateBottomSpacer({
+        composerHeight: 104,
+        keyboardHeight: 300,
+        viewportHeight: 700,
+        anchoredTurnHeight: 640,
+      }),
+    ).toBe(404);
+  });
+});

--- a/examples/ai-chat/tests/native-interactions.test.ts
+++ b/examples/ai-chat/tests/native-interactions.test.ts
@@ -4,7 +4,10 @@ import path from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 
 import { bindKeyboardAvoidance } from '../src/composables/useKeyboardAvoidance';
-import { setNativeInputValue } from '../src/composables/useNativeInputValue';
+import {
+  createNativeInputValueSync,
+  setNativeInputValue,
+} from '../src/composables/useNativeInputValue';
 import { inputEventValue } from '../src/lib/input-event';
 
 describe('cross-platform text input', () => {
@@ -16,6 +19,16 @@ describe('cross-platform text input', () => {
 });
 
 describe('native keyboard avoidance', () => {
+  it('does not subscribe to the native keyboard emitter in Lynx Web', async () => {
+    const source = await readFile(
+      path.resolve(import.meta.dirname, '../src/composables/useKeyboardAvoidance.ts'),
+      'utf8',
+    );
+
+    expect(source).toMatch(/SystemInfo\?\.platform\s*===\s*['"]web['"]/);
+    expect(source).toMatch(/if \(isWeb\) return;/);
+  });
+
   it('moves the composer by the keyboard height and restores it on close', () => {
     let listener: ((status: unknown, height: unknown) => void) | undefined;
     const emitter = {
@@ -131,10 +144,28 @@ describe('native keyboard avoidance', () => {
 });
 
 describe('native drawer motion', () => {
-  it('animates the persistent backdrop and panel with native-safe style updates', async () => {
+  it('keeps the mobile navbar below the iOS full-screen safe area', async () => {
+    const source = await readFile(
+      path.resolve(import.meta.dirname, '../src/components/Navbar.vue'),
+      'utf8',
+    );
+
+    expect(source).toContain("SystemInfo?.platform === 'iOS'");
+    expect(source).toContain('safeAreaTop');
+    expect(source).toContain("hostProps?.fullscreen === true || hostProps?.fullscreen === 'true'");
+    expect(source).toContain('paddingTop: isMobile.value && safeAreaTop > 0');
+    expect(source).toContain("height: isMobile.value ? `${48 + safeAreaTop}px` : '48px'");
+    expect(source).toContain(':style="navbarStyle"');
+  });
+
+  it('animates the persistent backdrop and panel with direct native style updates', async () => {
     const source = await readFile(path.resolve(import.meta.dirname, '../src/App.vue'), 'utf8');
 
-    expect(source).toMatch(/\.drawer-panel\s*{[^}]*transition:\s*transform 240ms/);
+    expect(source).toContain("const drawerRef = useTemplateRef<ShadowElement>('drawerRef')");
+    expect(source).toMatch(/drawerRef\.value\s*\?\.setNativeProps\(\{/);
+    expect(source).toContain("transform: open ? 'translateX(0px)' : 'translateX(-288px)'");
+    expect(source).toContain("transition: reducedMotion.value ? 'none' : `transform 240ms ${DRAWER_EASING}`");
+    expect(source).toContain('ref="drawerRef"');
     expect(source).toMatch(/\.drawer-backdrop\s*{[^}]*transition:\s*opacity 240ms/);
     expect(source).toContain("opacity: sidebarOpen ? '1' : '0'");
   });
@@ -146,8 +177,11 @@ describe('native drawer motion', () => {
     expect(source).toContain('class="absolute inset-0 drawer-backdrop"');
     expect(source).toContain('@tap="handleSidebarShowChange(false)"');
     expect(source).toContain(':event-through="false"');
-    expect(source).toMatch(/v-if="isMobile"\s+class="absolute top-0 bottom-0 left-0/);
-    expect(source).toContain("transform: sidebarOpen ? 'translateX(0px)' : 'translateX(-288px)'");
+    expect(source).toMatch(
+      /v-if="isMobile"[\s\S]*?ref="drawerRef"[\s\S]*?class="absolute top-0 bottom-0 left-0/,
+    );
+    expect(source).toContain("transform: 'translateX(-288px)'");
+    expect(source).not.toContain("transform: sidebarOpen ? 'translateX(0px)' : 'translateX(-288px)'");
     expect(source).not.toContain('drawer-layer');
     expect(source).not.toContain('<Transition name="drawer-panel"');
   });
@@ -159,6 +193,7 @@ describe('native drawer motion', () => {
     );
     expect(source).toContain("const drawerTopPadding = isIOS ? '60px' : '16px'");
     expect(source).toContain('paddingTop: drawer ? drawerTopPadding : undefined');
+    expect(source).toContain('accessibility-label="Close navigation"');
   });
 });
 
@@ -176,6 +211,23 @@ describe('native message editing', () => {
     expect(exec).toHaveBeenCalledOnce();
   });
 
+  it('waits for native layout availability and only initializes once', () => {
+    const exec = vi.fn();
+    const invoke = vi.fn(() => ({ exec }));
+    const target: { value: { invoke: typeof invoke } | null } = { value: null };
+    const sync = createNativeInputValueSync(target, () => 'Why use Nuxt UI?');
+
+    sync();
+    expect(invoke).not.toHaveBeenCalled();
+
+    target.value = { invoke };
+    sync();
+    sync();
+
+    expect(invoke).toHaveBeenCalledOnce();
+    expect(exec).toHaveBeenCalledOnce();
+  });
+
   it('syncs the editor value after its native input is mounted', async () => {
     const source = await readFile(
       path.resolve(import.meta.dirname, '../src/components/chat/message/MessageEdit.vue'),
@@ -184,6 +236,9 @@ describe('native message editing', () => {
 
     expect(source).toContain('v-model="editingText"');
     expect(source).toContain('ref="inputRef"');
-    expect(source).toContain('useNativeInputValue(inputRef, () => editingText.value)');
+    expect(source).toContain(
+      'const syncInitialValue = useNativeInputValue(inputRef, () => editingText.value)',
+    );
+    expect(source).toContain('@layoutchange="syncInitialValue"');
   });
 });

--- a/examples/ai-chat/tests/native-interactions.test.ts
+++ b/examples/ai-chat/tests/native-interactions.test.ts
@@ -5,16 +5,23 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { bindKeyboardAvoidance } from '../src/composables/useKeyboardAvoidance';
 import { setNativeInputValue } from '../src/composables/useNativeInputValue';
+import { inputEventValue } from '../src/lib/input-event';
+
+describe('cross-platform text input', () => {
+  it('reads both Lynx detail values and Web DOM target values', () => {
+    expect(inputEventValue({ detail: { value: 'native' } })).toBe('native');
+    expect(inputEventValue({ target: { value: 'web' } })).toBe('web');
+    expect(inputEventValue({ detail: 'legacy' })).toBe('legacy');
+  });
+});
 
 describe('native keyboard avoidance', () => {
   it('moves the composer by the keyboard height and restores it on close', () => {
     let listener: ((status: unknown, height: unknown) => void) | undefined;
     const emitter = {
-      addListener: vi.fn(
-        (_name: string, callback: (status: unknown, height: unknown) => void) => {
-          listener = callback;
-        },
-      ),
+      addListener: vi.fn((_name: string, callback: (status: unknown, height: unknown) => void) => {
+        listener = callback;
+      }),
       removeListener: vi.fn(),
     };
     const exec = vi.fn();
@@ -42,14 +49,35 @@ describe('native keyboard avoidance', () => {
     expect(emitter.removeListener).toHaveBeenCalledWith('keyboardstatuschanged', listener);
   });
 
+  it('reports keyboard obstruction changes so the message viewport can follow selectively', () => {
+    let listener: ((status: unknown, height: unknown) => void) | undefined;
+    const emitter = {
+      addListener: vi.fn((_name: string, callback: (status: unknown, height: unknown) => void) => {
+        listener = callback;
+      }),
+      removeListener: vi.fn(),
+    };
+    const onHeightChange = vi.fn();
+
+    bindKeyboardAvoidance(
+      emitter,
+      () => ({ setNativeProps: () => ({ exec: vi.fn() }) }),
+      onHeightChange,
+    );
+
+    listener?.('on', 320);
+    listener?.('off', 320);
+
+    expect(onHeightChange).toHaveBeenNthCalledWith(1, 320, 0);
+    expect(onHeightChange).toHaveBeenNthCalledWith(2, 0, 320);
+  });
+
   it('ignores invalid keyboard heights', () => {
     let listener: ((status: unknown, height: unknown) => void) | undefined;
     const emitter = {
-      addListener: vi.fn(
-        (_name: string, callback: (status: unknown, height: unknown) => void) => {
-          listener = callback;
-        },
-      ),
+      addListener: vi.fn((_name: string, callback: (status: unknown, height: unknown) => void) => {
+        listener = callback;
+      }),
       removeListener: vi.fn(),
     };
     const setNativeProps = vi.fn(() => ({ exec: vi.fn() }));
@@ -63,7 +91,7 @@ describe('native keyboard avoidance', () => {
     });
   });
 
-  it('anchors the chat composer to the bottom before translating it above the keyboard', async () => {
+  it('coordinates measured composer and scroll geometry instead of fixed padding', async () => {
     const source = await readFile(
       path.resolve(import.meta.dirname, '../src/pages/ChatPage.vue'),
       'utf8',
@@ -75,7 +103,30 @@ describe('native keyboard avoidance', () => {
     expect(source).toMatch(/\.chat-page\s*{[^}]*position:\s*relative/);
     expect(source).toMatch(/\.prompt-dock\s*{[^}]*position:\s*absolute/);
     expect(source).toMatch(/\.prompt-dock\s*{[^}]*bottom:\s*0/);
-    expect(source).toMatch(/\.chat-container\s*{[^}]*padding-bottom:\s*128px/);
+    expect(source).toContain('@layoutchange="handleComposerLayout"');
+    expect(source).toContain('@layoutchange="handleViewportLayout"');
+    expect(source).toMatch(/ref="promptRef"[\s\S]*?:flatten="false"/);
+    expect(source).toMatch(/:id="`chat-message-\$\{message\.id\}`"[\s\S]*?:flatten="false"/);
+    expect(source).toContain('@scroll="handleScroll"');
+    expect(source).toContain('@contentsizechanged="handleContentSizeChanged"');
+    expect(source).toContain('class="chat-bottom-spacer"');
+    expect(source).not.toMatch(/\.chat-container\s*{[^}]*padding-bottom:\s*128px/);
+  });
+
+  it('uses a multiline composer whose mirror drives its native and web height', async () => {
+    const source = await readFile(
+      path.resolve(import.meta.dirname, '../src/components/chat/PromptBox.vue'),
+      'utf8',
+    );
+
+    expect(source).toContain('<textarea');
+    expect(source).toContain('<x-textarea');
+    expect(source).toMatch(/\.SystemInfo\s*\?\.platform === ["']web["']/);
+    expect(source).toContain('class="prompt-input-mirror');
+    expect(source).toContain(':maxlines="5"');
+    expect(source).toMatch(/\.prompt-input-stack\s*{[^}]*position:\s*relative/);
+    expect(source).toMatch(/\.prompt-input-web\s*{[^}]*position:\s*absolute/);
+    expect(source).toMatch(/\.prompt-input\s*{[^}]*box-sizing:\s*border-box/);
   });
 });
 


### PR DESCRIPTION
## Summary

- keep the composer keyboard-safe and bottom-aligned while preserving scroll position for readers away from the latest turn
- add a measured, monotonic Native launch for the complete sent-message unit with no target overshoot, then stagger the assistant reveal
- make Web use its observed `scroll-top` attribute after send and throughout followed streaming updates so second and later turns remain at the bottom
- clear both Vue state and the renderer-owned Native textarea after every accepted send
- add native-first user-bubble, assistant, streamed-block, and submit-state motion with main-thread press feedback
- honor host reduced-motion preferences, including imperative Native interactions
- use the fullscreen host safe-area inset instead of a device constant
- animate and reliably close the mobile drawer
- initialize native message editing only after the input is ready so existing text is never cleared
- dismiss the keyboard on message-list drag and show a single inline retry card for generation failures

## Verification

- `pnpm test -- --pool=forks --poolOptions.forks.singleFork=true` — 69/69 tests
- `pnpm lint` — 77 files checked, no errors
- cache-clean `pnpm build` — Lynx 261.7 kB and Web 266.1 kB production bundles
- iPhone 17 Pro, iOS 26.2, Lynx SDK 1.4.0 with Lynx DevTool + persistent WDA
  - established a full first turn, then sent a second message from the bottom-docked composer
  - recorded the complete second-message launch; frame sampling shows monotonic travel to the anchored turn with no rebound
  - WDA observed the composer follow the keyboard and the Native textarea return to its placeholder
  - clean Explorer restart and fresh bundle load produced no DevTool warnings or errors
- Web preview at 402×874
  - after a long first response, sent a second message and observed the list finish at `scrollTop=367`, `scrollHeight=1193`, `clientHeight=826`, bottom distance `0`
  - streaming content growth repeatedly reset the bottom distance to `0`
  - textbox value is empty after sending and browser console has no errors