### PR TITLE
fix(vapor): preserve ShadowElement DOM contracts

### DIFF
--- a/packages/upstream-tests/src/vapor/shadow-element-dom-contract.spec.ts
+++ b/packages/upstream-tests/src/vapor/shadow-element-dom-contract.spec.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { nextTick, resetForTesting } from 'vue-lynx';
+import { OP } from 'vue-lynx/internal/ops';
+import {
+  createVaporApp,
+  defineVaporComponent,
+  isProxy,
+  reactive,
+  ref,
+  ShadowElement,
+  template,
+} from 'vue-lynx/vapor';
+import { collectFlushedOps, resetCapturedOps } from '../local-test-setup.js';
+import { decodeOps, opsOf } from './ops-test-utils.js';
+
+let mountedApp: ReturnType<typeof createVaporApp> | undefined;
+
+async function flushedOps() {
+  await nextTick();
+  return decodeOps(collectFlushedOps());
+}
+
+beforeEach(() => {
+  resetForTesting();
+  resetCapturedOps();
+});
+
+afterEach(() => {
+  mountedApp?.unmount();
+  mountedApp = undefined;
+});
+
+describe('ShadowElement DOM contracts', () => {
+  it('retains its identity through deep reactive and ref conversion', () => {
+    const element = new ShadowElement('view');
+
+    const fromReactive = reactive({ element }).element;
+    const fromRef = ref(element).value;
+
+    expect(fromReactive).toBe(element);
+    expect(fromRef).toBe(element);
+    expect(isProxy(fromReactive)).toBe(false);
+    expect(isProxy(fromRef)).toBe(false);
+  });
+
+  it('coerces CharacterData nodeValue and data writes to strings', async () => {
+    const text = new ShadowElement('#text');
+    const comment = new ShadowElement('#comment');
+
+    (text as unknown as { nodeValue: unknown }).nodeValue = 42;
+    (comment as unknown as { data: unknown }).data = false;
+
+    expect(text.nodeValue).toBe('42');
+    expect(comment.data).toBe('false');
+    expect(opsOf(await flushedOps(), OP.SET_TEXT)).toContainEqual({
+      op: OP.SET_TEXT,
+      args: [text.uid, '42'],
+    });
+  });
+
+  it('coerces aliased CharacterData before emitting its host text op', async () => {
+    const create = template('<text>seed', 1);
+    const host = create() as ShadowElement;
+    const aliasedText = host.firstChild!;
+    await flushedOps();
+
+    (aliasedText as unknown as { data: unknown }).data = 7;
+
+    expect(aliasedText.data).toBe('7');
+    expect(opsOf(await flushedOps(), OP.SET_TEXT)).toEqual([
+      { op: OP.SET_TEXT, args: [host.uid, '7'] },
+    ]);
+  });
+
+  it('does not emit the raw Vapor mount marker on the page root', async () => {
+    const create = template('<view>', 1);
+    const App = defineVaporComponent(() => create());
+
+    mountedApp = createVaporApp(App);
+    mountedApp.mount();
+
+    const pageRootOps = (await flushedOps()).filter(
+      ({ op, args }) =>
+        args[0] === 1 && (op === OP.SET_CLASS || op === OP.SET_PROP),
+    );
+    expect(pageRootOps).toEqual([]);
+  });
+
+  it('still turns scoped SFC data-v attributes into scope classes', async () => {
+    const element = new ShadowElement('view');
+
+    element.setAttribute('data-v-a1b2c3d4', '');
+
+    expect(element._scopeClasses).toEqual(new Set(['data-v-a1b2c3d4']));
+    expect(opsOf(await flushedOps(), OP.SET_CLASS)).toEqual([
+      { op: OP.SET_CLASS, args: [element.uid, 'data-v-a1b2c3d4'] },
+    ]);
+  });
+});

--- a/packages/upstream-tests/src/vapor/vapor-dynamic-event-stop.spec.ts
+++ b/packages/upstream-tests/src/vapor/vapor-dynamic-event-stop.spec.ts
@@ -1,0 +1,209 @@
+/**
+ * Regression coverage for dynamic Vapor event names with `.stop`.
+ *
+ * The real Vapor compiler emits `onBinding()` inside a render effect for
+ * `@[event].stop`. The runtime must preserve the Lynx `_lynxCatch` marker
+ * through its invoker and through effect cleanup/rebinding.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { compileScript, parse } from '@vue/compiler-sfc';
+import { nextTick, ref, resetForTesting } from 'vue-lynx';
+import { OP } from 'vue-lynx/internal/ops';
+import {
+  createVaporApp,
+  defineVaporComponent,
+  onBinding,
+  renderEffect,
+  template,
+  withVaporModifiers,
+} from 'vue-lynx/vapor';
+import { publishEvent } from '../../../vue-lynx/runtime/src/event-registry.js';
+import { collectFlushedOps, resetCapturedOps } from '../local-test-setup.js';
+import {
+  decodeOps,
+  expandOps,
+  opsOf,
+  resetTemplateExpander,
+} from './ops-test-utils.js';
+import type { DecodedOp } from './ops-test-utils.js';
+
+const _dirname = path.dirname(fileURLToPath(import.meta.url));
+const generatedDir = path.join(_dirname, '.generated');
+const generatedFiles: string[] = [];
+const mountedApps: Array<ReturnType<typeof createVaporApp>> = [];
+let fixtureCounter = 0;
+
+async function compileAndImport(source: string): Promise<{
+  code: string;
+  component: unknown;
+}> {
+  const { descriptor, errors } = parse(source, {
+    filename: 'DynamicEventStop.vue',
+  });
+  expect(errors).toEqual([]);
+  expect(descriptor.vapor).toBe(true);
+
+  const result = compileScript(descriptor, {
+    id: 'dynamic-event-stop',
+    inlineTemplate: true,
+    templateOptions: {
+      compilerOptions: {
+        isNativeTag: () => true,
+        whitespace: 'condense',
+        eventDelegation: false,
+      },
+    },
+  });
+  const code = result.content.replace(
+    /from\s*(['"])vue\1/g,
+    "from 'vue-lynx/vapor'",
+  );
+
+  fs.mkdirSync(generatedDir, { recursive: true });
+  const file = path.join(
+    generatedDir,
+    `dynamic-event-stop-${process.pid}-${fixtureCounter++}.mts`,
+  );
+  fs.writeFileSync(file, code);
+  generatedFiles.push(file);
+  const mod = (await import(
+    /* @vite-ignore */ `${file}?t=${Date.now()}`
+  )) as { default: unknown };
+  return { code, component: mod.default };
+}
+
+async function flushedOps(): Promise<DecodedOp[]> {
+  await nextTick();
+  return expandOps(decodeOps(collectFlushedOps()));
+}
+
+beforeEach(() => {
+  resetForTesting();
+  resetCapturedOps();
+  resetTemplateExpander();
+});
+
+afterEach(() => {
+  for (const app of mountedApps.splice(0)) app.unmount();
+});
+
+afterAll(() => {
+  for (const file of generatedFiles) fs.rmSync(file, { force: true });
+});
+
+describe('Vapor dynamic event names with .stop', () => {
+  it('compiles to onBinding and rebinds as native catchEvent', async () => {
+    const { code, component } = await compileAndImport(`
+      <script setup vapor>
+      import { ref } from 'vue'
+      const event = ref('tap')
+      const count = ref(0)
+      function handle() { count.value++ }
+      function switchEvent() { event.value = 'longpress' }
+      </script>
+      <template>
+        <view>
+          <text>{{ count }}</text>
+          <view @[event].stop="handle" />
+          <view @switch="switchEvent" />
+        </view>
+      </template>
+    `);
+
+    expect(code).toContain('onBinding');
+    expect(code).toContain('withModifiers');
+
+    const app = createVaporApp(component as never);
+    mountedApps.push(app);
+    app.mount();
+
+    let decoded = await flushedOps();
+    const initialEvent = opsOf(decoded, OP.SET_EVENT).find(
+      (operation) => operation.args[2] === 'tap',
+    );
+    const switchEvent = opsOf(decoded, OP.SET_EVENT).find(
+      (operation) => operation.args[2] === 'switch',
+    );
+    expect(initialEvent?.args[1]).toBe('catchEvent');
+    expect(switchEvent?.args[1]).toBe('bindEvent');
+
+    const initialSign = initialEvent!.args[3] as string;
+    publishEvent(initialSign, {});
+    decoded = await flushedOps();
+    expect(opsOf(decoded, OP.SET_TEXT).map((operation) => operation.args[1]))
+      .toContain('1');
+
+    publishEvent(switchEvent!.args[3] as string, {});
+    decoded = await flushedOps();
+    expect(opsOf(decoded, OP.REMOVE_EVENT)).toContainEqual({
+      op: OP.REMOVE_EVENT,
+      args: [initialEvent!.args[0], 'catchEvent', 'tap'],
+    });
+    const reboundEvent = opsOf(decoded, OP.SET_EVENT).find(
+      (operation) => operation.args[2] === 'longpress',
+    );
+    expect(reboundEvent?.args[1]).toBe('catchEvent');
+
+    publishEvent(initialSign, {});
+    decoded = await flushedOps();
+    expect(opsOf(decoded, OP.SET_TEXT)).toHaveLength(0);
+
+    publishEvent(reboundEvent!.args[3] as string, {});
+    decoded = await flushedOps();
+    expect(opsOf(decoded, OP.SET_TEXT).map((operation) => operation.args[1]))
+      .toContain('2');
+  });
+
+  it('uses catchEvent when a later handler in an array has .stop', async () => {
+    const event = ref('tap');
+    const first = vi.fn();
+    const second = vi.fn();
+    const handlers = [
+      first,
+      withVaporModifiers(second, ['stop'])!,
+    ];
+    const createRoot = template('<view>', 1);
+
+    const App = defineVaporComponent(() => {
+      const root = createRoot();
+      renderEffect(() => onBinding(root, event.value, handlers));
+      return root;
+    });
+    const app = createVaporApp(App);
+    mountedApps.push(app);
+    app.mount();
+
+    let decoded = await flushedOps();
+    const initialEvent = opsOf(decoded, OP.SET_EVENT)[0]!;
+    expect(initialEvent.args[1]).toBe('catchEvent');
+
+    const initialSign = initialEvent.args[3] as string;
+    publishEvent(initialSign, {});
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+
+    event.value = 'longpress';
+    decoded = await flushedOps();
+    expect(opsOf(decoded, OP.REMOVE_EVENT)[0]?.args).toEqual([
+      initialEvent.args[0],
+      'catchEvent',
+      'tap',
+    ]);
+    const reboundEvent = opsOf(decoded, OP.SET_EVENT)[0]!;
+    expect(reboundEvent.args[1]).toBe('catchEvent');
+    expect(reboundEvent.args[2]).toBe('longpress');
+
+    publishEvent(initialSign, {});
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+
+    publishEvent(reboundEvent.args[3] as string, {});
+    expect(first).toHaveBeenCalledTimes(2);
+    expect(second).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/vue-lynx/runtime/src/shadow-element.ts
+++ b/packages/vue-lynx/runtime/src/shadow-element.ts
@@ -191,6 +191,11 @@ function createClassList(el: ShadowElement): ClassListFacade {
 export class ShadowElement {
   static nextUid = 2; // 1 is reserved for the page root
 
+  /** @internal Native host nodes must retain object identity through Vue reactivity. */
+  get __v_skip(): true {
+    return true;
+  }
+
   uid: number;
   tag: string;
   parent: ShadowElement | null = null;
@@ -466,7 +471,7 @@ export class ShadowElement {
   }
 
   set nodeValue(value: string | null) {
-    const text = value ?? '';
+    const text = String(value ?? '');
     this._text = text;
     if (this.tag !== '#text' || this._inert) return;
     // Aliased only-child text lives on the host element on the MT side.
@@ -684,6 +689,11 @@ export class ShadowElement {
   // --- attributes --------------------------------------------------------------
 
   setAttribute(key: string, value: unknown): void {
+    // runtime-vapor adds this browser-only mount marker to its container.
+    // The Lynx page root is not a DOM element, so do not emit a native prop
+    // or misclassify the marker as a scoped-CSS class. Preserve normal
+    // data-v-app attribute behavior on user-created elements.
+    if (this.uid === PAGE_ROOT_ID && key === 'data-v-app') return;
     if (!this._inert && applyMainThreadProp(this, key, value)) return;
     // Vapor compiles ReactLynx-style event props (`:bindtap="fn"`,
     // `:catchtap="fn"`, …) to plain attribute writes — including

--- a/packages/vue-lynx/runtime/src/vapor/index.ts
+++ b/packages/vue-lynx/runtime/src/vapor/index.ts
@@ -13,6 +13,7 @@
  *
  *  - `withVaporModifiers` / `withVaporKeys` — Lynx event modifier semantics
  *    (`.stop` → native catchEvent, `.prevent` no-op, …)
+ *  - `on` / `onBinding` — preserve `.stop` through Vapor invoker wrappers
  *  - `applyTextModel` — v-model on <input>/<textarea> via Lynx `input` /
  *    `confirm` events carrying `detail.value`
  *  - `setHtml` / `setBlockHtml` — v-html is unsupported (no HTML on Lynx)
@@ -34,6 +35,7 @@ installVaporDomShim();
 import {
   createInvoker,
   createVaporApp as _createVaporApp,
+  onBinding as _onBinding,
   renderEffect,
 } from '@vue/runtime-vapor';
 import * as runtimeDom from '@vue/runtime-dom';
@@ -57,7 +59,9 @@ export * from '@vue/runtime-vapor';
 // Event modifier helpers — Lynx semantics
 // ---------------------------------------------------------------------------
 
-type AnyFn = (...args: unknown[]) => unknown;
+type AnyFn = ReturnType<typeof createInvoker>;
+type EventHandlerValue = Parameters<typeof _onBinding>[2];
+type OnBindingOptions = NonNullable<Parameters<typeof _onBinding>[3]>;
 
 /**
  * Vapor counterpart of vue-lynx's `withModifiers`: wraps the handler with
@@ -82,13 +86,29 @@ export function withVaporKeys(fn: AnyFn, keys: string[]): AnyFn {
 }
 
 // ---------------------------------------------------------------------------
-// on — preserve the `.stop` → catchEvent tag through the invoker wrapper
+// Events — preserve the `.stop` → catchEvent tag through invoker wrappers
 // ---------------------------------------------------------------------------
 
 interface OnOptions {
   once?: boolean;
   capture?: boolean;
   passive?: boolean;
+}
+
+function usesLynxCatch(handler: AnyFn): boolean {
+  return !!(handler as { _lynxCatch?: boolean })._lynxCatch;
+}
+
+function addVaporEventListener(
+  el: ShadowElement,
+  event: string,
+  handler: AnyFn,
+  options: OnOptions,
+  forceCatch = usesLynxCatch(handler),
+): void {
+  const invoker = createInvoker(handler) as AnyFn & { _lynxCatch?: boolean };
+  if (forceCatch) invoker._lynxCatch = true;
+  el.addEventListener(event, invoker as (data: unknown) => void, options);
 }
 
 /**
@@ -105,15 +125,66 @@ export function on(
   options: OnOptions = {},
 ): void {
   if (Array.isArray(handler)) {
-    for (const fn of handler) on(el, event, fn, options);
+    const forceCatch = handler.some(usesLynxCatch);
+    for (const fn of handler) {
+      addVaporEventListener(el, event, fn, options, forceCatch);
+    }
     return;
   }
   if (!handler) return;
-  const invoker = createInvoker(handler) as AnyFn & { _lynxCatch?: boolean };
-  if ((handler as { _lynxCatch?: boolean })._lynxCatch) {
-    invoker._lynxCatch = true;
-  }
-  el.addEventListener(event, invoker as (data: unknown) => void, options);
+  addVaporEventListener(el, event, handler, options);
+}
+
+/**
+ * Reactive event binding used by the Vapor compiler for dynamic event names.
+ *
+ * Delegate effect cleanup and array handling to upstream `onBinding`, but
+ * intercept its generated invoker before it reaches ShadowElement so the
+ * original handler's `_lynxCatch` marker survives. The adapter forwards the
+ * exact same invoker to removal, preserving upstream's onEffectCleanup
+ * identity and rebinding semantics.
+ * @public
+ */
+export function onBinding(
+  el: ShadowElement,
+  event: string,
+  handler: EventHandlerValue,
+  options: OnBindingOptions = {},
+): void {
+  if (!handler) return;
+
+  const handlers = Array.isArray(handler) ? handler : [handler];
+  const forceCatch = handlers.some(usesLynxCatch);
+
+  const target = {
+    addEventListener(
+      name: string,
+      invoker: EventListener,
+      eventOptions?: AddEventListenerOptions | boolean,
+    ) {
+      if (forceCatch) {
+        (invoker as unknown as { _lynxCatch?: boolean })._lynxCatch = true;
+      }
+      el.addEventListener(
+        name,
+        invoker as unknown as (data: unknown) => void,
+        eventOptions,
+      );
+    },
+    removeEventListener(name: string, invoker: EventListener) {
+      el.removeEventListener(
+        name,
+        invoker as unknown as (data: unknown) => void,
+      );
+    },
+  };
+
+  _onBinding(
+    target as unknown as Element,
+    event,
+    handler,
+    options,
+  );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- keep `ShadowElement` host nodes raw through Vue reactivity, coerce CharacterData writes to DOM-compatible strings, and suppress the browser-only `data-v-app` marker on the Lynx page root
- preserve Lynx `catchEvent` metadata through runtime-vapor dynamic event-name bindings and mixed handler arrays while retaining upstream cleanup, error-boundary, and listener-option behavior
- add compiler-backed regressions for `@[event].stop` rebinding and focused host-node contract tests

## Root causes

1. `ShadowElement` instances were eligible for reactive proxying, so template refs could lose host-node identity.
2. `nodeValue` forwarded non-string payloads directly into `SET_TEXT`, diverging from DOM CharacterData coercion.
3. runtime-vapor's browser mount path wrote `data-v-app` to the page root, producing an irrelevant Lynx op.
4. runtime-vapor's dynamic `onBinding` invokers did not carry vue-lynx's `_lynxCatch` marker, so `.stop` could silently register as `bindEvent`; mixed arrays also depended on handler order.

## Verification

- `pnpm --filter vue-lynx-upstream-tests run test:local` — 67 passed
- `pnpm --filter vue-lynx-testing-library run test` — 163 passed
- `pnpm run test:upstream` — 917 core, 67 DOM, and 67 local tests passed (with the repository's existing explicit skips/todos)
- `pnpm run lint`
- `pnpm --filter vue-lynx run build`

This PR intentionally contains only the runtime fixes and their local regressions; the runtime-vapor upstream-suite port remains in a separate branch/commit.
