### PR TITLE
fix(vapor): route ReactLynx-style event props (:bindtap etc.) to native Lynx events

### DIFF
--- a/.changeset/vapor-bindtap-event-props.md
+++ b/.changeset/vapor-bindtap-event-props.md
@@ -1,0 +1,14 @@
+---
+"vue-lynx": patch
+---
+
+Fix ReactLynx-style event props (`:bindtap`, `:catchtap`, `:global-bind*`,
+`onTap`) being silently dropped in Vapor mode. The Vapor template compiler
+emits these as plain attribute writes (`setAttr`), so handlers were
+serialized into a SET_PROP op the Main Thread can't act on — buttons in
+`examples/css-features` did nothing, which also made CSS `v-bind()` look
+broken (variables applied on mount but never updated). Function-valued
+event-shaped keys are now routed through `ShadowElement.setAttribute` to the
+same event registration the vdom renderer's `patchProp` uses, covering the
+compiled `setAttr`/`setProp` sites and runtime-vapor's internal paths
+(attribute fallthrough onto a child component's root, `v-bind` spreads).

--- a/packages/upstream-tests/src/vapor/vapor-sfc-e2e.spec.ts
+++ b/packages/upstream-tests/src/vapor/vapor-sfc-e2e.spec.ts
@@ -81,13 +81,18 @@ function compileVaporSfc(filename: string, source: string): CompiledFixture {
 
 let fixtureCounter = 0;
 
-async function importCompiled(code: string): Promise<{ default: unknown }> {
+function writeCompiled(code: string): string {
   fs.mkdirSync(generatedDir, { recursive: true });
   const file = path.join(
     generatedDir,
     `fixture-${process.pid}-${fixtureCounter++}.mts`,
   );
   fs.writeFileSync(file, code);
+  return file;
+}
+
+async function importCompiled(code: string): Promise<{ default: unknown }> {
+  const file = writeCompiled(code);
   return (await import(/* @vite-ignore */ `${file}?t=${Date.now()}`)) as {
     default: unknown;
   };
@@ -192,6 +197,68 @@ import { ref } from 'vue'
 const color = ref('#1565c0')
 </script>
 <template><view><text class="label">css var styled</text></view></template>
+<style>.label { color: v-bind(color); }</style>
+`;
+
+// ReactLynx-style event props (:bindtap / :catchtap) compile to setAttr in
+// Vapor — the runtime must route them to event registration, exactly like
+// the vdom renderer's patchProp does (regression: examples/css-features
+// VBindCSS.vue buttons were dead in Vapor mode).
+const BINDTAP_SFC = `
+<script setup vapor lang="ts">
+import { ref } from 'vue'
+const count = ref(0)
+function inc() { count.value++ }
+function noopCatch() {}
+</script>
+<template>
+  <view>
+    <text class="label">Count: {{ count }}</text>
+    <view class="btn" :bindtap="inc"><text>+1</text></view>
+    <view class="stopper" :catchtap="noopCatch"><text>stop</text></view>
+  </view>
+</template>
+`;
+
+// Fallthrough: an event prop on a component tag must reach the child's root
+// element. runtime-vapor applies fallthrough attrs through its internal
+// setAttr (not the compiled import), so this exercises the
+// ShadowElement.setAttribute event routing specifically.
+const BINDTAP_CHILD_SFC = `
+<script setup vapor lang="ts">
+const label = 'child'
+</script>
+<template>
+  <view class="child-root"><text>{{ label }}</text></view>
+</template>
+`;
+
+const BINDTAP_PARENT_SFC = `
+<script setup vapor lang="ts">
+import { ref } from 'vue'
+import Child from './Child.vue'
+const count = ref(0)
+function inc() { count.value++ }
+</script>
+<template>
+  <view>
+    <text class="label">Count: {{ count }}</text>
+    <Child :bindtap="inc" />
+  </view>
+</template>
+`;
+
+// CSS v-bind() must track updates: tapping changes the ref, and the root
+// block's inline style must re-emit with the new custom property value.
+const CSS_VARS_UPDATE_SFC = `
+<script setup vapor lang="ts">
+import { ref } from 'vue'
+const color = ref('#1565c0')
+function cycle() { color.value = '#c62828' }
+</script>
+<template>
+  <view :bindtap="cycle"><text class="label">css var styled</text></view>
+</template>
 <style>.label { color: v-bind(color); }</style>
 `;
 
@@ -370,6 +437,60 @@ describe('vapor SFC e2e: CSS modules', () => {
   });
 });
 
+describe('vapor SFC e2e: Lynx event props', () => {
+  it('registers :bindtap / :catchtap as native Lynx events', async () => {
+    const { code } = compileVaporSfc('BindTap.vue', BINDTAP_SFC);
+    const mod = await importCompiled(code);
+
+    const app = vaporSurface.createApp(mod.default as never);
+    app.mount();
+
+    let decoded = await flushedOps();
+    const events = opsOf(decoded, OP.SET_EVENT);
+    const bind = events.find((e) => e.args[1] === 'bindEvent' && e.args[2] === 'tap');
+    const catchEv = events.find((e) => e.args[1] === 'catchEvent' && e.args[2] === 'tap');
+    expect(bind).toBeDefined();
+    expect(catchEv).toBeDefined();
+    // The handler must NOT leak into the ops stream as a serialized prop.
+    expect(
+      opsOf(decoded, OP.SET_PROP).some((p) => p.args[1] === 'bindtap'),
+    ).toBe(false);
+
+    // Fire through the Lynx event pipeline: state updates flow back out.
+    publishEvent(bind!.args[3] as string, {});
+    decoded = await flushedOps();
+    expect(opsOf(decoded, OP.SET_TEXT).map((t) => t.args[1]))
+      .toContain('Count: 1');
+
+    app.unmount();
+  });
+
+  it('routes :bindtap fallthrough onto a child component root', async () => {
+    const child = compileVaporSfc('Child.vue', BINDTAP_CHILD_SFC);
+    const childFile = writeCompiled(child.code);
+    const parent = compileVaporSfc('Parent.vue', BINDTAP_PARENT_SFC);
+    const mod = await importCompiled(
+      parent.code.replace('./Child.vue', childFile),
+    );
+
+    const app = vaporSurface.createApp(mod.default as never);
+    app.mount();
+
+    let decoded = await flushedOps();
+    const bind = opsOf(decoded, OP.SET_EVENT).find(
+      (e) => e.args[1] === 'bindEvent' && e.args[2] === 'tap',
+    );
+    expect(bind).toBeDefined();
+
+    publishEvent(bind!.args[3] as string, {});
+    decoded = await flushedOps();
+    expect(opsOf(decoded, OP.SET_TEXT).map((t) => t.args[1]))
+      .toContain('Count: 1');
+
+    app.unmount();
+  });
+});
+
 describe('vapor SFC e2e: CSS variables', () => {
   it('applies SFC v-bind variables to the component root block', async () => {
     const { code } = compileVaporSfc('CssVars.vue', CSS_VARS_SFC);
@@ -386,6 +507,31 @@ describe('vapor SFC e2e: CSS variables', () => {
         ([property, value]) => property.startsWith('--') && value === '#1565c0',
       )
     )).toBe(true);
+
+    app.unmount();
+  });
+
+  it('re-applies v-bind variables when the bound ref changes', async () => {
+    const { code } = compileVaporSfc('CssVarsUpdate.vue', CSS_VARS_UPDATE_SFC);
+    const mod = await importCompiled(code);
+
+    const app = vaporSurface.createApp(mod.default as never);
+    app.mount();
+
+    let decoded = await flushedOps();
+    const varOf = (ops: DecodedOp[]): unknown[] =>
+      opsOf(ops, OP.SET_STYLE).flatMap((operation) =>
+        Object.entries(operation.args[1] as Record<string, unknown>)
+          .filter(([property]) => property.startsWith('--'))
+          .map(([, value]) => value)
+      );
+    expect(varOf(decoded)).toContain('#1565c0');
+
+    const tap = opsOf(decoded, OP.SET_EVENT).find((e) => e.args[2] === 'tap')!;
+    publishEvent(tap.args[3] as string, {});
+
+    decoded = await flushedOps();
+    expect(varOf(decoded)).toContain('#c62828');
 
     app.unmount();
   });

--- a/packages/vue-lynx/runtime/src/event-props.ts
+++ b/packages/vue-lynx/runtime/src/event-props.ts
@@ -1,0 +1,158 @@
+// Copyright 2026 Xuan Huang (huxpro). All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * Lynx event-prop handling shared by the vdom renderer and the Vapor
+ * DOM-compat surface.
+ *
+ * ReactLynx-style event props (`bindtap`, `catchtap`, `global-bind*`,
+ * `onTap`, `onTapOnce`, …) arrive through two pipelines:
+ *
+ *  - vdom: `nodeOps.patchProp` intercepts the prop key.
+ *  - Vapor: the template compiler has no notion of Lynx event props, so
+ *    `:bindtap="fn"` compiles to a plain attribute write (`setAttr` →
+ *    `el.setAttribute`), including runtime-vapor's internal paths
+ *    (fallthrough attrs, `v-bind` spreads). `ShadowElement.setAttribute`
+ *    routes function-valued event keys here.
+ */
+
+import { register, unregister, updateHandler } from './event-registry.js';
+import { scheduleFlush } from './flush.js';
+import { OP, pushOp } from './ops.js';
+import type { ShadowElement } from './shadow-element.js';
+
+interface EventSpec {
+  type: string;
+  name: string;
+  /** True when the Vue compiler emitted an `onXxxOnce` prop key. */
+  once: boolean;
+}
+
+function parseEventProp(key: string): EventSpec | null {
+  if (key.startsWith('global-bind')) {
+    return { type: 'bindGlobalEvent', name: key.slice('global-bind'.length), once: false };
+  }
+  if (key.startsWith('global-catch')) {
+    return { type: 'catchGlobalEvent', name: key.slice('global-catch'.length), once: false };
+  }
+  if (key.startsWith('catch')) {
+    return { type: 'catchEvent', name: key.slice('catch'.length), once: false };
+  }
+  if (/^bind(?!ingx)/.test(key)) {
+    return { type: 'bindEvent', name: key.slice('bind'.length), once: false };
+  }
+  if (/^on[A-Z]/.test(key)) {
+    // onTap        → { name: 'tap',       once: false }
+    // onTapOnce    → { name: 'tap',       once: true  }
+    // onTouchStart → { name: 'touchStart', once: false }
+    let name = key.slice(2, 3).toLowerCase() + key.slice(3);
+    let once = false;
+    if (name.endsWith('Once')) {
+      name = name.slice(0, -4);
+      once = true;
+    }
+    return { type: 'bindEvent', name, once };
+  }
+  return null;
+}
+
+// Track the sign registered for each (element, propKey) so we can unregister
+// on prop removal / update.
+const elementEventSigns = new Map<number, Map<string, string>>();
+
+// For once-events (onXxxOnce prop keys): the once-wrapper closes over a
+// mutable `inner` reference so re-renders can update the underlying handler
+// without resetting the `called` state.
+interface OnceWrapper {
+  called: boolean;
+  inner: (data: unknown) => void;
+}
+const onceWrappers = new Map<string, OnceWrapper>();
+
+/**
+ * Register / update / remove a Lynx event prop on an element.
+ *
+ * Returns `false` when `key` is not an event prop — the caller falls through
+ * to its regular attribute/prop path.
+ */
+export function patchEventProp(
+  el: ShadowElement,
+  key: string,
+  nextValue: unknown,
+): boolean {
+  const event = parseEventProp(key);
+  if (!event) return false;
+
+  let signs = elementEventSigns.get(el.uid);
+  const oldSign = signs?.get(key);
+
+  if (nextValue != null) {
+    const handler = nextValue as (data: unknown) => void;
+    if (event.once) {
+      if (oldSign) {
+        // Re-render of a once-event: update the inner handler so the
+        // fresh closure is used when the event eventually fires.
+        // The `called` state is preserved — if it already fired, the
+        // wrapper will keep returning early.
+        const wrapper = onceWrappers.get(oldSign);
+        if (wrapper) wrapper.inner = handler;
+      } else {
+        // First registration of a once-event.
+        const wrapper: OnceWrapper = { called: false, inner: handler };
+        const onceHandler = (data: unknown): void => {
+          if (wrapper.called) return;
+          wrapper.called = true;
+          wrapper.inner(data);
+        };
+        const sign = register(onceHandler);
+        onceWrappers.set(sign, wrapper);
+        if (!signs) {
+          signs = new Map<string, string>();
+          elementEventSigns.set(el.uid, signs);
+        }
+        signs.set(key, sign);
+        // Respect _lynxCatch even on once-events (e.g. @tap.once.stop).
+        // The Vue compiler emits onTapOnce: withModifiers(fn, ['stop']),
+        // so _lynxCatch lives on the handler, not on the onceHandler wrapper.
+        const onceEventType = (handler as { _lynxCatch?: boolean })._lynxCatch
+          ? 'catchEvent'
+          : event.type;
+        pushOp(OP.SET_EVENT, el.uid, onceEventType, event.name, sign);
+      }
+    } else if (oldSign) {
+      // Re-render: update handler in-place so the sign on the Main Thread
+      // stays valid.  No new SET_EVENT op needed.
+      updateHandler(oldSign, handler);
+    } else {
+      // First time this event is bound on this element.
+      // If the handler is tagged _lynxCatch (from withModifiers '.stop'),
+      // use catchEvent so native Lynx stops bubbling at this element.
+      const eventType = (handler as { _lynxCatch?: boolean })._lynxCatch
+        ? 'catchEvent'
+        : event.type;
+      const sign = register(handler);
+      if (!signs) {
+        signs = new Map<string, string>();
+        elementEventSigns.set(el.uid, signs);
+      }
+      signs.set(key, sign);
+      pushOp(OP.SET_EVENT, el.uid, eventType, event.name, sign);
+    }
+  } else if (oldSign) {
+    // Handler removed entirely.
+    onceWrappers.delete(oldSign);
+    unregister(oldSign);
+    signs!.delete(key);
+    pushOp(OP.REMOVE_EVENT, el.uid, event.type, event.name);
+  }
+
+  scheduleFlush();
+  return true;
+}
+
+/** Reset module state – for testing only. */
+export function resetEventPropState(): void {
+  elementEventSigns.clear();
+  onceWrappers.clear();
+}

--- a/packages/vue-lynx/runtime/src/node-ops.ts
+++ b/packages/vue-lynx/runtime/src/node-ops.ts
@@ -4,7 +4,7 @@
 
 import type { RendererOptions } from '@vue/runtime-core';
 
-import { register, unregister, updateHandler } from './event-registry.js';
+import { patchEventProp, resetEventPropState } from './event-props.js';
 import { scheduleFlush } from './flush.js';
 import { applyMainThreadProp } from './main-thread-props.js';
 import { OP, pushOp } from './ops.js';
@@ -19,60 +19,12 @@ import {
   setIdAttr,
 } from './tree-ops.js';
 
-// ---------------------------------------------------------------------------
-// Event prop classification
-// ---------------------------------------------------------------------------
-
-interface EventSpec {
-  type: string;
-  name: string;
-  /** True when the Vue compiler emitted an `onXxxOnce` prop key. */
-  once: boolean;
-}
-
-function parseEventProp(key: string): EventSpec | null {
-  if (key.startsWith('global-bind')) {
-    return { type: 'bindGlobalEvent', name: key.slice('global-bind'.length), once: false };
-  }
-  if (key.startsWith('global-catch')) {
-    return { type: 'catchGlobalEvent', name: key.slice('global-catch'.length), once: false };
-  }
-  if (key.startsWith('catch')) {
-    return { type: 'catchEvent', name: key.slice('catch'.length), once: false };
-  }
-  if (/^bind(?!ingx)/.test(key)) {
-    return { type: 'bindEvent', name: key.slice('bind'.length), once: false };
-  }
-  if (/^on[A-Z]/.test(key)) {
-    // onTap        → { name: 'tap',       once: false }
-    // onTapOnce    → { name: 'tap',       once: true  }
-    // onTouchStart → { name: 'touchStart', once: false }
-    let name = key.slice(2, 3).toLowerCase() + key.slice(3);
-    let once = false;
-    if (name.endsWith('Once')) {
-      name = name.slice(0, -4);
-      once = true;
-    }
-    return { type: 'bindEvent', name, once };
-  }
-  return null;
-}
-
-// Track the sign registered for each (element, propKey) so we can unregister
-// on prop removal / update.
-const elementEventSigns = new Map<number, Map<string, string>>();
-
-// For once-events (onXxxOnce prop keys): the once-wrapper closes over a
-// mutable `inner` reference so re-renders can update the underlying handler
-// without resetting the `called` state.
-interface OnceWrapper {
-  called: boolean;
-  inner: (data: unknown) => void;
-}
-const onceWrappers = new Map<string, OnceWrapper>();
-
 // Class resolution is shared with the Vapor DOM-compat layer.
 export { resolveClass } from './tree-ops.js';
+
+// Event prop patching lives in event-props.ts — shared with
+// ShadowElement.setAttribute (the Vapor pipeline's chokepoint).
+export { patchEventProp } from './event-props.js';
 
 // ---------------------------------------------------------------------------
 // RendererOptions implementation
@@ -136,71 +88,8 @@ export const nodeOps: RendererOptions<ShadowElement, ShadowElement> = {
     // ------------------------------------------------------------------
     if (applyMainThreadProp(el, key, nextValue)) return;
 
-    const event = parseEventProp(key);
-
-    if (event) {
-      let signs = elementEventSigns.get(el.uid);
-      const oldSign = signs?.get(key);
-
-      if (nextValue != null) {
-        const handler = nextValue as (data: unknown) => void;
-        if (event.once) {
-          if (oldSign) {
-            // Re-render of a once-event: update the inner handler so the
-            // fresh closure is used when the event eventually fires.
-            // The `called` state is preserved — if it already fired, the
-            // wrapper will keep returning early.
-            const wrapper = onceWrappers.get(oldSign);
-            if (wrapper) wrapper.inner = handler;
-          } else {
-            // First registration of a once-event.
-            const wrapper: OnceWrapper = { called: false, inner: handler };
-            const onceHandler = (data: unknown): void => {
-              if (wrapper.called) return;
-              wrapper.called = true;
-              wrapper.inner(data);
-            };
-            const sign = register(onceHandler);
-            onceWrappers.set(sign, wrapper);
-            if (!signs) {
-              signs = new Map<string, string>();
-              elementEventSigns.set(el.uid, signs);
-            }
-            signs.set(key, sign);
-            // Respect _lynxCatch even on once-events (e.g. @tap.once.stop).
-            // The Vue compiler emits onTapOnce: withModifiers(fn, ['stop']),
-            // so _lynxCatch lives on the handler, not on the onceHandler wrapper.
-            const onceEventType = (handler as { _lynxCatch?: boolean })._lynxCatch
-              ? 'catchEvent'
-              : event.type;
-            pushOp(OP.SET_EVENT, el.uid, onceEventType, event.name, sign);
-          }
-        } else if (oldSign) {
-          // Re-render: update handler in-place so the sign on the Main Thread
-          // stays valid.  No new SET_EVENT op needed.
-          updateHandler(oldSign, handler);
-        } else {
-          // First time this event is bound on this element.
-          // If the handler is tagged _lynxCatch (from withModifiers '.stop'),
-          // use catchEvent so native Lynx stops bubbling at this element.
-          const eventType = (handler as { _lynxCatch?: boolean })._lynxCatch
-            ? 'catchEvent'
-            : event.type;
-          const sign = register(handler);
-          if (!signs) {
-            signs = new Map<string, string>();
-            elementEventSigns.set(el.uid, signs);
-          }
-          signs.set(key, sign);
-          pushOp(OP.SET_EVENT, el.uid, eventType, event.name, sign);
-        }
-      } else if (oldSign) {
-        // Handler removed entirely.
-        onceWrappers.delete(oldSign);
-        unregister(oldSign);
-        signs!.delete(key);
-        pushOp(OP.REMOVE_EVENT, el.uid, event.type, event.name);
-      }
+    if (patchEventProp(el, key, nextValue)) {
+      return;
     } else if (key === 'style') {
       const style = nextValue != null && typeof nextValue === 'object'
         ? normalizeStyleObject(nextValue as Record<string, unknown>)
@@ -251,7 +140,6 @@ export const nodeOps: RendererOptions<ShadowElement, ShadowElement> = {
 
 /** Reset module state – for testing only. */
 export function resetNodeOpsState(): void {
-  elementEventSigns.clear();
-  onceWrappers.clear();
+  resetEventPropState();
   idRegistry.clear();
 }

--- a/packages/vue-lynx/runtime/src/shadow-element.ts
+++ b/packages/vue-lynx/runtime/src/shadow-element.ts
@@ -29,6 +29,7 @@ import type {
   TemplateNode,
   TemplateNodeProps,
 } from 'vue-lynx/internal/ops';
+import { patchEventProp } from './event-props.js';
 import { scheduleFlush } from './flush.js';
 import { applyMainThreadProp } from './main-thread-props.js';
 import { OP, pushOp } from './ops.js';
@@ -656,6 +657,19 @@ export class ShadowElement {
 
   setAttribute(key: string, value: unknown): void {
     if (!this._inert && applyMainThreadProp(this, key, value)) return;
+    // Vapor compiles ReactLynx-style event props (`:bindtap="fn"`,
+    // `:catchtap="fn"`, …) to plain attribute writes — including
+    // runtime-vapor's internal paths (fallthrough attrs, v-bind spreads),
+    // which all funnel through setAttribute. Function values on
+    // event-shaped keys register native Lynx events, mirroring the vdom
+    // renderer's patchProp.
+    if (
+      !this._inert
+      && typeof value === 'function'
+      && patchEventProp(this, key, value)
+    ) {
+      return;
+    }
     const strValue = value == null ? '' : String(value);
     if (this._inert) {
       // Template prototype: record only; ops are emitted on clone.
@@ -697,6 +711,10 @@ export class ShadowElement {
 
   removeAttribute(key: string): void {
     if (!this._inert && applyMainThreadProp(this, key, null)) return;
+    // Unregister an event previously bound through setAttribute's event
+    // routing (`:bindtap="cond ? fn : null"` → removeAttribute). No-op if
+    // the key never registered; falls through to clear any attr record.
+    if (!this._inert) patchEventProp(this, key, null);
     if (key === 'class') {
       if (!this._baseClass) return;
       this._baseClass = '';

--- a/website/docs/guide/vapor-mode.mdx
+++ b/website/docs/guide/vapor-mode.mdx
@@ -171,6 +171,7 @@ A few Lynx-specific translations happen along the way:
 | Template HTML strings (`template("<view class=…>")`) | Parsed by a built-in parser into inert prototypes; cloned per instance |
 | Document-level event delegation | Compiled away (`eventDelegation: false`); events register per element |
 | `@tap.stop` | Native `catchEvent` (Lynx's stop-propagation) |
+| `:bindtap` / `:catchtap` / `:global-bind*` props | Routed to native Lynx event registration (same handling as vdom mode), including fallthrough onto a child component's root |
 | `v-model` on `<input>` | Lynx `input` / `confirm` (`.lazy`) events carrying `detail.value` |
 | Scoped CSS `data-v-*` attributes | Composable scope **classes** (the build rewrites `[data-v-*]` selectors to class selectors; same mechanism as vdom mode) |
 

--- a/website/docs/zh/guide/vapor-mode.mdx
+++ b/website/docs/zh/guide/vapor-mode.mdx
@@ -163,6 +163,7 @@ Vue Lynx 目前不支持混用（见[限制](#当前限制)），模式因此成
 | 模板 HTML 字符串（`template("<view class=…>")`） | 内置解析器解析为惰性原型，按实例克隆 |
 | 文档级事件委托 | 编译期关闭（`eventDelegation: false`），事件逐元素注册 |
 | `@tap.stop` | 原生 `catchEvent`（Lynx 的阻止冒泡机制） |
+| `:bindtap` / `:catchtap` / `:global-bind*` 属性 | 路由到原生 Lynx 事件注册（与 vdom 模式同一处理），包括透传到子组件根元素的场景 |
 | `<input>` 上的 `v-model` | Lynx `input` / `confirm`（`.lazy`）事件，取 `detail.value` |
 | Scoped CSS 的 `data-v-*` 属性 | 可组合的 scope **class**（构建期把 `[data-v-*]` 选择器改写为 class 选择器；与 vdom 模式同一机制） |
 


### PR DESCRIPTION
## What

Triage of "CSS `v-bind()` doesn't work in Vapor mode" on `examples/css-features`.

**`v-bind()` was never the bug.** CSS variables apply correctly on mount in Vapor — which is exactly why the example-harness visual-parity smoke check recorded `css-features` as passed. The real defect: the example's buttons use ReactLynx-style event props (`:bindtap="cycleColor"`), and those were **silently dead in Vapor**, so state never changed and the vars never re-applied. From the outside that looks like broken `v-bind()`.

### Root cause

The Vapor template compiler has no notion of Lynx event props: `@tap` compiles to `on()` (handled), but `:bindtap="fn"` compiles to a plain attribute write —

```js
_setAttr(n3, "bindtap", cycleColor, true)
```

— which flowed into a `SET_PROP` op carrying a stringified function the Main Thread can't act on. The vdom renderer intercepts these keys (`bind*`, `catch*`, `global-bind*`, `on[A-Z]*`) in `patchProp`; Vapor had no equivalent. All existing Vapor examples happened to use `@tap`, so the gap went unnoticed.

### Fix

- Extract the `patchProp` event branch into a shared `runtime/src/event-props.ts` (`patchEventProp`); vdom behavior is unchanged (the module split also avoids a `node-ops` ↔ `shadow-element` import cycle).
- Route function-valued event-shaped keys in `ShadowElement.setAttribute` / `removeAttribute`. This single chokepoint covers the compiled `setAttr`/`setProp` sites **and** runtime-vapor's internal paths that never touch the aliased helpers — attribute fallthrough onto a child component's root (`<Child :bindtap="fn"/>`) and `v-bind` spreads.
- Docs: add the event-prop translation row to the Vapor guide (en/zh); changeset included.

## Test plan

- **End-to-end repro**: standalone Lynx-for-Web harness (prebuilt `@lynx-js/web-core` client + `lynx-view`) driving real taps via Playwright against both `dist/` (vdom) and `dist-vapor/` builds of `examples/css-features`. Before: Vapor colors/opacity frozen after taps. After: both modes produce identical computed styles through Cycle Color (blue→red, computed inverts) and Cycle Opacity (1→0.7).
- **New regression tests** in `vapor-sfc-e2e.spec.ts`:
  - `:bindtap` / `:catchtap` register `bindEvent`/`catchEvent` and fire through the event pipeline; the handler must not leak into `SET_PROP`
  - `:bindtap` fallthrough onto a child component root (exercises the `setAttribute` chokepoint specifically)
  - CSS `v-bind()` re-emits updated custom property values on ref change (the exact reported symptom)
- Suites green: 917 upstream + 68 dom + 60 local + 107 testing-library; lint clean.

## Follow-up worth considering

The harness `smoke()` scenario screenshots only the initial frame, so any update-path breakage passes "parity". Upgrading `css-features/main` to an interaction scenario (tap → assert change) would have caught this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018LQxK6q8sNVmcytUWT2Nmn

---
_Generated by [Claude Code](https://claude.ai/code/session_018LQxK6q8sNVmcytUWT2Nmn)_