### PR TITLE
test(upstream): add runtime-vapor smoke suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "examples:verify:status": "pnpm --filter vue-lynx-example-harness verify:status",
     "test": "pnpm --filter vue-lynx-testing-library run test",
     "test:dev-smoke": "node scripts/dev-smoke.mjs",
-    "test:upstream": "pnpm --filter vue-lynx-upstream-tests run test && pnpm --filter vue-lynx-upstream-tests run test:dom && pnpm --filter vue-lynx-upstream-tests run test:local",
+    "test:upstream": "pnpm --filter vue-lynx-upstream-tests run test && pnpm --filter vue-lynx-upstream-tests run test:dom && pnpm --filter vue-lynx-upstream-tests run test:vapor && pnpm --filter vue-lynx-upstream-tests run test:local",
     "check-links": "node scripts/check-links.mjs",
     "lint": "biome check .",
     "changeset": "changeset",

--- a/packages/upstream-tests/README.md
+++ b/packages/upstream-tests/README.md
@@ -10,7 +10,8 @@ This package runs the official `vuejs/core` test suites against our **ShadowElem
 | ---------------------------------------------- | ------ | ------- | ------ | ----- |
 | `pnpm test` (runtime-core, reactivity, shared) | 44     | 824     | 89     | 0     |
 | `pnpm test:dom` (runtime-dom)                  | 7      | 58      | 42     | 0     |
-| **Total**                                      | **51** | **882** | **131** | **0** |
+| `pnpm test:vapor` (runtime-vapor)             | 1      | 1       | 6      | 0     |
+| **Total**                                      | **52** | **883** | **137** | **0** |
 
 ### By package
 
@@ -20,6 +21,7 @@ This package runs the official `vuejs/core` test suites against our **ShadowElem
 | reactivity   | 15     | 345  | 18   |
 | shared       | 5      | 46   | 0    |
 | runtime-dom  | 7      | 58   | 42   |
+| runtime-vapor | 1      | 1    | 6    |
 
 > _Note: `computed.spec.ts` (48 tests) excluded due to module initialization conflict; 4 gc tests auto-skipped by `describe.skipIf(!global.gc)`. reactivity and shared test the upstream npm packages themselves (version compatibility smoke tests), not our pipeline._
 
@@ -27,7 +29,7 @@ This package runs the official `vuejs/core` test suites against our **ShadowElem
 
 ## Testing Approach
 
-We run Vue's upstream tests at two layers, each with a different adapter that exercises a different slice of our pipeline. A third layer of hand-written tests covers Lynx-specific functionality that the upstream suite cannot reach.
+We run Vue's upstream tests at three upstream layers, each with a different adapter that exercises a different slice of our pipeline. A fourth layer of hand-written tests covers Lynx-specific functionality that the upstream suite cannot reach.
 
 The tests that actually validate our pipeline are runtime-core + runtime-dom:
 
@@ -35,7 +37,8 @@ The tests that actually validate our pipeline are runtime-core + runtime-dom:
 | ---------------- | --------------------------------------------- | ------- | ------ |
 | **runtime-core** | ShadowElement linked-list + Vue VDOM diff      | 407     | 59     |
 | **runtime-dom**  | patchProp / render -> ops -> applyOps -> PAPI -> jsdom  | 58      | 42     |
-| **Total**        |                                               | **465** | **101** |
+| **runtime-vapor** | Vapor block helpers through vue-lynx/vapor + ShadowElement DOM shim | 1 | 6 |
+| **Total**        |                                               | **466** | **107** |
 
 ### Layer 1: Conformance tests (`pnpm test`)
 
@@ -86,7 +89,16 @@ These shims run after the full pipeline so ops serialization and cross-thread tr
 
 Covers: runtime-dom (7 suites: patchStyle, patchClass, patchEvents, patchProps, patchAttrs, vOn, vModel).
 
-### Layer 3: E2E pipeline tests (`testing-library/`)
+
+### Layer 3: Vapor upstream smoke tests (`pnpm test:vapor`)
+
+**Config**: `vitest.vapor.config.ts` | **Adapter**: `src/lynx-runtime-vapor-bridge.ts` + `src/vapor-setup.ts`
+
+Runs selected upstream `runtime-vapor` tests against `vue-lynx/vapor`, with relative `../src` imports rewritten to a bridge that re-exports the vue-lynx Vapor surface and fills the first low-level private block helper needed by the upstream suite. The initial port intentionally starts with `block.spec.ts`: `normalizeBlock` passes against `ShadowElement` text nodes and `VaporFragment`; the remaining low-level insertion/removal helpers are explicit skiplist entries with reasons in `skiplist-vapor.json` while the ShadowElement bridge grows.
+
+Covers: runtime-vapor (1 suite: block).
+
+### Layer 4: E2E pipeline tests (`testing-library/`)
 
 **Config**: `testing-library/vitest.config.ts` | **No adapter** -- uses vue-lynx directly
 
@@ -106,7 +118,7 @@ Since we run upstream test files from outside the `vuejs/core` monorepo, three m
 
 **Module instance unification**: Explicit Vite aliases ensure that bare specifiers (`@vue/runtime-core`) resolve to the same ESM bundle files that the import-rewrite plugins target. Without this, Vite creates separate module instances with independent module-scoped variables (`currentRenderingInstance`, scheduler queues, etc.), breaking ref owner tracking, flush timing, and injection context.
 
-**Skiplist**: A Vite transform plugin reads `skiplist.json` / `skiplist-dom.json` and converts `it('name'` to `it.skip('name'` for listed test names. This avoids modifying upstream test files.
+**Skiplist**: A Vite transform plugin reads `skiplist.json` / `skiplist-dom.json` / `skiplist-vapor.json` and converts `it('name'` to `it.skip('name'` for listed test names. This avoids modifying upstream test files.
 
 ---
 

--- a/packages/upstream-tests/package.json
+++ b/packages/upstream-tests/package.json
@@ -12,7 +12,9 @@
     "test:local:watch": "vitest --config vitest.local.config.ts",
     "test:watch": "vitest",
     "vuejs:init": "git clone --depth 1 --branch v3.6.0-beta.17 https://github.com/vuejs/core.git core",
-    "vuejs:status": "cd core && git log --oneline -1"
+    "vuejs:status": "cd core && git log --oneline -1",
+    "test:vapor": "vitest run --config vitest.vapor.config.ts",
+    "test:vapor:watch": "vitest --config vitest.vapor.config.ts"
   },
   "devDependencies": {
     "@lynx-js/testing-environment": "^0.1.11",
@@ -22,6 +24,8 @@
     "@vue/shared": "3.6.0-beta.17",
     "jsdom": "^25.0.0",
     "vitest": "^3.0.0",
-    "vue-lynx": "workspace:*"
+    "vue-lynx": "workspace:*",
+    "@vue/runtime-vapor": "3.6.0-beta.17",
+    "@vue/runtime-dom": "3.6.0-beta.17"
   }
 }

--- a/packages/upstream-tests/skiplist-vapor.json
+++ b/packages/upstream-tests/skiplist-vapor.json
@@ -1,0 +1,28 @@
+{
+  "skip_list": [
+    {
+      "name": "insert",
+      "reason": "Uses low-level DOM insertion error behavior that currently hangs with the ShadowElement ops scheduler; tracked as a Vapor bridge follow-up, not silently filtered."
+    },
+    {
+      "name": "single node helpers",
+      "reason": "Low-level helper currently depends on exact DOM parent/anchor mutation semantics not yet fully mirrored by the minimal ShadowElement bridge."
+    },
+    {
+      "name": "fragment helper",
+      "reason": "Low-level fragment insertion helper currently depends on exact DOM parent/anchor mutation semantics not yet fully mirrored by the minimal ShadowElement bridge."
+    },
+    {
+      "name": "fragment remove helper",
+      "reason": "Low-level fragment removal helper currently depends on exact DOM parent/anchor mutation semantics not yet fully mirrored by the minimal ShadowElement bridge."
+    },
+    {
+      "name": "prepend",
+      "reason": "Low-level prepend helper currently depends on exact DOM parent/anchor mutation semantics not yet fully mirrored by the minimal ShadowElement bridge."
+    },
+    {
+      "name": "remove",
+      "reason": "Low-level removal helper currently depends on exact DOM parent/anchor mutation semantics not yet fully mirrored by the minimal ShadowElement bridge."
+    }
+  ]
+}

--- a/packages/upstream-tests/src/lynx-runtime-vapor-bridge.ts
+++ b/packages/upstream-tests/src/lynx-runtime-vapor-bridge.ts
@@ -1,0 +1,52 @@
+export * from 'vue-lynx/vapor';
+export { default as _Fragment } from '@vue/runtime-dom';
+
+interface FragmentLike { nodes?: unknown[]; anchor?: Node | null; }
+type Block = Node | FragmentLike | Array<Block>;
+
+export function normalizeBlock(block: Block | Block[]): Node[] {
+  const out: Node[] = [];
+  const walk = (item: Block): void => {
+    if (Array.isArray(item)) {
+      for (const child of item) walk(child);
+    } else if (item && typeof item === 'object' && 'anchor' in item) {
+      const frag = item as FragmentLike;
+      if (Array.isArray(frag.nodes)) for (const node of frag.nodes) walk(node as Block);
+      else if (frag.nodes) walk(frag.nodes as Block);
+      else if ((item as { el?: Node }).el) out.push((item as { el: Node }).el);
+      if (frag.anchor) out.push(frag.anchor);
+    } else {
+      out.push(item as Node);
+    }
+  };
+  walk(block as Block);
+  return out;
+}
+
+export function insertNode(node: Node, parent: Node, anchor?: Node | null): void {
+  parent.insertBefore(node, anchor ?? null);
+}
+
+export function removeNode(node: Node, parent?: Node): void {
+  (parent ?? node.parentNode)?.removeChild(node);
+}
+
+export function insertFragment(fragment: FragmentLike, parent: Node, anchor?: Node | null): void {
+  insert(normalizeBlock(fragment as Block), parent, anchor);
+}
+
+export function removeFragment(fragment: FragmentLike, parent?: Node): void {
+  remove(normalizeBlock(fragment as Block), parent);
+}
+
+export function insert(block: Block | Block[], parent: Node, anchor?: Node | null): void {
+  for (const node of normalizeBlock(block)) insertNode(node, parent, anchor ?? null);
+}
+
+export function prepend(block: Block | Block[], parent: Node): void {
+  insert(block, parent, parent.firstChild);
+}
+
+export function remove(block: Block | Block[], parent?: Node): void {
+  for (const node of normalizeBlock(block)) removeNode(node, parent);
+}

--- a/packages/upstream-tests/src/vapor-setup.ts
+++ b/packages/upstream-tests/src/vapor-setup.ts
@@ -1,0 +1,59 @@
+import { beforeEach } from 'vitest';
+import { resetForTesting, ShadowElement } from 'vue-lynx';
+import 'vue-lynx/vapor';
+
+function escapeHtml(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function escapeAttr(value: string): string {
+  return escapeHtml(value).replace(/"/g, '&quot;');
+}
+
+function serialize(node: ShadowElement): string {
+  if (node.nodeType === 3) return escapeHtml(node.textContent);
+  if (node.nodeType === 8) return `<!--${node.textContent}-->`;
+  if (node.nodeType === 11) return node.childNodes.map(serialize).join('');
+
+  const attrs: string[] = [];
+  const anyNode = node as ShadowElement & {
+    _attrs?: Map<string, string>;
+    _baseClass?: string;
+    _style?: Record<string, unknown>;
+    id?: string;
+  };
+  if (anyNode.id) attrs.push(`id="${escapeAttr(anyNode.id)}"`);
+  if (anyNode._baseClass) attrs.push(`class="${escapeAttr(anyNode._baseClass)}"`);
+  const style = anyNode.getAttribute?.('style');
+  if (style) attrs.push(`style="${escapeAttr(style)}"`);
+  if (anyNode._attrs) {
+    for (const [key, value] of anyNode._attrs) {
+      if (key === 'id' || key === 'class' || key === 'style') continue;
+      attrs.push(value === '' ? key : `${key}="${escapeAttr(value)}"`);
+    }
+  }
+  const open = attrs.length > 0 ? `<${node.localName} ${attrs.join(' ')}>` : `<${node.localName}>`;
+  return `${open}${node.childNodes.map(serialize).join('') || escapeHtml(node.textContent)}${`</${node.localName}>`}`;
+}
+
+if (!Object.getOwnPropertyDescriptor(ShadowElement.prototype, 'innerHTML')) {
+  Object.defineProperty(ShadowElement.prototype, 'innerHTML', {
+    configurable: true,
+    get(this: ShadowElement) {
+      return this.childNodes.map(serialize).join('') || escapeHtml(this.textContent);
+    },
+    set(this: ShadowElement, value: string) {
+      this.textContent = value;
+    },
+  });
+}
+
+const doc = globalThis.document as unknown as Record<string, unknown>;
+if (doc && !doc.body) {
+  const body = new ShadowElement('body');
+  doc.body = body;
+}
+
+beforeEach(() => {
+  resetForTesting();
+});

--- a/packages/upstream-tests/vitest.config.ts
+++ b/packages/upstream-tests/vitest.config.ts
@@ -273,6 +273,10 @@ export default defineConfig({
     include: includedTests,
     alias: [
       {
+        find: 'vue-lynx/internal/ops',
+        replacement: path.resolve(__dirname, '../vue-lynx/internal/src/ops.ts'),
+      },
+      {
         find: '@vue/runtime-test',
         replacement: path.resolve(__dirname, 'src/lynx-runtime-test.ts'),
       },

--- a/packages/upstream-tests/vitest.vapor.config.ts
+++ b/packages/upstream-tests/vitest.vapor.config.ts
@@ -1,0 +1,93 @@
+import { defineConfig } from 'vitest/config';
+import path from 'node:path';
+import fs from 'node:fs';
+
+type SkipEntry = string | { name: string; reason: string };
+interface Skiplist { skip_list: SkipEntry[]; }
+
+const skiplistPath = path.resolve(__dirname, 'skiplist-vapor.json');
+const skiplist: Skiplist = JSON.parse(fs.readFileSync(skiplistPath, 'utf-8'));
+const skipSet = new Set(skiplist.skip_list.map((entry) => typeof entry === 'string' ? entry : entry.name));
+
+function skiplistPlugin() {
+  return {
+    name: 'vue-upstream-vapor-skiplist',
+    enforce: 'pre' as const,
+    transform(code: string, id: string) {
+      if (!id.includes('runtime-vapor/__tests__') || !id.endsWith('.spec.ts')) return;
+      if (skipSet.size === 0) return;
+
+      const pattern = /\b((?:describe|it|test)(?:\.only)?)\s*\(\s*(['"`])((?:(?!\2).)*)\2/g;
+      let modified = false;
+      const result = code.replace(pattern, (match, keyword, quote, testName) => {
+        if (skipSet.has(testName)) {
+          modified = true;
+          const base = keyword.startsWith('describe') ? 'describe' : keyword.startsWith('test') ? 'test' : 'it';
+          return `${base}.skip(${quote}${testName}${quote}`;
+        }
+        return match;
+      });
+      return modified ? result : undefined;
+    },
+  };
+}
+
+function rewriteRuntimeVaporImportsPlugin() {
+  const vaporPath = path.resolve(__dirname, 'src/lynx-runtime-vapor-bridge.ts');
+  return {
+    name: 'vue-upstream-rewrite-runtime-vapor-imports',
+    enforce: 'pre' as const,
+    transform(code: string, id: string) {
+      if (!id.includes('runtime-vapor/__tests__')) return;
+      let result = code;
+      result = result.replace(/from\s+['"](\.\.\/)+src(?:\/[^'"]*)?['"]/g, `from '${vaporPath}'`);
+      result = result.replace(/from\s+['"]@vue\/runtime-vapor['"]/g, `from '${vaporPath}'`);
+      result = result.replace(/from\s+['"]vue['"]/g, `from '${vaporPath}'`);
+      return result !== code ? result : undefined;
+    },
+  };
+}
+
+const testDir = 'core/packages/runtime-vapor/__tests__';
+const includedTests = [
+  'block',
+].map((name) => `${testDir}/${name}.spec.ts`);
+
+export default defineConfig({
+  plugins: [skiplistPlugin(), rewriteRuntimeVaporImportsPlugin()],
+  define: {
+    __DEV__: 'true',
+    __TEST__: 'true',
+    __BROWSER__: 'false',
+    __GLOBAL__: 'false',
+    __ESM_BUNDLER__: 'true',
+    __ESM_BROWSER__: 'false',
+    __CJS__: 'false',
+    __SSR__: 'false',
+    __FEATURE_OPTIONS_API__: 'true',
+    __FEATURE_SUSPENSE__: 'true',
+    __FEATURE_PROD_DEVTOOLS__: 'false',
+    __FEATURE_PROD_HYDRATION_MISMATCH_DETAILS__: 'false',
+    __COMPAT__: 'false',
+    __VUE_LYNX_AUTO_PIXEL_UNIT__: 'true',
+    __VERSION__: '"3.6.0-beta.17"',
+  },
+  test: {
+    globals: true,
+    include: includedTests,
+    setupFiles: [
+      path.resolve(__dirname, 'src/vapor-setup.ts'),
+      path.resolve(__dirname, 'core/scripts/setup-vitest.ts'),
+    ],
+    testTimeout: 10000,
+    alias: [
+      { find: '@vue/runtime-dom', replacement: path.resolve(__dirname, 'node_modules/@vue/runtime-dom/dist/runtime-dom.esm-bundler.js') },
+      { find: 'vue', replacement: path.resolve(__dirname, 'node_modules/vue/dist/vue.runtime.esm-bundler.js') },
+      { find: 'vue-lynx/entry-background', replacement: path.resolve(__dirname, '../vue-lynx/runtime/src/entry-background.ts') },
+      { find: 'vue-lynx/main-thread', replacement: path.resolve(__dirname, '../vue-lynx/main-thread/src/entry-main.ts') },
+      { find: 'vue-lynx/internal/ops', replacement: path.resolve(__dirname, '../vue-lynx/internal/src/ops.ts') },
+      { find: 'vue-lynx/vapor', replacement: path.resolve(__dirname, '../vue-lynx/runtime/src/vapor/index.ts') },
+      { find: /^vue-lynx$/, replacement: path.resolve(__dirname, '../vue-lynx/runtime/src/index.ts') },
+    ],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -755,6 +755,12 @@ importers:
       '@vue/runtime-core':
         specifier: 3.6.0-beta.17
         version: 3.6.0-beta.17
+      '@vue/runtime-dom':
+        specifier: 3.6.0-beta.17
+        version: 3.6.0-beta.17
+      '@vue/runtime-vapor':
+        specifier: 3.6.0-beta.17
+        version: 3.6.0-beta.17(@vue/runtime-dom@3.6.0-beta.17)
       '@vue/shared':
         specifier: 3.6.0-beta.17
         version: 3.6.0-beta.17
@@ -910,28 +916,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@ast-grep/napi-linux-arm64-musl@0.37.0':
     resolution: {integrity: sha512-LF9sAvYy6es/OdyJDO3RwkX3I82Vkfsng1sqUBcoWC1jVb1wX5YVzHtpQox9JrEhGl+bNp7FYxB4Qba9OdA5GA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@ast-grep/napi-linux-x64-gnu@0.37.0':
     resolution: {integrity: sha512-TViz5/klqre6aSmJzswEIjApnGjJzstG/SE8VDWsrftMBMYt2PTu3MeluZVwzSqDao8doT/P+6U11dU05UOgxw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@ast-grep/napi-linux-x64-musl@0.37.0':
     resolution: {integrity: sha512-/BcCH33S9E3ovOAEoxYngUNXgb+JLg991sdyiNP2bSoYd30a9RHrG7CYwW6fMgua3ijQ474eV6cq9yZO1bCpXg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@ast-grep/napi-win32-arm64-msvc@0.37.0':
     resolution: {integrity: sha512-TjQA4cFoIEW2bgjLkaL9yqT4XWuuLa5MCNd0VCDhGRDMNQ9+rhwi9eLOWRaap3xzT7g+nlbcEHL3AkVCD2+b3A==}
@@ -1153,28 +1155,24 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-arm64@1.9.4':
     resolution: {integrity: sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@1.9.4':
     resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-x64@1.9.4':
     resolution: {integrity: sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@1.9.4':
     resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
@@ -2090,42 +2088,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -2193,79 +2185,66 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -2516,97 +2495,81 @@ packages:
     resolution: {integrity: sha512-pBKnS2Fbn9cDtWe1KcD1qRjQlJwQhP9pFW2KpxdjE7qXbaO11IHtem6dLZwdpNqbDn9QgyfdVGXBDvBaP1tGwA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rspack/binding-linux-arm64-gnu@1.7.8':
     resolution: {integrity: sha512-dD6gSHA18Uj0eqc1FCwwQ5IO5mIckrpYN4H4kPk9Pjau+1mxWvC4y5Lryz1Z8P/Rh1lnQ/wwGE0XL9nd80+LqQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rspack/binding-linux-arm64-gnu@2.0.0-beta.3':
     resolution: {integrity: sha512-iFPj4TQZKewnqWPfTbyk3F8QCBI/Edv7TVSRIPBHRnCM0lvYZl/8IZlUzXSamLvrtDpouF0nUzht/fktoWOhAg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rspack/binding-linux-arm64-gnu@2.0.8':
     resolution: {integrity: sha512-pSI+npPQE/uDtiboqvcOIRJbEV2+B+H1xffmko/gw50la92oTUW60kVULFwsb6L0+GVCzIcwX3yq60GtYIn+Ug==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rspack/binding-linux-arm64-musl@1.3.9':
     resolution: {integrity: sha512-0B+iiINW0qOEkBE9exsRcdmcHtYIWAoJGnXrz9tUiiewRxX0Cmm0MjD2HAVUAggJZo+9IN8RGz5PopCjJ/dn1g==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rspack/binding-linux-arm64-musl@1.7.8':
     resolution: {integrity: sha512-m+uBi9mEVGkZ02PPOAYN2BSmmvc00XGa6v9CjV8qLpolpUXQIMzDNG+i1fD5SHp8LO+XWsZJOHypMsT0MzGTGw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rspack/binding-linux-arm64-musl@2.0.0-beta.3':
     resolution: {integrity: sha512-355mygfCNb0eF/y4HgtJcd0i9csNTG4Z15PCCplIkSAKJpFpkORM2xJb50BqsbhVafYl6AHoBlGWAo9iIzUb/w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rspack/binding-linux-arm64-musl@2.0.8':
     resolution: {integrity: sha512-igjJ43yxWQ72GZqjDDZSSHax9/Vg+6rLMmOvFglTJUkQpB4Tyvu/YjW+WRjYj2xRw6blOjLxUSJWASvuSqqlvg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rspack/binding-linux-x64-gnu@1.3.9':
     resolution: {integrity: sha512-82izGJw/qxJ4xaHJy/A4MF7aTRT9tE6VlWoWM4rJmqRszfujN/w54xJRie9jkt041TPvJWGNpYD4Hjpt0/n/oA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rspack/binding-linux-x64-gnu@1.7.8':
     resolution: {integrity: sha512-IAPp2L3yS33MAEkcGn/I1gO+a+WExJHXz2ZlRlL2oFCUGpYi2ZQHyAcJ3o2tJqkXmdqsTiN+OjEVMd/RcLa24g==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rspack/binding-linux-x64-gnu@2.0.0-beta.3':
     resolution: {integrity: sha512-U8a+bcP/tkMyiwiO9XfeRYYO20YPGiZNxWWt7FEsdmRuRAl6M+EmWaJllJFQtKH+GG8IN93pNoVPMvARjLoJOQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rspack/binding-linux-x64-gnu@2.0.8':
     resolution: {integrity: sha512-zrkoEOnqj1hOEBO5T2I/2Ts2HSJsYFh1qXwMpK4dMJFGGNWDfNeUa6/LF5uq3VINF3JUl7RL47AgrucoSZJXPA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rspack/binding-linux-x64-musl@1.3.9':
     resolution: {integrity: sha512-V9nDg63iPI6Z7kM11UPV5kBdOdLXPIu3IgI2ObON5Rd4KEZr7RLo/Q4HKzj0IH27Zwl5qeBJdx69zZdu66eOqg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rspack/binding-linux-x64-musl@1.7.8':
     resolution: {integrity: sha512-do/QNzb4GWdXCsipblDcroqRDR3BFcbyzpZpAw/3j9ajvEqsOKpdHZpILT2NZX/VahhjqfqB3k0kJVt3uK7UYQ==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rspack/binding-linux-x64-musl@2.0.0-beta.3':
     resolution: {integrity: sha512-g81rqkaqDFRTID2VrHBYeM+xZe8yWov7IcryTrl9RGXXr61s+6Tu/mWyM378PuHOCyMNu7G3blVaSjLvKauG6Q==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rspack/binding-linux-x64-musl@2.0.8':
     resolution: {integrity: sha512-6CtDaGZjNDvJd9TBp7a9zABbrPORO21W96+3ZcGBn0YNUPUk4ARxIxrTTpeJ/1F41QDM8AYIkGDdqEYMqTYBsA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rspack/binding-wasm32-wasi@1.7.8':
     resolution: {integrity: sha512-mHtgYTpdhx01i0XNKFYBZyCjtv9YUe/sDfpD1QK4FytPFB+1VpYnmZiaJIMM77VpNsjxGAqWhmUYxi2P6jWifw==}
@@ -2764,25 +2727,21 @@ packages:
     resolution: {integrity: sha512-wGvkxm2G4mNTztslaOzLzx5JuySQSy5DcOWEZxHcjJJzp5L3ODbYLK18HtUc6cvmaVOmjaGrrYPrqJJ0hHTVFg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rspack/resolver-binding-linux-arm64-musl@0.2.8':
     resolution: {integrity: sha512-EqRJ9zLQsLAvyDKJKVZ45BSqRIMS12f5HtJdy3KkAHU14ZmsGv8e5IKkwUZN5CNBRad8xVlOMMx3dOfF4whJzg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rspack/resolver-binding-linux-x64-gnu@0.2.8':
     resolution: {integrity: sha512-eXbeotNCTntL4/+mxJRVCxK63YeWzTfp0F3POeHJFSs6Nt0f2J/mZNFlasJmd6xm7zvE80h/HWOwbwjRBLcElA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rspack/resolver-binding-linux-x64-musl@0.2.8':
     resolution: {integrity: sha512-KWFHlOWGkT+eMngoUgPGXrDi+rU04VCh9jyk0U6Ot2RTWvhGxwKykjmLS+CWZI/EBrzr9A6g2U3jzKTMNz9oCw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rspack/resolver-binding-wasm32-wasi@0.2.8':
     resolution: {integrity: sha512-I6GIhgICFViE88jejIV74oiiWHnpLpQ5ogaZM1ozM9KDnfqcHoX0IVEyrIh5KqA8iLDyhuoFSW+Hf0qN7VTBBQ==}
@@ -6179,56 +6138,48 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: glibc
 
   sass-embedded-linux-arm@1.98.0:
     resolution: {integrity: sha512-03baQZCxVyEp8v1NWBRlzGYrmVT/LK7ZrHlF1piscGiGxwfdxoLXVuxsylx3qn/dD/4i/rh7Bzk7reK1br9jvQ==}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: glibc
 
   sass-embedded-linux-musl-arm64@1.98.0:
     resolution: {integrity: sha512-LeqNxQA8y4opjhe68CcFvMzCSrBuJqYVFbwElEj9bagHXQHTp9xVPJRn6VcrC+0VLEDq13HVXMv7RslIuU0zmA==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: musl
 
   sass-embedded-linux-musl-arm@1.98.0:
     resolution: {integrity: sha512-OBkjTDPYR4hSaueOGIM6FDpl9nt/VZwbSRpbNu9/eEJcxE8G/vynRugW8KRZmCFjPy8j/jkGBvvS+k9iOqKV3g==}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: musl
 
   sass-embedded-linux-musl-riscv64@1.98.0:
     resolution: {integrity: sha512-7w6hSuOHKt8FZsmjRb3iGSxEzM87fO9+M8nt5JIQYMhHTj5C+JY/vcske0v715HCVj5e1xyTnbGXf8FcASeAIw==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
-    libc: musl
 
   sass-embedded-linux-musl-x64@1.98.0:
     resolution: {integrity: sha512-QikNyDEJOVqPmxyCFkci8ZdCwEssdItfjQFJB+D+Uy5HFqcS5Lv3d3GxWNX/h1dSb23RPyQdQc267ok5SbEyJw==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: musl
 
   sass-embedded-linux-riscv64@1.98.0:
     resolution: {integrity: sha512-E7fNytc/v4xFBQKzgzBddV/jretA4ULAPO6XmtBiQu4zZBdBozuSxsQLe2+XXeb0X4S2GIl72V7IPABdqke/vA==}
     engines: {node: '>=14.0.0'}
     cpu: [riscv64]
     os: [linux]
-    libc: glibc
 
   sass-embedded-linux-x64@1.98.0:
     resolution: {integrity: sha512-VsvP0t/uw00mMNPv3vwyYKUrFbqzxQHnRMO+bHdAMjvLw4NFf6mscpym9Bzf+NXwi1ZNKnB6DtXjmcpcvqFqYg==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: glibc
 
   sass-embedded-unknown-all@1.98.0:
     resolution: {integrity: sha512-C4MMzcAo3oEDQnW7L8SBgB9F2Fq5qHPnaYTZRMOH3Mp/7kM4OooBInXpCiiFjLnjY95hzP4KyctVx0uYR6MYlQ==}


### PR DESCRIPTION
### Motivation

- Port a first pass of the upstream `runtime-vapor` tests to the vue-lynx Vapor surface so we can catch Vapor-specific regressions and avoid drifting from upstream behavior.
- Run a small, well-scoped subset of `core/packages/runtime-vapor/__tests__` on the ShadowElement-backed Vapor runtime and explicitly skip tests that require semantics we intentionally differ on or haven't implemented yet.

### Description

- Add a new Vitest config `packages/upstream-tests/vitest.vapor.config.ts` and root/workspace scripts `test:vapor` / `test:vapor:watch` to run a selected subset of `runtime-vapor` upstream tests through a vapor bridge. 
- Introduce `packages/upstream-tests/src/lynx-runtime-vapor-bridge.ts` which re-exports `vue-lynx/vapor` and implements the low-level `normalizeBlock` and basic block helpers used by the upstream `block.spec.ts` suite so that that suite can run against ShadowElement nodes. 
- Add a `packages/upstream-tests/src/vapor-setup.ts` setup file that installs the Vapor DOM shim surface for tests, exposes a ShadowElement-backed `document.body` and `innerHTML` serialization, and resets runtime testing state before each test. 
- Add `packages/upstream-tests/skiplist-vapor.json` with named skip entries and explicit reasons for low-level DOM insertion/removal helpers that are intentionally not yet mirrored by the ShadowElement bridge. 
- Wire aliases and import-rewrite transforms so upstream `runtime-vapor` tests import the local `vue-lynx/vapor` surface instead of the upstream `../src` internals, and update `packages/upstream-tests/package.json` and the monorepo `package.json` `test:upstream` sequence. 
- Update `packages/upstream-tests/README.md` to document the new vapor suite and current pass/skip counts.

### Testing

- Ran `pnpm --filter vue-lynx-upstream-tests run test:vapor` which completed with `1` passing suite and `6` tests explicitly skipped by `skiplist-vapor.json` (1 pass / 6 skipped). 
- Ran `pnpm --filter vue-lynx-upstream-tests run test:local` and `pnpm --filter vue-lynx-upstream-tests run test:dom` and observed those configs pass as expected. 
- Ran the full upstream adapter `pnpm --filter vue-lynx-upstream-tests run test` and the existing runtime-core/reactivity/shared suites remained green (upstream counts unchanged). 
- Ran top-level `pnpm test` and `pnpm lint` and observed the test and lint commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a581c0081e48329bba186d9a3c6b284)