### PR TITLE
chore: skip unchanged Vercel docs builds

### DIFF
--- a/website/scripts/vercel-ignore.mjs
+++ b/website/scripts/vercel-ignore.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/**
+ * Vercel Ignored Build Step for the docs site.
+ *
+ * Exit 0 to skip a deployment, exit 1 to build.  The site renders generated
+ * API docs from packages/* and copies example source/bundles from examples/*,
+ * so changes in those paths should still trigger a build.  Changes outside of
+ * docs inputs (for example CI-only files) can safely avoid spending a Vercel
+ * build minute.
+ */
+
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const websiteRoot = path.resolve(__dirname, '..');
+const repoRoot = path.resolve(websiteRoot, '..');
+
+const previousSha = process.env.VERCEL_GIT_PREVIOUS_SHA;
+const currentSha = process.env.VERCEL_GIT_COMMIT_SHA || 'HEAD';
+
+const watchedPaths = [
+  'website',
+  'examples',
+  'packages',
+  'package.json',
+  'pnpm-lock.yaml',
+  'pnpm-workspace.yaml',
+  'tsconfig.json',
+];
+
+function build(reason) {
+  console.info(`Vercel build required: ${reason}`);
+  process.exit(1);
+}
+
+function skip(reason) {
+  console.info(`Skipping Vercel build: ${reason}`);
+  process.exit(0);
+}
+
+if (!previousSha) {
+  build('VERCEL_GIT_PREVIOUS_SHA is unavailable');
+}
+
+if (/^0+$/.test(previousSha)) {
+  build('initial deployment has no previous commit to diff against');
+}
+
+try {
+  execFileSync(
+    'git',
+    ['diff', '--quiet', previousSha, currentSha, '--', ...watchedPaths],
+    { cwd: repoRoot, stdio: 'ignore' },
+  );
+  skip('no docs, package, or example inputs changed');
+} catch (error) {
+  if (error && typeof error === 'object' && 'status' in error) {
+    if (error.status === 1) {
+      build('docs, package, or example inputs changed');
+    }
+    build(`git diff failed with status ${error.status}`);
+  }
+  build('git diff failed');
+}

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -2,5 +2,6 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "pnpm run build",
   "outputDirectory": "doc_build",
-  "cleanUrls": true
+  "cleanUrls": true,
+  "ignoreCommand": "node scripts/vercel-ignore.mjs"
 }


### PR DESCRIPTION
### Motivation
- Reduce unnecessary Vercel build minutes and cost by skipping docs-site builds when commits do not touch docs inputs, examples, packages, or workspace config files.

### Description
- Add `website/scripts/vercel-ignore.mjs` which compares `VERCEL_GIT_PREVIOUS_SHA` → `VERCEL_GIT_COMMIT_SHA` and runs `git diff --quiet` against a watched paths list to decide whether to skip the build (exit `0`) or require a build (exit `1`).
- Treat missing or zeroed `VERCEL_GIT_PREVIOUS_SHA` as a required build to avoid skipping initial deployments. 
- Wire the docs Vercel config to call the ignore step by adding `"ignoreCommand": "node scripts/vercel-ignore.mjs"` to `website/vercel.json`.
- Watched inputs are `website`, `examples`, `packages`, `package.json`, `pnpm-lock.yaml`, `pnpm-workspace.yaml`, and `tsconfig.json` so changes that affect generated API docs or example bundles still trigger a build.

### Testing
- Ran `VERCEL_GIT_PREVIOUS_SHA=HEAD VERCEL_GIT_COMMIT_SHA=HEAD node website/scripts/vercel-ignore.mjs` which returned exit `0` and printed a skip message confirming unchanged inputs are skipped. 
- Ran `VERCEL_GIT_PREVIOUS_SHA=0000000000000000000000000000000000000000 VERCEL_GIT_COMMIT_SHA=HEAD node website/scripts/vercel-ignore.mjs` which returned exit `1` and printed a build-required message for initial deployments. 
- Invoking the script with no `VERCEL_GIT_PREVIOUS_SHA` also triggers a build-required exit `1` as expected. 
- `pnpm lint` completed successfully; `pnpm exec biome check website/scripts/vercel-ignore.mjs website/vercel.json` reported that no files were processed for the specific paths (informational).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a581e428ca08329b9781dbde85fbc52)