### PR TITLE
Deck Chapter IV: how Vue Lynx was built (stacked on #214)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -695,6 +695,9 @@ importers:
         specifier: ^2.0.4
         version: 2.0.4
     devDependencies:
+      playwright-core:
+        specifier: ^1.49.0
+        version: 1.61.1
       vite:
         specifier: ^5.4.10
         version: 5.4.21(@types/node@25.5.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.46.0)
@@ -4683,6 +4686,11 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -10776,6 +10784,8 @@ snapshots:
       typescript: 5.9.3
 
   pirates@4.0.7: {}
+
+  playwright-core@1.61.1: {}
 
   possible-typed-array-names@1.1.0: {}
 

--- a/slides/index.html
+++ b/slides/index.html
@@ -24,7 +24,7 @@
     </button>
   </div>
   <div class="chrome chrome--bottom">
-    <span data-counter>01 / 44</span>
+    <span data-counter>01 / 62</span>
   </div>
   <div class="chrome chrome--bottom-right">
     <a href="https://vue.lynxjs.org" target="_blank" rel="noreferrer">vue.lynxjs.org</a>
@@ -303,10 +303,10 @@
 
   <section class="slide stage">
     <span class="eyebrow">II · The proof</span>
-    <div class="mega"><span class="brand-text">852</span><small style="font-size:0.4em;color:var(--ink-mute)"> / 949</small></div>
+    <div class="mega"><span class="brand-text">882</span><small style="font-size:0.4em;color:var(--ink-mute)"> / 1013</small></div>
     <p class="lead">upstream Vue core tests, passing on our renderer.</p>
     <aside class="notes">
-      <p><strong>The hard number first.</strong> We re-run Vue core's own test suites against the Vue Lynx renderer: 852 of 949 pass; every skip is documented and accounted for. "Compatible with Vue" here is a measured claim, not a vibe.</p>
+      <p><strong>The hard number first.</strong> We run Vue core's own test suites against the Vue Lynx renderer: 882 of 1013 pass, 131 documented skips, <strong>zero failures</strong>. "Compatible with Vue" here is a measured claim, not a vibe.</p>
     </aside>
   </section>
 
@@ -801,62 +801,530 @@
   </section>
 
   <!-- ====================================================
-       How it works — two threads, then the equation
+       Chapter IV · How we did it
        ==================================================== -->
-  <section class="slide stage">
-    <span class="eyebrow">How it works</span>
-    <div class="archflow is-solo">
-      <div class="node" data-flip="node-bg">
-        <span class="node__label"><span class="dot"></span>Background thread</span>
-        <h3 class="node__title">Vue 3 runtime &amp; your code</h3>
-        <ul class="node__list">
-          <li>reactivity &amp; lifecycle</li>
-          <li>component tree diff</li>
-          <li>event handlers</li>
-          <li>data fetching</li>
-        </ul>
-      </div>
+  <section class="slide divider">
+    <span class="eyebrow">Chapter IV</span>
+    <div class="divider__row">
+      <span class="divider__num numeral--brand">IV</span>
+      <h2 class="divider__title">
+        And how was <br/>this built?
+      </h2>
     </div>
-    <p class="lead" data-mm-fade>Your whole Vue app runs here — on a thread of its own.</p>
+    <p class="divider__tag">
+      Three adaptations — the runtime, the toolchain, the main thread — and an
+      AI harness running through all of them.
+    </p>
     <aside class="notes">
-      <p><strong>One minute of architecture</strong> — how all of this stays smooth. The Vue runtime — reactivity, diff, lifecycle, handlers — lives on the <strong>background</strong> thread. Next slide: the main thread lands beside it.</p>
+      <p><strong>The engineering chapter.</strong> Everything you just saw was built in two weeks by one person — and this chapter is the honest answer to "how". Three adaptations, each revealing one piece of Lynx's architecture: split Vue across two threads without breaking its semantics; make one toolchain emit both worlds; then make the main thread itself programmable. An AI harness threads through the whole story.</p>
     </aside>
   </section>
 
+  <!-- A1 — Vue lands on the background thread -->
   <section class="slide stage">
-    <span class="eyebrow">How it works</span>
-    <div class="archflow">
-      <div class="node" data-flip="node-bg">
-        <span class="node__label"><span class="dot"></span>Background thread</span>
-        <h3 class="node__title">Vue 3 runtime &amp; your code</h3>
-        <ul class="node__list">
-          <li>reactivity &amp; lifecycle</li>
-          <li>component tree diff</li>
-          <li>event handlers</li>
-          <li>data fetching</li>
-        </ul>
+    <span class="eyebrow">IV · Runtime</span>
+    <div class="flow">
+      <div class="flane" data-flip="lane-bg" style="--c:#5dd5a8;top:4%;height:42%">
+        <span class="flane__label"><i></i>Background thread</span>
       </div>
-      <div class="archflow__bus" data-mm-fade>
-        <span class="arrow">ops &rarr;</span>
-        <span>flat buffer</span>
-        <span class="arrow rev">&larr; events</span>
+      <div class="flane" data-flip="lane-mt" style="--c:#56b8f0;top:54%;height:42%">
+        <span class="flane__label"><i></i>Main (UI) thread</span>
       </div>
-      <div class="node node--main" data-flip="node-main">
-        <span class="node__label"><span class="dot"></span>Main (UI) thread</span>
-        <h3 class="node__title">Native elements &amp; render</h3>
-        <ul class="node__list">
-          <li>layout &amp; paint</li>
-          <li>gestures &amp; scrolling</li>
-          <li>Main-Thread Script</li>
-          <li>ops interpreter</li>
-        </ul>
+      <div class="fb is-hero" data-flip="fb-vue" style="--c:#42b883;left:50%;top:25%">
+        Vue 3 runtime
+        <small>@vue/runtime-core · untouched</small>
       </div>
     </div>
-    <p class="arch__caption" data-mm-fade>
-      One bundle, two layers — no JS bridge round-trip on the hot path.
+    <p class="lead arch-cap" data-mm-fade>
+      Vue runs <em>whole</em> — on the background thread.
     </p>
     <aside class="notes">
-      <p>They talk via a flat <em>ops</em> buffer, batched per Vue tick. <strong>No JS bridge on the hot path</strong> — that's why the keyboard, the sheet, the swipes stay 60fps while Vue reactivity does its job. The kicker: <em>Main-Thread Script</em> — the sheet gesture, the pressables — is your Vue code, compiled onto the UI thread.</p>
+      <p><strong>First decision: which thread does Vue live on?</strong> An early community experiment put Vue on the main thread — every event then had to be forwarded across. But Lynx delivers events to the background thread natively, so we run the entire runtime there: reactivity, diff, lifecycle, your handlers. Not a fork of Vue — the actual <code>@vue/runtime-core</code>, untouched.</p>
+    </aside>
+  </section>
+
+  <!-- A2 — ShadowElement -->
+  <section class="slide stage">
+    <span class="eyebrow">IV · Runtime</span>
+    <div class="flow">
+      <div class="flane" data-flip="lane-bg" style="--c:#5dd5a8;top:4%;height:42%">
+        <span class="flane__label"><i></i>Background thread</span>
+      </div>
+      <div class="flane" data-flip="lane-mt" style="--c:#56b8f0;top:54%;height:42%">
+        <span class="flane__label"><i></i>Main (UI) thread</span>
+      </div>
+      <div class="fb" data-flip="fb-vue" style="--c:#42b883;left:23%;top:25%">
+        Vue 3 runtime
+        <small>@vue/runtime-core · untouched</small>
+      </div>
+      <span class="farr" data-mm-fade style="left:41.5%;top:25%">nodeOps &rarr;</span>
+      <div class="fb is-hero" data-flip="fb-shadow" style="--c:#E8B44A;left:62%;top:25%">
+        ShadowElement tree
+        <small>linked list · sync reads</small>
+      </div>
+    </div>
+    <p class="lead arch-cap" data-mm-fade>
+      <code>createRenderer()</code> — a renderer, not a fork.
+    </p>
+    <aside class="notes">
+      <p><strong>Vue's official custom renderer API is the whole trick.</strong> <code>createRenderer()</code> wants synchronous nodes — <code>parentNode()</code>, <code>nextSibling()</code> must answer immediately, but the real elements live on another thread. So nodeOps dual-writes: it maintains a lightweight <em>ShadowElement</em> linked-list on the background thread (satisfying every synchronous read Vue makes) while queueing the real work for later. Same pattern ReactLynx uses for its snapshot instances.</p>
+    </aside>
+  </section>
+
+  <!-- A3 — ops buffer crosses -->
+  <section class="slide stage">
+    <span class="eyebrow">IV · Runtime</span>
+    <div class="flow">
+      <div class="flane" data-flip="lane-bg" style="--c:#5dd5a8;top:4%;height:42%">
+        <span class="flane__label"><i></i>Background thread</span>
+      </div>
+      <div class="flane" data-flip="lane-mt" style="--c:#56b8f0;top:54%;height:42%">
+        <span class="flane__label"><i></i>Main (UI) thread</span>
+      </div>
+      <div class="fb" data-flip="fb-vue" style="--c:#42b883;left:23%;top:25%">
+        Vue 3 runtime
+        <small>@vue/runtime-core · untouched</small>
+      </div>
+      <span class="farr" style="left:41.5%;top:25%">nodeOps &rarr;</span>
+      <div class="fb" data-flip="fb-shadow" style="--c:#E8B44A;left:62%;top:25%">
+        ShadowElement tree
+        <small>linked list · sync reads</small>
+      </div>
+      <span class="farr" data-mm-fade style="--c:#4FB8F0;left:80%;top:31%">&#8600;</span>
+      <div class="fb is-hero" data-flip="fb-ops" style="--c:#4FB8F0;left:86%;top:50%">
+        ops
+        <small>flat array · per tick</small>
+      </div>
+    </div>
+    <p class="lead arch-cap" data-mm-fade>
+      Updates leave as a <b style="color:#4FB8F0">flat ops buffer</b> — once per tick.
+    </p>
+    <aside class="notes">
+      <p><strong>The only thing that crosses the thread boundary is data.</strong> <code>[CREATE, id, tag, INSERT, parent, child, SET_PROP, id, key, value…]</code> — numbers and strings, no objects to marshal, no functions. Batched on Vue's own flush cycle, so one reactive tick = one send. And Vue's compiler helps for free: static content produces zero ops — only dynamic bindings travel.</p>
+    </aside>
+  </section>
+
+  <!-- A4 — interpreter + PAPI -->
+  <section class="slide stage">
+    <span class="eyebrow">IV · Runtime</span>
+    <div class="flow">
+      <div class="flane" data-flip="lane-bg" style="--c:#5dd5a8;top:4%;height:42%">
+        <span class="flane__label"><i></i>Background thread</span>
+      </div>
+      <div class="flane" data-flip="lane-mt" style="--c:#56b8f0;top:54%;height:42%">
+        <span class="flane__label"><i></i>Main (UI) thread</span>
+      </div>
+      <div class="fb" data-flip="fb-vue" style="--c:#42b883;left:23%;top:25%">
+        Vue 3 runtime
+        <small>@vue/runtime-core · untouched</small>
+      </div>
+      <span class="farr" style="left:41.5%;top:25%">nodeOps &rarr;</span>
+      <div class="fb" data-flip="fb-shadow" style="--c:#E8B44A;left:62%;top:25%">
+        ShadowElement tree
+        <small>linked list · sync reads</small>
+      </div>
+      <span class="farr" style="--c:#4FB8F0;left:80%;top:31%">&#8600;</span>
+      <div class="fb" data-flip="fb-ops" style="--c:#4FB8F0;left:86%;top:50%">
+        ops
+        <small>flat array · per tick</small>
+      </div>
+      <span class="farr" data-mm-fade style="--c:#4FB8F0;left:80%;top:66%">&#8601;</span>
+      <div class="fb" data-flip="fb-interp" style="--c:#56b8f0;left:62%;top:75%">
+        ops interpreter
+        <small>a switch loop</small>
+      </div>
+      <span class="farr" data-mm-fade style="left:43%;top:75%">&larr; replay</span>
+      <div class="fb is-hero" data-flip="fb-papi" style="--c:#F27A9E;left:24%;top:75%">
+        Element PAPI
+        <small>__CreateView · __SetAttribute · …</small>
+      </div>
+    </div>
+    <p class="lead arch-cap" data-mm-fade>
+      The main thread <b style="color:#F27A9E">replays</b> them — native elements appear.
+    </p>
+    <aside class="notes">
+      <p><strong>Here's Lynx's framework-agnostic seam, up close.</strong> The main thread runs a tiny interpreter — literally a switch loop — that replays ops against the <em>Element PAPI</em>: <code>__CreateView</code>, <code>__AppendElement</code>, <code>__SetAttribute</code>… That C-flavored API is the contract Lynx offers every framework; ReactLynx feeds it, we feed it, the next framework will too. VDOM → ShadowElement → ops → PAPI: four stops, one straight line.</p>
+    </aside>
+  </section>
+
+  <!-- A5 — events ride back -->
+  <section class="slide stage">
+    <span class="eyebrow">IV · Runtime</span>
+    <div class="flow">
+      <div class="flane" data-flip="lane-bg" style="--c:#5dd5a8;top:4%;height:42%">
+        <span class="flane__label"><i></i>Background thread</span>
+      </div>
+      <div class="flane" data-flip="lane-mt" style="--c:#56b8f0;top:54%;height:42%">
+        <span class="flane__label"><i></i>Main (UI) thread</span>
+      </div>
+      <div class="fb" data-flip="fb-vue" style="--c:#42b883;left:23%;top:25%">
+        Vue 3 runtime
+        <small>@vue/runtime-core · untouched</small>
+      </div>
+      <span class="farr" style="left:41.5%;top:25%">nodeOps &rarr;</span>
+      <div class="fb" data-flip="fb-shadow" style="--c:#E8B44A;left:62%;top:25%">
+        ShadowElement tree
+        <small>linked list · sync reads</small>
+      </div>
+      <span class="farr" style="--c:#4FB8F0;left:80%;top:31%">&#8600;</span>
+      <div class="fb" data-flip="fb-ops" style="--c:#4FB8F0;left:86%;top:50%">
+        ops
+        <small>flat array · per tick</small>
+      </div>
+      <span class="farr" style="--c:#4FB8F0;left:80%;top:66%">&#8601;</span>
+      <div class="fb" data-flip="fb-interp" style="--c:#56b8f0;left:62%;top:75%">
+        ops interpreter
+        <small>a switch loop</small>
+      </div>
+      <span class="farr" style="left:43%;top:75%">&larr; replay</span>
+      <div class="fb" data-flip="fb-papi" style="--c:#F27A9E;left:24%;top:75%">
+        Element PAPI
+        <small>__CreateView · __SetAttribute · …</small>
+      </div>
+      <div class="fb is-hero" data-flip="fb-evt" style="--c:#3deae7;left:8%;top:50%">
+        events
+        <small>&uarr; by sign, not by function</small>
+      </div>
+    </div>
+    <p class="lead arch-cap" data-mm-fade>
+      Events ride back <b style="color:#3deae7">up</b> — handlers never leave Vue.
+    </p>
+    <aside class="notes">
+      <p><strong>The return path closes the loop.</strong> Functions can't cross threads, so they never do: each handler registers under a numeric <em>sign</em>; the main thread dispatches the sign, the background thread looks it up and calls your Vue function right where it lives — closures, reactivity and all. That's why every Vue semantics survives: nothing that matters ever crossed.</p>
+    </aside>
+  </section>
+
+  <!-- A6 — one lap = nextTick -->
+  <section class="slide stage">
+    <span class="eyebrow">IV · Runtime</span>
+    <div class="flow">
+      <div class="flane" data-flip="lane-bg" style="--c:#5dd5a8;top:4%;height:42%">
+        <span class="flane__label"><i></i>Background thread</span>
+      </div>
+      <div class="flane" data-flip="lane-mt" style="--c:#56b8f0;top:54%;height:42%">
+        <span class="flane__label"><i></i>Main (UI) thread</span>
+      </div>
+      <div class="fb is-dim" data-flip="fb-vue" style="--c:#42b883;left:23%;top:25%">
+        Vue 3 runtime
+        <small>@vue/runtime-core · untouched</small>
+      </div>
+      <div class="fb is-dim" data-flip="fb-shadow" style="--c:#E8B44A;left:62%;top:25%">
+        ShadowElement tree
+        <small>linked list · sync reads</small>
+      </div>
+      <div class="fb is-dim" data-flip="fb-ops" style="--c:#4FB8F0;left:86%;top:50%">
+        ops
+        <small>flat array · per tick</small>
+      </div>
+      <div class="fb is-dim" data-flip="fb-interp" style="--c:#56b8f0;left:62%;top:75%">
+        ops interpreter
+        <small>a switch loop</small>
+      </div>
+      <div class="fb is-dim" data-flip="fb-papi" style="--c:#F27A9E;left:24%;top:75%">
+        Element PAPI
+        <small>__CreateView · __SetAttribute · …</small>
+      </div>
+      <div class="fb is-dim" data-flip="fb-evt" style="--c:#3deae7;left:8%;top:50%">
+        events
+        <small>&uarr; by sign, not by function</small>
+      </div>
+      <span class="fcenter" data-mm-fade style="left:50%;top:50%">one lap = <b>nextTick()</b></span>
+    </div>
+    <p class="lead arch-cap" data-mm-fade>
+      The threading leaks into your code in exactly <em>one</em> place.
+    </p>
+    <aside class="notes">
+      <p><strong>How much of this do users feel? Almost none.</strong> The one visible seam: native elements materialize a beat after mount, so "wait for the DOM" means <code>onMounted(() =&gt; nextTick(() =&gt; lynx.createSelectorQuery()…))</code> — the same <code>nextTick</code> mental model as web Vue, stretched across a thread. One lap of this diagram <em>is</em> one tick. Everything else — reactivity, lifecycle, composables — behaves exactly as on the web. (Docs: Understanding the Dual-Thread Model.)</p>
+    </aside>
+  </section>
+
+  <!-- A7 — upstream tests -->
+  <section class="slide stage">
+    <span class="eyebrow">IV · Runtime · proof</span>
+    <div class="mega"><span class="brand-text">882</span><small style="font-size:0.4em;color:var(--ink-mute)"> / 1013</small></div>
+    <p class="lead">Vue core's own tests, replayed on our renderer. <b>0 fail.</b></p>
+    <aside class="notes">
+      <p><strong>"Semantics preserved" is a measured claim.</strong> We vendored <code>vuejs/core</code>'s test suites and run them against Vue Lynx at two layers: an adapter backing <code>@vue/runtime-test</code> with our real ShadowElement linked-list (validates the full renderer contract — keyed diff, LIS, fragments, lifecycle), and a runtime-dom layer that pushes <code>patchProp → ops → applyOps → PAPI</code> into jsdom. 882 of 1013 pass, 131 documented skips, zero failures.</p>
+    </aside>
+  </section>
+
+  <!-- A8 — testing library, the AI's eyes -->
+  <section class="slide stage">
+    <span class="eyebrow">IV · Runtime · proof</span>
+    <h2 class="h-section" style="text-align:center;max-width:22ch">
+      …and the tests are the <span class="brand-text">AI's eyes</span>.
+    </h2>
+    <div class="demo__meta" style="justify-content:center">
+      <span class="chip chip--brand">upstream suites</span>
+      <span class="chip chip--brand">vue-lynx-testing-library</span>
+      <span class="chip">render / fireEvent / getByText</span>
+    </div>
+    <aside class="notes">
+      <p><strong>The AI-harness side of testing.</strong> We also built <code>vue-lynx-testing-library</code> — <code>render</code>, <code>fireEvent</code>, <code>getByText</code>, dual-thread abstracted away via <code>@lynx-js/testing-environment</code> — so component behavior is assertable in plain vitest. For a human that's good hygiene; for the AI harness it's <em>perception</em>: red/green is how the agent knows what it just did. The upstream suite was the reward signal that kept two weeks of generated code honest.</p>
+    </aside>
+  </section>
+
+  <!-- B1 — one bundle, two worlds -->
+  <section class="slide stage">
+    <span class="eyebrow">IV · Toolchain</span>
+    <div class="flow">
+      <div class="fbox" style="--c:#5dd5a8;left:50%;top:52%;width:56%;height:76%">
+        <span class="fbox__label">app.lynx.bundle</span>
+      </div>
+      <div class="fb" data-flip="fb-bgjs" style="--c:#42b883;left:50%;top:34%">
+        background.js
+        <small>Vue + your app · JS VM</small>
+      </div>
+      <div class="fb" data-flip="fb-mtjs" style="--c:#56b8f0;left:50%;top:70%">
+        main-thread.js
+        <small>Lepus · PrimJS VM</small>
+      </div>
+    </div>
+    <p class="lead arch-cap" data-mm-fade>
+      One file ships <em>both</em> threads.
+    </p>
+    <aside class="notes">
+      <p><strong>Lynx's deliverable is one bundle carrying two programs</strong> — background code for the JS VM, main-thread code for Lepus (PrimJS). Two VMs, two entries, one artifact; the same file renders natively and, through Lynx for Web, in the browser. So the toolchain question becomes: how does one build emit both worlds from one Vue codebase?</p>
+    </aside>
+  </section>
+
+  <!-- B2 — same code enters twice (layers) -->
+  <section class="slide stage">
+    <span class="eyebrow">IV · Toolchain</span>
+    <div class="flow">
+      <div class="fb is-hero" style="--c:#42b883;left:50%;top:8%">
+        App.vue
+        <small>one source</small>
+      </div>
+      <span class="farr" data-mm-fade style="left:32%;top:22%">&#8601;</span>
+      <span class="farr" data-mm-fade style="left:68%;top:22%">&#8600;</span>
+      <div class="fbox" data-mm-fade style="--c:#42b883;left:27%;top:60%;width:38%;height:56%">
+        <span class="fbox__label">layer: vue:background</span>
+      </div>
+      <div class="fbox" data-mm-fade style="--c:#56b8f0;left:73%;top:60%;width:38%;height:56%">
+        <span class="fbox__label">layer: vue:main-thread</span>
+      </div>
+      <div class="fb" data-mm-fade style="--c:#9E86F0;left:27%;top:45%">
+        vue-loader
+        <small>SFC compile</small>
+      </div>
+      <div class="fb" data-mm-fade style="--c:#9E86F0;left:73%;top:45%">
+        vue-loader
+        <small>+ script extractor</small>
+      </div>
+      <div class="fb" data-mm-fade style="--c:#E8B44A;left:27%;top:63%">
+        worklet-loader
+        <small>SWC · JS pass</small>
+      </div>
+      <div class="fb" data-mm-fade style="--c:#E8B44A;left:73%;top:63%">
+        worklet-loader-mt
+        <small>SWC · LEPUS pass</small>
+      </div>
+      <div class="fb" data-flip="fb-bgjs" style="--c:#42b883;left:27%;top:81%">
+        background.js
+        <small>Vue + your app · JS VM</small>
+      </div>
+      <div class="fb" data-flip="fb-mtjs" style="--c:#56b8f0;left:73%;top:81%">
+        main-thread.js
+        <small>Lepus · PrimJS VM</small>
+      </div>
+    </div>
+    <p class="lead arch-cap" data-mm-fade>
+      The same code enters <em>twice</em> — webpack layers route it.
+    </p>
+    <aside class="notes">
+      <p><strong>Both entries import your actual app.</strong> Each entry is compiled under a webpack <em>layer</em> — <code>vue:background</code> and <code>vue:main-thread</code> — and <code>issuerLayer</code> rules give each layer its own loader chain: the BG side compiles the full SFC; the MT side extracts only what the main thread needs. Per-entry scoping falls out of webpack's dependency graph for free. (We adopted this layer approach from ReactLynx after our first flat-bundle architecture couldn't isolate multi-entry apps.)</p>
+    </aside>
+  </section>
+
+  <!-- B3 — a plugin, not a compiler -->
+  <section class="slide stage">
+    <span class="eyebrow">IV · Toolchain</span>
+    <h2 class="h-section" style="text-align:center;max-width:22ch">
+      We wrote a <span class="brand-text">plugin</span> — not a compiler.
+    </h2>
+    <div class="demo__meta" style="justify-content:center">
+      <span class="chip chip--brand">Rspeedy</span>
+      <span class="chip chip--brand">Rspack / Rsbuild</span>
+      <span class="chip">rspack-vue-loader</span>
+      <span class="chip">PostCSS</span>
+    </div>
+    <aside class="notes">
+      <p><strong>The reuse story, toolchain edition.</strong> Lynx's toolchain (Rspeedy) is Rspack/Rsbuild — and the Vue ecosystem already runs on Rspack, so the entire SFC pipeline came off the shelf: <code>rspack-vue-loader</code>, PostCSS, HMR. <code>pluginVueLynx()</code> is a thin adapter: split each entry into the two layers, wire the worklet loaders, configure CSS — that's the whole surface. Framework-agnostic isn't a slogan; it's measured in how little we had to write.</p>
+    </aside>
+  </section>
+
+  <!-- B4 — CSS is CSS -->
+  <section class="slide stage">
+    <span class="eyebrow">IV · Toolchain</span>
+    <div class="flow" style="height:clamp(200px,30cqh,240px)">
+      <div class="fb" style="--c:#9E86F0;left:30%;top:50%">
+        &lt;style scoped&gt;
+        <small>SFC CSS · modules · v-bind()</small>
+      </div>
+      <span class="farr" data-mm-fade style="left:50%;top:50%">&rarr; as-is &rarr;</span>
+      <div class="fb is-hero" style="--c:#F27A9E;left:70%;top:50%">
+        native CSS engine
+        <small>selectors · cascade · animation</small>
+      </div>
+    </div>
+    <p class="lead arch-cap" data-mm-fade>
+      Your CSS isn't translated. It's just <b style="color:#F27A9E">CSS</b>.
+    </p>
+    <aside class="notes">
+      <p><strong>The quiet superpower behind the whole styling chapter:</strong> Lynx ships a real CSS engine on the native side — selectors, cascade, animations. So <code>&lt;style scoped&gt;</code> maps to Lynx's cssId scoping, CSS modules and imported stylesheets pass straight through, <code>v-bind()</code> in CSS rides CSS variables, and Tailwind works because PostCSS is just PostCSS. No StyleSheet-object dialect, no translation layer to leak.</p>
+    </aside>
+  </section>
+
+  <!-- C1 — why gestures lag -->
+  <section class="slide stage">
+    <span class="eyebrow">IV · Main-Thread Script</span>
+    <div class="flow">
+      <div class="flane" data-flip="lane-bg" style="--c:#5dd5a8;top:4%;height:42%">
+        <span class="flane__label"><i></i>Background thread</span>
+      </div>
+      <div class="flane" data-flip="lane-mt" style="--c:#56b8f0;top:54%;height:42%">
+        <span class="flane__label"><i></i>Main (UI) thread</span>
+      </div>
+      <div class="fb is-hero" data-flip="fb-fn" style="--c:#42b883;left:50%;top:25%">
+        onScroll()
+        <small>a Vue handler</small>
+      </div>
+      <span class="farr" style="--c:#3deae7;left:26%;top:50%">&uarr; event</span>
+      <span class="farr" style="--c:#4FB8F0;left:74%;top:50%">&darr; ops</span>
+      <span class="fcenter" data-mm-fade style="left:50%;top:66%"><b style="color:#F27A9E">2</b> crossings behind your finger</span>
+    </div>
+    <p class="lead arch-cap" data-mm-fade>
+      The dual-thread <em>cost</em>: gestures wait for the round trip.
+    </p>
+    <aside class="notes">
+      <p><strong>Honest about the cost before selling the reward.</strong> A scroll-follow animation the normal way: the event fires on the main thread, hops to the background for your handler, and the resulting ops hop back — two crossings on every frame of a gesture. On a busy page that's visible lag. This is the one place the dual-thread architecture charges you.</p>
+    </aside>
+  </section>
+
+  <!-- C2 — the function changes threads -->
+  <section class="slide stage">
+    <span class="eyebrow">IV · Main-Thread Script</span>
+    <div class="flow">
+      <div class="flane" data-flip="lane-bg" style="--c:#5dd5a8;top:4%;height:42%">
+        <span class="flane__label"><i></i>Background thread</span>
+      </div>
+      <div class="flane" data-flip="lane-mt" style="--c:#56b8f0;top:54%;height:42%">
+        <span class="flane__label"><i></i>Main (UI) thread</span>
+      </div>
+      <div class="fb is-hero" data-flip="fb-fn" style="--c:#42b883;left:50%;top:75%">
+        onScroll()
+        <small>'main thread'</small>
+      </div>
+      <span class="fcenter" data-mm-fade style="left:50%;top:25%"><b>0</b> crossings — it runs where events fire</span>
+    </div>
+    <p class="lead arch-cap" data-mm-fade>
+      One directive. The function <em>changes threads</em>.
+    </p>
+    <aside class="notes">
+      <p><strong>Watch the block move.</strong> Add <code>'main thread'</code> as the first line and the compiler relocates that function into the main-thread bundle — it now runs synchronously where events fire, with direct element access. The rest of your component stays ordinary Vue. That's the progressive-enhancement shape again: the dual-thread reward stays, the cost becomes opt-out per function.</p>
+    </aside>
+  </section>
+
+  <!-- C3 — the code -->
+  <section class="slide stage">
+    <div class="codeframe" style="width:100%;max-width:680px;text-align:left">
+      <div class="codeframe__head">
+        <span class="dots"><span></span><span></span><span></span></span>
+        <span>Draggable.vue</span>
+      </div>
+<pre><span class="code-tag">&lt;script setup&gt;</span>
+<span class="code-key">import</span> { useMainThreadRef } <span class="code-key">from</span> <span class="code-str">'vue-lynx'</span>
+<span class="code-key">const</span> box <span class="code-key">=</span> <span class="code-fn">useMainThreadRef</span>()
+
+<span class="code-key">const</span> onScroll <span class="code-key">=</span> (e) <span class="code-key">=&gt;</span> {
+  <span class="code-str">'main thread'</span>
+  box.current?.<span class="code-fn">setStyleProperty</span>(<span class="code-str">'transform'</span>,
+    <span class="code-str">`translateX(${e.detail.scrollLeft}px)`</span>)
+}
+<span class="code-tag">&lt;/script&gt;</span>
+
+<span class="code-tag">&lt;template&gt;</span>
+  <span class="code-tag">&lt;scroll-view</span> <span class="code-attr">:main-thread-bindscroll</span>=<span class="code-str">"onScroll"</span> <span class="code-tag">/&gt;</span>
+  <span class="code-tag">&lt;view</span> <span class="code-attr">:main-thread-ref</span>=<span class="code-str">"box"</span> <span class="code-tag">/&gt;</span>
+<span class="code-tag">&lt;/template&gt;</span></pre>
+    </div>
+    <p class="lead" data-mm-fade>
+      Still a <code>.vue</code> file. Still <code>ref</code>-shaped. Zero-latency.
+    </p>
+    <aside class="notes">
+      <p>The whole MTS surface in one file: <code>'main thread'</code> marks the function, <code>main-thread-bind*</code> attaches it to the event, <code>useMainThreadRef()</code> gives synchronous element access — <code>setStyleProperty</code> lands the same frame the finger moves.</p>
+    </aside>
+  </section>
+
+  <!-- C4 — tutorials remade, live -->
+  <section class="slide demo demo--reverse">
+    <div class="demo__stage">
+      <div class="phone">
+        <div class="phone__inner">
+          <vl-demo bundle="swiper/dist/Swiper.web.bundle"></vl-demo>
+        </div>
+      </div>
+    </div>
+    <div class="demo__body">
+      <span class="eyebrow">IV · Main-Thread Script</span>
+      <h2 class="demo__title">
+        ReactLynx's tutorials, <span class="brand-text">remade in Vue</span>.
+      </h2>
+      <p class="demo__copy">
+        Lynx's two official MTS tutorials — the gallery scrollbar and this
+        swiper — rebuilt line-for-line on Vue Lynx.
+      </p>
+      <div class="demo__meta">
+        <span class="chip chip--brand">tutorial: swiper</span>
+        <span class="chip chip--brand">tutorial: gallery</span>
+        <span class="chip">MTS · 60fps</span>
+      </div>
+    </div>
+    <aside class="notes">
+      <p><strong>Proof by replication.</strong> lynxjs.org teaches MTS through two tutorials, written for ReactLynx. Both are remade on Vue Lynx and live on our docs — same drag physics, same snap, same main-thread scrollbar. If the platform tutorials port cleanly, the capability is really there.</p>
+      <p><strong>Do live:</strong> drag slowly — the indicator is pixel-synced; flick to snap.</p>
+    </aside>
+  </section>
+
+  <!-- C5 — reuse + the open API space -->
+  <section class="slide stage">
+    <span class="eyebrow">IV · Main-Thread Script</span>
+    <h2 class="h-section" style="text-align:center;max-width:24ch">
+      Same worklet engine as ReactLynx — <em style="font-family:var(--serif);font-weight:400">today</em>.
+    </h2>
+    <p class="lead">
+      A Vue-flavored MTS API is the open design space.
+    </p>
+    <aside class="notes">
+      <p><strong>Reuse, then evolve.</strong> Under the hood we run ReactLynx's worklet runtime and its API shapes (<code>main-thread-bind*</code>, <code>useMainThreadRef</code>) — battle-tested, and instantly familiar across the Lynx ecosystem. But Vue deserves Vue-shaped ergonomics: think <code>&lt;script main-thread setup&gt;</code>, main-thread computed/watch. That design space is open — and it's a great place for the community to leave a mark.</p>
+    </aside>
+  </section>
+
+  <!-- H1 — the harness -->
+  <section class="slide stage">
+    <span class="eyebrow">IV · The harness</span>
+    <div class="mega" style="font-size:clamp(52px,7.5cqw,120px)"><span class="brand-text">2</span> weeks.</div>
+    <div class="demo__meta" style="justify-content:center">
+      <span class="chip">160 commits</span>
+      <span class="chip">21 active days</span>
+      <span class="chip chip--brand">1 human + Claude</span>
+    </div>
+    <aside class="notes">
+      <p><strong>Now the number makes sense.</strong> Everything in this chapter — renderer, toolchain, MTS — was built nights-and-weekends in two weeks: plans written as specs, an agent harness executing them, upstream tests as the reward signal, AGENTS.md encoding the debugging playbook. And a quiet takeaway for the room: Lynx turned out to be remarkably <em>AI-legible</em> — web-standard APIs and real CSS mean the model's web instincts mostly just transfer.</p>
+    </aside>
+  </section>
+
+  <!-- H2 — the write-up -->
+  <section class="slide stage">
+    <span class="eyebrow">IV · The harness</span>
+    <h2 class="h-section" style="text-align:center;max-width:22ch">
+      &ldquo;How I <span class="brand-text">vibed</span> this in two weeks&rdquo;
+    </h2>
+    <div class="qr-solo" data-qr="https://x.com/Huxpro/status/2036993665965416601" aria-label="QR: the write-up on X"></div>
+    <p class="lead">The full write-up — harness, prompts, receipts. <b>@Huxpro</b> on X.</p>
+    <aside class="notes">
+      <p><strong>Point the phones here.</strong> The complete methodology is written up on X — how the harness was structured, what the plans looked like, where the AI failed and how the tests caught it. It's also linked from the vue.lynxjs.org homepage badge. Then bridge out: "so that's how it was built — and here's what it adds up to."</p>
     </aside>
   </section>
 
@@ -892,9 +1360,9 @@
        Chapter IV · Close
        ==================================================== -->
   <section class="slide divider">
-    <span class="eyebrow">Chapter IV</span>
+    <span class="eyebrow">Chapter V</span>
     <div class="divider__row">
-      <span class="divider__num numeral--brand">IV</span>
+      <span class="divider__num numeral--brand">V</span>
       <h2 class="divider__title">
         And we'd love <br/>your help.
       </h2>

--- a/slides/index.html
+++ b/slides/index.html
@@ -24,7 +24,7 @@
     </button>
   </div>
   <div class="chrome chrome--bottom">
-    <span data-counter>01 / 62</span>
+    <span data-counter>01 / 64</span>
   </div>
   <div class="chrome chrome--bottom-right">
     <a href="https://vue.lynxjs.org" target="_blank" rel="noreferrer">vue.lynxjs.org</a>
@@ -748,7 +748,65 @@
     </div>
     <aside class="notes">
       <p><strong>What changed — the upgrades.</strong> ① <em>Keyboard avoidance</em>: the native <code>keyboardstatuschanged</code> event drives <code>setNativeProps</code> transforms, so the prompt box and thread follow the keyboard with a native curve — no web viewport hacks. ② <em>Send motion</em>: your message physically detaches from the input and flies into the thread as a bubble. ③ Press feedback runs as Main-Thread Script.</p>
+      <p>Credit where due: this native-chat bar was set by Vercel's <em>"How we built the v0 iOS app"</em> write-up — the next two slides show how the same feel costs far less on Lynx.</p>
       <p><strong>Do live:</strong> focus the input (keyboard slides, layout follows), then send a message — watch the bubble.</p>
+    </aside>
+  </section>
+
+  <!-- Case 1 · AI Chat · the keyboard, in code -->
+  <section class="slide stage">
+    <span class="eyebrow">III · Case 1 · AI Chat</span>
+    <div class="codeframe" style="width:100%;max-width:660px;text-align:left">
+      <div class="codeframe__head">
+        <span class="dots"><span></span><span></span><span></span></span>
+        <span>useKeyboardAvoidance.ts</span>
+      </div>
+<pre>lynx.<span class="code-fn">getJSModule</span>(<span class="code-str">'GlobalEventEmitter'</span>)
+  .<span class="code-fn">addListener</span>(<span class="code-str">'keyboardstatuschanged'</span>,
+    (status, height) <span class="code-key">=&gt;</span> {
+      <span class="code-key">const</span> off <span class="code-key">=</span> status <span class="code-key">===</span> <span class="code-str">'on'</span> ? height : <span class="code-str">0</span>
+      composer.<span class="code-fn">setNativeProps</span>({
+        transform: <span class="code-str">`translateY(${-off}px)`</span>,
+        transition: <span class="code-str">'transform 0.3s cubic-bezier(0.25, 1, 0.5, 1)'</span>,
+      }).<span class="code-fn">exec</span>()
+    })</pre>
+    </div>
+    <p class="lead" data-mm-fade>
+      One native event. One <code>setNativeProps</code>. No viewport hacks.
+    </p>
+    <aside class="notes">
+      <p><strong>The keyboard, in code.</strong> Lynx surfaces the platform keyboard as a first-class event with its height; the composer rides it with a <code>setNativeProps</code> transform on a native curve (0.3s in, 0.1s out). The keyboard height also feeds the launch-distance math and the bottom spacer.</p>
+      <p><strong>The contrast to land:</strong> the v0 iOS team describes a ~1,000-line <code>useKeyboardAwareMessageList</code> hook juggling six keyboard behaviors to make React Native feel native. Here the platform hands you the event — the whole composable is under 60 lines.</p>
+    </aside>
+  </section>
+
+  <!-- Case 1 · AI Chat · anatomy of the send -->
+  <section class="slide stage">
+    <span class="eyebrow">III · Case 1 · AI Chat</span>
+    <div class="flow" style="height:clamp(190px,26cqh,230px)">
+      <div class="fb" style="--c:#4FB8F0;left:17%;top:40%">
+        align
+        <small>scrollIntoView · behavior: none</small>
+      </div>
+      <span class="farr" data-mm-fade style="left:33.5%;top:40%">+2 frames &rarr;</span>
+      <div class="fb" style="--c:#E8B44A;left:50%;top:40%">
+        stage
+        <small>1 real frame at launch transform</small>
+      </div>
+      <span class="farr" data-mm-fade style="left:66.5%;top:40%">+1 frame &rarr;</span>
+      <div class="fb is-hero" style="--c:#42b883;left:83%;top:40%">
+        fly
+        <small>one-way transition · .95 &rarr; 1</small>
+      </div>
+      <span class="fcenter" data-mm-fade style="left:50%;top:82%;font-size:clamp(13px,1.2cqw,16px);color:var(--ink-mute)">earlier turns stay masked until the motion starts</span>
+    </div>
+    <p class="lead arch-cap" data-mm-fade>
+      Send isn't an animation — it's a <em>handoff</em>, choreographed in frames.
+    </p>
+    <aside class="notes">
+      <p><strong>Anatomy of the send (merged as PR #212).</strong> Two native realities force the choreography: the list must reset its scroll before the bubble can move, and Lynx can register a keyframe animation one display frame after the class change — naïvely you get a 34–51ms flash of the previous turn, or the bubble blinking at its destination.</p>
+      <p>So send is an explicit handoff: ① earlier turns and the Thinking row are hidden while the list <em>instantly</em> aligns (<code>behavior: none</code> — the bubble supplies the transition, not the scroller); ② the bubble commits one real frame at its measured launch transform (<code>translateY(distance) scale(0.95)</code>, distance keyboard-aware, clamped 44–420px); ③ then a one-way CSS <em>transition</em> flies it home and the old content is restored above the viewport. Even the empty assistant shell's 9⅓px native footprint is reserved so max-scroll stays stable during streaming.</p>
+      <p>Verified frame-by-frame on device — 15fps contact sheets, no ghost, no flash, no end-of-motion correction.</p>
     </aside>
   </section>
 

--- a/slides/index.html
+++ b/slides/index.html
@@ -831,7 +831,7 @@
         <span class="flane__label"><i></i>Main (UI) thread</span>
       </div>
       <div class="fb is-hero" data-flip="fb-vue" style="--c:#42b883;left:50%;top:25%">
-        Vue 3 runtime
+        Vue 3 runtime · VDOM
         <small>@vue/runtime-core · untouched</small>
       </div>
     </div>
@@ -854,7 +854,7 @@
         <span class="flane__label"><i></i>Main (UI) thread</span>
       </div>
       <div class="fb" data-flip="fb-vue" style="--c:#42b883;left:23%;top:25%">
-        Vue 3 runtime
+        Vue 3 runtime · VDOM
         <small>@vue/runtime-core · untouched</small>
       </div>
       <span class="farr" data-mm-fade style="left:41.5%;top:25%">nodeOps &rarr;</span>
@@ -882,7 +882,7 @@
         <span class="flane__label"><i></i>Main (UI) thread</span>
       </div>
       <div class="fb" data-flip="fb-vue" style="--c:#42b883;left:23%;top:25%">
-        Vue 3 runtime
+        Vue 3 runtime · VDOM
         <small>@vue/runtime-core · untouched</small>
       </div>
       <span class="farr" style="left:41.5%;top:25%">nodeOps &rarr;</span>
@@ -915,7 +915,7 @@
         <span class="flane__label"><i></i>Main (UI) thread</span>
       </div>
       <div class="fb" data-flip="fb-vue" style="--c:#42b883;left:23%;top:25%">
-        Vue 3 runtime
+        Vue 3 runtime · VDOM
         <small>@vue/runtime-core · untouched</small>
       </div>
       <span class="farr" style="left:41.5%;top:25%">nodeOps &rarr;</span>
@@ -958,7 +958,7 @@
         <span class="flane__label"><i></i>Main (UI) thread</span>
       </div>
       <div class="fb" data-flip="fb-vue" style="--c:#42b883;left:23%;top:25%">
-        Vue 3 runtime
+        Vue 3 runtime · VDOM
         <small>@vue/runtime-core · untouched</small>
       </div>
       <span class="farr" style="left:41.5%;top:25%">nodeOps &rarr;</span>
@@ -1005,7 +1005,7 @@
         <span class="flane__label"><i></i>Main (UI) thread</span>
       </div>
       <div class="fb is-dim" data-flip="fb-vue" style="--c:#42b883;left:23%;top:25%">
-        Vue 3 runtime
+        Vue 3 runtime · VDOM
         <small>@vue/runtime-core · untouched</small>
       </div>
       <div class="fb is-dim" data-flip="fb-shadow" style="--c:#E8B44A;left:62%;top:25%">

--- a/slides/package.json
+++ b/slides/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "dev": "vite --host 0.0.0.0 --port 4321",
     "build": "vite build",
-    "preview": "vite preview --host 0.0.0.0 --port 4321"
+    "preview": "vite preview --host 0.0.0.0 --port 4321",
+    "test:morph": "node tests/morph-invariant.mjs"
   },
   "dependencies": {
     "@lynx-js/web-core": "^0.20.0",
@@ -15,6 +16,7 @@
     "qrcode-generator": "^2.0.4"
   },
   "devDependencies": {
+    "playwright-core": "^1.49.0",
     "vite": "^5.4.10"
   }
 }

--- a/slides/src/framework/README.md
+++ b/slides/src/framework/README.md
@@ -22,6 +22,29 @@ object built in `../main.js` (next/prev/goto, flags, theme/lang, overview,
 blackout, speaker, stageScale, …) plus a `deck:change` DOM event. Swap the
 controller and content and the framework is reusable elsewhere.
 
+## The FLIP contract (magic-move.js)
+
+A `data-flip` element **keeps its own layout while morphing** — the engine
+must never change how the element is positioned or replace its transform:
+
+- **Positioning**: the `.is-flipping` class must NOT set `position` (only a
+  positioned box is needed, for z-index). The engine promotes *static*
+  elements to `relative` via inline style and restores them at cleanup.
+  Forcing `relative` from CSS yanks absolutely-positioned elements (logos,
+  diagram blocks, thread lanes) into flow mid-morph: they tween from a wrong
+  origin, then snap into place when the morph ends.
+- **Transforms**: the FLIP delta is **composed with** the element's own
+  computed transform (e.g. a `translate(-50%,-50%)` centering) and released
+  back to it — never overwritten, which would shift the element by half its
+  size for the duration of the morph.
+
+Both rules are guarded by `slides/tests/morph-invariant.mjs`
+(`pnpm test:morph`): it walks every adjacent slide pair sharing `data-flip`
+ids, asserts each element's mid-morph rect stays inside the corridor spanned
+by its source/target rects, and that it lands exactly where a fresh load of
+the target slide puts it. Run it whenever you touch `magic-move.js`, the
+`.is-flipping` styles, or add a new positioned flip-element type.
+
 ## What's *not* in here (deck content — lives in `src/`)
 
 - `index.html` — the slides themselves

--- a/slides/src/framework/magic-move.js
+++ b/slides/src/framework/magic-move.js
@@ -48,24 +48,45 @@ export function createMagicMove({ deck, getScale, reducedMotion = false, embed =
     //    Rects are in scaled viewport px; divide the translation by the stage
     //    scale so it maps to the element's own (unscaled) coordinate space.
     const s = (getScale?.() || 1);
-    pairs.forEach(({ fromRect, toRect, toEl }) => {
+    pairs.forEach((p) => {
+      const { fromRect, toRect, toEl } = p;
       const dx = (fromRect.left - toRect.left) / s;
       const dy = (fromRect.top - toRect.top) / s;
       const sx = toRect.width ? fromRect.width / toRect.width : 1;
       const sy = toRect.height ? fromRect.height / toRect.height : 1;
       toEl.classList.add('is-flipping');
+      // FLIP contract: an element keeps its OWN positioning scheme while
+      // morphing. We only need a positioned box (for z-index), so promote
+      // static elements to relative via inline style — never via the class,
+      // which would yank absolutely-positioned elements (logos, diagram
+      // blocks, thread lanes) into flow mid-morph: they'd tween from a wrong
+      // origin, then snap into place at cleanup.
+      const cs = getComputedStyle(toEl);
+      if (cs.position === 'static') {
+        toEl.style.position = 'relative';
+        p.promoted = true;
+      }
+      // Same contract for transforms: elements may carry their OWN transform
+      // (e.g. .fb's translate(-50%,-50%) centering). The FLIP delta must
+      // COMPOSE with it, not replace it — replacing shifts the element by
+      // half its size for the whole morph, then snaps at cleanup. Both rects
+      // were measured with the own transform applied, so prepending the
+      // delta and releasing back to the own matrix is exact.
+      p.own = cs.transform === 'none' ? '' : cs.transform;
       toEl.style.transformOrigin = 'top left';
       toEl.style.transition = 'none';
       toEl.style.transform =
-        `translate(${dx}px, ${dy}px) scale(${sx || 1}, ${sy || 1})`;
+        `translate(${dx}px, ${dy}px) scale(${sx || 1}, ${sy || 1})` +
+        (p.own ? ` ${p.own}` : '');
     });
 
-    // 5. Play — release to the identity transform on the next frame.
+    // 5. Play — release to the (own) identity transform on the next frame.
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
-        pairs.forEach(({ toEl }) => {
+        pairs.forEach(({ toEl, own }) => {
           toEl.style.transition = `transform ${FLIP_MS}ms ${FLIP_EASE}`;
-          toEl.style.transform = 'translate(0, 0) scale(1, 1)';
+          toEl.style.transform =
+            `translate(0, 0) scale(1, 1)${own ? ` ${own}` : ''}`;
         });
       });
     });
@@ -73,11 +94,12 @@ export function createMagicMove({ deck, getScale, reducedMotion = false, embed =
     // 6. Cleanup.
     const cleanup = () => {
       clearTimeout(timer);
-      pairs.forEach(({ toEl }) => {
+      pairs.forEach(({ toEl, promoted }) => {
         toEl.classList.remove('is-flipping');
         toEl.style.transform = '';
         toEl.style.transition = '';
         toEl.style.transformOrigin = '';
+        if (promoted) toEl.style.position = '';
       });
       fromSlide.classList.remove('is-morphing-out');
       toSlide.classList.remove('is-morphing-in');

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -104,6 +104,12 @@ export const ZH = {
   'keyboard avoidance': '键盘回避',
   'send motion': '发送动效',
   'MTS pressables': 'MTS 按压反馈',
+  'One native event. One setNativeProps. No viewport hacks.':
+    '一个原生事件,一次 <code>setNativeProps</code>。没有任何视口 hack。',
+  "Send isn't an animation — it's a handoff, choreographed in frames.":
+    '发送不是一段动画 —— 是一次按显示帧编排的<em>接力</em>。',
+  'earlier turns stay masked until the motion starts':
+    '动画启动之前,先前的对话保持遮蔽',
   'III · Case 2 · Elk': 'III · 案例二 · Elk',
   'Elk — a production-scale fork.':
     'Elk —— 一次<span class="brand-text">生产级规模</span>的 fork。',
@@ -313,61 +319,65 @@ export const ZH_NOTES = [
   // 33 AI Chat unchanged
   `<p><strong>不变的部分。</strong>这是 Nuxt 官方 AI Chatbot 模板,逐特性移植:流式 + 思维链、markdown + 代码高亮、天气/图表工具卡片、历史、投票、编辑、主题。里面的 Vue —— 组件、composable、store —— 才是重点:<strong>它们毫无波澜地搬了过来。</strong></p>`,
   // 34 AI Chat native
-  `<p><strong>变的部分 —— 升级项。</strong>① <em>键盘回避</em>:原生 <code>keyboardstatuschanged</code> 事件驱动 <code>setNativeProps</code> 变换,输入框和对话流跟着键盘一起、按原生曲线上滑 —— 不需要任何 Web 视口 hack。② <em>发送动效</em>:消息从输入框里"physically"飞出,变成气泡落进对话流。③ 按压反馈全部是主线程脚本。</p><p><strong>现场:</strong>先聚焦输入框(键盘升、布局跟),再发一条消息 —— 看气泡。</p>`,
-  // 35 Elk unchanged
+  `<p><strong>变的部分 —— 升级项。</strong>① <em>键盘回避</em>:原生 <code>keyboardstatuschanged</code> 事件驱动 <code>setNativeProps</code> 变换,输入框和对话流跟着键盘一起、按原生曲线上滑 —— 不需要任何 Web 视口 hack。② <em>发送动效</em>:消息从输入框里"physically"飞出,变成气泡落进对话流。③ 按压反馈全部是主线程脚本。</p><p>致谢:这套原生聊天体验的标准,是 Vercel 的《How we built the v0 iOS app》立下的 —— 接下来两页看同样的手感在 Lynx 上要付出多少。</p><p><strong>现场:</strong>先聚焦输入框(键盘升、布局跟),再发一条消息 —— 看气泡。</p>`,
+  // 35 AI Chat · 键盘代码
+  `<p><strong>键盘,用代码讲。</strong>Lynx 把平台键盘作为一等事件暴露出来,连高度一起给你;输入区用一次 <code>setNativeProps</code> 变换、按原生曲线(入 0.3s、出 0.1s)跟着键盘走。键盘高度还同时喂给发射距离计算和底部 spacer。</p><p><strong>要落的对比:</strong>v0 iOS 团队描述过一个约 1000 行的 <code>useKeyboardAwareMessageList</code> hook,要同时对付六种键盘行为才能让 RN 有原生手感。这里平台直接把事件递到手上 —— 整个 composable 不到 60 行。</p>`,
+  // 36 AI Chat · 发送解剖
+  `<p><strong>发送的解剖(已合入 PR #212)。</strong>两个原生现实决定了这套编排:气泡动之前列表必须先重置滚动;而 Lynx 可能在 class 变更后一个显示帧才注册 keyframe 动画 —— 天真写法要么闪 34–51ms 的上一轮对话,要么气泡在终点闪现。</p><p>所以发送是一次显式接力:① 先前的轮次和 Thinking 行先遮蔽,列表<em>瞬时</em>对齐(<code>behavior: none</code> —— 过渡由气泡提供,不由滚动器提供);② 气泡在测得的发射变换上(<code>translateY(distance) scale(0.95)</code>,距离感知键盘、夹在 44–420px)先落一个真实帧;③ 再用单向 CSS <em>transition</em> 飞到位,旧内容恢复到视口上方。连空的 assistant 壳的 9⅓px 原生底高都被预留,保证流式期间最大滚动稳定。</p><p>逐帧验证过 —— 15fps contact sheet,无鬼影、无闪现、无落点修正。</p>`,
+  // 37 Elk unchanged
   `<p><strong>这一页讲规模。</strong>Elk 是真实的 Mastodon 客户端,不是 demo:时间线、会话、个人页、投票、内容警告、自定义表情、搜索、发帖。我们 fork 它,保住它的"大脑" —— masto.js API 客户端、Mastodon-HTML 内容管线、主题、领域逻辑 —— 只把视图层重建到原生元素上。这就是移植经济学:<strong>应用越大,能复用的越多。</strong></p>`,
-  // 36 Elk gestures
+  // 38 Elk gestures
   `<p><strong>手势升级。</strong>底部抽屉从头到尾是主线程脚本:8px 手势锁判定谁接管拖拽,超限后的橡皮筋阻尼,带真实速度 + 减速度的甩动开合 —— 零后台线程往返,流式加载中也不掉帧。</p><p><strong>下一步</strong>(也是贡献切入点):原生 view pager,横滑切时间线 tab —— 抽屉展示了范式,pager 复用它。</p><p><strong>现场:</strong>滚时间线,慢拖抽屉(橡皮筋),再甩一下。</p>`,
-  // 37 Divider IV · How we did it
+  // 39 Divider IV · How we did it
   `<p><strong>工程章。</strong>刚才看到的一切,是一个人两周做出来的 —— 这一章诚实回答"怎么做到的"。三次适配,每一次都揭开 Lynx 架构的一角:把 Vue 拆上双线程而不破坏语义;让一条工具链吐出两个世界;再让主线程本身可编程。AI harness 贯穿全程。</p>`,
-  // 38 A1 · Vue 落在后台线程
+  // 40 A1 · Vue 落在后台线程
   `<p><strong>第一个决定:Vue 住哪条线程?</strong>早期社区实验把 Vue 放在主线程 —— 于是每个事件都要跨线程转发。而 Lynx 原生就把事件送到后台线程,所以我们把整个运行时放在这里:响应式、diff、生命周期、你的回调。不是 fork —— 是原封不动的 <code>@vue/runtime-core</code>。</p>`,
-  // 39 A2 · ShadowElement
+  // 41 A2 · ShadowElement
   `<p><strong>Vue 官方的自定义渲染器 API 就是全部诀窍。</strong><code>createRenderer()</code> 要求同步的节点 —— <code>parentNode()</code>、<code>nextSibling()</code> 必须立刻有答案,但真实元素在另一条线程上。所以 nodeOps 双写:在后台线程维护一棵轻量 <em>ShadowElement</em> 链表(满足 Vue 的所有同步读取),同时把真正的工作排进队列。和 ReactLynx 的 snapshot instance 是同一个 pattern。</p>`,
-  // 40 A3 · ops 缓冲
+  // 42 A3 · ops 缓冲
   `<p><strong>唯一跨过线程边界的,是数据。</strong><code>[CREATE, id, tag, INSERT, parent, child, SET_PROP, id, key, value…]</code> —— 只有数字和字符串,没有对象要序列化,没有函数。按 Vue 自己的 flush 周期批处理:一个响应式 tick = 一次发送。Vue 编译器还白送一层:静态内容零 ops,只有动态绑定在路上跑。</p>`,
-  // 41 A4 · 解释器 + PAPI
+  // 43 A4 · 解释器 + PAPI
   `<p><strong>这里就是 Lynx 框架无关的那条缝,凑近看。</strong>主线程跑一个小解释器 —— 字面意义上的 switch 循环 —— 把 ops 重放到 <em>Element PAPI</em> 上:<code>__CreateView</code>、<code>__AppendElement</code>、<code>__SetAttribute</code>……这套 C 风格 API 是 Lynx 给每个框架的合同;ReactLynx 在喂它,我们在喂它,下一个框架也会。VDOM → ShadowElement → ops → PAPI:四站,一条直线。</p>`,
-  // 42 A5 · 事件回程
+  // 44 A5 · 事件回程
   `<p><strong>回程闭环。</strong>函数不能跨线程,所以它们从来不跨:每个回调注册一个数字 <em>sign</em>;主线程派发 sign,后台线程查表,就地调用你的 Vue 函数 —— 闭包、响应式,全都还在原地。这就是 Vue 语义得以保全的原因:真正要紧的东西从来没离开过。</p>`,
-  // 43 A6 · nextTick
+  // 45 A6 · nextTick
   `<p><strong>用户能感觉到多少?几乎为零。</strong>唯一可见的接缝:原生元素在 mount 之后一拍才落地,所以"等 DOM"写成 <code>onMounted(() =&gt; nextTick(() =&gt; lynx.createSelectorQuery()…))</code> —— 和 Web Vue 同一个 <code>nextTick</code> 心智模型,只是跨了一条线程。这张图绕一圈,<em>就是</em>一个 tick。其余一切 —— 响应式、生命周期、组合式函数 —— 行为和 Web 完全一致。(文档:Understanding the Dual-Thread Model。)</p>`,
-  // 44 A7 · 上游测试
+  // 46 A7 · 上游测试
   `<p><strong>"语义保全"是可测量的命题。</strong>我们把 <code>vuejs/core</code> 的测试套件搬进仓库,在两层上对着 Vue Lynx 跑:一层用我们真实的 ShadowElement 链表垫在 <code>@vue/runtime-test</code> 下面(验证完整渲染器合同 —— keyed diff、LIS、fragment、生命周期);另一层 runtime-dom 把 <code>patchProp → ops → applyOps → PAPI</code> 推进 jsdom。1013 个通过 882,131 个 skip 全部有记录,零失败。</p>`,
-  // 45 A8 · 测试是 AI 的眼睛
+  // 47 A8 · 测试是 AI 的眼睛
   `<p><strong>测试的 AI-harness 一面。</strong>我们还做了 <code>vue-lynx-testing-library</code> —— <code>render</code>、<code>fireEvent</code>、<code>getByText</code>,双线程被 <code>@lynx-js/testing-environment</code> 抽象掉 —— 组件行为在普通 vitest 里就能断言。对人来说这是卫生习惯;对 AI harness 来说这是<em>感知</em>:红绿就是 agent 知道自己刚才做了什么的方式。上游套件,就是让两周生成代码保持诚实的 reward signal。</p>`,
-  // 46 B1 · 一个 bundle 两个世界
+  // 48 B1 · 一个 bundle 两个世界
   `<p><strong>Lynx 的交付物是一个装着两个程序的 bundle</strong> —— 后台代码跑在 JS VM,主线程代码跑在 Lepus(PrimJS)。两个 VM、两个入口、一个产物;同一个文件既能原生渲染,也能经 Lynx for Web 跑在浏览器里。于是工具链的问题变成:一次构建,怎么从一份 Vue 代码吐出两个世界?</p>`,
-  // 47 B2 · 同一份代码进两次
+  // 49 B2 · 同一份代码进两次
   `<p><strong>两个入口都 import 你的真实应用。</strong>每个入口在一个 webpack <em>layer</em> 下编译 —— <code>vue:background</code> 和 <code>vue:main-thread</code> —— <code>issuerLayer</code> 规则给每层各自的 loader 链:BG 侧编译完整 SFC;MT 侧只抽取主线程需要的部分。逐 entry 的隔离,是 webpack 依赖图白送的。(这套 layer 方案我们是从 ReactLynx 学来的 —— 第一版扁平 bundle 架构隔离不了多入口应用。)</p>`,
-  // 48 B3 · 插件而非编译器
+  // 50 B3 · 插件而非编译器
   `<p><strong>复用故事的工具链篇。</strong>Lynx 的工具链(Rspeedy)就是 Rspack/Rsbuild —— 而 Vue 生态本来就跑在 Rspack 上,所以整条 SFC 流水线是现成的:<code>rspack-vue-loader</code>、PostCSS、HMR。<code>pluginVueLynx()</code> 是一层薄适配:把入口拆成两个 layer、接上 worklet loader、配好 CSS —— 表面积就这么大。框架无关不是口号,是用"我们只需要写多少"来度量的。</p>`,
-  // 49 B4 · CSS 就是 CSS
+  // 51 B4 · CSS 就是 CSS
   `<p><strong>整章样式能力背后安静的超能力:</strong>Lynx 在原生侧带了真正的 CSS 引擎 —— 选择器、级联、动画。所以 <code>&lt;style scoped&gt;</code> 映射到 Lynx 的 cssId 作用域,CSS Modules 和外链样式直接透传,CSS 里的 <code>v-bind()</code> 骑在 CSS 变量上,Tailwind 能跑是因为 PostCSS 就是 PostCSS。没有 StyleSheet 对象方言,没有会漏的翻译层。</p>`,
-  // 50 C1 · 手势为什么会迟
+  // 52 C1 · 手势为什么会迟
   `<p><strong>先诚实讲代价,再卖回报。</strong>普通写法的滚动跟随动画:事件在主线程触发,跳去后台跑你的回调,产生的 ops 再跳回来 —— 手势的每一帧背后是两次跨线程。页面一忙,肉眼可见地迟。这是双线程架构唯一收费的地方。</p>`,
-  // 51 C2 · 函数换线程
+  // 53 C2 · 函数换线程
   `<p><strong>看方块移动。</strong>把 <code>'main thread'</code> 写成函数第一行,编译器就把这个函数搬进主线程 bundle —— 它从此同步运行在事件发生的地方,直接访问元素。组件的其余部分还是普通 Vue。又是渐进增强的形状:双线程的回报留着,代价变成按函数粒度的可选项。</p>`,
-  // 52 C3 · 代码样例
+  // 54 C3 · 代码样例
   `<p>MTS 的全部表面积,一个文件讲完:<code>'main thread'</code> 标记函数,<code>main-thread-bind*</code> 挂到事件上,<code>useMainThreadRef()</code> 给出同步元素访问 —— <code>setStyleProperty</code> 在手指移动的同一帧落地。</p>`,
-  // 53 C4 · 教程复刻
+  // 55 C4 · 教程复刻
   `<p><strong>复刻即证明。</strong>lynxjs.org 用两个教程教 MTS,都是为 ReactLynx 写的。两个都在 Vue Lynx 上重做了,live 在我们的文档站上 —— 同样的拖拽物理、同样的吸附、同样的主线程滚动条。平台教程能干净地移植过来,能力就是真的在。</p><p><strong>现场:</strong>慢慢拖 —— 指示器逐像素同步;一甩,吸附。</p>`,
-  // 54 C5 · 复用与开放的 API 空间
+  // 56 C5 · 复用与开放的 API 空间
   `<p><strong>先复用,再演化。</strong>引擎层我们直接跑 ReactLynx 的 worklet runtime 和它的 API 形状(<code>main-thread-bind*</code>、<code>useMainThreadRef</code>)—— 久经考验,而且在 Lynx 生态里通用。但 Vue 值得 Vue 形状的人体工学:想象 <code>&lt;script main-thread setup&gt;</code>、主线程的 computed/watch。这个设计空间是开放的 —— 也是社区留下印记的好地方。</p>`,
-  // 55 H1 · 2 weeks
+  // 57 H1 · 2 weeks
   `<p><strong>现在这个数字说得通了。</strong>这一章的一切 —— 渲染器、工具链、MTS —— 是两周的夜晚和周末做出来的:plan 写成 spec,agent harness 执行,上游测试当 reward signal,AGENTS.md 固化调试手册。给在座各位一个安静的结论:Lynx 出乎意料地 <em>AI 可读</em> —— Web 标准的 API 和真 CSS,意味着模型的 Web 直觉基本直接迁移。</p>`,
-  // 56 H2 · X 复盘
+  // 58 H2 · X 复盘
   `<p><strong>让观众把手机对准这页。</strong>完整方法论写在 X 上 —— harness 怎么搭、plan 长什么样、AI 在哪儿失手、测试怎么接住的。vue.lynxjs.org 首页的 badge 也链着它。然后收束:"这就是它怎么被做出来的 —— 接下来看看它加起来意味着什么。"</p>`,
-  // 57 Combine
+  // 59 Combine
   `<p><strong>标题句。</strong>Vue × Lynx = Vue 跑在原生上。停顿,让等式落地。然后:"也很希望大家来一起把它做成。"</p>`,
-  // 58 Divider V · close
+  // 60 Divider V · close
   `<p><strong>转向请求。</strong>项目是真的,但需要社区。架构很稳;Vue 的表面积很大。</p>`,
-  // 59 Ask
+  // 61 Ask
   `<p>落在这句上 —— <em>"原生,不该是另一个团队的事。"</em>这是你想让他们记住的一句。</p>`,
-  // 60 What's there / open
+  // 62 What's there / open
   `<p>左边 = 今天就能用、可以做生产探索的。右边 = 贡献者能发力的地方 —— 第三章里 Elk 的 view pager,就在这个清单上。</p>`,
-  // 61 Try
+  // 63 Try
   `<p><strong>行动号召。</strong>一行命令 —— <code>npm create vue-lynx@latest</code>。"给 Agent"按钮会复制一段引导 prompt。承诺:"今晚回家的公交上,你就能让一个 Vue 应用跑在 iPhone 上。"</p>`,
-  // 62 Thank you
+  // 64 Thank you
   `<p><strong>收尾。</strong>感谢,邀请提问,停在这页做 Q&amp;A。</p><p>"能上生产吗?" —— pre-alpha,架构稳,已覆盖的部分测试充分。"Android?" —— Lynx 跨平台,同一产物两端都跑。</p>`,
 ];

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -120,25 +120,71 @@ export const ZH = {
   'MTS bottom sheet': 'MTS 底部抽屉',
   'next: view pager': '下一步:view pager',
 
-  // ---- How it works ----
-  'How it works': '原理一分钟',
-  'Background thread': '<span class="dot"></span>后台线程',
-  'Main (UI) thread': '<span class="dot"></span>主(UI)线程',
-  'Vue 3 runtime & your code': 'Vue 3 运行时与你的代码',
-  'Native elements & render': '原生元素与渲染',
-  'reactivity & lifecycle': '响应式与生命周期',
-  'component tree diff': '组件树 diff',
-  'event handlers': '事件处理',
-  'data fetching': '数据请求',
-  'layout & paint': '布局与绘制',
-  'gestures & scrolling': '手势与滚动',
   'Main-Thread Script': '<b>主线程脚本</b>',
-  'ops interpreter': 'ops 解释器',
-  'flat buffer': '扁平缓冲',
-  'Your whole Vue app runs here — on a thread of its own.':
-    '你的整个 Vue 应用都跑在这里 —— 一条属于自己的线程上。',
-  'One bundle, two layers — no JS bridge round-trip on the hot path.':
-    '一个产物,两个层 —— 热路径上没有 JS 桥的往返。',
+
+  // ---- Chapter IV · How we did it ----
+  'Chapter IV': '第四章',
+  'And how was this built?': '那,它是<br/>怎么被做出来的?',
+  'Three adaptations — the runtime, the toolchain, the main thread — and an AI harness running through all of them.':
+    '三次适配 —— 运行时、工具链、主线程 —— 以及一路贯穿其中的 AI harness。',
+  'IV · Runtime': 'IV · 运行时',
+  'IV · Runtime · proof': 'IV · 运行时 · 实证',
+  'IV · Toolchain': 'IV · 工具链',
+  'IV · Main-Thread Script': 'IV · 主线程脚本',
+  'IV · The harness': 'IV · Harness',
+  'Background thread': '<i></i>后台线程',
+  'Main (UI) thread': '<i></i>主(UI)线程',
+  'Vue runs whole — on the background thread.':
+    'Vue <em>整个</em>跑在后台线程上。',
+  'createRenderer() — a renderer, not a fork.':
+    '<code>createRenderer()</code> —— 写一个渲染器,而不是 fork 一个 Vue。',
+  'Updates leave as a flat ops buffer — once per tick.':
+    '更新以<b style="color:#4FB8F0">扁平 ops 缓冲</b>的形式离开 —— 每个 tick 一次。',
+  'The main thread replays them — native elements appear.':
+    '主线程把它们<b style="color:#F27A9E">重放</b>出来 —— 原生元素出现。',
+  'Events ride back up — handlers never leave Vue.':
+    '事件坐车<b style="color:#3deae7">回来</b> —— 回调从未离开过 Vue。',
+  'The threading leaks into your code in exactly one place.':
+    '双线程漏进你代码里的,只有<em>一个</em>地方。',
+  'one lap = nextTick()': '绕一圈 = <b>nextTick()</b>',
+  "Vue core's own tests, replayed on our renderer. 0 fail.":
+    'Vue core 自己的测试,在我们的渲染器上重放。<b>0 失败。</b>',
+  "…and the tests are the AI's eyes.":
+    '……而这些测试,就是 <span class="brand-text">AI 的眼睛</span>。',
+  'One file ships both threads.': '一个文件,装下<em>两条</em>线程。',
+  'The same code enters twice — webpack layers route it.':
+    '同一份代码,进两次 —— webpack layers 负责分流。',
+  'We wrote a plugin — not a compiler.':
+    '我们写的是一个<span class="brand-text">插件</span> —— 不是编译器。',
+  "Your CSS isn't translated. It's just CSS.":
+    '你的 CSS 没有被翻译。它就是 <b style="color:#F27A9E">CSS</b>。',
+  '2 crossings behind your finger':
+    '你的手指背后,是 <b style="color:#F27A9E">2</b> 次跨线程',
+  'The dual-thread cost: gestures wait for the round trip.':
+    '双线程的<em>代价</em>:手势要等一个来回。',
+  '0 crossings — it runs where events fire':
+    '<b>0</b> 次跨线程 —— 它就跑在事件发生的地方',
+  'One directive. The function changes threads.':
+    '一行指令。函数<em>换了线程</em>。',
+  'Still a .vue file. Still ref-shaped. Zero-latency.':
+    '仍然是 <code>.vue</code> 文件,仍然是 <code>ref</code> 的形状。零延迟。',
+  "ReactLynx's tutorials, remade in Vue.":
+    'ReactLynx 的官方教程,<span class="brand-text">用 Vue 重做了一遍</span>。',
+  "Lynx's two official MTS tutorials — the gallery scrollbar and this swiper — rebuilt line-for-line on Vue Lynx.":
+    'Lynx 的两个官方 MTS 教程 —— gallery 滚动条和这个 swiper —— 在 Vue Lynx 上逐行重建。',
+  'tutorial: swiper': '教程:swiper',
+  'tutorial: gallery': '教程:gallery',
+  'Same worklet engine as ReactLynx — today.':
+    '与 ReactLynx <em style="font-family:var(--serif);font-weight:400">同一套</em> worklet 引擎 —— 这是今天。',
+  'A Vue-flavored MTS API is the open design space.':
+    '而 Vue 味的 MTS API,是留给未来的设计空间。',
+  '2 weeks.': '<span class="brand-text">2</span> 周。',
+  '160 commits': '160 次提交',
+  '21 active days': '21 个活跃日',
+  '1 human + Claude': '1 个人 + Claude',
+  'The full write-up — harness, prompts, receipts. @Huxpro on X.':
+    '完整复盘 —— harness、prompt、全部凭证。X 上的 <b>@Huxpro</b>。',
+  'Chapter V': '第五章',
 
   // ---- Combine ----
   'A new path': '一条新路',
@@ -272,20 +318,56 @@ export const ZH_NOTES = [
   `<p><strong>这一页讲规模。</strong>Elk 是真实的 Mastodon 客户端,不是 demo:时间线、会话、个人页、投票、内容警告、自定义表情、搜索、发帖。我们 fork 它,保住它的"大脑" —— masto.js API 客户端、Mastodon-HTML 内容管线、主题、领域逻辑 —— 只把视图层重建到原生元素上。这就是移植经济学:<strong>应用越大,能复用的越多。</strong></p>`,
   // 36 Elk gestures
   `<p><strong>手势升级。</strong>底部抽屉从头到尾是主线程脚本:8px 手势锁判定谁接管拖拽,超限后的橡皮筋阻尼,带真实速度 + 减速度的甩动开合 —— 零后台线程往返,流式加载中也不掉帧。</p><p><strong>下一步</strong>(也是贡献切入点):原生 view pager,横滑切时间线 tab —— 抽屉展示了范式,pager 复用它。</p><p><strong>现场:</strong>滚时间线,慢拖抽屉(橡皮筋),再甩一下。</p>`,
-  // 37 Arch bg solo
-  `<p><strong>一分钟原理</strong> —— 刚才那些为什么能这么顺。Vue 运行时 —— 响应式、diff、生命周期、事件处理 —— 住在<strong>后台</strong>线程。下一页:主线程落到它旁边。</p>`,
-  // 38 Arch both
-  `<p>两条线程用一段扁平 <em>ops</em> 缓冲通信,按 Vue 的 tick 批处理。<strong>热路径上没有 JS 桥</strong> —— 这就是键盘、抽屉、滑动能稳在 60fps 的原因。点睛:<em>主线程脚本</em> —— 抽屉手势、按压反馈 —— 就是你的 Vue 代码,被编译到 UI 线程上。</p>`,
-  // 39 Combine
+  // 37 Divider IV · How we did it
+  `<p><strong>工程章。</strong>刚才看到的一切,是一个人两周做出来的 —— 这一章诚实回答"怎么做到的"。三次适配,每一次都揭开 Lynx 架构的一角:把 Vue 拆上双线程而不破坏语义;让一条工具链吐出两个世界;再让主线程本身可编程。AI harness 贯穿全程。</p>`,
+  // 38 A1 · Vue 落在后台线程
+  `<p><strong>第一个决定:Vue 住哪条线程?</strong>早期社区实验把 Vue 放在主线程 —— 于是每个事件都要跨线程转发。而 Lynx 原生就把事件送到后台线程,所以我们把整个运行时放在这里:响应式、diff、生命周期、你的回调。不是 fork —— 是原封不动的 <code>@vue/runtime-core</code>。</p>`,
+  // 39 A2 · ShadowElement
+  `<p><strong>Vue 官方的自定义渲染器 API 就是全部诀窍。</strong><code>createRenderer()</code> 要求同步的节点 —— <code>parentNode()</code>、<code>nextSibling()</code> 必须立刻有答案,但真实元素在另一条线程上。所以 nodeOps 双写:在后台线程维护一棵轻量 <em>ShadowElement</em> 链表(满足 Vue 的所有同步读取),同时把真正的工作排进队列。和 ReactLynx 的 snapshot instance 是同一个 pattern。</p>`,
+  // 40 A3 · ops 缓冲
+  `<p><strong>唯一跨过线程边界的,是数据。</strong><code>[CREATE, id, tag, INSERT, parent, child, SET_PROP, id, key, value…]</code> —— 只有数字和字符串,没有对象要序列化,没有函数。按 Vue 自己的 flush 周期批处理:一个响应式 tick = 一次发送。Vue 编译器还白送一层:静态内容零 ops,只有动态绑定在路上跑。</p>`,
+  // 41 A4 · 解释器 + PAPI
+  `<p><strong>这里就是 Lynx 框架无关的那条缝,凑近看。</strong>主线程跑一个小解释器 —— 字面意义上的 switch 循环 —— 把 ops 重放到 <em>Element PAPI</em> 上:<code>__CreateView</code>、<code>__AppendElement</code>、<code>__SetAttribute</code>……这套 C 风格 API 是 Lynx 给每个框架的合同;ReactLynx 在喂它,我们在喂它,下一个框架也会。VDOM → ShadowElement → ops → PAPI:四站,一条直线。</p>`,
+  // 42 A5 · 事件回程
+  `<p><strong>回程闭环。</strong>函数不能跨线程,所以它们从来不跨:每个回调注册一个数字 <em>sign</em>;主线程派发 sign,后台线程查表,就地调用你的 Vue 函数 —— 闭包、响应式,全都还在原地。这就是 Vue 语义得以保全的原因:真正要紧的东西从来没离开过。</p>`,
+  // 43 A6 · nextTick
+  `<p><strong>用户能感觉到多少?几乎为零。</strong>唯一可见的接缝:原生元素在 mount 之后一拍才落地,所以"等 DOM"写成 <code>onMounted(() =&gt; nextTick(() =&gt; lynx.createSelectorQuery()…))</code> —— 和 Web Vue 同一个 <code>nextTick</code> 心智模型,只是跨了一条线程。这张图绕一圈,<em>就是</em>一个 tick。其余一切 —— 响应式、生命周期、组合式函数 —— 行为和 Web 完全一致。(文档:Understanding the Dual-Thread Model。)</p>`,
+  // 44 A7 · 上游测试
+  `<p><strong>"语义保全"是可测量的命题。</strong>我们把 <code>vuejs/core</code> 的测试套件搬进仓库,在两层上对着 Vue Lynx 跑:一层用我们真实的 ShadowElement 链表垫在 <code>@vue/runtime-test</code> 下面(验证完整渲染器合同 —— keyed diff、LIS、fragment、生命周期);另一层 runtime-dom 把 <code>patchProp → ops → applyOps → PAPI</code> 推进 jsdom。1013 个通过 882,131 个 skip 全部有记录,零失败。</p>`,
+  // 45 A8 · 测试是 AI 的眼睛
+  `<p><strong>测试的 AI-harness 一面。</strong>我们还做了 <code>vue-lynx-testing-library</code> —— <code>render</code>、<code>fireEvent</code>、<code>getByText</code>,双线程被 <code>@lynx-js/testing-environment</code> 抽象掉 —— 组件行为在普通 vitest 里就能断言。对人来说这是卫生习惯;对 AI harness 来说这是<em>感知</em>:红绿就是 agent 知道自己刚才做了什么的方式。上游套件,就是让两周生成代码保持诚实的 reward signal。</p>`,
+  // 46 B1 · 一个 bundle 两个世界
+  `<p><strong>Lynx 的交付物是一个装着两个程序的 bundle</strong> —— 后台代码跑在 JS VM,主线程代码跑在 Lepus(PrimJS)。两个 VM、两个入口、一个产物;同一个文件既能原生渲染,也能经 Lynx for Web 跑在浏览器里。于是工具链的问题变成:一次构建,怎么从一份 Vue 代码吐出两个世界?</p>`,
+  // 47 B2 · 同一份代码进两次
+  `<p><strong>两个入口都 import 你的真实应用。</strong>每个入口在一个 webpack <em>layer</em> 下编译 —— <code>vue:background</code> 和 <code>vue:main-thread</code> —— <code>issuerLayer</code> 规则给每层各自的 loader 链:BG 侧编译完整 SFC;MT 侧只抽取主线程需要的部分。逐 entry 的隔离,是 webpack 依赖图白送的。(这套 layer 方案我们是从 ReactLynx 学来的 —— 第一版扁平 bundle 架构隔离不了多入口应用。)</p>`,
+  // 48 B3 · 插件而非编译器
+  `<p><strong>复用故事的工具链篇。</strong>Lynx 的工具链(Rspeedy)就是 Rspack/Rsbuild —— 而 Vue 生态本来就跑在 Rspack 上,所以整条 SFC 流水线是现成的:<code>rspack-vue-loader</code>、PostCSS、HMR。<code>pluginVueLynx()</code> 是一层薄适配:把入口拆成两个 layer、接上 worklet loader、配好 CSS —— 表面积就这么大。框架无关不是口号,是用"我们只需要写多少"来度量的。</p>`,
+  // 49 B4 · CSS 就是 CSS
+  `<p><strong>整章样式能力背后安静的超能力:</strong>Lynx 在原生侧带了真正的 CSS 引擎 —— 选择器、级联、动画。所以 <code>&lt;style scoped&gt;</code> 映射到 Lynx 的 cssId 作用域,CSS Modules 和外链样式直接透传,CSS 里的 <code>v-bind()</code> 骑在 CSS 变量上,Tailwind 能跑是因为 PostCSS 就是 PostCSS。没有 StyleSheet 对象方言,没有会漏的翻译层。</p>`,
+  // 50 C1 · 手势为什么会迟
+  `<p><strong>先诚实讲代价,再卖回报。</strong>普通写法的滚动跟随动画:事件在主线程触发,跳去后台跑你的回调,产生的 ops 再跳回来 —— 手势的每一帧背后是两次跨线程。页面一忙,肉眼可见地迟。这是双线程架构唯一收费的地方。</p>`,
+  // 51 C2 · 函数换线程
+  `<p><strong>看方块移动。</strong>把 <code>'main thread'</code> 写成函数第一行,编译器就把这个函数搬进主线程 bundle —— 它从此同步运行在事件发生的地方,直接访问元素。组件的其余部分还是普通 Vue。又是渐进增强的形状:双线程的回报留着,代价变成按函数粒度的可选项。</p>`,
+  // 52 C3 · 代码样例
+  `<p>MTS 的全部表面积,一个文件讲完:<code>'main thread'</code> 标记函数,<code>main-thread-bind*</code> 挂到事件上,<code>useMainThreadRef()</code> 给出同步元素访问 —— <code>setStyleProperty</code> 在手指移动的同一帧落地。</p>`,
+  // 53 C4 · 教程复刻
+  `<p><strong>复刻即证明。</strong>lynxjs.org 用两个教程教 MTS,都是为 ReactLynx 写的。两个都在 Vue Lynx 上重做了,live 在我们的文档站上 —— 同样的拖拽物理、同样的吸附、同样的主线程滚动条。平台教程能干净地移植过来,能力就是真的在。</p><p><strong>现场:</strong>慢慢拖 —— 指示器逐像素同步;一甩,吸附。</p>`,
+  // 54 C5 · 复用与开放的 API 空间
+  `<p><strong>先复用,再演化。</strong>引擎层我们直接跑 ReactLynx 的 worklet runtime 和它的 API 形状(<code>main-thread-bind*</code>、<code>useMainThreadRef</code>)—— 久经考验,而且在 Lynx 生态里通用。但 Vue 值得 Vue 形状的人体工学:想象 <code>&lt;script main-thread setup&gt;</code>、主线程的 computed/watch。这个设计空间是开放的 —— 也是社区留下印记的好地方。</p>`,
+  // 55 H1 · 2 weeks
+  `<p><strong>现在这个数字说得通了。</strong>这一章的一切 —— 渲染器、工具链、MTS —— 是两周的夜晚和周末做出来的:plan 写成 spec,agent harness 执行,上游测试当 reward signal,AGENTS.md 固化调试手册。给在座各位一个安静的结论:Lynx 出乎意料地 <em>AI 可读</em> —— Web 标准的 API 和真 CSS,意味着模型的 Web 直觉基本直接迁移。</p>`,
+  // 56 H2 · X 复盘
+  `<p><strong>让观众把手机对准这页。</strong>完整方法论写在 X 上 —— harness 怎么搭、plan 长什么样、AI 在哪儿失手、测试怎么接住的。vue.lynxjs.org 首页的 badge 也链着它。然后收束:"这就是它怎么被做出来的 —— 接下来看看它加起来意味着什么。"</p>`,
+  // 57 Combine
   `<p><strong>标题句。</strong>Vue × Lynx = Vue 跑在原生上。停顿,让等式落地。然后:"也很希望大家来一起把它做成。"</p>`,
-  // 40 Divider IV
+  // 58 Divider V · close
   `<p><strong>转向请求。</strong>项目是真的,但需要社区。架构很稳;Vue 的表面积很大。</p>`,
-  // 41 Ask
+  // 59 Ask
   `<p>落在这句上 —— <em>"原生,不该是另一个团队的事。"</em>这是你想让他们记住的一句。</p>`,
-  // 42 What's there / open
+  // 60 What's there / open
   `<p>左边 = 今天就能用、可以做生产探索的。右边 = 贡献者能发力的地方 —— 第三章里 Elk 的 view pager,就在这个清单上。</p>`,
-  // 43 Try
+  // 61 Try
   `<p><strong>行动号召。</strong>一行命令 —— <code>npm create vue-lynx@latest</code>。"给 Agent"按钮会复制一段引导 prompt。承诺:"今晚回家的公交上,你就能让一个 Vue 应用跑在 iPhone 上。"</p>`,
-  // 44 Thank you
+  // 62 Thank you
   `<p><strong>收尾。</strong>感谢,邀请提问,停在这页做 Q&amp;A。</p><p>"能上生产吗?" —— pre-alpha,架构稳,已覆盖的部分测试充分。"Android?" —— Lynx 跨平台,同一产物两端都跑。</p>`,
 ];

--- a/slides/src/main.js
+++ b/slides/src/main.js
@@ -513,6 +513,7 @@ const I18N_SELECTOR = [
   '.chip', '.pstack__item', '.cover__tagline', '.cover__title-line',
   '.combine__name', '.result-label', '.tl-item__week', '.node__label',
   '.arrow', '.cta__link', '.agent', '.mega', '.label',
+  '.flane__label', '.fcenter',
 ].map((s) => `.slide ${s}`).join(', ') + ', .gate-legend span';
 
 let i18nEls = [];

--- a/slides/src/qrcodes.js
+++ b/slides/src/qrcodes.js
@@ -24,6 +24,12 @@ export function initQRCodes() {
   // Speaker-preview iframes don't need the codes (and shouldn't duplicate them).
   if (new URLSearchParams(location.search).has('embed')) return;
 
+  // Standalone QR marks — any element tagged data-qr="<url>" renders a QR of
+  // that URL (e.g. the write-up slide). Independent of the demo pair below.
+  document.querySelectorAll('[data-qr]').forEach((el) => {
+    if (!el.querySelector('svg')) el.innerHTML = qrSvg(el.dataset.qr);
+  });
+
   document.querySelectorAll('.slide').forEach((slide) => {
     const demo = slide.querySelector('vl-demo[bundle]');
     const body = slide.querySelector('.demo__body');

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -1947,8 +1947,13 @@ body.is-blackout::after {
 }
 .fb.is-dim { opacity: 0.45; }
 .fb.is-hero { box-shadow: 0 0 22px -4px var(--c, #5dd5a8); }
-/* Keep absolute positioning while FLIPping (same fix as .logo). */
+/* Keep absolute positioning while FLIPping (same fix as .logo) — the
+   framework's generic .is-flipping rule forces position:relative, which
+   drops these out of their absolute spots mid-morph: the whole lane falls
+   into flow (the MT lane visibly sinks by one lane-height), tweens from the
+   wrong origin, then snaps at cleanup. */
 .slide .fb.is-flipping { position: absolute; }
+.slide .flane.is-flipping { position: absolute; }
 
 /* Text arrow / inline flow label — mono, colorable, fades in. */
 .farr {

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -1805,9 +1805,12 @@ body.is-blackout::after {
   transition: opacity 0.16s ease !important;
   z-index: 1;
 }
+/* NB: no `position` here on purpose. The engine (framework/magic-move.js)
+   promotes static elements to relative inline; forcing it from CSS yanked
+   absolutely-positioned flip elements (.logo/.fb/.flane) into flow mid-morph.
+   Contract guarded by slides/tests/morph-invariant.mjs. */
 .slide .is-flipping {
   will-change: transform;
-  position: relative;
   z-index: 4;
 }
 /* Elements marked to wash in behind a morph */
@@ -1839,11 +1842,6 @@ body.is-blackout::after {
   display: grid;
   place-items: center;
 }
-/* The FLIP engine tags morphing elements `.is-flipping`, whose framework rule
-   forces `position: relative` (fine for in-flow targets). For an absolutely-
-   positioned logo that would drop it into flow mid-morph — the element tweens
-   at the wrong spot, then snaps back on cleanup. Keep it absolute. */
-.slide .logo.is-flipping { position: absolute; }
 .logo svg { width: 100%; height: 100%; display: block; }
 
 .logo--lynx svg { fill: #ffffff; }
@@ -1947,13 +1945,6 @@ body.is-blackout::after {
 }
 .fb.is-dim { opacity: 0.45; }
 .fb.is-hero { box-shadow: 0 0 22px -4px var(--c, #5dd5a8); }
-/* Keep absolute positioning while FLIPping (same fix as .logo) — the
-   framework's generic .is-flipping rule forces position:relative, which
-   drops these out of their absolute spots mid-morph: the whole lane falls
-   into flow (the MT lane visibly sinks by one lane-height), tweens from the
-   wrong origin, then snaps at cleanup. */
-.slide .fb.is-flipping { position: absolute; }
-.slide .flane.is-flipping { position: absolute; }
 
 /* Text arrow / inline flow label — mono, colorable, fades in. */
 .farr {

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -1867,6 +1867,136 @@ body.is-blackout::after {
   to   { opacity: 1; translate: 0 0; }
 }
 
+/* Standalone QR card (data-qr) — white so it scans on the dark stage. */
+.qr-solo {
+  width: clamp(120px, 15cqw, 168px);
+  height: clamp(120px, 15cqw, 168px);
+  padding: 12px;
+  background: #ffffff;
+  border-radius: 16px;
+  box-shadow: 0 14px 44px -18px rgba(0, 0, 0, 0.7);
+}
+.qr-solo svg { width: 100%; height: 100%; display: block; }
+
+/* =========================================================
+   Flow diagram — generic canvas for the "how we did it"
+   chapter. Colored blocks = concepts, lanes = threads, text
+   arrows = data flow. Everything absolutely positioned per
+   slide (like .logos) so magic-move FLIPs carry the story.
+   ========================================================= */
+.flow {
+  position: relative;
+  width: min(100%, 1060px);
+  height: clamp(300px, 52cqh, 400px);
+}
+
+/* Thread lanes — soft tinted strips with a mono label at the left. */
+.flane {
+  position: absolute;
+  left: 0;
+  right: 0;
+  border-radius: 14px;
+  border: 1px solid color-mix(in srgb, var(--c, #5dd5a8) 26%, transparent);
+  background: color-mix(in srgb, var(--c, #5dd5a8) 6%, transparent);
+}
+.flane__label {
+  position: absolute;
+  top: 10px;
+  left: 14px;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--c, #5dd5a8) 72%, var(--ink));
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+.flane__label i {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--c, #5dd5a8);
+  box-shadow: 0 0 8px var(--c, #5dd5a8);
+}
+
+/* Concept block — one colored box per concept, stable data-flip id. */
+.fb {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  padding: 11px 18px;
+  border-radius: 11px;
+  border: 1.6px solid var(--c, #5dd5a8);
+  background: color-mix(in srgb, var(--c, #5dd5a8) 13%, var(--paper));
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: 15px;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+  white-space: nowrap;
+  z-index: 2;
+}
+.fb small {
+  font-family: var(--mono);
+  font-weight: 400;
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  color: color-mix(in srgb, var(--c, #5dd5a8) 80%, var(--ink));
+}
+.fb.is-dim { opacity: 0.45; }
+.fb.is-hero { box-shadow: 0 0 22px -4px var(--c, #5dd5a8); }
+/* Keep absolute positioning while FLIPping (same fix as .logo). */
+.slide .fb.is-flipping { position: absolute; }
+
+/* Text arrow / inline flow label — mono, colorable, fades in. */
+.farr {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  font-family: var(--mono);
+  font-size: 12.5px;
+  letter-spacing: 0.06em;
+  color: var(--c, var(--ink-mute));
+  white-space: nowrap;
+  z-index: 1;
+}
+.farr b { font-weight: 600; }
+
+/* Big center annotation (e.g. “= 1 tick”). */
+.fcenter {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  font-family: var(--mono);
+  font-size: clamp(18px, 2cqw, 26px);
+  color: var(--ink);
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+  z-index: 3;
+}
+.fcenter b { color: var(--vue-green); font-weight: 600; }
+
+/* Container box — e.g. the .lynx.bundle anatomy. */
+.fbox {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  border-radius: 16px;
+  border: 1.6px dashed color-mix(in srgb, var(--c, #5dd5a8) 55%, transparent);
+  background: color-mix(in srgb, var(--c, #5dd5a8) 4%, transparent);
+  z-index: 0;
+}
+.fbox__label {
+  position: absolute;
+  top: -11px;
+  left: 22px;
+  padding: 0 10px;
+  background: var(--paper);
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  color: color-mix(in srgb, var(--c, #5dd5a8) 80%, var(--ink));
+}
+
 /* =========================================================
    Framework icon row — the "many answers" landscape teaser
    ========================================================= */

--- a/slides/tests/morph-invariant.mjs
+++ b/slides/tests/morph-invariant.mjs
@@ -72,15 +72,25 @@ try {
 
   const grabRects = () => page.evaluate(() => {
     const out = {};
+    const slides = [...document.querySelectorAll('.slide')];
+    const active = document.querySelector('.slide.is-active');
     document
       .querySelectorAll('.slide.is-active [data-flip]')
       .forEach((el) => {
         const r = el.getBoundingClientRect();
         out[el.getAttribute('data-flip')] = {
           left: r.left, top: r.top, right: r.right, bottom: r.bottom,
+          // Designed entrance offsets (data-logo-enter) legitimately travel
+          // outside the from→to corridor — exempt them from the path check.
+          enter: el.hasAttribute('data-logo-enter'),
         };
       });
-    return out;
+    // 1-based index of the active slide, so callers can verify they sampled
+    // the slide they think they did (guards boot/navigation races).
+    Object.defineProperty(out, '__slide', {
+      value: slides.indexOf(active) + 1, enumerable: false,
+    });
+    return { rects: out, slide: slides.indexOf(active) + 1 };
   });
 
   // Fixed sleeps are flaky under load (the slide-enter transition may still
@@ -90,7 +100,7 @@ try {
     a && b && Object.keys(a).length === Object.keys(b).length &&
     Object.keys(a).every((k) => b[k] &&
       Math.abs(a[k].left - b[k].left) < 0.5 && Math.abs(a[k].top - b[k].top) < 0.5);
-  async function stableRects(tries = 20) {
+  async function stableRects(expectSlide, tries = 20) {
     // The slide-enter transition (translateY(20px) -> 0) can START late when
     // boot work (QR generation, demo loaders) blocks the main thread — two
     // early samples would agree on the frozen pre-transition state. Wait for
@@ -106,7 +116,11 @@ try {
     for (let t = 0; t < tries; t++) {
       await page.waitForTimeout(160);
       const next = await grabRects();
-      if (same(prev, next)) return next;
+      if (expectSlide != null && next.slide !== expectSlide) {
+        prev = next;
+        continue; // navigation not landed yet — keep waiting
+      }
+      if (same(prev.rects, next.rects) && prev.slide === next.slide) return next;
       prev = next;
     }
     return prev; // last read; the assertions will surface any residual drift
@@ -119,9 +133,15 @@ try {
   const total = await page.evaluate(() => document.querySelectorAll('.slide').length);
   const resting = [null]; // 1-indexed
   for (let i = 1; i <= total; i++) {
-    await page.goto(`${BASE}/?lang=en&mi=${i}#${i}`, { waitUntil: 'domcontentloaded' });
-    await page.waitForTimeout(400);
-    resting[i] = await stableRects();
+    // Retry the load if the deck booted onto the wrong slide (rare race).
+    let got = null;
+    for (let attempt = 0; attempt < 3 && (!got || got.slide !== i); attempt++) {
+      await page.goto(`${BASE}/?lang=en&mi=${i}r${attempt}#${i}`, { waitUntil: 'domcontentloaded' });
+      await page.waitForTimeout(400);
+      got = await stableRects(i);
+    }
+    if (got.slide !== i) throw new Error(`could not land on slide ${i} (got ${got.slide})`);
+    resting[i] = got.rects;
   }
 
   // Pass 2 — drive each transition that shares flip ids; sample mid + settled.
@@ -133,12 +153,18 @@ try {
 
     await page.goto(`${BASE}/?lang=en&mv=${i}#${i}`, { waitUntil: 'domcontentloaded' });
     await page.waitForTimeout(400);
-    await stableRects(); // let the entry settle before driving the morph
+    await stableRects(i); // let the entry settle before driving the morph
     await page.keyboard.press('ArrowRight');
     await page.waitForTimeout(250); // mid-FLIP (engine runs 640ms)
-    const mid = await grabRects();
+    const midSample = await grabRects();
     await page.waitForTimeout(700);
-    const end = await stableRects();
+    const endSample = await stableRects(i + 1);
+    if (midSample.slide !== i + 1 || endSample.slide !== i + 1) {
+      failures.push(`#${i}->#${i + 1} transition never landed (mid on ${midSample.slide}, end on ${endSample.slide})`);
+      continue;
+    }
+    const mid = midSample.rects;
+    const end = endSample.rects;
 
     for (const id of shared) {
       checked++;
@@ -152,7 +178,7 @@ try {
         right: Math.max(a.right, b.right) + PATH_MARGIN,
         bottom: Math.max(a.bottom, b.bottom) + PATH_MARGIN,
       };
-      if (m && (m.left < box.left || m.top < box.top ||
+      if (m && !m.enter && (m.left < box.left || m.top < box.top ||
                 m.right > box.right || m.bottom > box.bottom)) {
         failures.push(
           `#${i}->#${i + 1} [${id}] OFF-PATH mid-morph: ` +

--- a/slides/tests/morph-invariant.mjs
+++ b/slides/tests/morph-invariant.mjs
@@ -1,0 +1,183 @@
+// =============================================================================
+// Magic-move invariant test — guards the FLIP contract so the "absolutely-
+// positioned element dropped into flow mid-morph" class of bug can't return.
+//
+// For every adjacent slide pair that shares data-flip ids, this script:
+//   1. loads each slide fresh and records every flip element's resting rect;
+//   2. drives the real transition (ArrowRight) and samples each shared
+//      element's rect mid-morph;
+//   3. asserts the mid-morph rect stays inside the bounding box spanned by
+//      its source and target rects (a FLIP tween is a straight-line
+//      interpolation — anything off-path means the element lost its
+//      positioning scheme, e.g. the .flane bug where the MT lane sank by a
+//      full lane-height on the first frame);
+//   4. asserts the settled rect matches the fresh-load rect of the target
+//      slide (no end-of-animation snap).
+//
+// Run:  pnpm test:morph          (spawns its own vite dev server)
+// Env:  CHROMIUM_PATH=<binary>   (defaults: $PLAYWRIGHT_BROWSERS_PATH/chromium,
+//                                 then macOS Chrome, then /opt/pw-browsers/chromium)
+// =============================================================================
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright-core';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const PORT = 4399;
+const BASE = `http://127.0.0.1:${PORT}`;
+
+const PATH_MARGIN = 24; // px of slack around the from→to bounding box
+const LAND_EPSILON = 2; // px tolerance for the settled position
+
+function chromiumPath() {
+  const candidates = [
+    process.env.CHROMIUM_PATH,
+    process.env.PLAYWRIGHT_BROWSERS_PATH &&
+      path.join(process.env.PLAYWRIGHT_BROWSERS_PATH, 'chromium'),
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+    '/opt/pw-browsers/chromium',
+  ].filter(Boolean);
+  const found = candidates.find((p) => existsSync(p));
+  if (!found) {
+    console.error('No Chromium binary found — set CHROMIUM_PATH.');
+    process.exit(2);
+  }
+  return found;
+}
+
+async function waitForServer(url, tries = 60) {
+  for (let i = 0; i < tries; i++) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return;
+    } catch { /* not up yet */ }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw new Error(`vite dev server never became ready at ${url}`);
+}
+
+const vite = spawn(
+  path.join(ROOT, 'node_modules', '.bin', 'vite'),
+  ['--port', String(PORT), '--host', '127.0.0.1'],
+  { cwd: ROOT, stdio: 'ignore', detached: false },
+);
+process.on('exit', () => vite.kill());
+
+try {
+  await waitForServer(BASE);
+  const browser = await chromium.launch({ executablePath: chromiumPath() });
+  const page = await browser.newPage({ viewport: { width: 1280, height: 720 } });
+
+  const grabRects = () => page.evaluate(() => {
+    const out = {};
+    document
+      .querySelectorAll('.slide.is-active [data-flip]')
+      .forEach((el) => {
+        const r = el.getBoundingClientRect();
+        out[el.getAttribute('data-flip')] = {
+          left: r.left, top: r.top, right: r.right, bottom: r.bottom,
+        };
+      });
+    return out;
+  });
+
+  // Fixed sleeps are flaky under load (the slide-enter transition may still
+  // be running when we'd sample). A rect only counts once two consecutive
+  // reads agree — i.e. all motion has genuinely stopped.
+  const same = (a, b) =>
+    a && b && Object.keys(a).length === Object.keys(b).length &&
+    Object.keys(a).every((k) => b[k] &&
+      Math.abs(a[k].left - b[k].left) < 0.5 && Math.abs(a[k].top - b[k].top) < 0.5);
+  async function stableRects(tries = 20) {
+    // The slide-enter transition (translateY(20px) -> 0) can START late when
+    // boot work (QR generation, demo loaders) blocks the main thread — two
+    // early samples would agree on the frozen pre-transition state. Wait for
+    // the active slide's transform to be identity first; that's the
+    // deterministic "entrance finished" signal.
+    await page.waitForFunction(() => {
+      const s = document.querySelector('.slide.is-active');
+      if (!s) return false;
+      const t = getComputedStyle(s).transform;
+      return t === 'none' || t === 'matrix(1, 0, 0, 1, 0, 0)';
+    }, null, { timeout: 10000 });
+    let prev = await grabRects();
+    for (let t = 0; t < tries; t++) {
+      await page.waitForTimeout(160);
+      const next = await grabRects();
+      if (same(prev, next)) return next;
+      prev = next;
+    }
+    return prev; // last read; the assertions will surface any residual drift
+  }
+
+  // Pass 1 — resting rects for every slide (fresh load each, cache-busted so
+  // the deck reboots instead of doing a same-document hash navigation).
+  await page.goto(`${BASE}/?lang=en&mi=0#1`, { waitUntil: 'domcontentloaded' });
+  await page.waitForTimeout(800);
+  const total = await page.evaluate(() => document.querySelectorAll('.slide').length);
+  const resting = [null]; // 1-indexed
+  for (let i = 1; i <= total; i++) {
+    await page.goto(`${BASE}/?lang=en&mi=${i}#${i}`, { waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(400);
+    resting[i] = await stableRects();
+  }
+
+  // Pass 2 — drive each transition that shares flip ids; sample mid + settled.
+  const failures = [];
+  let checked = 0;
+  for (let i = 1; i < total; i++) {
+    const shared = Object.keys(resting[i]).filter((k) => resting[i + 1][k]);
+    if (shared.length === 0) continue;
+
+    await page.goto(`${BASE}/?lang=en&mv=${i}#${i}`, { waitUntil: 'domcontentloaded' });
+    await page.waitForTimeout(400);
+    await stableRects(); // let the entry settle before driving the morph
+    await page.keyboard.press('ArrowRight');
+    await page.waitForTimeout(250); // mid-FLIP (engine runs 640ms)
+    const mid = await grabRects();
+    await page.waitForTimeout(700);
+    const end = await stableRects();
+
+    for (const id of shared) {
+      checked++;
+      const a = resting[i][id];
+      const b = resting[i + 1][id];
+      const m = mid[id];
+      const e = end[id];
+      const box = {
+        left: Math.min(a.left, b.left) - PATH_MARGIN,
+        top: Math.min(a.top, b.top) - PATH_MARGIN,
+        right: Math.max(a.right, b.right) + PATH_MARGIN,
+        bottom: Math.max(a.bottom, b.bottom) + PATH_MARGIN,
+      };
+      if (m && (m.left < box.left || m.top < box.top ||
+                m.right > box.right || m.bottom > box.bottom)) {
+        failures.push(
+          `#${i}->#${i + 1} [${id}] OFF-PATH mid-morph: ` +
+          `top ${Math.round(m.top)} vs corridor ${Math.round(box.top)}..${Math.round(box.bottom)}`,
+        );
+      }
+      if (e && (Math.abs(e.left - b.left) > LAND_EPSILON ||
+                Math.abs(e.top - b.top) > LAND_EPSILON)) {
+        failures.push(
+          `#${i}->#${i + 1} [${id}] LANDING SNAP: settled at ` +
+          `(${Math.round(e.left)},${Math.round(e.top)}), expected ` +
+          `(${Math.round(b.left)},${Math.round(b.top)})`,
+        );
+      }
+    }
+  }
+
+  await browser.close();
+  console.log(`morph-invariant: ${checked} flip transitions checked across ${total} slides`);
+  if (failures.length) {
+    console.error(`FAIL (${failures.length}):`);
+    for (const f of failures) console.error('  ' + f);
+    process.exit(1);
+  }
+  console.log('PASS');
+} finally {
+  vite.kill();
+}

--- a/slides/tests/morph-invariant.mjs
+++ b/slides/tests/morph-invariant.mjs
@@ -171,13 +171,13 @@ try {
   }
 
   await browser.close();
-  console.log(`morph-invariant: ${checked} flip transitions checked across ${total} slides`);
-  if (failures.length) {
+  console.info(`morph-invariant: ${checked} flip transitions checked across ${total} slides`);
+  if (failures.length > 0) {
     console.error(`FAIL (${failures.length}):`);
     for (const f of failures) console.error('  ' + f);
     process.exit(1);
   }
-  console.log('PASS');
+  console.info('PASS');
 } finally {
   vite.kill();
 }


### PR DESCRIPTION
## Summary

**Stacked on #214** — adds the second act of the talk: after the demonstration part ends at the Elk slide, a new **Chapter IV · "And how was this built?"** internalizes the old story-of-Vue-Lynx into the technical walkthrough (44 → **64** slides). Same design rules: one point per slide, prose in speaker notes, magic-move progressive reveals, diagrams over text.

New `.flow` diagram language: colored blocks = concepts, tinted lanes = threads, mono text arrows = data flow — all `data-flip`-stable so the same blocks carry across slides.

### Chapter III addition · AI Chat deep dive (post-#212)
Two slides dissecting the just-merged native chat UX (inspired by Vercel's *"How we built the v0 iOS app"*): **"The keyboard, in code"** — `keyboardstatuschanged` + one `setNativeProps` transform (notes contrast v0's ~1,000-line RN hook with the <60-line composable here); and **"Anatomy of the send"** — the align → stage → fly handoff choreographed in display frames (masked turns, `behavior: none` scroll, one real frame at the measured launch transform, one-way transition). Also merges `origin/main` so the live ai-chat demo ships the #212 handoff.

### Section A · Runtime (Vue on two threads, semantics intact)
Lane diagram builds one hop per slide: **Vue 3 runtime · VDOM (untouched `@vue/runtime-core`) → ShadowElement linked-list (nodeOps dual-write) → flat ops buffer (once per tick) → ops interpreter → Element PAPI** (`__CreateView…` — Lynx's framework-agnostic contract), then **events riding back by sign** (handlers never leave Vue), closing on **"one lap = `nextTick()`"** — the single programming-model leak. Proof pair follows: **882/1013 upstream Vue core tests, 0 fail** (two adapter layers) and **vue-lynx-testing-library** framed as the AI harness's eyes.

### Section B · Toolchain (one bundle, two worlds)
`.lynx.bundle` anatomy (two entries, two JS VMs) → the same `App.vue` entering twice through webpack **layers** (`vue:background` / `vue:main-thread` loader chains — the outputs FLIP out of the bundle box) → **"a plugin, not a compiler"** (Rspeedy/Rspack/`rspack-vue-loader` reuse) → **CSS passes through untranslated** (real native CSS engine).

### Section C · Main-Thread Script (making dual-thread reward > cost)
The honest cost (2 crossings behind a gesture) → `'main thread'` directive — the function block **physically changes lanes** via FLIP (0 crossings) → full code sample (`useMainThreadRef` + `main-thread-bindscroll`) → live swiper demo: **both ReactLynx MTS tutorials remade in Vue** → reuse of ReactLynx's worklet engine today, with a Vue-flavored MTS API as the open design space.

### Side track · The harness
"2 weeks" stats slide, then the X write-up slide — *"How I vibed this in two weeks"* — with a standalone QR (new `data-qr` hook in `qrcodes.js` + `.qr-solo` card) pointing at the article linked from the site's homepage badge.

### FLIP engine hardening
The magic-move engine now owns the positioning/transform contract: static elements are promoted to `relative` via inline style (the CSS class no longer forces `position: relative`, which yanked absolutely-positioned flip elements into flow mid-morph), and the FLIP delta **composes with** each element's own transform instead of overwriting it. Guarded by a new invariant test — `pnpm test:morph` walks every adjacent pair sharing `data-flip` ids and asserts mid-morph rects stay in the source→target corridor and land exactly on the fresh-load position (mutation-validated: re-adding the old CSS rule fails 40 checks). Contract documented in `framework/README.md`.

### Also
- Chapter II receipts refreshed to current upstream-tests numbers (was 852/949, now **882/1013, 0 fail** per `packages/upstream-tests/README`)
- Close chapter renumbered IV → V
- i18n: new ZH strings; `ZH_NOTES` reindexed for the 64-slide order (notes carry the spoken script)

Verified with a full Playwright walk (all slides, zh default, magic moves, overview), two consecutive `test:morph` passes (43 flip transitions), and `pnpm lint` + deck build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017nNAqSYKbbtKVWMR1gkFvm