### PR TITLE
docs(elk): clarify native viewpager variant, link XElement doc, highlight pager code

### DIFF
--- a/website/docs/guide/elk.mdx
+++ b/website/docs/guide/elk.mdx
@@ -13,7 +13,11 @@ live Mastodon instance; switch to the **QR Code** tab and scan it with
 Lynx Go / Lynx Explorer (see [Quick Start](/guide/quick-start) for
 installing it) to run the same `main.lynx.bundle` natively on your phone.
 
-<Go example="elk" defaultFile="src/App.vue" />
+<Go
+  example="elk"
+  defaultFile="src/App.vue"
+  schema="{{{url}}}?fullscreen=true&bar_color=fafafa&bg_color=fafafa"
+/>
 
 ### Native viewpager variant <Badge text="newer Lynx engine" type="warning" />
 
@@ -37,6 +41,7 @@ use the extracted `<viewpager>` / `<viewpager-item>`.
 <Go
   example="elk-viewpager"
   defaultFile="src/components/TabPager.vue"
+  schema="{{{url}}}?fullscreen=true&bar_color=fafafa&bg_color=fafafa"
   highlight={{
     'src/components/TabPager.vue': '{12-18,40-56,72-87}',
   }}

--- a/website/docs/guide/elk.mdx
+++ b/website/docs/guide/elk.mdx
@@ -1,3 +1,5 @@
+import { Badge } from '@theme';
+
 # Elk — a Mastodon Client
 
 To prove Vue Lynx can carry a real product-grade app, we ported

--- a/website/docs/guide/elk.mdx
+++ b/website/docs/guide/elk.mdx
@@ -16,18 +16,39 @@ installing it) to run the same `main.lynx.bundle` natively on your phone.
 ### Native viewpager variant <Badge text="newer Lynx engine" type="warning" />
 
 The `elk-viewpager` fork backs the Explore and Notifications tabs with the
-**native viewpager element** ([`TabPager.vue`](https://github.com/huxpro/vue-lynx/blob/main/examples/elk-viewpager/src/components/TabPager.vue)):
-panes swipe horizontally with a native snap animation, keep content and
-scroll position across swipes, and the tab bar syncs both ways (the
-pager's `change` event ↔ the `selectTab` UI method). It feels closer to a
-native client, at the cost of a heavier host requirement: on the web it
-uses `<x-viewpager-ng>` and works today, but native hosts need a Lynx
-engine that registers the extracted `<viewpager>` element
-(lynx-family/lynx develop after 2026-04 — newer than any released
-LynxExplorer, whose builds ship neither name). On older hosts the tab
-area renders blank; prefer the original example above there.
+native [`<viewpager>`](https://lynxjs.org/guide/ui/elements-components.html#xelement)
+element instead of the default's conditionally rendered panes. In
+[`TabPager.vue`](https://github.com/huxpro/vue-lynx/blob/main/examples/elk-viewpager/src/components/TabPager.vue)
+each pane is a `<viewpager-item>` child of a `<viewpager>`: panes swipe
+horizontally with a native snap animation, keep content and scroll
+position across swipes, and the tab bar stays in sync both ways — swiping
+fires the pager's `change` event (→ moves the active tab), while tapping a
+tab calls the pager's `selectTab` UI method (→ animates to that page). It
+feels much closer to a native client.
 
-<Go example="elk-viewpager" defaultFile="src/components/TabPager.vue" />
+`viewpager` ships as a Lynx [XElement](https://lynxjs.org/guide/ui/elements-components.html#xelement)
+that is registered under a different tag per platform, so `TabPager.vue`
+picks the tag at runtime from `SystemInfo.platform` (highlighted below):
+Lynx for Web uses the legacy `<x-viewpager-ng>`, while native OSS engines
+use the extracted `<viewpager>` / `<viewpager-item>`.
+
+<Go
+  example="elk-viewpager"
+  defaultFile="src/components/TabPager.vue"
+  highlight={{
+    'src/components/TabPager.vue': '{12-18,40-56,72-87}',
+  }}
+/>
+
+:::warning Engine version dependency
+The extracted native `<viewpager>` element landed in the OSS engine in
+lynx-family/lynx `c1d8d7920` (2026-04), which is **newer than any released
+LynxExplorer**: 3.8.1 and earlier register neither `<viewpager>` nor
+`<x-viewpager-ng>`, so the tab area renders blank there (with a
+`LynxCreateUIException`). Run this variant on a host built from lynx
+`develop`; on today's released Explorers, use the default Elk example
+above, whose tabs render conditionally and need no pager element.
+:::
 
 ## Why Elk is a serious test
 

--- a/website/docs/zh/guide/elk.mdx
+++ b/website/docs/zh/guide/elk.mdx
@@ -1,3 +1,5 @@
+import { Badge } from '@theme';
+
 # Elk — Mastodon 客户端
 
 为了验证 Vue Lynx 能承载真正产品级的应用，我们把 Anthony Fu 团队广受喜爱的

--- a/website/docs/zh/guide/elk.mdx
+++ b/website/docs/zh/guide/elk.mdx
@@ -14,17 +14,38 @@ Mastodon 实例；切换到 **二维码** 标签页，用 Lynx Go / Lynx Explore
 
 ### 原生 viewpager 变体 <Badge text="需要较新的 Lynx 引擎" type="warning" />
 
-`elk-viewpager` 分叉用**原生 viewpager 元件**承载 Explore 与通知页的标签页
-（[`TabPager.vue`](https://github.com/huxpro/vue-lynx/blob/main/examples/elk-viewpager/src/components/TabPager.vue)）：
-面板可以横向滑动翻页、带原生吸附动画，滑走再滑回时内容与滚动位置都保留，
-标签栏与翻页器双向同步（翻页器的 `change` 事件 ↔ `selectTab` UI 方法）。
-体验更接近原生客户端，代价是对宿主要求更高：Web 端使用 `<x-viewpager-ng>`
-现在即可运行；原生端则需要注册了新版 `<viewpager>` 元件的 Lynx 引擎
-（lynx-family/lynx develop 2026-04 之后——比任何已发布的 LynxExplorer 都新，
-已发布版本两个名字都没有）。在旧宿主上标签区域会渲染为空白，
-届时请使用上方的原始示例。
+`elk-viewpager` 分叉用原生
+[`<viewpager>`](https://lynxjs.org/guide/ui/elements-components.html#xelement)
+元件承载 Explore 与通知页的标签页，取代默认示例里按条件渲染的面板。在
+[`TabPager.vue`](https://github.com/huxpro/vue-lynx/blob/main/examples/elk-viewpager/src/components/TabPager.vue)
+中，每个面板都是 `<viewpager>` 下的一个 `<viewpager-item>`：面板可以横向
+滑动翻页、带原生吸附动画，滑走再滑回时内容与滚动位置都保留，标签栏与翻页器
+双向同步——滑动会触发翻页器的 `change` 事件（→ 切换当前标签），点按标签则
+调用翻页器的 `selectTab` UI 方法（→ 动画翻到该页）。体验更接近原生客户端。
 
-<Go example="elk-viewpager" defaultFile="src/components/TabPager.vue" />
+`viewpager` 以 Lynx
+[XElement](https://lynxjs.org/guide/ui/elements-components.html#xelement)
+形式提供，在不同平台上注册为不同的标签名，因此 `TabPager.vue` 会在运行时
+根据 `SystemInfo.platform` 选择标签名（下方高亮处）：Lynx for Web 使用旧版
+`<x-viewpager-ng>`，而原生 OSS 引擎使用抽取出来的 `<viewpager>` /
+`<viewpager-item>`。
+
+<Go
+  example="elk-viewpager"
+  defaultFile="src/components/TabPager.vue"
+  highlight={{
+    'src/components/TabPager.vue': '{12-18,40-56,72-87}',
+  }}
+/>
+
+:::warning 引擎版本依赖
+抽取出来的原生 `<viewpager>` 元件是在 lynx-family/lynx `c1d8d7920`
+（2026-04）才进入 OSS 引擎的，**比任何已发布的 LynxExplorer 都新**：
+3.8.1 及更早版本既没有 `<viewpager>` 也没有 `<x-viewpager-ng>`，因此标签
+区域在这些宿主上会渲染为空白（并伴随 `LynxCreateUIException`）。请在从
+lynx `develop` 构建的宿主上运行该变体；在当前已发布的 Explorer 上，请使用
+上方的默认 Elk 示例——它的标签按条件渲染，无需 pager 元件。
+:::
 
 ## 为什么 Elk 是一块试金石
 

--- a/website/docs/zh/guide/elk.mdx
+++ b/website/docs/zh/guide/elk.mdx
@@ -12,7 +12,11 @@ Mastodon 实例；切换到 **二维码** 标签页，用 Lynx Go / Lynx Explore
 （安装方式见[快速开始](/zh/guide/quick-start)）扫码，即可在手机上原生运行
 同一份 `main.lynx.bundle`。
 
-<Go example="elk" defaultFile="src/App.vue" />
+<Go
+  example="elk"
+  defaultFile="src/App.vue"
+  schema="{{{url}}}?fullscreen=true&bar_color=fafafa&bg_color=fafafa"
+/>
 
 ### 原生 viewpager 变体 <Badge text="需要较新的 Lynx 引擎" type="warning" />
 
@@ -35,6 +39,7 @@ Mastodon 实例；切换到 **二维码** 标签页，用 Lynx Go / Lynx Explore
 <Go
   example="elk-viewpager"
   defaultFile="src/components/TabPager.vue"
+  schema="{{{url}}}?fullscreen=true&bar_color=fafafa&bg_color=fafafa"
   highlight={{
     'src/components/TabPager.vue': '{12-18,40-56,72-87}',
   }}


### PR DESCRIPTION
Follow-up to #223. The elk-viewpager guide section now:
- links <viewpager> to the lynxjs XElement doc and explains the
  per-platform tag selection and two-way tab-bar sync more clearly
- highlights the pager-relevant lines of TabPager.vue in the <Go> viewer
- states the engine version dependency in a dedicated Rspress :::warning
  callout (matching the hackernews guide) alongside the heading badge

Applied to both en and zh docs.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01GYQ8X2CpBvQ77wYNxxxqN5