### PR TITLE
slides: IFR + Element Templates chapter (Chapter IV)

### DIFF
--- a/slides/index.html
+++ b/slides/index.html
@@ -1773,6 +1773,352 @@
     </aside>
   </section>
 
+  <!-- IFR1 — the first frame waits a full lap -->
+  <section class="slide stage">
+    <span class="eyebrow">IV · Instant first frame</span>
+    <div class="ifrtl">
+      <div class="ifrlane" style="--c:#56b8f0;top:6%;height:38%">
+        <span class="ifrlane__label"><i></i>Main (UI) thread</span>
+        <div class="tblk is-wait" style="left:3%;width:55%;top:58%">empty page</div>
+        <div class="tblk" style="--c:#F27A9E;left:60%;width:15%;top:58%">apply ops</div>
+        <div class="tblk is-paint" data-flip="ifr-paint" style="left:77%;width:16%;top:58%">paint</div>
+      </div>
+      <div class="ifrlane" style="--c:#5dd5a8;top:56%;height:38%">
+        <span class="ifrlane__label"><i></i>Background thread</span>
+        <div class="tblk" style="--c:#5dd5a8;left:3%;width:20%;top:58%">boot</div>
+        <div class="tblk" style="--c:#5dd5a8;left:25%;width:30%;top:58%">render · one lap</div>
+        <div class="tblk" style="--c:#4FB8F0;left:57%;width:16%;top:58%">ops &rarr;</div>
+      </div>
+    </div>
+    <p class="lead arch-cap" data-mm-fade>
+      Without IFR, the first paint waits a <em>whole lap</em> — BG boot, render,
+      the ops send — all before anything appears.
+    </p>
+    <aside class="notes">
+      <p><strong>The cost of the round-trip.</strong> Everything the last six
+      slides described — VDOM → ShadowElement → ops → PAPI — has to happen once
+      before the very first frame. On device that whole lap plus BG-thread boot
+      and bundle eval is tens of milliseconds of blank screen.</p>
+    </aside>
+  </section>
+
+  <!-- IFR2 — IFR: paint first, hydrate later (magic-move the paint flag) -->
+  <section class="slide stage">
+    <span class="eyebrow">IV · Instant first frame</span>
+    <div class="ifrtl">
+      <div class="ifrlane" style="--c:#56b8f0;top:6%;height:38%">
+        <span class="ifrlane__label"><i></i>Main (UI) thread</span>
+        <div class="tblk" style="--c:#56b8f0;left:3%;width:16%;top:58%">loadTemplate</div>
+        <div class="tblk" style="--c:#56b8f0;left:21%;width:24%;top:58%">render</div>
+        <div class="tblk is-paint" data-flip="ifr-paint" style="left:47%;width:15%;top:58%">paint</div>
+        <div class="tblk is-idle" style="left:64%;width:33%;top:58%">hands the tree over &rarr;</div>
+      </div>
+      <div class="ifrlane" style="--c:#5dd5a8;top:56%;height:38%">
+        <span class="ifrlane__label"><i></i>Background thread</span>
+        <div class="tblk" style="--c:#5dd5a8;left:3%;width:20%;top:58%">boot</div>
+        <div class="tblk" style="--c:#5dd5a8;left:25%;width:30%;top:58%">render</div>
+        <div class="tblk" style="--c:#3deae7;left:57%;width:22%;top:58%">hydrate</div>
+      </div>
+    </div>
+    <p class="lead arch-cap" data-mm-fade>
+      IFR puts the whole runtime in the <b style="color:#56b8f0">main-thread</b>
+      bundle — it renders during <code>loadTemplate</code>, so
+      <b>paint lands first</b> and the background boots alongside.
+    </p>
+    <aside class="notes">
+      <p><strong>首屏直出 — ported from ReactLynx.</strong> With
+      <code>enableIFR</code>, the main-thread bundle carries the full Vue runtime
+      + app (not just worklets). <code>renderPage</code> mounts it synchronously
+      inside <code>loadTemplate</code> — watch the <strong>paint</strong> flag
+      jump left. The background thread still runs the same code, just in
+      parallel and off the critical path.</p>
+    </aside>
+  </section>
+
+  <!-- IFR3 — the trick: record + reconcile -->
+  <section class="slide stage">
+    <span class="eyebrow">IV · Instant first frame</span>
+    <h2 class="h-section" style="text-align:center;max-width:20ch">
+      Both threads render. The ops stream <span class="brand-text">is</span> the recording.
+    </h2>
+    <div class="recon">
+      <div class="recon__row">
+        <span class="recon__pair">
+          <code class="op">SET_TEXT 3 "Hi"</code>
+          <span class="recon__eq">=</span>
+          <code class="op">SET_TEXT 3 "Hi"</code>
+        </span>
+        <span class="recon__out is-skip">identical &rarr; skip</span>
+      </div>
+      <div class="recon__row">
+        <span class="recon__pair">
+          <code class="op">SET_TEXT 3 "Hi"</code>
+          <span class="recon__eq recon__eq--ne">&ne;</span>
+          <code class="op op--hot">SET_TEXT 3 "你好"</code>
+        </span>
+        <span class="recon__out is-patch">value differs &rarr; patch in place</span>
+      </div>
+      <div class="recon__row">
+        <span class="recon__pair">
+          <code class="op">CREATE 4 view</code>
+          <span class="recon__eq recon__eq--ne">&ne;</span>
+          <code class="op op--bad">CREATE 4 text</code>
+        </span>
+        <span class="recon__out is-tear">structural &rarr; tear down &amp; rebuild</span>
+      </div>
+    </div>
+    <p class="lead arch-cap" data-mm-fade>
+      The MT render records its ops; the BG's first batches hydrate against them.
+      Correctness never depends on the two matching — deterministic ids &amp;
+      <code>vue:N</code> signs route taps to Vue with no rebinding.
+    </p>
+    <aside class="notes">
+      <p><strong>Hydration by ops reconciliation.</strong> The flat ops stream
+      doubles as the recorded PAPI calls. The BG's initial
+      <code>vuePatchUpdate</code> batches walk the recording frame-by-frame:
+      identical → skipped (already on screen), value diff → patched, structural
+      divergence → tear the first-screen tree down and re-apply. A mismatch only
+      loses the perf win, never correctness (logs
+      <code>IFR hydration mismatch</code> in dev).</p>
+    </aside>
+  </section>
+
+  <!-- IFR4 — Element Templates: the pivot -->
+  <section class="slide stage">
+    <span class="eyebrow">IV · Instant first frame</span>
+    <h2 class="h-section" style="text-align:center;max-width:24ch">
+      IFR changes <em class="ifr-em">when</em> the frame renders.<br/>
+      <span class="brand-text">Element Templates</span> change how much work it does.
+    </h2>
+    <aside class="notes">
+      <p><strong>The second lever.</strong> IFR moves the paint earlier;
+      enabling it turns on Element Templates by default. They make the render
+      itself an order of magnitude cheaper — and shrink the cross-thread protocol
+      for <em>every</em> update, not just the first frame.</p>
+    </aside>
+  </section>
+
+  <!-- IFR5 — the pipeline, per node (reuses the runtime flow boxes) -->
+  <section class="slide stage">
+    <span class="eyebrow">IV · Instant first frame</span>
+    <div class="flow ifr-pipe">
+      <div class="fb" data-flip="etp-vdom" style="--c:#42b883;left:9%;top:50%">VDOM<small>one vnode / node</small></div>
+      <span class="farr" data-mm-fade style="left:21%;top:50%">&rarr;</span>
+      <div class="fb" data-mm-fade style="--c:#E8B44A;left:32%;top:50%">Shadow<small>one node</small></div>
+      <span class="farr" data-mm-fade style="left:42%;top:50%">&rarr;</span>
+      <div class="fb" data-mm-fade style="--c:#4FB8F0;left:51%;top:50%">ops<small>several frames</small></div>
+      <span class="farr" data-mm-fade style="left:60%;top:50%">&rarr;</span>
+      <div class="fb" data-mm-fade style="--c:#56b8f0;left:69%;top:50%">interp<small>a switch loop</small></div>
+      <span class="farr" data-mm-fade style="left:79%;top:50%">&rarr;</span>
+      <div class="fb" data-flip="etp-papi" style="--c:#F27A9E;left:90%;top:50%">PAPI<small>__CreateView</small></div>
+      <span class="fcenter" data-mm-fade style="left:50%;top:88%">&times; every static node</span>
+    </div>
+    <p class="lead arch-cap" data-mm-fade>
+      Normally every static element pays the whole chain — a vnode, a shadow
+      node, ops frames, a thread crossing, an interpreter dispatch.
+    </p>
+    <aside class="notes">
+      <p>The same pipeline from the Runtime chapter — but notice it runs
+      <em>per node</em>, even for structure that never changes.</p>
+    </aside>
+  </section>
+
+  <!-- IFR6 — Element Templates collapse the pipeline (magic-move) -->
+  <section class="slide stage">
+    <span class="eyebrow">IV · Instant first frame</span>
+    <div class="flow ifr-pipe">
+      <div class="fb" data-flip="etp-vdom" style="--c:#42b883;left:16%;top:50%">one vnode<small>__vlx-tpl:…</small></div>
+      <span class="farr" data-mm-fade style="left:33%;top:50%">&rarr;</span>
+      <div class="fb is-hero" data-mm-fade style="--c:#5dd5a8;left:50%;top:50%">INSTANTIATE_TEMPLATE<small>one op · whole subtree</small></div>
+      <span class="farr" data-mm-fade style="left:67%;top:50%">&rarr;</span>
+      <div class="fb" data-flip="etp-papi" style="--c:#F27A9E;left:84%;top:50%">create()<small>straight-line PAPI</small></div>
+      <span class="fcenter" data-mm-fade style="left:50%;top:88%">holes update via ordinary <b>SET_*</b> ops</span>
+    </div>
+    <p class="lead arch-cap" data-mm-fade>
+      The compiler lowers the static subtree to one <code>create()</code>
+      function. Vue sends <b>one</b> op; only the dynamic holes travel after.
+    </p>
+    <aside class="notes">
+      <p>Watch <code>VDOM</code> and <code>PAPI</code> stay put while the middle
+      of the pipeline collapses. These are <em>framework</em> templates —
+      ordinary typed Element PAPI calls, not Lynx's binary engine templates.</p>
+    </aside>
+  </section>
+
+  <!-- IFR7 — baked skeleton + holes + generated create() -->
+  <section class="slide stage">
+    <span class="eyebrow">IV · Instant first frame</span>
+    <div class="etcode">
+      <div class="codeframe etcode__src">
+        <div class="codeframe__head">
+          <span class="dots"><span></span><span></span><span></span></span>
+          <span>Card.vue · template</span>
+        </div>
+<pre><span class="et-static">&lt;<span class="code-tag">view</span> <span class="code-attr">class</span>=<span class="code-str">"card"</span>&gt;</span>
+  <span class="et-static">&lt;<span class="code-tag">image</span> <span class="code-attr">class</span>=<span class="code-str">"icon"</span> /&gt;</span>
+  <span class="et-static">&lt;<span class="code-tag">text</span> <span class="code-attr">class</span>=<span class="code-str">"title"</span>&gt;</span><span class="et-hole">{{ title }}</span><span class="et-static">&lt;/<span class="code-tag">text</span>&gt;</span>
+  <span class="et-static">&lt;<span class="code-tag">view</span> <span class="et-hole">:class</span>=<span class="et-hole">"badge"</span>&gt;…&lt;/<span class="code-tag">view</span>&gt;</span>
+<span class="et-static">&lt;/<span class="code-tag">view</span>&gt;</span></pre>
+      </div>
+      <div class="etcode__legend" aria-hidden="true">
+        <span><i class="et-sw is-static"></i>baked skeleton</span>
+        <span><i class="et-sw is-hole"></i>dynamic hole</span>
+      </div>
+      <div class="codeframe etcode__out">
+        <div class="codeframe__head">
+          <span class="dots"><span></span><span></span><span></span></span>
+          <span>compiler output</span>
+        </div>
+<pre><span class="code-fn">registerElementTemplate</span>(
+  <span class="code-str">"__vlx-tpl:rflz…"</span>,
+  [<span class="code-str">"#text"</span>, <span class="code-str">"class"</span>], <span class="code-com">// holes</span>
+  <span class="code-key">function</span> (P) {
+    <span class="code-com">…straight-line PAPI…</span>
+    <span class="code-key">return</span> [e0, e3, e5]
+  },
+)</pre>
+      </div>
+    </div>
+    <p class="lead arch-cap" data-mm-fade>
+      Static structure bakes into a <code>create()</code> skeleton; only the
+      holes — dynamic text, class, style, attrs — stay on the vnode path.
+    </p>
+    <aside class="notes">
+      <p>Eligible = every node is a plain Lynx element and only values or text
+      are dynamic. Components, slots, <code>v-if</code>/<code>v-for</code> hosts,
+      <code>&lt;list&gt;</code>, ref/id nodes stay on the normal vnode path;
+      their plain-element bodies can still lower. Scoped-CSS scope ids bake in.</p>
+    </aside>
+  </section>
+
+  <!-- IFR8 — benchmark table (proof) -->
+  <section class="slide stage">
+    <span class="eyebrow">IV · Instant first frame · proof</span>
+    <table class="bench-table">
+      <thead>
+        <tr><th>configuration</th><th>FCP</th><th>render cost</th><th>TTI proxy</th><th>bundle gzip</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="bench-cfg">No IFR</td>
+          <td>96.6 ms</td><td>9.4 ms</td><td>1.00&times;</td><td>1.00&times;</td>
+        </tr>
+        <tr class="bench-row--hero">
+          <td class="bench-cfg">IFR + ET <span class="chip chip--brand">recommended</span></td>
+          <td class="is-good">75.4 ms <small>&minus;22%</small></td>
+          <td class="is-good">1.3 ms</td>
+          <td>~1.36&times;</td>
+          <td class="is-cost">~2.26&times;</td>
+        </tr>
+        <tr>
+          <td class="bench-cfg">IFR without ET</td>
+          <td>75.8 ms <small>&minus;22%</small></td>
+          <td>8.4 ms</td>
+          <td>~1.36&times;</td>
+          <td class="is-cost">~2.26&times;</td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="lead arch-cap" data-mm-fade>
+      FCP across a real Web Worker + IPC (Lynx for Web) — suite median
+      &minus;12% to &minus;19%, ReactLynx control &minus;23%. ET stays flat on
+      FCP; its win is render cost (~1,000 el, jitless) and ops payload.
+    </p>
+    <aside class="notes">
+      <p>Separate campaigns, not one trace. The FCP win (median &minus;12…&minus;19%,
+      ReactLynx control &minus;23%) comes from removing background boot + IPC —
+      it needs a real thread boundary, and both IFR rows share it (ET is flat on
+      web FCP). Element Templates' own win is render cost 9.4&nbsp;ms →
+      <strong>1.3&nbsp;ms</strong> (~6&ndash;15&times; across reruns) and the ops
+      payload — the reason ET is on by default. Cost: ~2.26&times; gzip.</p>
+    </aside>
+  </section>
+
+  <!-- IFR9 — benchmark data-viz (proof) -->
+  <section class="slide stage">
+    <span class="eyebrow">IV · Instant first frame · proof</span>
+    <div class="bench-viz">
+      <div class="bench-chart">
+        <h3 class="bench-chart__title">render cost <span>~1,000 el · jitless · ms</span></h3>
+        <div class="bench-bar">
+          <span class="bench-bar__label">No IFR</span>
+          <span class="bench-bar__track"><span class="bench-bar__fill" style="--w:94%"></span></span>
+          <span class="bench-bar__val">9.4</span>
+        </div>
+        <div class="bench-bar">
+          <span class="bench-bar__label">IFR, no ET</span>
+          <span class="bench-bar__track"><span class="bench-bar__fill" style="--w:84%"></span></span>
+          <span class="bench-bar__val">8.4</span>
+        </div>
+        <div class="bench-bar bench-bar--hero">
+          <span class="bench-bar__label">IFR + ET</span>
+          <span class="bench-bar__track"><span class="bench-bar__fill is-brand" style="--w:13%"></span></span>
+          <span class="bench-bar__val">1.3</span>
+        </div>
+      </div>
+      <div class="bench-chart bench-chart--proto">
+        <h3 class="bench-chart__title">recorded ops payload <span>1,400-el static screen</span></h3>
+        <div class="bench-proto">
+          <div class="bench-proto__col">
+            <span class="bench-proto__bar" style="--h:100%"></span>
+            <span class="bench-proto__cap">77.6 KB</span>
+            <span class="bench-proto__sub">per-node ops</span>
+          </div>
+          <div class="bench-proto__arrow">&rarr;</div>
+          <div class="bench-proto__col">
+            <span class="bench-proto__bar is-brand" style="--h:2%"></span>
+            <span class="bench-proto__cap is-brand">69 B</span>
+            <span class="bench-proto__sub">one template op</span>
+          </div>
+          <div class="mega bench-proto__mult">1000&times;<small>smaller</small></div>
+        </div>
+      </div>
+    </div>
+    <p class="lead arch-cap" data-mm-fade>
+      Element Templates shrink the recorded ops payload 3&ndash;1000&times; — and
+      that protocol shrink helps every update, not just the first frame.
+    </p>
+    <aside class="notes">
+      <p>Left: render cost collapses with ET. Right: the cross-thread protocol
+      for a static-heavy screen drops ~78&nbsp;KB → 69&nbsp;bytes. PAPI call
+      counts only drop 5&ndash;20% — native element work is a shared floor; what
+      lowers away is the framework JS and the protocol around it.</p>
+    </aside>
+  </section>
+
+  <!-- IFR10 — honest trade-offs -->
+  <section class="slide stage">
+    <span class="eyebrow">IV · Instant first frame</span>
+    <div class="ifr-trade">
+      <div class="stack-y gap-sm">
+        <span class="eyebrow ifr-trade__head ifr-trade__head--cost">what it costs</span>
+        <ul class="ifr-trade__list is-cost">
+          <li>MT bundle carries the runtime + app — <b>~2.26&times;</b> gzip</li>
+          <li>App evaluates on <b>both</b> threads — serial TTI +35%</li>
+          <li>Can't accelerate a <b>fetch-first</b> screen</li>
+        </ul>
+      </div>
+      <div class="stack-y gap-sm">
+        <span class="eyebrow ifr-trade__head ifr-trade__head--use">when to reach for it</span>
+        <ul class="ifr-trade__list is-use">
+          <li><b>Content-first</b> screens with sync initial data</li>
+          <li>Render a real <b>skeleton</b> if data is async</li>
+          <li>Keep first-screen render <b>deterministic</b> &amp; thread-agnostic</li>
+        </ul>
+      </div>
+    </div>
+    <p class="lead arch-cap" data-mm-fade>
+      A tool, not a default-on switch — but for content-first screens,
+      <b class="brand-text">IFR + ET</b> is the recommended setup.
+    </p>
+    <aside class="notes">
+      <p>Honest costs: bundle roughly doubles, the app double-evaluates (on
+      device the MT render overlaps BG startup, so serial TTI is an upper
+      bound). The win is real for content-first screens; fetch-driven screens
+      pay size for no FCP benefit.</p>
+    </aside>
+  </section>
+
   <!-- B1 — one bundle, two worlds -->
   <section class="slide stage">
     <span class="eyebrow">IV · Toolchain</span>

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -228,6 +228,58 @@ export const ZH = {
     'Vue core 自己的测试,在我们的渲染器上重放。<b>0 失败。</b>',
   "…and the tests are the AI's eyes.":
     '……而这些测试,就是 <span class="brand-text">AI 的眼睛</span>。',
+
+  // ---- IV · Instant First-Frame Rendering + Element Templates ----
+  'IV · Instant first frame': 'IV · 首屏直出',
+  'IV · Instant first frame · proof': 'IV · 首屏直出 · 佐证',
+  // headlines
+  'Both threads render. The ops stream is the recording.':
+    '两条线程都渲染。那条 ops 流<span class="brand-text">就是</span>录制。',
+  'IFR changes when the frame renders. Element Templates change how much work it does.':
+    'IFR 改变的是<em class="ifr-em">何时</em>渲染这一帧。<br/><span class="brand-text">Element Templates</span> 改变的是这一帧要做多少活。',
+  // leads
+  'Without IFR, the first paint waits a whole lap — BG boot, render, the ops send — all before anything appears.':
+    '没有 IFR,首帧要等<em>整整一圈</em> —— 后台启动、渲染、送 ops —— 全部跑完才有画面。',
+  'IFR puts the whole runtime in the main-thread bundle — it renders during loadTemplate, so paint lands first and the background boots alongside.':
+    'IFR 把整个运行时放进<b style="color:#56b8f0">主线程</b>产物 —— 它在 <code>loadTemplate</code> 期间渲染,于是<b>先出画面</b>,后台在一旁并行启动。',
+  "The MT render records its ops; the BG's first batches hydrate against them. Correctness never depends on the two matching — deterministic ids & vue:N signs route taps to Vue with no rebinding.":
+    '主线程渲染时录下自己的 ops;后台最初的几批拿去和它水合对账。正确性从不依赖两者一致 —— 确定性 id 与 <code>vue:N</code> 签名让点击无需重绑就路由回 Vue。',
+  'Normally every static element pays the whole chain — a vnode, a shadow node, ops frames, a thread crossing, an interpreter dispatch.':
+    '常规下每个静态元素都要付整条链 —— 一个 vnode、一个影子节点、若干 ops 帧、一次跨线程、一次解释器分发。',
+  'The compiler lowers the static subtree to one create() function. Vue sends one op; only the dynamic holes travel after.':
+    '编译器把静态子树下沉成一个 <code>create()</code> 函数。Vue 只发<b>一个</b> op;之后只有动态空洞在传输。',
+  'Static structure bakes into a create() skeleton; only the holes — dynamic text, class, style, attrs — stay on the vnode path.':
+    '静态结构烘焙进 <code>create()</code> 骨架;只有空洞 —— 动态的文本、class、style、属性 —— 留在 vnode 路径上。',
+  'FCP across a real Web Worker + IPC (Lynx for Web) — suite median −12% to −19%, ReactLynx control −23%. ET stays flat on FCP; its win is render cost (~1,000 el, jitless) and ops payload.':
+    'FCP:跨真实 Web Worker + IPC(Lynx for Web)—— 全套中位数 −12% 到 −19%,ReactLynx 对照 −23%。ET 对 FCP 基本持平;它的收益在渲染开销(约 1,000 元素,jitless)和 ops 负载。',
+  'Element Templates shrink the recorded ops payload 3–1000× — and that protocol shrink helps every update, not just the first frame.':
+    'Element Templates 把录制的 ops 负载缩小 3–1000× —— 这份协议瘦身惠及每一次更新,不只是首帧。',
+  'A tool, not a default-on switch — but for content-first screens, IFR + ET is the recommended setup.':
+    '它是一件工具,不是默认打开的开关 —— 但对内容优先的屏幕,<b class="brand-text">IFR + ET</b> 是推荐配置。',
+  // flow-center labels
+  '× every static node': '× 每个静态节点',
+  'holes update via ordinary SET_* ops': '空洞照走普通 <b>SET_*</b> ops 更新',
+  // chart titles
+  'render cost ~1,000 el · jitless · ms': '渲染开销 <span>~1,000 元素 · jitless · ms</span>',
+  'recorded ops payload 1,400-el static screen': '录制的 ops 负载 <span>1,400 元素静态屏</span>',
+  // chip
+  'recommended': '推荐',
+  // trade-off columns
+  'what it costs': '有什么代价',
+  'when to reach for it': '什么时候用它',
+  'MT bundle carries the runtime + app — ~2.26× gzip':
+    '主线程产物带上运行时 + 应用 —— gzip <b>~2.26×</b>',
+  'App evaluates on both threads — serial TTI +35%':
+    '应用在<b>两条</b>线程都求值 —— 串行 TTI +35%',
+  "Can't accelerate a fetch-first screen":
+    '无法加速<b>请求优先</b>的屏幕',
+  'Content-first screens with sync initial data':
+    '带同步初始数据的<b>内容优先</b>屏幕',
+  'Render a real skeleton if data is async':
+    '数据异步时,先渲染一个真实<b>骨架</b>',
+  'Keep first-screen render deterministic & thread-agnostic':
+    '让首屏渲染保持<b>确定性</b>、与线程无关',
+
   'One file ships both threads.': '一个文件,装下<em>两条</em>线程。',
   'The same code enters twice — webpack layers route it.':
     '同一份代码,进两次 —— webpack layers 负责分流。',
@@ -552,6 +604,26 @@ export const ZH_NOTES = [
   `<p><strong>"语义保全"是可测量的命题。</strong>我们把 <code>vuejs/core</code> 的测试套件搬进仓库,在两层上对着 Vue Lynx 跑:一层用我们真实的 ShadowElement 链表垫在 <code>@vue/runtime-test</code> 下面(验证完整渲染器合同 —— keyed diff、LIS、fragment、生命周期);另一层 runtime-dom 把 <code>patchProp → ops → applyOps → PAPI</code> 推进 jsdom。1013 个通过 882,131 个 skip 全部有记录,零失败。</p>`,
   // 43 A8 · 测试是 AI 的眼睛
   `<p><strong>测试的 AI-harness 一面。</strong>我们还做了 <code>vue-lynx-testing-library</code> —— <code>render</code>、<code>fireEvent</code>、<code>getByText</code>,双线程被 <code>@lynx-js/testing-environment</code> 抽象掉 —— 组件行为在普通 vitest 里就能断言。对人来说这是卫生习惯;对 AI harness 来说这是<em>感知</em>:红绿就是 agent 知道自己刚才做了什么的方式。上游套件,就是让两周生成代码保持诚实的 reward signal。</p>`,
+  // IFR1 · 空白首帧
+  `<p><strong>往返的代价。</strong>前六页讲的 VDOM → ShadowElement → ops → PAPI,在第一帧之前必须先整整跑一圈。设备上,这一圈再加后台线程启动与 bundle 求值,就是几十毫秒的白屏。</p>`,
+  // IFR2 · IFR:先出画面
+  `<p><strong>首屏直出 —— 从 ReactLynx 移植。</strong>开了 <code>enableIFR</code>,主线程产物就带上完整 Vue 运行时 + 应用(不只是 worklet)。<code>renderPage</code> 在 <code>loadTemplate</code> 里同步挂载 —— 看 <strong>paint</strong> 旗标跳到左边。后台线程照样跑同一份代码,只是并行、离开关键路径。</p>`,
+  // IFR3 · 录制 + 对账
+  `<p><strong>用 ops 对账做水合。</strong>那条扁平 ops 流本身就是"录下来的 PAPI 调用"。后台最初的 <code>vuePatchUpdate</code> 批次逐帧走这份录制:相同 → 跳过(已在屏上),值不同 → 打补丁,结构分歧 → 拆掉首屏树重建。不一致只损失性能收益,绝不损失正确性(开发期打印 <code>IFR hydration mismatch</code>)。</p>`,
+  // IFR4 · Element Templates 转折
+  `<p><strong>第二个杠杆。</strong>IFR 把绘制提前;打开它会默认打开 Element Templates。它们让渲染本身便宜一个数量级 —— 而且瘦身的是<em>每一次</em>更新的跨线程协议,不只首帧。</p>`,
+  // IFR5 · 逐节点的管线
+  `<p>还是 Runtime 那章的同一条管线 —— 但注意它是<em>逐节点</em>跑的,哪怕这些结构永远不变。</p>`,
+  // IFR6 · ET 折叠管线
+  `<p>看 <code>VDOM</code> 和 <code>PAPI</code> 留在原地,而管线中段整个塌陷。这是<em>框架级</em>模板 —— 普通的带类型 Element PAPI 调用,不是 Lynx 的二进制引擎模板。</p>`,
+  // IFR7 · 骨架 + 空洞
+  `<p>可下沉 = 每个节点都是纯 Lynx 元素、只有值或文本动态。组件、插槽、<code>v-if</code>/<code>v-for</code> 宿主、<code>&lt;list&gt;</code>、带 ref/id 的节点留在普通 vnode 路径;它们的纯元素子体仍可下沉。scoped-CSS 的 scope id 会被烘焙进去。</p>`,
+  // IFR8 · 基准测试表
+  `<p>几组独立的实验,不是一条 trace。FCP 收益(中位数 −12…−19%,ReactLynx 对照 −23%)来自去掉后台启动 + IPC —— 需要真实的线程边界,两种 IFR 配置都能拿到(ET 对 web FCP 基本持平)。Element Templates 自己的收益在渲染开销 9.4ms → <strong>1.3ms</strong>(多次重跑约 6–15×)和 ops 负载 —— 这也是 ET 默认打开的原因。代价:约 2.26× gzip。</p>`,
+  // IFR9 · 基准测试图
+  `<p>左:渲染开销随 ET 塌陷。右:静态偏重屏幕的跨线程协议从约 78KB 降到 69 字节。PAPI 调用次数只降 5–20% —— 原生元素工作是共享地板;被下沉掉的是框架 JS 和它周围的协议。</p>`,
+  // IFR10 · 诚实的取舍
+  `<p>诚实说代价:包体大约翻倍、应用双线程各求值一遍(设备上主线程渲染与后台启动重叠,所以串行 TTI 是上界)。内容优先的屏幕收益是真的;请求优先的屏幕只付包体、拿不到 FCP 收益。</p>`,
   // 44 B1 · 一个 bundle 两个世界
   `<p><strong>Lynx 的交付物是一个装着两个程序的 bundle</strong> —— 后台代码跑在 JS VM,主线程代码跑在 Lepus(PrimJS)。两个 VM、两个入口、一个产物;同一个文件既能原生渲染,也能经 Lynx for Web 跑在浏览器里。于是工具链的问题变成:一次构建,怎么从一份 Vue 代码吐出两个世界?</p>`,
   // 45 B2 · 同一份代码进两次

--- a/slides/src/main.js
+++ b/slides/src/main.js
@@ -610,7 +610,7 @@ const I18N_SELECTOR = [
   '.chip', '.pstack__item', '.cover__tagline', '.cover__title-line',
   '.combine__name', '.result-label', '.tl-item__week', '.node__label',
   '.arrow', '.cta__link', '.agent', '.mega', '.label',
-  '.flane__label', '.fcenter', '.lgtag',
+  '.flane__label', '.ifrlane__label', '.fcenter', '.lgtag',
   '.demo__caption', '.videopair figcaption',
   '.tile', '.wlab', '.wattr', '.wg b',
 ].map((s) => `.slide ${s}`).join(', ') + ', .gate-legend span';

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -3199,3 +3199,313 @@ vl-media.snap.is-missing .vl-ph {
   color: rgba(15, 18, 22, 0.5);
 }
 vl-media.snap.is-missing .vl-ph__kind { color: rgba(15, 18, 22, 0.65); }
+
+/* =========================================================
+   IV · Instant First-Frame Rendering + Element Templates.
+   Reuses the runtime chapter's .flow / .fb / .farr / .fcenter
+   system; adds timelines, hydration reconcile, template code,
+   and benchmark charts in the same design language.
+   ========================================================= */
+
+/* ---- thread timeline (blank frame vs IFR) ---- */
+.ifrtl {
+  position: relative;
+  width: min(100%, 1040px);
+  height: clamp(260px, 42cqh, 340px);
+}
+.ifrlane {
+  position: absolute;
+  left: 0;
+  right: 0;
+  border-radius: 14px;
+  border: 1px solid color-mix(in srgb, var(--c, #5dd5a8) 26%, transparent);
+  background: color-mix(in srgb, var(--c, #5dd5a8) 6%, transparent);
+}
+.ifrlane__label {
+  position: absolute;
+  top: 9px;
+  left: 14px;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--c, #5dd5a8) 72%, var(--ink));
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  z-index: 3;
+}
+.ifrlane__label i {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--c, #5dd5a8);
+  box-shadow: 0 0 9px var(--c, #5dd5a8);
+}
+.tblk {
+  position: absolute;
+  transform: translateY(-50%);
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9px;
+  border: 1.4px solid var(--c, #5dd5a8);
+  background: color-mix(in srgb, var(--c, #5dd5a8) 13%, var(--paper));
+  font-family: var(--mono);
+  font-size: 12px;
+  color: color-mix(in srgb, var(--c, #5dd5a8) 85%, var(--ink));
+  white-space: nowrap;
+  overflow: hidden;
+}
+.tblk.is-wait {
+  border-style: dashed;
+  border-color: color-mix(in srgb, #F27A9E 55%, transparent);
+  background: color-mix(in srgb, #F27A9E 7%, transparent);
+  color: #f4a6ba;
+}
+.tblk.is-paint {
+  border: none;
+  color: var(--paper);
+  font-weight: 700;
+  background: var(--brand-gradient);
+  background-size: 200% 100%;
+  animation: gradientMove 6s linear infinite;
+  box-shadow: 0 0 24px -4px var(--brand-emerald);
+  z-index: 2;
+}
+.tblk.is-idle {
+  border: 1px dashed var(--line);
+  background: transparent;
+  color: var(--ink-faint);
+}
+
+/* ---- hydration reconcile (3-way) ---- */
+.recon {
+  width: 100%;
+  max-width: 860px;
+  display: flex;
+  flex-direction: column;
+  gap: 11px;
+}
+.recon__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 12px 20px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--paper-elev);
+}
+.recon__pair { display: flex; align-items: center; gap: 13px; }
+.recon__pair .op {
+  font-family: var(--mono);
+  font-size: 13.5px;
+  color: var(--ink-soft);
+  padding: 4px 10px;
+  border-radius: 7px;
+  background: rgba(255, 255, 255, 0.04);
+}
+.recon__pair .op--hot,
+.recon__pair .op--bad { color: #f4a6ba; }
+.recon__eq { font-family: var(--mono); color: var(--vue-green); font-size: 15px; }
+.recon__eq--ne { color: var(--ink-mute); }
+.recon__out {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+.recon__out.is-skip { color: var(--vue-green); background: color-mix(in srgb, var(--vue-green) 14%, transparent); }
+.recon__out.is-patch { color: #E8B44A; background: color-mix(in srgb, #E8B44A 14%, transparent); }
+.recon__out.is-tear { color: #f4a6ba; background: color-mix(in srgb, #F27A9E 14%, transparent); }
+
+/* ---- when vs how-much emphasis ---- */
+.ifr-em { font-family: var(--serif); font-style: italic; font-weight: 400; color: var(--ink); }
+
+/* ---- ET pipeline (single-row reuse of .flow / .fb) ---- */
+.flow.ifr-pipe { height: clamp(220px, 34cqh, 300px); }
+.ifr-pipe .fb { font-size: 14px; }
+.ifr-pipe .fb small { font-size: 9.5px; }
+
+/* ---- element template: skeleton + holes + create() ---- */
+.etcode {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: clamp(14px, 2cqw, 26px);
+  width: 100%;
+  max-width: 1060px;
+}
+.etcode .codeframe { text-align: left; font-size: 13px; }
+.etcode pre { padding: 15px 18px; line-height: 1.7; }
+.et-static { color: var(--ink-mute); opacity: 0.72; }
+.et-hole {
+  color: var(--paper);
+  background: var(--brand-gradient);
+  background-size: 200% 100%;
+  animation: gradientMove 6s linear infinite;
+  border-radius: 4px;
+  padding: 1px 5px;
+  font-weight: 600;
+}
+.etcode__legend {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.etcode__legend span { display: flex; align-items: center; gap: 8px; white-space: nowrap; }
+.et-sw { width: 14px; height: 14px; border-radius: 4px; flex: none; }
+.et-sw.is-static { background: var(--line); border: 1px solid var(--ink-faint); }
+.et-sw.is-hole { background: var(--brand-emerald); box-shadow: 0 0 10px -2px var(--brand-emerald); }
+
+/* ---- benchmark table ---- */
+.bench-table {
+  border-collapse: collapse;
+  width: 100%;
+  max-width: 920px;
+  font-family: var(--mono);
+  font-size: 15px;
+}
+.bench-table th, .bench-table td {
+  padding: 13px 18px;
+  text-align: right;
+  border-bottom: 1px solid var(--line-soft);
+  color: var(--ink-soft);
+  white-space: nowrap;
+}
+.bench-table th {
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  border-bottom-color: var(--line);
+}
+.bench-table th:first-child, .bench-table td.bench-cfg { text-align: left; }
+.bench-table td.bench-cfg { color: var(--ink); font-family: var(--display); font-weight: 500; }
+.bench-table td small { color: var(--vue-green); margin-left: 6px; font-size: 0.8em; }
+.bench-table .is-good { color: var(--vue-green); font-weight: 600; }
+.bench-table .is-cost { color: #f4a6ba; }
+.bench-row--hero { background: color-mix(in srgb, var(--vue-green) 7%, transparent); }
+.bench-row--hero td { border-bottom-color: color-mix(in srgb, var(--vue-green) 25%, transparent); }
+.bench-table .chip--brand { margin-left: 10px; vertical-align: middle; }
+
+/* ---- benchmark data viz ---- */
+.bench-viz {
+  display: grid;
+  grid-template-columns: 1.15fr 1fr;
+  gap: clamp(24px, 4cqw, 56px);
+  width: 100%;
+  max-width: 1040px;
+  align-items: start;
+}
+.bench-chart__title {
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: 17px;
+  color: var(--ink);
+  text-align: left;
+  margin-bottom: 16px;
+  letter-spacing: -0.01em;
+}
+.bench-chart__title span {
+  font-family: var(--mono);
+  font-weight: 400;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  margin-left: 8px;
+}
+.bench-bar {
+  display: grid;
+  grid-template-columns: 84px 1fr 42px;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 11px;
+}
+.bench-bar__label { font-family: var(--mono); font-size: 12px; color: var(--ink-mute); text-align: right; }
+.bench-bar__track { height: 22px; border-radius: 6px; background: var(--line-soft); overflow: hidden; }
+.bench-bar__fill {
+  display: block; height: 100%; width: 0; border-radius: 6px;
+  background: rgba(244, 245, 247, 0.28);
+  transition: width 0.9s cubic-bezier(0.2, 0.7, 0.2, 1) 0.15s;
+}
+.bench-bar__fill.is-brand {
+  background: var(--brand-gradient);
+  background-size: 200% 100%;
+  animation: gradientMove 6s linear infinite;
+  box-shadow: 0 0 20px -6px var(--brand-emerald);
+}
+.slide.is-active .bench-bar__fill { width: var(--w); }
+.bench-bar__val { font-family: var(--mono); font-size: 14px; color: var(--ink-soft); text-align: left; }
+.bench-bar--hero .bench-bar__label,
+.bench-bar--hero .bench-bar__val { color: var(--vue-green); font-weight: 600; }
+
+.bench-proto { display: flex; align-items: flex-end; justify-content: center; gap: 16px; height: 172px; }
+.bench-proto__col { display: flex; flex-direction: column; align-items: center; justify-content: flex-end; gap: 8px; height: 100%; }
+.bench-proto__bar {
+  width: 60px; height: 0; border-radius: 8px 8px 0 0;
+  background: rgba(244, 245, 247, 0.22); margin-top: auto;
+  transition: height 0.9s cubic-bezier(0.2, 0.7, 0.2, 1) 0.2s;
+}
+.slide.is-active .bench-proto__bar { height: var(--h); }
+.bench-proto__bar.is-brand {
+  background: var(--brand-gradient);
+  background-size: 200% 100%;
+  animation: gradientMove 6s linear infinite;
+  box-shadow: 0 0 20px -6px var(--brand-emerald);
+  min-height: 4px;
+}
+.bench-proto__cap { font-family: var(--mono); font-size: 15px; color: var(--ink-soft); }
+.bench-proto__cap.is-brand { color: var(--vue-green); font-weight: 600; }
+.bench-proto__sub { font-family: var(--mono); font-size: 10px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--ink-faint); }
+.bench-proto__arrow { align-self: center; color: var(--ink-faint); font-family: var(--mono); padding-bottom: 38px; }
+.mega.bench-proto__mult {
+  align-self: center;
+  font-family: var(--display);
+  font-weight: 700;
+  font-size: 34px;
+  line-height: 1;
+  color: var(--vue-green);
+  letter-spacing: -0.02em;
+  padding-bottom: 28px;
+  display: flex;
+  flex-direction: column;
+}
+.bench-proto__mult small {
+  font-family: var(--mono); font-weight: 400; font-size: 10px;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--ink-mute); margin-top: 4px;
+}
+
+/* ---- honest trade-offs ---- */
+.ifr-trade {
+  display: flex;
+  gap: clamp(32px, 6vw, 88px);
+  flex-wrap: wrap;
+  justify-content: center;
+  text-align: left;
+}
+.ifr-trade__head { margin-bottom: 8px; }
+.ifr-trade__head::before { display: none; }
+.ifr-trade__head--cost { color: #f4a6ba; }
+.ifr-trade__head--use { color: var(--vue-green); }
+.ifr-trade__list {
+  list-style: none; padding: 0; margin: 0;
+  display: flex; flex-direction: column; gap: 12px;
+  font-size: clamp(15px, 1.4cqw, 19px);
+  color: var(--ink-soft); max-width: 34ch;
+}
+.ifr-trade__list li { position: relative; padding-left: 20px; line-height: 1.45; }
+.ifr-trade__list li::before {
+  content: ''; position: absolute; left: 0; top: 0.55em;
+  width: 7px; height: 7px; border-radius: 2px;
+}
+.ifr-trade__list.is-cost li::before { background: #f4a6ba; }
+.ifr-trade__list.is-use li::before { background: var(--vue-green); }
+.ifr-trade__list b { color: var(--ink); font-weight: 600; }


### PR DESCRIPTION
## Summary

Adds a 10-slide **Instant First-Frame Rendering (首屏直出) + Element Templates** chapter to the talk deck, landing in Chapter IV as an `IV · Instant first frame` subsection — right after *Runtime · proof*, before *Toolchain*. Based on `vueconf-2026`.

The chapter reuses the Runtime chapter's own `.flow` / `.flane` / `.fb` design system so the visuals read as one language — in particular, Element Templates literally **collapses the same VDOM → ShadowElement → ops → interpreter → PAPI pipeline** the audience just learned, down to a single `INSTANTIATE_TEMPLATE` op.

## Slides

- Blank-frame vs IFR thread **timelines** (magic-move: the paint flag jumps to the front)
- Ops-stream **recording** + 3-way hydration **reconcile** (skip / patch / teardown)
- Element Templates **pipeline collapse** (per-node chain → one `INSTANTIATE_TEMPLATE` op)
- Baked **skeleton + holes** with the generated `registerElementTemplate()`
- **Benchmark** table + animated bars and the 77.6 KB → 69 B protocol collapse
- Honest **trade-offs** + when-to-use

## Notes

- Benchmark numbers align with the merged `main` docs (`ifr-benchmarks.mdx`): real-thread FCP median **−12% to −19%** (ReactLynx control −23%); **ET is flat on web FCP** — its win is render cost (~6–15×) and ops payload; cost ~2.26× gzip, TTI ≤1.36×.
- Bilingual (中文 default + English) with speaker notes; `.ifrlane__label` added to the i18n selector.
- Additive: new diagram CSS in the head's palette; no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZ1MEyrnNXQT1nzypZ9rkq