### PR TITLE
Set up Cloud Agent dev environment for Vue Lynx

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,3 +65,11 @@ The `packages/upstream-tests/` directory re-runs selected Vue core test suites a
 - `worklet-loader-mt` must emit `export default {};` for vue script sub-modules (`?vue&type=script`) to satisfy the `experimentalInlineMatchResource` proxy re-export.
 - Bootstrap packages (`vue-lynx/main-thread`, `vue-lynx/internal/ops`) must be excluded from MT loaders — in pnpm workspaces they resolve via symlinks (not under `node_modules/`), so `/node_modules/` exclude alone is insufficient.
 - `VueMarkMainThreadPlugin` must add `RuntimeGlobals.startup` for MT entry chunks — without it, `chunkLoading: 'lynx'` prevents module factory execution.
+
+## Cursor Cloud specific instructions
+
+Environment already has Node 22 + pnpm 10, and the startup update script runs `pnpm install` and clones `vuejs/core@v3.5.12` into `packages/upstream-tests/core` (git-ignored, not a submodule — there is no `.gitmodules`). The upstream tests will fail to collect without that clone.
+
+- **Build before running examples or tests.** Run `pnpm build` (root) once per session before `pnpm test`, `pnpm test:upstream`, `pnpm test:dev-smoke`, or any `examples/*` dev server — examples and tests import the compiled `vue-lynx` package. The update script intentionally does not build. Standard commands are in the root `README.md` and root `package.json`.
+- **Running an example on the web (no device needed).** `cd examples/<name> && pnpm dev` starts Rspeedy on port 3000; open the Lynx-for-Web preview at `http://localhost:3000/__web_preview?casename=main.web.bundle`. This is enough for interactive E2E; LynxExplorer (native iOS/Android) is only needed for on-device testing.
+- **Web preview refresh gotcha.** A hard browser refresh (F5) can leave the `__web_preview` page blank/broken. Re-navigate by re-entering the URL in the address bar to reset it cleanly instead of pressing F5.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cursor Cloud development environment for this Vue Lynx monorepo and verifies it end-to-end. The only code change is documentation.

- Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` capturing durable, non-obvious setup/run caveats for future agents.
- Configures the startup update script (`pnpm install` + guarded clone of `vuejs/core@v3.5.12` into the git-ignored `packages/upstream-tests/core`, required by the upstream tests).

## Environment

- Node 22, pnpm 10 (matches CI in `.github/workflows/ci.yml`).
- `pnpm build` (root) must run once per session before tests/examples — examples and tests import the compiled `vue-lynx`. The update script intentionally omits build commands.

## Verification

All lint/test suites pass, and the `basic` example was run in dev mode and exercised in the browser via the Lynx-for-Web preview (counter increments, conditional styling, and toggle all working live).

| Check | Command | Result |
|-------|---------|--------|
| Lint | `pnpm lint` | pass |
| Pipeline tests | `pnpm test` | 196 passed |
| Upstream Vue tests | `pnpm test:upstream` | pass (runtime/dom/local) |
| Dev smoke | `pnpm test:dev-smoke` | pass |
| Run app | `cd examples/basic && pnpm dev` → `__web_preview` | pass (interactive) |

### Hello-world demo (examples/basic)

Live counter interaction on the Lynx-for-Web preview:

[Initial state](https://cursor.com/agents/bc-4a11b27c-2260-4ace-97f6-dce24d770ec4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcounter_00_initial.webp)
[Count 1](https://cursor.com/agents/bc-4a11b27c-2260-4ace-97f6-dce24d770ec4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcounter_01.webp)
[Count 3](https://cursor.com/agents/bc-4a11b27c-2260-4ace-97f6-dce24d770ec4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcounter_03.webp)
[Count 6, button turns orange, history list](https://cursor.com/agents/bc-4a11b27c-2260-4ace-97f6-dce24d770ec4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcounter_06_orange.webp)
[Hide detail toggle](https://cursor.com/agents/bc-4a11b27c-2260-4ace-97f6-dce24d770ec4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcounter_hide_detail.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4a11b27c-2260-4ace-97f6-dce24d770ec4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4a11b27c-2260-4ace-97f6-dce24d770ec4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

