### PR TITLE
fix(ai-chat): stabilize native send handoff

### DIFF
--- a/examples/ai-chat/src/App.css
+++ b/examples/ai-chat/src/App.css
@@ -160,12 +160,37 @@
 /* The user bubble is the signature transition: Native supplies a measured
    distance from the composer while Web uses a zero-distance fade. Streamed
    blocks stay quiet so the launch remains the focus. */
+.user-message-pending,
+.user-message-staged,
+.user-message-enter {
+  transition:
+    transform 500ms cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 220ms cubic-bezier(0.25, 1, 0.5, 1);
+}
+
 .user-message-pending {
   opacity: 0;
 }
 
+.user-message-staged {
+  opacity: 0.5;
+}
+
+/* Native aligns the new turn while its bubble is still pending. Keep the
+   previous turns out of that reset frame; they are restored atomically when
+   the new bubble starts, after the old content has moved above the viewport. */
+.turn-handoff-hidden {
+  opacity: 0;
+  transition: none;
+}
+
 .user-message-enter {
-  animation: user-message-enter 500ms cubic-bezier(0.22, 1, 0.36, 1) both;
+  opacity: 1;
+  transform: translateY(0px) scale(1);
+}
+
+.user-message-enter-web {
+  animation: user-message-enter-web 500ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
 .assistant-turn-enter {
@@ -184,17 +209,6 @@
   animation: submit-icon-enter 160ms cubic-bezier(0.22, 1, 0.36, 1) both;
 }
 
-@keyframes user-message-enter {
-  from {
-    opacity: 0.5;
-    transform: translateY(var(--user-message-launch-distance)) scale(0.95);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0px) scale(1);
-  }
-}
-
 @keyframes assistant-turn-enter {
   from {
     opacity: 0;
@@ -203,6 +217,17 @@
   to {
     opacity: 1;
     transform: translateY(0px);
+  }
+}
+
+@keyframes user-message-enter-web {
+  from {
+    opacity: 0.5;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
   }
 }
 
@@ -242,6 +267,7 @@
 /* Lynx's CSS parser does not expose media queries. The host preference is
    mapped to this runtime class by useReducedMotion instead. */
 .motion-reduced .user-message-enter,
+.motion-reduced .user-message-enter-web,
 .motion-reduced .assistant-turn-enter,
 .motion-reduced .stream-block-enter,
 .motion-reduced .message-part-enter,
@@ -249,6 +275,7 @@
 .motion-reduced .shimmer-pulse,
 .motion-reduced .spin {
   animation-duration: 1ms;
+  transition-duration: 1ms;
   animation-delay: 0ms;
   animation-iteration-count: 1;
 }

--- a/examples/ai-chat/src/lib/chat-viewport.ts
+++ b/examples/ai-chat/src/lib/chat-viewport.ts
@@ -23,6 +23,10 @@ interface MessageLaunchMetrics {
   messageHeight: number;
 }
 
+interface MessageIdentity {
+  id: string;
+}
+
 function positive(value: number): number {
   return Number.isFinite(value) && value > 0 ? value : 0;
 }
@@ -75,4 +79,15 @@ export function calculateMessageLaunchDistance(metrics: MessageLaunchMetrics): n
     NEW_TURN_TOP_GAP;
 
   return Math.min(420, Math.max(44, distance));
+}
+
+export function isEarlierMessageDuringHandoff(
+  messages: readonly MessageIdentity[],
+  messageId: string,
+  pendingMessageId: string | null,
+): boolean {
+  if (!pendingMessageId) return false;
+  const pendingIndex = messages.findIndex((message) => message.id === pendingMessageId);
+  const messageIndex = messages.findIndex((message) => message.id === messageId);
+  return pendingIndex > 0 && messageIndex >= 0 && messageIndex < pendingIndex;
 }

--- a/examples/ai-chat/src/pages/ChatPage.vue
+++ b/examples/ai-chat/src/pages/ChatPage.vue
@@ -24,6 +24,7 @@ import { apiFetch } from '../lib/api';
 import {
   calculateBottomSpacer,
   calculateMessageLaunchDistance,
+  isEarlierMessageDuringHandoff,
   isNearBottom,
   nextWebBottomOffset,
   turnScrollMode,
@@ -117,6 +118,7 @@ const keyboardHeight = ref(0);
 const anchoredMessageId = ref<string | null>(null);
 const animatedUserMessageId = ref<string | null>(null);
 const pendingAnimatedUserMessageId = ref<string | null>(null);
+const stagedUserMessageId = ref<string | null>(null);
 const userMessageLaunchDistance = ref(0);
 const anchoredTurnHeight = ref(0);
 const followsOutput = ref(true);
@@ -226,6 +228,7 @@ function beginAnchoredTurn(message: UIMessage | undefined, animateUser: boolean)
   if (turnMode === 'bottom') {
     anchoredMessageId.value = null;
     pendingAnimatedUserMessageId.value = null;
+    stagedUserMessageId.value = null;
     animatedUserMessageId.value = animateUser ? message.id : null;
     userMessageLaunchDistance.value = 0;
     updateAnchoredTurnHeight();
@@ -235,6 +238,7 @@ function beginAnchoredTurn(message: UIMessage | undefined, animateUser: boolean)
 
   anchoredMessageId.value = message.id;
   pendingAnimatedUserMessageId.value = animateUser ? message.id : null;
+  stagedUserMessageId.value = null;
   animatedUserMessageId.value = null;
   updateAnchoredTurnHeight();
   if (!animateUser) void scrollMessageToTop(message.id);
@@ -242,14 +246,31 @@ function beginAnchoredTurn(message: UIMessage | undefined, animateUser: boolean)
 
 function userMessageLaunchStyle(messageId: string) {
   if (
-    messageId !== animatedUserMessageId.value &&
-    messageId !== pendingAnimatedUserMessageId.value
+    messageId !== pendingAnimatedUserMessageId.value &&
+    messageId !== stagedUserMessageId.value
   ) {
     return undefined;
   }
   return {
-    '--user-message-launch-distance': `${userMessageLaunchDistance.value}px`,
+    transform: `translateY(${userMessageLaunchDistance.value}px) scale(0.95)`,
   };
+}
+
+function userMessageMotionClass(message: UIMessage) {
+  if (message.role !== 'user') return '';
+  if (message.id === animatedUserMessageId.value) {
+    return turnMode === 'bottom' ? 'user-message-enter-web' : 'user-message-enter';
+  }
+  if (message.id === stagedUserMessageId.value) return 'user-message-staged';
+  if (message.id === pendingAnimatedUserMessageId.value) return 'user-message-pending';
+  return '';
+}
+
+function isMessageHiddenDuringHandoff(messageId: string) {
+  return (
+    turnMode === 'anchor' &&
+    isEarlierMessageDuringHandoff(messages.value, messageId, pendingAnimatedUserMessageId.value)
+  );
 }
 
 function isAssistantForAnimatedTurn(message: UIMessage) {
@@ -341,10 +362,22 @@ function handleMessageLayout(messageId: string, event: LayoutEvent) {
     try {
       if (pendingAnimatedUserMessageId.value !== messageId) return;
       pendingAnimatedUserMessageId.value = null;
+      stagedUserMessageId.value = null;
       animatedUserMessageId.value = messageId;
     } finally {
       preparingAnimatedMessageIds.delete(messageId);
     }
+  };
+  const stageAlignedAnimation = () => {
+    if (pendingAnimatedUserMessageId.value !== messageId) {
+      preparingAnimatedMessageIds.delete(messageId);
+      return;
+    }
+    // Commit a real launch-position frame before changing transform. Native
+    // can register keyframe animations one display frame after the class op;
+    // a staged CSS transition avoids the target-position flash that caused.
+    stagedUserMessageId.value = messageId;
+    setTimeout(beginAlignedAnimation, 17);
   };
   const commitAlignment = () => {
     if (pendingAnimatedUserMessageId.value !== messageId) {
@@ -356,7 +389,7 @@ function handleMessageLayout(messageId: string, event: LayoutEvent) {
     // transform class is enabled. Do not await nextTick from layoutchange:
     // Lynx SDK 1.4 can keep that promise pending for this commit cycle.
     invokeScrollMessageToTop(messageId);
-    setTimeout(beginAlignedAnimation, 34);
+    setTimeout(stageAlignedAnimation, 34);
   };
   setTimeout(commitAlignment, 17);
 }
@@ -533,6 +566,14 @@ const showIndicator = computed(
 
 const showGenerationError = computed(() => status.value === 'error' && Boolean(error.value));
 
+const assistantTurnEntranceClass = computed(() =>
+  pendingAnimatedUserMessageId.value
+    ? 'turn-handoff-hidden'
+    : animatedUserMessageId.value
+      ? 'assistant-turn-enter'
+      : '',
+);
+
 watch(showIndicator, () => {
   void nextTick().then(updateAnchoredTurnHeight);
 });
@@ -598,11 +639,8 @@ const bottomSpacerHeight = computed(
             class="flex flex-col"
             :class="[
               message.role === 'user' ? 'items-end' : 'items-start',
-              message.role === 'user' && message.id === animatedUserMessageId
-                ? 'user-message-enter'
-                : message.role === 'user' && message.id === pendingAnimatedUserMessageId
-                  ? 'user-message-pending'
-                  : '',
+              userMessageMotionClass(message),
+              isMessageHiddenDuringHandoff(message.id) ? 'turn-handoff-hidden' : '',
               isAssistantForAnimatedTurn(message) ? 'assistant-turn-enter' : '',
             ]"
             :style="userMessageLaunchStyle(message.id)"
@@ -642,7 +680,7 @@ const bottomSpacerHeight = computed(
           <view
             v-if="showIndicator"
             class="flex flex-row items-center gap-1.5"
-            :class="animatedUserMessageId ? 'assistant-turn-enter' : ''"
+            :class="assistantTurnEntranceClass"
           >
             <Indicator />
             <text class="text-sm text-muted shimmer-pulse">Thinking...</text>
@@ -651,7 +689,7 @@ const bottomSpacerHeight = computed(
           <view
             v-if="showGenerationError"
             class="flex flex-row items-center gap-2 rounded-lg border border-default bg-muted px-3 py-2.5 generation-error"
-            :class="animatedUserMessageId ? 'assistant-turn-enter' : ''"
+            :class="assistantTurnEntranceClass"
           >
             <Icon name="i-lucide-alert-circle" tone="error" :size="16" />
             <text class="text-sm text-muted flex-1" text-maxline="2">

--- a/examples/ai-chat/src/pages/ChatPage.vue
+++ b/examples/ai-chat/src/pages/ChatPage.vue
@@ -96,6 +96,11 @@ interface TouchLikeEvent {
   detail?: { touches?: TouchPoint[] };
 }
 
+// Streaming first mounts an empty assistant shell whose Native minimum
+// footprint is 9⅓ CSS px before its measured height reaches Vue. Matching
+// that shell exactly keeps max scroll stable across the streaming handoff.
+const ALIGNMENT_SCROLL_RESERVE = 28 / 3;
+
 const systemInfo = (
   globalThis as {
     SystemInfo?: { pixelHeight?: number; pixelRatio?: number; platform?: string };
@@ -117,6 +122,7 @@ const anchoredTurnHeight = ref(0);
 const followsOutput = ref(true);
 const webScrollOffset = ref<number>();
 const messageHeights = new Map<string, number>();
+const preparingAnimatedMessageIds = new Set<string>();
 let scrollTop = 0;
 let scrollHeight = 0;
 let scrollDragStartY: number | null = null;
@@ -169,8 +175,7 @@ async function scrollToBottom(smooth = false) {
     .exec();
 }
 
-async function scrollMessageToTop(messageId: string) {
-  await nextTick();
+function invokeScrollMessageToTop(messageId: string) {
   if (typeof lynx === 'undefined') return;
   lynx
     .createSelectorQuery()
@@ -181,11 +186,18 @@ async function scrollMessageToTop(messageId: string) {
         scrollIntoViewOptions: {
           block: 'start',
           inline: 'start',
-          behavior: 'smooth',
+          // The bubble already supplies the transition. A second scroll
+          // animation leaves the previous turn visible until it catches up.
+          behavior: 'none',
         },
       },
     })
     .exec();
+}
+
+async function scrollMessageToTop(messageId: string) {
+  await nextTick();
+  invokeScrollMessageToTop(messageId);
 }
 
 function updateAnchoredTurnHeight() {
@@ -202,7 +214,8 @@ function updateAnchoredTurnHeight() {
     0,
   );
   height += Math.max(0, anchoredMessages.length - 1) * 24;
-  if (showIndicator.value) height += 48;
+  // Reserve the imminent thinking row before status catches up.
+  if (showIndicator.value || pendingAnimatedUserMessageId.value === anchorId) height += 48;
   anchoredTurnHeight.value = Math.max(84, height);
 }
 
@@ -224,7 +237,7 @@ function beginAnchoredTurn(message: UIMessage | undefined, animateUser: boolean)
   pendingAnimatedUserMessageId.value = animateUser ? message.id : null;
   animatedUserMessageId.value = null;
   updateAnchoredTurnHeight();
-  void scrollMessageToTop(message.id);
+  if (!animateUser) void scrollMessageToTop(message.id);
 }
 
 function userMessageLaunchStyle(messageId: string) {
@@ -308,7 +321,13 @@ function handleMessageLayout(messageId: string, event: LayoutEvent) {
     messageHeights.set(messageId, height);
     updateAnchoredTurnHeight();
   }
-  if (pendingAnimatedUserMessageId.value !== messageId) return;
+  if (
+    pendingAnimatedUserMessageId.value !== messageId ||
+    preparingAnimatedMessageIds.has(messageId)
+  ) {
+    return;
+  }
+  preparingAnimatedMessageIds.add(messageId);
 
   userMessageLaunchDistance.value = calculateMessageLaunchDistance({
     platform: systemInfo?.platform,
@@ -317,8 +336,29 @@ function handleMessageLayout(messageId: string, event: LayoutEvent) {
     keyboardHeight: keyboardHeight.value,
     messageHeight: height,
   });
-  pendingAnimatedUserMessageId.value = null;
-  animatedUserMessageId.value = messageId;
+
+  const beginAlignedAnimation = () => {
+    try {
+      if (pendingAnimatedUserMessageId.value !== messageId) return;
+      pendingAnimatedUserMessageId.value = null;
+      animatedUserMessageId.value = messageId;
+    } finally {
+      preparingAnimatedMessageIds.delete(messageId);
+    }
+  };
+  const commitAlignment = () => {
+    if (pendingAnimatedUserMessageId.value !== messageId) {
+      preparingAnimatedMessageIds.delete(messageId);
+      return;
+    }
+    // The first timer lets the measured spacer reach Native layout. The
+    // instant scroll then gets two display frames to commit before the
+    // transform class is enabled. Do not await nextTick from layoutchange:
+    // Lynx SDK 1.4 can keep that promise pending for this commit cycle.
+    invokeScrollMessageToTop(messageId);
+    setTimeout(beginAlignedAnimation, 34);
+  };
+  setTimeout(commitAlignment, 17);
 }
 
 // The title is generated server-side before streaming starts on the first
@@ -497,14 +537,22 @@ watch(showIndicator, () => {
   void nextTick().then(updateAnchoredTurnHeight);
 });
 
-const bottomSpacerHeight = computed(() =>
-  calculateBottomSpacer({
+const alignmentScrollReserve = computed(() =>
+  turnMode === 'anchor' &&
+  (showIndicator.value || pendingAnimatedUserMessageId.value === anchoredMessageId.value)
+    ? ALIGNMENT_SCROLL_RESERVE
+    : 0,
+);
+
+const bottomSpacerHeight = computed(
+  () =>
+    calculateBottomSpacer({
     composerHeight: isOwner.value ? composerHeight.value : 0,
     keyboardHeight: isOwner.value ? keyboardHeight.value : 0,
     viewportHeight: viewportHeight.value,
     anchoredTurnHeight:
       turnMode === 'anchor' && anchoredMessageId.value ? anchoredTurnHeight.value : undefined,
-  }),
+    }) + alignmentScrollReserve.value,
 );
 </script>
 

--- a/examples/ai-chat/tests/chat-motion.test.ts
+++ b/examples/ai-chat/tests/chat-motion.test.ts
@@ -13,22 +13,30 @@ describe('native-first chat motion', () => {
 
     expect(chatPage).toContain('animatedUserMessageId');
     expect(chatPage).toContain('pendingAnimatedUserMessageId');
+    expect(chatPage).toContain('stagedUserMessageId');
     expect(chatPage).toContain('calculateMessageLaunchDistance');
-    expect(chatPage).toContain("'--user-message-launch-distance'");
+    expect(chatPage).toContain('translateY(${userMessageLaunchDistance.value}px) scale(0.95)');
     expect(chatPage).toContain("'user-message-enter'");
+    expect(chatPage).toContain("'user-message-enter-web'");
+    expect(chatPage).toContain("'user-message-staged'");
     expect(chatPage).toContain("'assistant-turn-enter'");
     expect(chatPage).toMatch(/beginAnchoredTurn\([^)]*,\s*true\)/);
     expect(chatPage).toMatch(/beginAnchoredTurn\([^)]*,\s*false\)/);
     expect(chatPage).toMatch(
       /v-for="message in messages"[\s\S]*?:style="userMessageLaunchStyle\(message\.id\)"[\s\S]*?@layoutchange/,
     );
+    expect(css).toMatch(/\.user-message-pending,[\s\S]*?\.user-message-enter\s*\{[^}]*transition:/s);
+    expect(css).toContain('transform 500ms cubic-bezier(0.22, 1, 0.36, 1)');
+    expect(css).toMatch(/\.user-message-staged\s*\{[^}]*opacity:\s*0\.5/s);
     expect(css).toMatch(
-      /\.user-message-enter\s*{[^}]*500ms cubic-bezier\(0\.22, 1, 0\.36, 1\)/s,
+      /\.user-message-enter\s*\{[^}]*opacity:\s*1[^}]*transform:\s*translateY\(0px\) scale\(1\)/s,
     );
-    expect(css).toContain('var(--user-message-launch-distance)');
     expect(css).toMatch(/\.assistant-turn-enter\s*{[^}]*240ms[^}]*360ms/s);
-    expect(css).not.toMatch(/@keyframes user-message-enter[\s\S]*?70%/);
-    expect(css).not.toMatch(/@keyframes user-message-enter[\s\S]*?86%/);
+    expect(css).not.toMatch(/@keyframes user-message-enter\s*\{/);
+    expect(css).toMatch(
+      /\.user-message-enter-web\s*\{[^}]*animation:\s*user-message-enter-web 500ms/s,
+    );
+    expect(css).toContain('@keyframes user-message-enter-web');
   });
 
   it('falls back to bottom-follow scrolling for Web turns', async () => {
@@ -60,17 +68,43 @@ describe('native-first chat motion', () => {
       /scrollIntoViewOptions:\s*\{[\s\S]*?behavior:\s*'smooth'/,
     );
     expect(chatPage).toContain('setTimeout(commitAlignment, 17)');
-    expect(chatPage).toContain('setTimeout(beginAlignedAnimation, 34)');
+    expect(chatPage).toContain('setTimeout(stageAlignedAnimation, 34)');
+    expect(chatPage).toContain('setTimeout(beginAlignedAnimation, 17)');
     expect(chatPage).toMatch(/if \(!animateUser\) void scrollMessageToTop\(message\.id\)/);
     expect(layoutHandler).toBeDefined();
     expect(layoutHandler).toMatch(/invokeScrollMessageToTop\(messageId\)/);
     expect(layoutHandler).toMatch(
-      /const commitAlignment[\s\S]*?invokeScrollMessageToTop\(messageId\);\s*setTimeout\(beginAlignedAnimation, 34\)/,
+      /const commitAlignment[\s\S]*?invokeScrollMessageToTop\(messageId\);\s*setTimeout\(stageAlignedAnimation, 34\)/,
     );
     expect(chatPage).toContain('const ALIGNMENT_SCROLL_RESERVE = 28 / 3');
     expect(chatPage).toMatch(
       /calculateBottomSpacer\([\s\S]*?\) \+ alignmentScrollReserve\.value/,
     );
+  });
+
+  it('keeps previous turns out of the reset frame until the new bubble takes over', async () => {
+    const chatPage = await source('src/pages/ChatPage.vue');
+    const css = await source('src/App.css');
+
+    expect(chatPage).toContain('isEarlierMessageDuringHandoff');
+    expect(chatPage).toContain("'turn-handoff-hidden'");
+    expect(css).toMatch(/\.turn-handoff-hidden\s*\{[^}]*opacity:\s*0/s);
+    expect(css).toMatch(/\.turn-handoff-hidden\s*\{[^}]*transition:\s*none/s);
+  });
+
+  it('keeps the pending assistant and bubble on their handoff start frames', async () => {
+    const chatPage = await source('src/pages/ChatPage.vue');
+    const css = await source('src/App.css');
+
+    expect(chatPage).toContain('assistantTurnEntranceClass');
+    expect(chatPage).toContain(':class="assistantTurnEntranceClass"');
+    expect(chatPage).toMatch(
+      /pendingAnimatedUserMessageId\.value\s*\?\s*'turn-handoff-hidden'/,
+    );
+    expect(chatPage).toMatch(
+      /stagedUserMessageId\.value = messageId;\s*setTimeout\(beginAlignedAnimation, 17\)/,
+    );
+    expect(css).toMatch(/\.user-message-staged\s*\{[^}]*opacity:\s*0\.5/s);
   });
 
   it('reveals streamed semantic blocks without replaying loaded history', async () => {

--- a/examples/ai-chat/tests/chat-motion.test.ts
+++ b/examples/ai-chat/tests/chat-motion.test.ts
@@ -47,6 +47,32 @@ describe('native-first chat motion', () => {
     );
   });
 
+  it('aligns the Native turn before starting the bubble animation', async () => {
+    const chatPage = await source('src/pages/ChatPage.vue');
+    const layoutHandler = chatPage.match(
+      /function handleMessageLayout[\s\S]*?\n}\n\n\/\/ The title/,
+    )?.[0];
+
+    expect(chatPage).toMatch(
+      /scrollIntoViewOptions:\s*\{[\s\S]*?block:\s*'start'[\s\S]*?behavior:\s*'none'/,
+    );
+    expect(chatPage).not.toMatch(
+      /scrollIntoViewOptions:\s*\{[\s\S]*?behavior:\s*'smooth'/,
+    );
+    expect(chatPage).toContain('setTimeout(commitAlignment, 17)');
+    expect(chatPage).toContain('setTimeout(beginAlignedAnimation, 34)');
+    expect(chatPage).toMatch(/if \(!animateUser\) void scrollMessageToTop\(message\.id\)/);
+    expect(layoutHandler).toBeDefined();
+    expect(layoutHandler).toMatch(/invokeScrollMessageToTop\(messageId\)/);
+    expect(layoutHandler).toMatch(
+      /const commitAlignment[\s\S]*?invokeScrollMessageToTop\(messageId\);\s*setTimeout\(beginAlignedAnimation, 34\)/,
+    );
+    expect(chatPage).toContain('const ALIGNMENT_SCROLL_RESERVE = 28 / 3');
+    expect(chatPage).toMatch(
+      /calculateBottomSpacer\([\s\S]*?\) \+ alignmentScrollReserve\.value/,
+    );
+  });
+
   it('reveals streamed semantic blocks without replaying loaded history', async () => {
     const markdown = await source('src/components/chat/MarkdownView.vue');
     const content = await source('src/components/chat/message/MessageContent.vue');

--- a/examples/ai-chat/tests/chat-viewport.test.ts
+++ b/examples/ai-chat/tests/chat-viewport.test.ts
@@ -4,6 +4,7 @@ import {
   bottomDistance,
   calculateBottomSpacer,
   calculateMessageLaunchDistance,
+  isEarlierMessageDuringHandoff,
   isNearBottom,
   nextWebBottomOffset,
   turnScrollMode,
@@ -118,5 +119,21 @@ describe('chat viewport geometry', () => {
         messageHeight: 72,
       }),
     ).toBe(0);
+  });
+
+  it('masks only messages before the pending bubble during a Native handoff', () => {
+    const messages = [
+      { id: 'first-user' },
+      { id: 'first-assistant' },
+      { id: 'second-user' },
+      { id: 'second-assistant' },
+      { id: 'third-user' },
+    ];
+
+    expect(isEarlierMessageDuringHandoff(messages, 'first-user', 'third-user')).toBe(true);
+    expect(isEarlierMessageDuringHandoff(messages, 'second-assistant', 'third-user')).toBe(true);
+    expect(isEarlierMessageDuringHandoff(messages, 'third-user', 'third-user')).toBe(false);
+    expect(isEarlierMessageDuringHandoff(messages, 'first-user', null)).toBe(false);
+    expect(isEarlierMessageDuringHandoff(messages, 'missing', 'third-user')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- align the Native message list before moving the sent bubble from the composer
- hide earlier turns and the assistant indicator during the otherwise-visible reset frame
- stage the bubble at its measured launch transform before starting a one-way CSS transition
- retain the original zero-distance fade on Web
- cover second/third-turn handoff ordering and masking with regression tests

## Root cause

Native needs to reset the scroll position before the sent-bubble motion begins. The pending bubble was transparent during that reset, so the previous turn became the only visible content for 34–51 ms. Lynx could also register the keyframe animation one display frame after the class update, briefly drawing the new bubble at its destination before returning it to the launch position.

The fix treats send as an explicit handoff. Earlier turns and `Thinking…` stay hidden while the list aligns; the new bubble then commits one real frame at its measured composer-side transform and transitions only toward the destination. Once motion begins, the old content is restored above the viewport. Web keeps its independent bottom-follow scroll and fade entrance.

## Verification

- AI Chat tests: 73/73 passed
- repository lint: 77 files checked, no errors
- cache-clean build: Lynx 262.9 kB, Web 267.4 kB
- `git diff --check`
- iPhone 17 Pro simulator, iOS 26.2, Lynx SDK 1.4.0
  - verified both second- and third-message sends from the bottom composer with the keyboard open
  - recorded the full transition and inspected 15 fps contact sheets plus individual transition frames
  - no previous-turn ghost, early assistant indicator, destination flash, reverse movement, or end-position correction
  - final served bundle SHA-256 matched the local build: `95dd99e2a488193d2eb196bb5d578f324e2d9adeba78e52bb97f015f4ed40c3b`
