### PR TITLE
fix(examples): animate Elk settings sheets

### DIFF
--- a/examples/elk-viewpager/scripts/native-compat.test.mjs
+++ b/examples/elk-viewpager/scripts/native-compat.test.mjs
@@ -90,6 +90,7 @@ test('Vue Lynx Sheet keeps hybrid drag and settle work on the main thread', asyn
   assert.match(source, /modelValue/);
   assert.match(source, /v-show="modelValue"/);
   assert.doesNotMatch(source, /v-if="modelValue"/);
+  assert.match(source, /<Transition name="sheet" @after-leave="handleAfterLeave">/);
   assert.match(source, /class="sheet-backdrop"[^>]*:main-thread-ref="backdropRef"[^>]*@tap="requestClose"/s);
   assert.match(source, /class="sheet-surface"/);
   assert.match(
@@ -143,10 +144,27 @@ test('Vue Lynx Sheet keeps hybrid drag and settle work on the main thread', asyn
     'a recursive worklet rAF loop can collapse into one native render batch',
   );
   assert.match(source, /animationGenerationRef/);
-  assert.match(source, /watch\(\(\) => props\.modelValue/);
-  assert.match(source, /prepareSheetForOpen/);
+  assert.doesNotMatch(source, /watch\(\(\) => props\.modelValue/);
+  assert.doesNotMatch(source, /prepareSheetForOpen/);
+  assert.match(
+    source,
+    /class="sheet-surface-transition"[^>]*:style="surfaceStyle"/,
+    'transition motion must use a wrapper separate from gesture inline styles',
+  );
+  assert.doesNotMatch(
+    source,
+    /class="sheet-surface"[^>]*:style="surfaceStyle"/,
+    'top inset must only be subtracted by the transition wrapper',
+  );
+  assert.match(source, /\.sheet-surface\s*\{[^}]*height:\s*100%/s);
+  assert.match(
+    source,
+    /\.sheet-enter-from \.sheet-surface-transition,[\s\S]*?\.sheet-leave-to \.sheet-surface-transition\s*\{[^}]*transform:\s*translateY\(100%\)/s,
+    'v-show enter and leave classes must move the dedicated transition wrapper',
+  );
+  assert.doesNotMatch(source, /\.sheet-enter-from \.sheet-surface,/);
+  assert.match(source, /function resetSheetMotion\(\)[\s\S]*?applySheetMotion\(0\)/);
   assert.match(source, /runOnBackground\(requestClose\)/);
-  assert.match(source, /@after-leave="handleAfterLeave"/);
   assert.match(source, /transition:\s*opacity/);
   assert.match(source, /transition:\s*transform/);
   assert.doesNotMatch(source, /transition:\s*all/);
@@ -496,8 +514,13 @@ test('app-bar tabs page horizontally through the native viewpager', async () => 
 
   // Swiping between panes is native: the pager element owns the gesture,
   // and the tab bar syncs both ways (change event + selectTab method).
-  assert.match(tabPager, /'x-viewpager-ng'/);
-  assert.match(tabPager, /'x-viewpager-item-ng'/);
+  assert.match(tabPager, /const pagerTag = isWeb \? 'x-viewpager-ng' : 'viewpager'/);
+  assert.match(
+    tabPager,
+    /const pagerItemTag = isWeb \? 'x-viewpager-item-ng' : 'viewpager-item'/,
+  );
+  assert.match(tabPager, /:is="pagerTag"/);
+  assert.match(tabPager, /:is="pagerItemTag"/);
   assert.match(tabPager, /@change="onPagerChange"/);
   assert.match(tabPager, /method: 'selectTab'/);
   assert.match(explore, /<TabPager/);

--- a/examples/elk-viewpager/src/components/sheet/Sheet.vue
+++ b/examples/elk-viewpager/src/components/sheet/Sheet.vue
@@ -4,7 +4,6 @@ import {
   runOnBackground,
   runOnMainThread,
   useMainThreadRef,
-  watch,
 } from 'vue-lynx';
 import {
   resolveSheetDrag,
@@ -313,23 +312,6 @@ function resetSheetMotion() {
   setMotionTransition('', '');
 }
 
-function prepareSheetForOpen() {
-  'main thread';
-  if (
-    settleTimerRef.current === 0
-    && Math.abs(translationRef.current) < 0.5
-  ) {
-    return;
-  }
-
-  resetSheetMotion();
-}
-
-watch(() => props.modelValue, (visible) => {
-  if (visible)
-    runOnMainThread(prepareSheetForOpen)();
-});
-
 function handleAfterLeave() {
   runOnMainThread(resetSheetMotion)();
 }
@@ -343,35 +325,36 @@ function handleAfterLeave() {
         :main-thread-ref="backdropRef"
         @tap="requestClose"
       />
-      <view
-        class="sheet-surface"
-        :style="surfaceStyle"
-        :main-thread-ref="surfaceRef"
-        :main-thread-bindlayoutchange="handleSurfaceLayout"
-      >
-        <view class="sheet-rubber-fill" />
+      <view class="sheet-surface-transition" :style="surfaceStyle">
         <view
-          class="sheet-handle-hit-area"
-          :main-thread-bindtouchstart="handleHandleTouchStart"
-          :main-thread-bindtouchmove="handleTouchMove"
-          :main-thread-bindtouchend="handleTouchEnd"
-          :main-thread-bindtouchcancel="handleTouchCancel"
+          class="sheet-surface"
+          :main-thread-ref="surfaceRef"
+          :main-thread-bindlayoutchange="handleSurfaceLayout"
         >
-          <view class="sheet-handle" />
+          <view class="sheet-rubber-fill" />
+          <view
+            class="sheet-handle-hit-area"
+            :main-thread-bindtouchstart="handleHandleTouchStart"
+            :main-thread-bindtouchmove="handleTouchMove"
+            :main-thread-bindtouchend="handleTouchEnd"
+            :main-thread-bindtouchcancel="handleTouchCancel"
+          >
+            <view class="sheet-handle" />
+          </view>
+          <scroll-view
+            class="sheet-panel"
+            scroll-orientation="vertical"
+            :bounces="true"
+            :main-thread-ref="panelRef"
+            :main-thread-bindscroll="handlePanelScroll"
+            :main-thread-bindtouchstart="handleContentTouchStart"
+            :main-thread-bindtouchmove="handleTouchMove"
+            :main-thread-bindtouchend="handleTouchEnd"
+            :main-thread-bindtouchcancel="handleTouchCancel"
+          >
+            <slot />
+          </scroll-view>
         </view>
-        <scroll-view
-          class="sheet-panel"
-          scroll-orientation="vertical"
-          :bounces="true"
-          :main-thread-ref="panelRef"
-          :main-thread-bindscroll="handlePanelScroll"
-          :main-thread-bindtouchstart="handleContentTouchStart"
-          :main-thread-bindtouchmove="handleTouchMove"
-          :main-thread-bindtouchend="handleTouchEnd"
-          :main-thread-bindtouchcancel="handleTouchCancel"
-        >
-          <slot />
-        </scroll-view>
       </view>
     </view>
   </Transition>
@@ -403,12 +386,22 @@ function handleAfterLeave() {
   transition: opacity 250ms cubic-bezier(0.25, 1, 0.5, 1);
 }
 
-.sheet-surface {
+.sheet-surface-transition {
   position: relative;
   z-index: 1;
   display: flex;
   flex-direction: column;
   width: 100%;
+  transform: translateY(0);
+  transition: transform 250ms cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+.sheet-surface {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
   border-top: 1px solid var(--c-border);
   border-top-left-radius: 8px;
   border-top-right-radius: 8px;
@@ -460,8 +453,8 @@ function handleAfterLeave() {
   opacity: 0;
 }
 
-.sheet-enter-from .sheet-surface,
-.sheet-leave-to .sheet-surface {
+.sheet-enter-from .sheet-surface-transition,
+.sheet-leave-to .sheet-surface-transition {
   transform: translateY(100%);
 }
 
@@ -475,8 +468,9 @@ function handleAfterLeave() {
   transition-timing-function: ease-in;
 }
 
-.sheet-leave-active .sheet-surface {
+.sheet-leave-active .sheet-surface-transition {
   transition-duration: 188ms;
   transition-timing-function: ease-in;
 }
+
 </style>

--- a/examples/elk/scripts/native-compat.test.mjs
+++ b/examples/elk/scripts/native-compat.test.mjs
@@ -90,6 +90,7 @@ test('Vue Lynx Sheet keeps hybrid drag and settle work on the main thread', asyn
   assert.match(source, /modelValue/);
   assert.match(source, /v-show="modelValue"/);
   assert.doesNotMatch(source, /v-if="modelValue"/);
+  assert.match(source, /<Transition name="sheet" @after-leave="handleAfterLeave">/);
   assert.match(source, /class="sheet-backdrop"[^>]*:main-thread-ref="backdropRef"[^>]*@tap="requestClose"/s);
   assert.match(source, /class="sheet-surface"/);
   assert.match(
@@ -143,10 +144,27 @@ test('Vue Lynx Sheet keeps hybrid drag and settle work on the main thread', asyn
     'a recursive worklet rAF loop can collapse into one native render batch',
   );
   assert.match(source, /animationGenerationRef/);
-  assert.match(source, /watch\(\(\) => props\.modelValue/);
-  assert.match(source, /prepareSheetForOpen/);
+  assert.doesNotMatch(source, /watch\(\(\) => props\.modelValue/);
+  assert.doesNotMatch(source, /prepareSheetForOpen/);
+  assert.match(
+    source,
+    /class="sheet-surface-transition"[^>]*:style="surfaceStyle"/,
+    'transition motion must use a wrapper separate from gesture inline styles',
+  );
+  assert.doesNotMatch(
+    source,
+    /class="sheet-surface"[^>]*:style="surfaceStyle"/,
+    'top inset must only be subtracted by the transition wrapper',
+  );
+  assert.match(source, /\.sheet-surface\s*\{[^}]*height:\s*100%/s);
+  assert.match(
+    source,
+    /\.sheet-enter-from \.sheet-surface-transition,[\s\S]*?\.sheet-leave-to \.sheet-surface-transition\s*\{[^}]*transform:\s*translateY\(100%\)/s,
+    'v-show enter and leave classes must move the dedicated transition wrapper',
+  );
+  assert.doesNotMatch(source, /\.sheet-enter-from \.sheet-surface,/);
+  assert.match(source, /function resetSheetMotion\(\)[\s\S]*?applySheetMotion\(0\)/);
   assert.match(source, /runOnBackground\(requestClose\)/);
-  assert.match(source, /@after-leave="handleAfterLeave"/);
   assert.match(source, /transition:\s*opacity/);
   assert.match(source, /transition:\s*transform/);
   assert.doesNotMatch(source, /transition:\s*all/);

--- a/examples/elk/src/components/sheet/Sheet.vue
+++ b/examples/elk/src/components/sheet/Sheet.vue
@@ -4,7 +4,6 @@ import {
   runOnBackground,
   runOnMainThread,
   useMainThreadRef,
-  watch,
 } from 'vue-lynx';
 import {
   resolveSheetDrag,
@@ -313,23 +312,6 @@ function resetSheetMotion() {
   setMotionTransition('', '');
 }
 
-function prepareSheetForOpen() {
-  'main thread';
-  if (
-    settleTimerRef.current === 0
-    && Math.abs(translationRef.current) < 0.5
-  ) {
-    return;
-  }
-
-  resetSheetMotion();
-}
-
-watch(() => props.modelValue, (visible) => {
-  if (visible)
-    runOnMainThread(prepareSheetForOpen)();
-});
-
 function handleAfterLeave() {
   runOnMainThread(resetSheetMotion)();
 }
@@ -343,35 +325,36 @@ function handleAfterLeave() {
         :main-thread-ref="backdropRef"
         @tap="requestClose"
       />
-      <view
-        class="sheet-surface"
-        :style="surfaceStyle"
-        :main-thread-ref="surfaceRef"
-        :main-thread-bindlayoutchange="handleSurfaceLayout"
-      >
-        <view class="sheet-rubber-fill" />
+      <view class="sheet-surface-transition" :style="surfaceStyle">
         <view
-          class="sheet-handle-hit-area"
-          :main-thread-bindtouchstart="handleHandleTouchStart"
-          :main-thread-bindtouchmove="handleTouchMove"
-          :main-thread-bindtouchend="handleTouchEnd"
-          :main-thread-bindtouchcancel="handleTouchCancel"
+          class="sheet-surface"
+          :main-thread-ref="surfaceRef"
+          :main-thread-bindlayoutchange="handleSurfaceLayout"
         >
-          <view class="sheet-handle" />
+          <view class="sheet-rubber-fill" />
+          <view
+            class="sheet-handle-hit-area"
+            :main-thread-bindtouchstart="handleHandleTouchStart"
+            :main-thread-bindtouchmove="handleTouchMove"
+            :main-thread-bindtouchend="handleTouchEnd"
+            :main-thread-bindtouchcancel="handleTouchCancel"
+          >
+            <view class="sheet-handle" />
+          </view>
+          <scroll-view
+            class="sheet-panel"
+            scroll-orientation="vertical"
+            :bounces="true"
+            :main-thread-ref="panelRef"
+            :main-thread-bindscroll="handlePanelScroll"
+            :main-thread-bindtouchstart="handleContentTouchStart"
+            :main-thread-bindtouchmove="handleTouchMove"
+            :main-thread-bindtouchend="handleTouchEnd"
+            :main-thread-bindtouchcancel="handleTouchCancel"
+          >
+            <slot />
+          </scroll-view>
         </view>
-        <scroll-view
-          class="sheet-panel"
-          scroll-orientation="vertical"
-          :bounces="true"
-          :main-thread-ref="panelRef"
-          :main-thread-bindscroll="handlePanelScroll"
-          :main-thread-bindtouchstart="handleContentTouchStart"
-          :main-thread-bindtouchmove="handleTouchMove"
-          :main-thread-bindtouchend="handleTouchEnd"
-          :main-thread-bindtouchcancel="handleTouchCancel"
-        >
-          <slot />
-        </scroll-view>
       </view>
     </view>
   </Transition>
@@ -403,12 +386,22 @@ function handleAfterLeave() {
   transition: opacity 250ms cubic-bezier(0.25, 1, 0.5, 1);
 }
 
-.sheet-surface {
+.sheet-surface-transition {
   position: relative;
   z-index: 1;
   display: flex;
   flex-direction: column;
   width: 100%;
+  transform: translateY(0);
+  transition: transform 250ms cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+.sheet-surface {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
   border-top: 1px solid var(--c-border);
   border-top-left-radius: 8px;
   border-top-right-radius: 8px;
@@ -460,8 +453,8 @@ function handleAfterLeave() {
   opacity: 0;
 }
 
-.sheet-enter-from .sheet-surface,
-.sheet-leave-to .sheet-surface {
+.sheet-enter-from .sheet-surface-transition,
+.sheet-leave-to .sheet-surface-transition {
   transform: translateY(100%);
 }
 
@@ -475,8 +468,9 @@ function handleAfterLeave() {
   transition-timing-function: ease-in;
 }
 
-.sheet-leave-active .sheet-surface {
+.sheet-leave-active .sheet-surface-transition {
   transition-duration: 188ms;
   transition-timing-function: ease-in;
 }
+
 </style>


### PR DESCRIPTION
## What changed

- animate the settings sheet on both open and close in the standard Elk example
- apply the same behavior to the native viewpager variant
- separate the CSS transition wrapper from the gesture-controlled surface so both can own their transform independently
- keep the sheet flush with the bottom tab bar by applying the top inset only once
- update native compatibility coverage for both variants

## Dependency

Built on #249, which fixes Vue Lynx persisted `Transition` behavior for `v-show`. This PR intentionally contains only Elk example changes.

## Validation

- `elk` native compatibility: 30/30 passed
- `elk-viewpager` native compatibility: 31/31 passed
- both examples: Lynx and Web production builds passed
- repeated open/close animation verified on Web and native Lynx
- Lynx DevTool geometry: sheet bottom `y=784`, bottom tab top `y=784`