### PR TITLE
feat(elk-viewpager): native collapsing profile — sticky tabs + paged panes

### DIFF
--- a/examples/elk-viewpager/scripts/native-compat.test.mjs
+++ b/examples/elk-viewpager/scripts/native-compat.test.mjs
@@ -469,17 +469,22 @@ test('status actions and bottom navigation acknowledge native touch input', asyn
 });
 
 test('tabs animate persistent indicators and Explore explains trending content', async () => {
-  const [explore, account, tabPager] = await Promise.all([
+  const [explore, account, tabPager, stickyTabView] = await Promise.all([
     readFile(new URL('../src/pages/ExplorePage.vue', import.meta.url), 'utf8'),
     readFile(new URL('../src/pages/AccountPage.vue', import.meta.url), 'utf8'),
     readFile(new URL('../src/components/TabPager.vue', import.meta.url), 'utf8'),
+    readFile(new URL('../src/components/StickyTabView.vue', import.meta.url), 'utf8'),
   ]);
 
   assert.match(explore, /explore-intro/);
   assert.doesNotMatch(tabPager, /v-if="modelValue === t\.key" class="tab-pager-underline"/);
   assert.match(tabPager, /tab-pager-underline-active/);
-  assert.doesNotMatch(account, /v-if="tab === t\.key" class="account-tab-underline"/);
-  assert.match(account, /account-tab-underline-active/);
+  // The profile tabs live in the sticky collapsing-header scaffold now; its
+  // underline is a persistent element toggled by class (animated), not
+  // mounted/unmounted per tab with v-if.
+  assert.match(account, /<StickyTabView/);
+  assert.doesNotMatch(stickyTabView, /v-if="modelValue === t\.key" class="stv-tab-underline"/);
+  assert.match(stickyTabView, /stv-tab-underline-active/);
 });
 
 test('app-bar tabs page horizontally through the native viewpager', async () => {
@@ -491,12 +496,38 @@ test('app-bar tabs page horizontally through the native viewpager', async () => 
 
   // Swiping between panes is native: the pager element owns the gesture,
   // and the tab bar syncs both ways (change event + selectTab method).
-  assert.match(tabPager, /<x-viewpager-ng/);
-  assert.match(tabPager, /<x-viewpager-item-ng/);
+  assert.match(tabPager, /'x-viewpager-ng'/);
+  assert.match(tabPager, /'x-viewpager-item-ng'/);
   assert.match(tabPager, /@change="onPagerChange"/);
   assert.match(tabPager, /method: 'selectTab'/);
   assert.match(explore, /<TabPager/);
   assert.match(notifications, /<TabPager/);
+});
+
+test('profile pins its tabs with a native collapsing header (scroll-coordinator)', async () => {
+  const [sticky, account] = await Promise.all([
+    readFile(new URL('../src/components/StickyTabView.vue', import.meta.url), 'utf8'),
+    readFile(new URL('../src/pages/AccountPage.vue', import.meta.url), 'utf8'),
+  ]);
+
+  // Per-platform coordinator element: legacy foldview names on Lynx for Web,
+  // the extracted scroll-coordinator on native OSS engines.
+  assert.match(sticky, /'x-foldview-ng'/);
+  assert.match(sticky, /'scroll-coordinator'/);
+  // header (collapses) + toolbar (sticky tab bar) + slot (the viewpager panes).
+  assert.match(sticky, /'x-foldview-header-ng'/);
+  assert.match(sticky, /'scroll-coordinator-header'/);
+  assert.match(sticky, /'x-foldview-toolbar-ng'/);
+  assert.match(sticky, /'scroll-coordinator-toolbar'/);
+  assert.match(sticky, /'x-foldview-slot-ng'/);
+  assert.match(sticky, /'scroll-coordinator-slot'/);
+  // The pinned tab bar still drives the viewpager, synced both ways.
+  assert.match(sticky, /'x-viewpager-ng'/);
+  assert.match(sticky, /method: 'selectTab'/);
+  // The profile supplies a collapsing #header and one pane per tab.
+  assert.match(account, /<StickyTabView/);
+  assert.match(account, /<template #header>/);
+  assert.match(account, /<template #posts>/);
 });
 
 test('media preview motion mirrors Elk using only opacity and transform', async () => {

--- a/examples/elk-viewpager/src/components/StickyTabView.vue
+++ b/examples/elk-viewpager/src/components/StickyTabView.vue
@@ -1,0 +1,182 @@
+<script setup lang="ts">
+// A collapsing-header + sticky-tab-bar + horizontally-paged scaffold — the
+// "native profile" pattern (Twitter/X, Mastodon apps): the #header slot
+// scrolls away, the tab bar pins to the top, and the panes below it keep
+// swiping horizontally, each with its own vertical scroll.
+//
+// It wraps Lynx's scroll-coordinator (a.k.a. foldview) — an outer vertical
+// scroller whose header collapses until the toolbar sticks, after which the
+// active pane's inner list takes over the scroll — around the same
+// two-way-synced viewpager used by TabPager.vue.
+import type { ShadowElement } from 'vue-lynx';
+import { computed, ref, useTemplateRef, watch } from 'vue-lynx';
+
+declare const SystemInfo: { platform?: string } | undefined;
+
+// Like the viewpager, the coordinator element is registered under different
+// names per platform: Lynx for Web ships the legacy XElement foldview names
+// (x-foldview-*-ng), while native OSS engines register the extracted
+// scroll-coordinator element (lynx-family/lynx). Both expose the same
+// header / toolbar / slot structure.
+const isWeb = typeof SystemInfo !== 'undefined' && SystemInfo?.platform === 'web';
+const foldTag = isWeb ? 'x-foldview-ng' : 'scroll-coordinator';
+const foldHeaderTag = isWeb ? 'x-foldview-header-ng' : 'scroll-coordinator-header';
+const foldToolbarTag = isWeb ? 'x-foldview-toolbar-ng' : 'scroll-coordinator-toolbar';
+const foldSlotTag = isWeb ? 'x-foldview-slot-ng' : 'scroll-coordinator-slot';
+const pagerTag = isWeb ? 'x-viewpager-ng' : 'viewpager';
+const pagerItemTag = isWeb ? 'x-viewpager-item-ng' : 'viewpager-item';
+
+const props = defineProps<{
+  tabs: readonly { key: string; label: string }[];
+  modelValue: string;
+}>();
+
+const emit = defineEmits<{
+  'update:modelValue': [key: string];
+}>();
+
+const pagerRef = useTemplateRef<ShadowElement>('pagerRef');
+
+const activeIndex = computed(() => {
+  const index = props.tabs.findIndex(t => t.key === props.modelValue);
+  return index === -1 ? 0 : index;
+});
+
+// Last page index the pager itself reported (via change). Used to skip the
+// selectTab() round-trip when the pager is already on the page.
+const pagerIndex = ref(activeIndex.value);
+
+function onPagerChange(e: { detail?: { index?: number }; params?: { index?: number } }) {
+  const index = e?.detail?.index ?? e?.params?.index;
+  if (typeof index !== 'number')
+    return;
+  pagerIndex.value = index;
+  const key = props.tabs[index]?.key;
+  if (key && key !== props.modelValue)
+    emit('update:modelValue', key);
+}
+
+watch(activeIndex, (index) => {
+  if (index === pagerIndex.value)
+    return;
+  pagerRef.value
+    ?.invoke({ method: 'selectTab', params: { index, smooth: true } })
+    .exec();
+});
+</script>
+
+<template>
+  <component :is="foldTag" class="stv">
+    <component :is="foldHeaderTag" class="stv-header">
+      <slot name="header" />
+    </component>
+
+    <component :is="foldToolbarTag" class="stv-toolbar">
+      <view class="stv-bar">
+        <view
+          v-for="t in tabs"
+          :key="t.key"
+          class="stv-tab"
+          @tap="$emit('update:modelValue', t.key)"
+        >
+          <text class="stv-tab-text" :class="modelValue === t.key ? 'stv-tab-text-active' : ''">{{ t.label }}</text>
+          <view class="stv-tab-underline" :class="modelValue === t.key ? 'stv-tab-underline-active' : ''" />
+        </view>
+      </view>
+    </component>
+
+    <component :is="foldSlotTag" class="stv-slot">
+      <component
+        :is="pagerTag"
+        ref="pagerRef"
+        class="stv-pages"
+        :initial-select-index="activeIndex"
+        @change="onPagerChange"
+      >
+        <component
+          :is="pagerItemTag"
+          v-for="t in tabs"
+          :key="t.key"
+          class="stv-page"
+        >
+          <slot :name="t.key" />
+        </component>
+      </component>
+    </component>
+  </component>
+</template>
+
+<style>
+.stv {
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+}
+
+.stv-toolbar {
+  /* Opaque so collapsed header content never shows through the pinned bar. */
+  background-color: var(--c-bg-base);
+}
+
+.stv-bar {
+  display: flex;
+  flex-direction: row;
+  border-bottom: 1px solid var(--c-border);
+}
+
+.stv-tab {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex: 1;
+  padding-top: 10px;
+}
+
+.stv-tab-text {
+  font-size: 14px;
+  color: var(--c-text-secondary);
+  padding-bottom: 8px;
+  transition: color var(--motion-state) var(--ease-out-quart), opacity var(--motion-state) var(--ease-out-quart);
+}
+
+.stv-tab-text-active {
+  color: var(--c-text-base);
+  font-weight: 600;
+}
+
+.stv-tab-underline {
+  height: 3px;
+  width: 60%;
+  border-radius: 2px;
+  background-color: var(--c-primary);
+  opacity: 0;
+  transform: scaleX(0.35);
+  transition: transform var(--motion-state) var(--ease-out-quart), opacity var(--motion-state) var(--ease-out-quart);
+}
+
+.stv-tab-underline-active {
+  opacity: 1;
+  transform: scaleX(1);
+}
+
+.stv-slot {
+  /* The coordinator element is a standard-flexbox container (not a Lynx
+     linear one), so a Lynx `flex: 1` weight doesn't reach this raw child —
+     give the slot a definite height so the viewpager/panes below it fill. */
+  height: 100%;
+  width: 100%;
+}
+
+.stv-pages {
+  flex: 1;
+  width: 100%;
+  height: 100%;
+}
+
+.stv-page {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+}
+</style>

--- a/examples/elk-viewpager/src/pages/AccountPage.vue
+++ b/examples/elk-viewpager/src/pages/AccountPage.vue
@@ -2,8 +2,13 @@
 // Ported from elk: app/pages/[[server]]/@[account]/index.vue +
 // app/components/account/AccountHeader.vue — banner, avatar, names, bio,
 // fields, stats, posts/replies/media tabs.
+//
+// This variant gives the profile a native feel: the header collapses and
+// the tab bar sticks to the top on scroll (StickyTabView / scroll-coordinator),
+// while the Posts / Replies / Media panes below page horizontally and each
+// keep their own feed and scroll position.
 import type { mastodon } from 'masto';
-import { computed, onMounted, ref, watch } from 'vue-lynx';
+import { computed, onMounted, reactive, ref, watch } from 'vue-lynx';
 import { useRoute, useRouter } from 'vue-router';
 import AccountAvatar from '../components/AccountAvatar.vue';
 import AccountDisplayName from '../components/AccountDisplayName.vue';
@@ -11,20 +16,21 @@ import ContentRich from '../components/ContentRich';
 import PageHeader from '../components/PageHeader.vue';
 import Spinner from '../components/Spinner.vue';
 import StatusCard from '../components/StatusCard.vue';
+import StickyTabView from '../components/StickyTabView.vue';
 import { fetchAccountByHandle } from '../composables/cache';
 import { formatCompactNumber } from '../composables/format';
 import { useMastoClient } from '../composables/masto';
 import { createProfileLoadGuard } from '../composables/profile-load';
 
+type TabKey = 'posts' | 'replies' | 'media';
+
 const route = useRoute();
 const router = useRouter();
 
 const account = ref<mastodon.v1.Account | null>(null);
-const statuses = ref<mastodon.v1.Status[]>([]);
 const loading = ref(true);
 const error = ref(false);
-const tab = ref<'posts' | 'replies' | 'media'>('posts');
-const statusesLoading = ref(false);
+const tab = ref<TabKey>('posts');
 const loadGuard = createProfileLoadGuard();
 
 const tabs = [
@@ -33,24 +39,46 @@ const tabs = [
   { key: 'media', label: 'Media' },
 ] as const;
 
-async function loadStatuses() {
+// One feed per tab so all three panes keep their own data and scroll
+// position while the pager swipes between them; panes load lazily the first
+// time they become active.
+const feeds = reactive<Record<TabKey, {
+  items: mastodon.v1.Status[];
+  loading: boolean;
+  loaded: boolean;
+}>>({
+  posts: { items: [], loading: false, loaded: false },
+  replies: { items: [], loading: false, loaded: false },
+  media: { items: [], loading: false, loaded: false },
+});
+
+function resetFeeds() {
+  for (const kind of ['posts', 'replies', 'media'] as const) {
+    feeds[kind].items = [];
+    feeds[kind].loading = false;
+    feeds[kind].loaded = false;
+  }
+}
+
+async function loadFeed(kind: TabKey) {
   if (!account.value)
     return;
-  statusesLoading.value = true;
-  statuses.value = [];
+  const feed = feeds[kind];
+  feed.loading = true;
   try {
     const paginator = useMastoClient().v1.accounts.$select(account.value.id).statuses.list({
       limit: 30,
-      excludeReplies: tab.value === 'posts',
-      onlyMedia: tab.value === 'media',
+      excludeReplies: kind === 'posts',
+      onlyMedia: kind === 'media',
     });
     const result = await paginator.values().next();
-    statuses.value = result.value ?? [];
+    feed.items = result.value ?? [];
+    feed.loaded = true;
   }
   catch (e) {
     console.error(e);
   }
-  statusesLoading.value = false;
+  feed.loading = false;
 }
 
 async function load() {
@@ -66,7 +94,8 @@ async function load() {
     if (!loadGuard.isCurrent(request))
       return;
     account.value = loadedAccount;
-    await loadStatuses();
+    resetFeeds();
+    await loadFeed(tab.value);
   }
   catch (e) {
     console.error(e);
@@ -79,7 +108,12 @@ async function load() {
 
 onMounted(load);
 watch(() => route.params.account, load);
-watch(tab, loadStatuses);
+
+// Lazy-load a pane's feed the first time it becomes active.
+watch(tab, (kind) => {
+  if (!feeds[kind].loaded && !feeds[kind].loading)
+    loadFeed(kind);
+});
 
 const joinDate = computed(() => {
   if (!account.value)
@@ -101,84 +135,114 @@ const joinDate = computed(() => {
         <text class="account-retry-text">Try again</text>
       </view>
     </view>
-    <scroll-view v-else scroll-orientation="vertical" class="account-scroll">
-      <!-- banner -->
-      <image :src="account.header" class="account-banner" mode="aspectFill" />
+    <StickyTabView v-else v-model="tab" :tabs="tabs" class="account-stv">
+      <template #header>
+        <!-- banner -->
+        <image :src="account.header" class="account-banner" mode="aspectFill" />
 
-      <view class="account-head">
-        <view class="account-avatar-row">
-          <view class="account-avatar-ring">
-            <AccountAvatar :account="account" :size="72" />
+        <view class="account-head">
+          <view class="account-avatar-row">
+            <view class="account-avatar-ring">
+              <AccountAvatar :account="account" :size="72" />
+            </view>
           </view>
-        </view>
 
-        <AccountDisplayName :account="account" :font-size="20" />
-        <text class="account-handle">@{{ account.acct }}</text>
+          <AccountDisplayName :account="account" :font-size="20" />
+          <text class="account-handle">@{{ account.acct }}</text>
 
-        <view v-if="account.note" class="account-note">
-          <ContentRich :content="account.note" :emojis="account.emojis" />
-        </view>
+          <view v-if="account.note" class="account-note">
+            <ContentRich :content="account.note" :emojis="account.emojis" />
+          </view>
 
-        <!-- fields (Elk AccountHeader fields table) -->
-        <view v-if="account.fields?.length" class="account-fields">
-          <view
-            v-for="field in account.fields"
-            :key="field.name"
-            class="account-field"
-            :class="field.verifiedAt ? 'account-field-verified' : ''"
-          >
-            <text class="account-field-name">{{ field.name }}</text>
-            <view class="account-field-value">
-              <ContentRich :content="field.value" :emojis="account.emojis" markdown />
+          <!-- fields (Elk AccountHeader fields table) -->
+          <view v-if="account.fields?.length" class="account-fields">
+            <view
+              v-for="field in account.fields"
+              :key="field.name"
+              class="account-field"
+              :class="field.verifiedAt ? 'account-field-verified' : ''"
+            >
+              <text class="account-field-name">{{ field.name }}</text>
+              <view class="account-field-value">
+                <ContentRich :content="field.value" :emojis="account.emojis" markdown />
+              </view>
+            </view>
+          </view>
+
+          <text class="account-joined">{{ joinDate }}</text>
+
+          <!-- stats row -->
+          <view class="account-stats">
+            <view class="account-stat">
+              <text class="account-stat-num">{{ formatCompactNumber(account.statusesCount) }}</text>
+              <text class="account-stat-label">Posts</text>
+            </view>
+            <view class="account-stat" @tap="router.push(`${route.path.replace(/\/$/, '')}/following`)">
+              <text class="account-stat-num">{{ formatCompactNumber(account.followingCount) }}</text>
+              <text class="account-stat-label">Following</text>
+            </view>
+            <view class="account-stat" @tap="router.push(`${route.path.replace(/\/$/, '')}/followers`)">
+              <text class="account-stat-num">{{ formatCompactNumber(account.followersCount) }}</text>
+              <text class="account-stat-label">Followers</text>
             </view>
           </view>
         </view>
+      </template>
 
-        <text class="account-joined">{{ joinDate }}</text>
-
-        <!-- stats row -->
-        <view class="account-stats">
-          <view class="account-stat">
-            <text class="account-stat-num">{{ formatCompactNumber(account.statusesCount) }}</text>
-            <text class="account-stat-label">Posts</text>
+      <template #posts>
+        <scroll-view scroll-orientation="vertical" class="account-pane">
+          <view v-if="feeds.posts.loading" class="account-loading">
+            <Spinner />
           </view>
-          <view class="account-stat" @tap="router.push(`${route.path.replace(/\/$/, '')}/following`)">
-            <text class="account-stat-num">{{ formatCompactNumber(account.followingCount) }}</text>
-            <text class="account-stat-label">Following</text>
+          <StatusCard v-for="s in feeds.posts.items" :key="s.id" :status="s" />
+          <view v-if="feeds.posts.loaded && !feeds.posts.loading && !feeds.posts.items.length" class="account-empty">
+            <text class="account-empty-text">No posts yet.</text>
           </view>
-          <view class="account-stat" @tap="router.push(`${route.path.replace(/\/$/, '')}/followers`)">
-            <text class="account-stat-num">{{ formatCompactNumber(account.followersCount) }}</text>
-            <text class="account-stat-label">Followers</text>
+          <view class="account-bottom-pad" />
+        </scroll-view>
+      </template>
+
+      <template #replies>
+        <scroll-view scroll-orientation="vertical" class="account-pane">
+          <view v-if="feeds.replies.loading" class="account-loading">
+            <Spinner />
           </view>
-        </view>
-      </view>
+          <StatusCard v-for="s in feeds.replies.items" :key="s.id" :status="s" />
+          <view v-if="feeds.replies.loaded && !feeds.replies.loading && !feeds.replies.items.length" class="account-empty">
+            <text class="account-empty-text">No posts yet.</text>
+          </view>
+          <view class="account-bottom-pad" />
+        </scroll-view>
+      </template>
 
-      <!-- tabs -->
-      <view class="account-tabs">
-        <view
-          v-for="t in tabs"
-          :key="t.key"
-          class="account-tab"
-          @tap="tab = t.key"
-        >
-          <text class="account-tab-text" :class="tab === t.key ? 'account-tab-active' : ''">{{ t.label }}</text>
-          <view class="account-tab-underline" :class="tab === t.key ? 'account-tab-underline-active' : ''" />
-        </view>
-      </view>
-
-      <view v-if="statusesLoading" class="account-loading">
-        <Spinner />
-      </view>
-      <StatusCard v-for="s in statuses" :key="s.id" :status="s" />
-      <view class="account-bottom-pad" />
-    </scroll-view>
+      <template #media>
+        <scroll-view scroll-orientation="vertical" class="account-pane">
+          <view v-if="feeds.media.loading" class="account-loading">
+            <Spinner />
+          </view>
+          <StatusCard v-for="s in feeds.media.items" :key="s.id" :status="s" />
+          <view v-if="feeds.media.loaded && !feeds.media.loading && !feeds.media.items.length" class="account-empty">
+            <text class="account-empty-text">No media yet.</text>
+          </view>
+          <view class="account-bottom-pad" />
+        </scroll-view>
+      </template>
+    </StickyTabView>
   </view>
 </template>
 
 <style>
-.account-scroll {
+.account-stv {
   flex: 1;
+  min-height: 0;
   width: 100%;
+}
+
+.account-pane {
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  height: 100%;
 }
 
 .account-loading {
@@ -186,6 +250,18 @@ const joinDate = computed(() => {
   flex-direction: column;
   align-items: center;
   padding: 48px 0;
+}
+
+.account-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 0;
+}
+
+.account-empty-text {
+  font-size: 14px;
+  color: var(--c-text-secondary);
 }
 
 .account-error {
@@ -311,47 +387,6 @@ const joinDate = computed(() => {
 .account-stat-label {
   font-size: 13px;
   color: var(--c-text-secondary);
-}
-
-.account-tabs {
-  display: flex;
-  flex-direction: row;
-  border-bottom: 1px solid var(--c-border);
-}
-
-.account-tab {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  flex: 1;
-  padding: 10px 0 0;
-}
-
-.account-tab-text {
-  font-size: 14px;
-  color: var(--c-text-secondary);
-  padding-bottom: 8px;
-  transition: color var(--motion-state) var(--ease-out-quart), opacity var(--motion-state) var(--ease-out-quart);
-}
-
-.account-tab-active {
-  color: var(--c-text-base);
-  font-weight: 600;
-}
-
-.account-tab-underline {
-  height: 3px;
-  width: 60%;
-  border-radius: 2px;
-  background-color: var(--c-primary);
-  opacity: 0;
-  transform: scaleX(0.35);
-  transition: transform var(--motion-state) var(--ease-out-quart), opacity var(--motion-state) var(--ease-out-quart);
-}
-
-.account-tab-underline-active {
-  opacity: 1;
-  transform: scaleX(1);
 }
 
 .account-bottom-pad {

--- a/website/docs/guide/elk.mdx
+++ b/website/docs/guide/elk.mdx
@@ -108,6 +108,22 @@ That's the trade: you give up "render only what's visible," and the panes
 stay warm — swipe away and back, and you're exactly where you left off, no
 reload.
 
+#### Going further: a collapsing profile
+
+The profile page takes the pattern one step further into "native profile"
+territory. [`AccountPage`](https://github.com/huxpro/vue-lynx/blob/main/examples/elk-viewpager/src/pages/AccountPage.vue)
+wraps the same viewpager in Lynx's collapsing-header coordinator
+([`StickyTabView.vue`](https://github.com/huxpro/vue-lynx/blob/main/examples/elk-viewpager/src/components/StickyTabView.vue)):
+scroll down and the banner/bio/stats **header collapses**, the **tab bar
+pins** to the top, and the Posts / Replies / Media panes below keep **paging
+horizontally**, each with its own feed and scroll position. The coordinator
+stacks as header (collapses) + toolbar (sticky tabs) + slot (the viewpager),
+and its nested scroll folds the header first, then hands off to the active
+pane's list. Like the viewpager it's registered per platform — the legacy
+`<x-foldview-ng>` on Lynx for Web, the extracted
+[`<scroll-coordinator>`](https://lynxjs.org/guide/ui/elements-components.html#xelement)
+on native OSS engines.
+
 ## Why Elk is a serious test
 
 Elk is a Nuxt 3 app with ~196 components, 55 pages and 50 composables.

--- a/website/docs/zh/guide/elk.mdx
+++ b/website/docs/zh/guide/elk.mdx
@@ -103,6 +103,20 @@ pager ↔ 标签双向同步，统统搬进 `TabPager`。
 这就是取舍：你放弃「只渲染可见内容」，换来面板始终「热着」——滑走再滑回，
 还停在你离开的位置，无需重新加载。
 
+#### 更进一步：会折叠的个人主页
+
+个人主页把这套模式又往「原生 profile」推进了一步。
+[`AccountPage`](https://github.com/huxpro/vue-lynx/blob/main/examples/elk-viewpager/src/pages/AccountPage.vue)
+把同一个 viewpager 包进了 Lynx 的折叠头部协调器
+（[`StickyTabView.vue`](https://github.com/huxpro/vue-lynx/blob/main/examples/elk-viewpager/src/components/StickyTabView.vue)）：
+向下滚动时，banner／简介／统计构成的**头部折叠收起**，**标签栏吸顶**，
+下面的 Posts / Replies / Media 面板继续**横向翻页**，各自保留自己的 feed
+和滚动位置。协调器按「头部（折叠）+ 工具栏（吸顶标签）+ 插槽（viewpager）」
+堆叠，其嵌套滚动会先折叠头部，再把滚动交给当前面板的列表。和 viewpager
+一样，它按平台注册不同标签名——Lynx for Web 用旧版 `<x-foldview-ng>`，
+原生 OSS 引擎用抽取出来的
+[`<scroll-coordinator>`](https://lynxjs.org/guide/ui/elements-components.html#xelement)。
+
 ## 为什么 Elk 是一块试金石
 
 Elk 是一个约 196 个组件、55 个页面、50 个 composable 的 Nuxt 3 应用。


### PR DESCRIPTION
## What

Rebuilds the Elk profile page into the authentic native pattern: the banner/bio/stats header **collapses on scroll**, the **tab bar pins to the top**, and the Posts / Posts & Replies / Media panes below keep **paging horizontally** — each with its own lazily-loaded feed and scroll position.

## How

New **`StickyTabView.vue`** wraps Lynx's collapsing-header coordinator around the same two-way-synced viewpager that `TabPager` already uses:

```
coordinator
├─ header   → banner + avatar + bio + fields + stats   (collapses)
├─ toolbar  → the tab bar                                (sticky)
└─ slot     → viewpager                                  (pages horizontally)
      ├─ viewpager-item → Posts list
      ├─ viewpager-item → Replies list
      └─ viewpager-item → Media list
```

- **Per-platform element**, mirroring the viewpager's own web↔native split: the legacy foldview names (`x-foldview-ng` / `x-foldview-header-ng` / `x-foldview-toolbar-ng` / `x-foldview-slot-ng`) on Lynx for Web, the extracted `scroll-coordinator` (`-header` / `-toolbar` / `-slot`) on native OSS engines. Both expose the same header / toolbar / slot structure, and the slot's nested-scroll handler folds the header first, then lets the active pane's list scroll, while horizontal gestures fall through to the viewpager.
- **`AccountPage.vue`** now supplies a collapsing `#header` and one pane per tab, with **one feed per tab** (independent data + scroll, lazy-loaded on first activation) — same approach the Notifications pager uses.
- The slot chain uses an explicit `height: 100%` rather than a Lynx `flex` weight, because the coordinator is a standard-flexbox container (not a Lynx linear one); a Lynx flex weight doesn't reach the raw child and the panes would collapse to zero height.

## Verification

Driven end-to-end on the Lynx-for-Web harness against a real profile (`@astro`): scrolling collapses the header and pins the tab bar, the inner list then scrolls, and a horizontal swipe pages between tabs under the still-pinned bar with the header staying collapsed. `pnpm build` (web + lynx) is clean and all 32 `native-compat` checks pass.

Test changes: retarget the profile-tabs assertion to `StickyTabView`, add coverage for the coordinator wiring, and correct one **pre-existing** stale assertion in the viewpager-paging test (it expected literal `<x-viewpager-ng` markup that no longer exists since `TabPager` moved to `:is="pagerTag"` — it was already red on `main`, unrelated to this change).

## Caveats

- **Web initial state:** `x-foldview-ng` pins the toolbar from the top initially (over the banner) rather than animating it up from below the header — its own source notes the collapse-visibility only reproduces in native / Android WebView. Behaviorally everything works; it's a cosmetic web-runtime limitation. Native `scroll-coordinator` renders the full collapse.
- **Native path is reasoned, not run** — only Lynx for Web is drivable in this environment; the `scroll-coordinator` tag names come from the official Lynx docs and mirror the foldview structure. Consistent with `elk-viewpager`'s existing "needs a newer Lynx engine" positioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYQ8X2CpBvQ77wYNxxxqN5

---
_Generated by [Claude Code](https://claude.ai/code/session_01GYQ8X2CpBvQ77wYNxxxqN5)_