### PR TITLE
feat(elk-viewpager): profile tabs rest below the card, stick on scroll

### DIFF
--- a/examples/elk-viewpager/scripts/native-compat.test.mjs
+++ b/examples/elk-viewpager/scripts/native-compat.test.mjs
@@ -504,30 +504,27 @@ test('app-bar tabs page horizontally through the native viewpager', async () => 
   assert.match(notifications, /<TabPager/);
 });
 
-test('profile pins its tabs with a native collapsing header (scroll-coordinator)', async () => {
+test('profile tabs sit below the header and stick on scroll', async () => {
   const [sticky, account] = await Promise.all([
     readFile(new URL('../src/components/StickyTabView.vue', import.meta.url), 'utf8'),
     readFile(new URL('../src/pages/AccountPage.vue', import.meta.url), 'utf8'),
   ]);
 
-  // Per-platform coordinator element: legacy foldview names on Lynx for Web,
-  // the extracted scroll-coordinator on native OSS engines.
-  assert.match(sticky, /'x-foldview-ng'/);
-  assert.match(sticky, /'scroll-coordinator'/);
-  // header (collapses) + toolbar (sticky tab bar) + slot (the viewpager panes).
-  assert.match(sticky, /'x-foldview-header-ng'/);
-  assert.match(sticky, /'scroll-coordinator-header'/);
-  assert.match(sticky, /'x-foldview-toolbar-ng'/);
-  assert.match(sticky, /'scroll-coordinator-toolbar'/);
-  assert.match(sticky, /'x-foldview-slot-ng'/);
-  assert.match(sticky, /'scroll-coordinator-slot'/);
-  // The pinned tab bar still drives the viewpager, synced both ways.
+  // One vertical <scroll-view> is the single scroller: header, then the tab
+  // bar as a sticky child (so it starts below the header and pins only once
+  // scrolled onto), then the viewpager panes.
+  assert.match(sticky, /<scroll-view scroll-orientation="vertical"/);
+  assert.match(sticky, /sticky class="stv-toolbar"/);
+  assert.match(sticky, /position: sticky/);
+  // Horizontal paging stays with the viewpager, synced both ways.
   assert.match(sticky, /'x-viewpager-ng'/);
   assert.match(sticky, /method: 'selectTab'/);
-  // The profile supplies a collapsing #header and one pane per tab.
+  // The profile supplies the header card and one pane per tab; the panes are
+  // plain views (the single scroll-view scrolls the whole page).
   assert.match(account, /<StickyTabView/);
   assert.match(account, /<template #header>/);
   assert.match(account, /<template #posts>/);
+  assert.match(account, /<view class="account-pane">/);
 });
 
 test('media preview motion mirrors Elk using only opacity and transform', async () => {

--- a/examples/elk-viewpager/scripts/native-compat.test.mjs
+++ b/examples/elk-viewpager/scripts/native-compat.test.mjs
@@ -510,21 +510,26 @@ test('profile tabs sit below the header and stick on scroll', async () => {
     readFile(new URL('../src/pages/AccountPage.vue', import.meta.url), 'utf8'),
   ]);
 
-  // One vertical <scroll-view> is the single scroller: header, then the tab
-  // bar as a sticky child (so it starts below the header and pins only once
-  // scrolled onto), then the viewpager panes.
-  assert.match(sticky, /<scroll-view scroll-orientation="vertical"/);
-  assert.match(sticky, /sticky class="stv-toolbar"/);
-  assert.match(sticky, /position: sticky/);
+  // Per-platform coordinator element: foldview on Lynx for Web, the extracted
+  // scroll-coordinator on native OSS engines.
+  assert.match(sticky, /'x-foldview-ng'/);
+  assert.match(sticky, /'scroll-coordinator'/);
+  assert.match(sticky, /'x-foldview-slot-ng'/);
+  assert.match(sticky, /'scroll-coordinator-slot'/);
+  // The tab bar lives INSIDE the slot, above the viewpager — that is what
+  // makes it start below the header and pin only on scroll. There is no
+  // sticky toolbar element (that variant pins the tabs from the top).
+  assert.doesNotMatch(sticky, /foldview-toolbar|scroll-coordinator-toolbar/);
+  assert.match(sticky, /class="stv-bar"/);
   // Horizontal paging stays with the viewpager, synced both ways.
   assert.match(sticky, /'x-viewpager-ng'/);
   assert.match(sticky, /method: 'selectTab'/);
-  // The profile supplies the header card and one pane per tab; the panes are
-  // plain views (the single scroll-view scrolls the whole page).
+  // The profile supplies the collapsing #header and one scrollable pane per
+  // tab (the coordinator hands scroll off to the active pane's list).
   assert.match(account, /<StickyTabView/);
   assert.match(account, /<template #header>/);
   assert.match(account, /<template #posts>/);
-  assert.match(account, /<view class="account-pane">/);
+  assert.match(account, /scroll-orientation="vertical" class="account-pane"/);
 });
 
 test('media preview motion mirrors Elk using only opacity and transform', async () => {

--- a/examples/elk-viewpager/src/components/StickyTabView.vue
+++ b/examples/elk-viewpager/src/components/StickyTabView.vue
@@ -1,23 +1,29 @@
 <script setup lang="ts">
 // A collapsing-header + sticky-tab-bar + horizontally-paged scaffold — the
-// "native profile" pattern (Twitter/X, Mastodon apps): the #header slot
-// scrolls away with the page, the tab bar sticks to the top once you scroll
-// onto it, and the panes below keep swiping horizontally.
+// "native profile" pattern (Twitter/X, Mastodon apps): the #header scrolls
+// away, the tab bar rises with it and pins to the top once you scroll onto
+// it, and the panes below keep swiping horizontally, each with its own
+// vertical scroll.
 //
-// One vertical <scroll-view> is the single scroller; the tab bar is a
-// sticky child (Lynx's scroll-view sticky capability — the `sticky`
-// attribute natively, `position: sticky` on the web runtime). The panes are
-// laid out at their natural height, so the whole page scrolls as one and
-// the header genuinely collapses before the list continues — no nested
-// scroll to fight. Horizontal paging is still owned by the viewpager.
+// It uses Lynx's scroll-coordinator (a.k.a. foldview): an absolutely
+// positioned header that collapses, and a flex slot that holds the tab bar
+// *above* the viewpager. As the coordinator scrolls, the whole slot slides
+// up under the collapsing header until the tab bar reaches the top and pins;
+// the slot then hands the scroll to the active viewpager pane's list. The
+// tabs live in the slot (not in a sticky toolbar), which is what makes them
+// start below the card and stick only on scroll.
 import type { ShadowElement } from 'vue-lynx';
 import { computed, ref, useTemplateRef, watch } from 'vue-lynx';
 
 declare const SystemInfo: { platform?: string } | undefined;
 
+// Like the viewpager, the coordinator element is registered under different
+// names per platform: Lynx for Web ships the legacy XElement foldview names,
+// while native OSS engines register the extracted scroll-coordinator element.
 const isWeb = typeof SystemInfo !== 'undefined' && SystemInfo?.platform === 'web';
-// The viewpager element is registered under different names per platform:
-// the legacy XElement name on Lynx for Web, the extracted element natively.
+const foldTag = isWeb ? 'x-foldview-ng' : 'scroll-coordinator';
+const foldHeaderTag = isWeb ? 'x-foldview-header-ng' : 'scroll-coordinator-header';
+const foldSlotTag = isWeb ? 'x-foldview-slot-ng' : 'scroll-coordinator-slot';
 const pagerTag = isWeb ? 'x-viewpager-ng' : 'viewpager';
 const pagerItemTag = isWeb ? 'x-viewpager-item-ng' : 'viewpager-item';
 
@@ -61,12 +67,14 @@ watch(activeIndex, (index) => {
 </script>
 
 <template>
-  <scroll-view scroll-orientation="vertical" class="stv">
-    <view class="stv-header">
+  <component :is="foldTag" class="stv">
+    <component :is="foldHeaderTag" class="stv-header">
       <slot name="header" />
-    </view>
+    </component>
 
-    <view sticky class="stv-toolbar">
+    <component :is="foldSlotTag" class="stv-slot">
+      <!-- Tab bar sits at the top of the slot, above the viewpager. It rides
+           up with the collapsing header and pins once it reaches the top. -->
       <view class="stv-bar">
         <view
           v-for="t in tabs"
@@ -78,54 +86,58 @@ watch(activeIndex, (index) => {
           <view class="stv-tab-underline" :class="modelValue === t.key ? 'stv-tab-underline-active' : ''" />
         </view>
       </view>
-    </view>
 
-    <component
-      :is="pagerTag"
-      ref="pagerRef"
-      class="stv-pages"
-      :initial-select-index="activeIndex"
-      @change="onPagerChange"
-    >
       <component
-        :is="pagerItemTag"
-        v-for="t in tabs"
-        :key="t.key"
-        class="stv-page"
+        :is="pagerTag"
+        ref="pagerRef"
+        class="stv-pages"
+        :initial-select-index="activeIndex"
+        @change="onPagerChange"
       >
-        <slot :name="t.key" />
+        <component
+          :is="pagerItemTag"
+          v-for="t in tabs"
+          :key="t.key"
+          class="stv-page"
+        >
+          <slot :name="t.key" />
+        </component>
       </component>
     </component>
-  </scroll-view>
+  </component>
 </template>
 
 <style>
 .stv {
+  display: flex;
+  flex-direction: column;
   flex: 1;
   min-height: 0;
   width: 100%;
 }
 
 .stv-header {
-  display: flex;
-  flex-direction: column;
+  position: absolute;
   width: 100%;
 }
 
-.stv-toolbar {
-  /* Sticks to the top of the scroll-view once scrolled onto. `sticky` is the
-     native Lynx attribute; `position: sticky` covers the web runtime. */
-  position: sticky;
-  top: 0;
-  z-index: 2;
+.stv-slot {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
   width: 100%;
-  background-color: var(--c-bg-base);
+  /* Web (foldview) is a standard-flexbox container, so a Lynx flex weight
+     doesn't reach this raw child — a definite height keeps the slot filled. */
+  height: 100%;
 }
 
 .stv-bar {
   display: flex;
   flex-direction: row;
+  flex-shrink: 0;
   border-bottom: 1px solid var(--c-border);
+  /* Opaque so the collapsing header never shows through the pinned tab bar. */
+  background-color: var(--c-bg-base);
 }
 
 .stv-tab {
@@ -164,6 +176,8 @@ watch(activeIndex, (index) => {
 }
 
 .stv-pages {
+  flex: 1;
+  min-height: 0;
   width: 100%;
 }
 
@@ -171,5 +185,6 @@ watch(activeIndex, (index) => {
   display: flex;
   flex-direction: column;
   width: 100%;
+  height: 100%;
 }
 </style>

--- a/examples/elk-viewpager/src/components/StickyTabView.vue
+++ b/examples/elk-viewpager/src/components/StickyTabView.vue
@@ -1,28 +1,23 @@
 <script setup lang="ts">
 // A collapsing-header + sticky-tab-bar + horizontally-paged scaffold — the
 // "native profile" pattern (Twitter/X, Mastodon apps): the #header slot
-// scrolls away, the tab bar pins to the top, and the panes below it keep
-// swiping horizontally, each with its own vertical scroll.
+// scrolls away with the page, the tab bar sticks to the top once you scroll
+// onto it, and the panes below keep swiping horizontally.
 //
-// It wraps Lynx's scroll-coordinator (a.k.a. foldview) — an outer vertical
-// scroller whose header collapses until the toolbar sticks, after which the
-// active pane's inner list takes over the scroll — around the same
-// two-way-synced viewpager used by TabPager.vue.
+// One vertical <scroll-view> is the single scroller; the tab bar is a
+// sticky child (Lynx's scroll-view sticky capability — the `sticky`
+// attribute natively, `position: sticky` on the web runtime). The panes are
+// laid out at their natural height, so the whole page scrolls as one and
+// the header genuinely collapses before the list continues — no nested
+// scroll to fight. Horizontal paging is still owned by the viewpager.
 import type { ShadowElement } from 'vue-lynx';
 import { computed, ref, useTemplateRef, watch } from 'vue-lynx';
 
 declare const SystemInfo: { platform?: string } | undefined;
 
-// Like the viewpager, the coordinator element is registered under different
-// names per platform: Lynx for Web ships the legacy XElement foldview names
-// (x-foldview-*-ng), while native OSS engines register the extracted
-// scroll-coordinator element (lynx-family/lynx). Both expose the same
-// header / toolbar / slot structure.
 const isWeb = typeof SystemInfo !== 'undefined' && SystemInfo?.platform === 'web';
-const foldTag = isWeb ? 'x-foldview-ng' : 'scroll-coordinator';
-const foldHeaderTag = isWeb ? 'x-foldview-header-ng' : 'scroll-coordinator-header';
-const foldToolbarTag = isWeb ? 'x-foldview-toolbar-ng' : 'scroll-coordinator-toolbar';
-const foldSlotTag = isWeb ? 'x-foldview-slot-ng' : 'scroll-coordinator-slot';
+// The viewpager element is registered under different names per platform:
+// the legacy XElement name on Lynx for Web, the extracted element natively.
 const pagerTag = isWeb ? 'x-viewpager-ng' : 'viewpager';
 const pagerItemTag = isWeb ? 'x-viewpager-item-ng' : 'viewpager-item';
 
@@ -66,12 +61,12 @@ watch(activeIndex, (index) => {
 </script>
 
 <template>
-  <component :is="foldTag" class="stv">
-    <component :is="foldHeaderTag" class="stv-header">
+  <scroll-view scroll-orientation="vertical" class="stv">
+    <view class="stv-header">
       <slot name="header" />
-    </component>
+    </view>
 
-    <component :is="foldToolbarTag" class="stv-toolbar">
+    <view sticky class="stv-toolbar">
       <view class="stv-bar">
         <view
           v-for="t in tabs"
@@ -83,27 +78,25 @@ watch(activeIndex, (index) => {
           <view class="stv-tab-underline" :class="modelValue === t.key ? 'stv-tab-underline-active' : ''" />
         </view>
       </view>
-    </component>
+    </view>
 
-    <component :is="foldSlotTag" class="stv-slot">
+    <component
+      :is="pagerTag"
+      ref="pagerRef"
+      class="stv-pages"
+      :initial-select-index="activeIndex"
+      @change="onPagerChange"
+    >
       <component
-        :is="pagerTag"
-        ref="pagerRef"
-        class="stv-pages"
-        :initial-select-index="activeIndex"
-        @change="onPagerChange"
+        :is="pagerItemTag"
+        v-for="t in tabs"
+        :key="t.key"
+        class="stv-page"
       >
-        <component
-          :is="pagerItemTag"
-          v-for="t in tabs"
-          :key="t.key"
-          class="stv-page"
-        >
-          <slot :name="t.key" />
-        </component>
+        <slot :name="t.key" />
       </component>
     </component>
-  </component>
+  </scroll-view>
 </template>
 
 <style>
@@ -113,8 +106,19 @@ watch(activeIndex, (index) => {
   width: 100%;
 }
 
+.stv-header {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
 .stv-toolbar {
-  /* Opaque so collapsed header content never shows through the pinned bar. */
+  /* Sticks to the top of the scroll-view once scrolled onto. `sticky` is the
+     native Lynx attribute; `position: sticky` covers the web runtime. */
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  width: 100%;
   background-color: var(--c-bg-base);
 }
 
@@ -159,24 +163,13 @@ watch(activeIndex, (index) => {
   transform: scaleX(1);
 }
 
-.stv-slot {
-  /* The coordinator element is a standard-flexbox container (not a Lynx
-     linear one), so a Lynx `flex: 1` weight doesn't reach this raw child —
-     give the slot a definite height so the viewpager/panes below it fill. */
-  height: 100%;
-  width: 100%;
-}
-
 .stv-pages {
-  flex: 1;
   width: 100%;
-  height: 100%;
 }
 
 .stv-page {
   display: flex;
   flex-direction: column;
   width: 100%;
-  height: 100%;
 }
 </style>

--- a/examples/elk-viewpager/src/pages/AccountPage.vue
+++ b/examples/elk-viewpager/src/pages/AccountPage.vue
@@ -190,7 +190,7 @@ const joinDate = computed(() => {
       </template>
 
       <template #posts>
-        <scroll-view scroll-orientation="vertical" class="account-pane">
+        <view class="account-pane">
           <view v-if="feeds.posts.loading" class="account-loading">
             <Spinner />
           </view>
@@ -199,11 +199,11 @@ const joinDate = computed(() => {
             <text class="account-empty-text">No posts yet.</text>
           </view>
           <view class="account-bottom-pad" />
-        </scroll-view>
+        </view>
       </template>
 
       <template #replies>
-        <scroll-view scroll-orientation="vertical" class="account-pane">
+        <view class="account-pane">
           <view v-if="feeds.replies.loading" class="account-loading">
             <Spinner />
           </view>
@@ -212,11 +212,11 @@ const joinDate = computed(() => {
             <text class="account-empty-text">No posts yet.</text>
           </view>
           <view class="account-bottom-pad" />
-        </scroll-view>
+        </view>
       </template>
 
       <template #media>
-        <scroll-view scroll-orientation="vertical" class="account-pane">
+        <view class="account-pane">
           <view v-if="feeds.media.loading" class="account-loading">
             <Spinner />
           </view>
@@ -225,7 +225,7 @@ const joinDate = computed(() => {
             <text class="account-empty-text">No media yet.</text>
           </view>
           <view class="account-bottom-pad" />
-        </scroll-view>
+        </view>
       </template>
     </StickyTabView>
   </view>
@@ -239,10 +239,9 @@ const joinDate = computed(() => {
 }
 
 .account-pane {
-  flex: 1;
-  min-height: 0;
+  display: flex;
+  flex-direction: column;
   width: 100%;
-  height: 100%;
 }
 
 .account-loading {

--- a/examples/elk-viewpager/src/pages/AccountPage.vue
+++ b/examples/elk-viewpager/src/pages/AccountPage.vue
@@ -190,7 +190,7 @@ const joinDate = computed(() => {
       </template>
 
       <template #posts>
-        <view class="account-pane">
+        <scroll-view scroll-orientation="vertical" class="account-pane">
           <view v-if="feeds.posts.loading" class="account-loading">
             <Spinner />
           </view>
@@ -199,11 +199,11 @@ const joinDate = computed(() => {
             <text class="account-empty-text">No posts yet.</text>
           </view>
           <view class="account-bottom-pad" />
-        </view>
+        </scroll-view>
       </template>
 
       <template #replies>
-        <view class="account-pane">
+        <scroll-view scroll-orientation="vertical" class="account-pane">
           <view v-if="feeds.replies.loading" class="account-loading">
             <Spinner />
           </view>
@@ -212,11 +212,11 @@ const joinDate = computed(() => {
             <text class="account-empty-text">No posts yet.</text>
           </view>
           <view class="account-bottom-pad" />
-        </view>
+        </scroll-view>
       </template>
 
       <template #media>
-        <view class="account-pane">
+        <scroll-view scroll-orientation="vertical" class="account-pane">
           <view v-if="feeds.media.loading" class="account-loading">
             <Spinner />
           </view>
@@ -225,7 +225,7 @@ const joinDate = computed(() => {
             <text class="account-empty-text">No media yet.</text>
           </view>
           <view class="account-bottom-pad" />
-        </view>
+        </scroll-view>
       </template>
     </StickyTabView>
   </view>
@@ -239,9 +239,10 @@ const joinDate = computed(() => {
 }
 
 .account-pane {
-  display: flex;
-  flex-direction: column;
+  flex: 1;
+  min-height: 0;
   width: 100%;
+  height: 100%;
 }
 
 .account-loading {


### PR DESCRIPTION
## What

Follow-up to #243. There the tab bar was pinned to the top from the start — on native too, not just the web preview — instead of the tabs **resting below the profile card and sticking only once you scroll onto them** (the behavior you described).

## Why the change

The `scroll-coordinator` / foldview element positions its toolbar at the top and folds the header behind it, so the tabs are effectively always pinned. To get "tabs below the card → stick on scroll," this reworks the scaffold around a plain sticky child instead of the coordinator.

## How

`StickyTabView` is now a single vertical **`<scroll-view>`** with three children:

```
<scroll-view scroll-orientation="vertical">
  <view>            → profile card (banner, bio, stats)
  <view sticky>     → tab bar        (sticks to top once scrolled onto)
  <viewpager>       → Posts / Replies / Media panes (horizontal paging)
</scroll-view>
```

- The tab bar uses the scroll-view **sticky capability** — the `sticky` attribute (native) plus `position: sticky` (web runtime) — so it starts below the header and pins when it reaches the top.
- The panes are plain views at their natural height, so the whole page is **one scroller**: the header genuinely scrolls away before the list continues, with no nested-scroll coordination to fight.
- Horizontal paging stays with the viewpager (two-way tab↔pager sync unchanged).
- `AccountPage` panes are now non-scrolling views; `native-compat` updated for the new structure.

## Status / please test

Verified: web build is clean and all 32 `native-compat` checks pass. The harness only drives **Lynx for Web**, so I could not confirm the exact sticky feel on a real native host — opening this so you can test it on device. Two things worth a look on native specifically:
- that the tab bar rests below the card and pins on scroll (the fix), and
- that the single-scroll + horizontal paging feels right (each pane loads its own feed lazily).

If anything's off on native I'll iterate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYQ8X2CpBvQ77wYNxxxqN5

---
_Generated by [Claude Code](https://claude.ai/code/session_01GYQ8X2CpBvQ77wYNxxxqN5)_