### PR TITLE
docs: shorten `<page>` notes into a bottom "顶层节点" section

### DIFF
--- a/website/docs/guide/vue-compatibility.mdx
+++ b/website/docs/guide/vue-compatibility.mdx
@@ -234,16 +234,7 @@ export default defineComponent({
 
 `<Teleport>` is supported for `to="#id"` string selectors. Direct element refs and non-ID selectors are not yet supported.
 
-## Unsupported Features
-
-Some Vue built-in features are not yet adapted to the dual-thread native environment:
-
-| Feature | Reason | Alternative |
-|---------|--------|-------------|
-| `<Transition>` auto-duration | `getComputedStyle()` is unavailable on the background thread | Always pass an explicit `:duration` prop |
-| `withKeys` key modifiers | No-op on native — Lynx's native runtime converts keyboard input to named events (e.g. `confirm`) before reaching JS, so `event.key` is never populated on iOS/Android. Works on web preview ([lynx-stack#2594](https://github.com/lynx-family/lynx-stack/pull/2594)). Native support requires an upstream runtime change. | Native: use `@confirm` directly on `<input>` |
-
-## Top-Level Nodes
+## The `<page>` Top-Level Node
 
 Every Lynx screen has one native [`<page>`](https://lynxjs.org/api/elements/built-in/page) root. Vue Lynx creates it automatically; write an explicit `<page>` only when you need to bind a class, style, event, or ref to the root:
 
@@ -256,3 +247,12 @@ Every Lynx screen has one native [`<page>`](https://lynxjs.org/api/elements/buil
 ```
 
 An explicit `<page>` compiles to a transparent built-in component that applies attributes to the existing native page — it does not create a second one. Use at most one per screen, as the outermost element. Prefer Lynx Engine **3.8.1+** when using an explicit `<page>`.
+
+## Unsupported Features
+
+Some Vue built-in features are not yet adapted to the dual-thread native environment:
+
+| Feature | Reason | Alternative |
+|---------|--------|-------------|
+| `<Transition>` auto-duration | `getComputedStyle()` is unavailable on the background thread | Always pass an explicit `:duration` prop |
+| `withKeys` key modifiers | No-op on native — Lynx's native runtime converts keyboard input to named events (e.g. `confirm`) before reaching JS, so `event.key` is never populated on iOS/Android. Works on web preview ([lynx-stack#2594](https://github.com/lynx-family/lynx-stack/pull/2594)). Native support requires an upstream runtime change. | Native: use `@confirm` directly on `<input>` |

--- a/website/docs/guide/vue-compatibility.mdx
+++ b/website/docs/guide/vue-compatibility.mdx
@@ -4,52 +4,6 @@ Vue Lynx is built on the official Vue 3 runtime core (`@vue/runtime-core`), so y
 
 Below is a feature-by-feature breakdown of the Vue features we've verified on Lynx. Where Lynx-specific caveats exist, they are called out inline. For details on how the dual-thread architecture works under the hood, see [Understanding the Dual-Thread Model](/guide/introduction#understanding-the-dual-thread-model).
 
-## The `<page>` Root
-
-Every Lynx screen has exactly one native [`<page>`](https://lynxjs.org/api/elements/built-in/page) root. Vue Lynx creates it automatically before mounting your app, so an explicit wrapper is optional:
-
-```vue
-<template>
-  <view class="app">...</view>
-</template>
-
-<style>
-page,
-:root {
-  background-color: white;
-}
-</style>
-```
-
-Use an explicit `<page>` when you need to bind a class, inline style, event, ID, or template ref directly to the native root:
-
-```vue
-<template>
-  <page class="app" :style="pageStyle" @tap="onPageTap">
-    <view>...</view>
-  </page>
-</template>
-```
-
-Vue Lynx compiles this wrapper to a transparent built-in component. Its attributes and events are applied to the already-created native page, while its children mount directly beneath that root. It does **not** create a second `<page>` element. The same behavior is available from render functions through `h('page', props, children)` or the exported `Page` component.
-
-Only one `<page>` wrapper is allowed, and it must be the outermost element representing the screen. Do not nest it or render multiple wrappers — nesting inside a native element is rejected at compile time, and rendering two wrappers at once reports a runtime error. As with Lynx itself, the containing native view controls the page dimensions: `width`, `height`, `left`, and `top` cannot resize or reposition the page directly.
-
-A few caveats follow from `<page>` compiling to a component rather than a native element:
-
-- **Directives** — `v-show` and custom directives on `<page>` are applied to the component's children, not the native root. Bind `:style` / `:class` directly instead.
-- **Template refs** — `ref` on `<page>` resolves to the exposed page root: `.id`, `.invoke()`, `.setNativeProps()`, and `.fields()` all work, but it is not a plain element reference.
-- **In templates**, use lowercase `<page>` (rewritten by the compiler). The capitalized `<Page>` form requires an explicit `import { Page } from 'vue-lynx'` in `<script setup>`.
-- **Ownership handoff** — when route components each render their own `<page>`, the incoming wrapper takes over the native root as soon as the outgoing one unmounts or is deactivated by `<KeepAlive>`. During a `<Transition>` without `mode="out-in"`, both wrappers briefly coexist; the incoming page's root attributes apply only after the leave finishes, so prefer `out-in` when the two pages style the root differently.
-
-:::warning Lynx engine compatibility
-Use Lynx Engine **3.8.1 or later** for applications that rely on an explicit `<page>` root. This is a conservative compatibility floor inferred from the [HackerNews engine bisect](/guide/hackernews#lynx-engine-compatibility): 3.8.1 is the oldest tested engine that rendered the complete application, while 3.6.0 and 3.7.0 loaded data but left the active route invisible. The fixed explicit-root bundle has been directly verified on a source-built Engine 4.1; the fix has not yet been rerun on every intermediate engine.
-
-The same pre-fix CSS bundle produced error `990100` on Engines 3.6.0, 3.8.1, and 4.1. This shows that the crash followed Vue Lynx's attempt to create a second native page rather than requiring Engine 4.1. When targeting 3.6.x or 3.7.x, omit the explicit wrapper, but note that those engines still have the separate route-rendering limitation found by the bisect.
-
-Use `SystemInfo.engineVersion` to identify the engine. In a source-built iOS Lynx without [`Lynx_POD_VERSION`](https://github.com/lynx-family/lynx/blob/develop/platform/darwin/common/lynx/base/LynxVersion.m), the DevTool `sdkVersion` field and the `sdk` field in error reports can contain the fallback value `1.4.0`; that value is not the Lynx Engine version.
-:::
-
 ## Reactivity + Composables
 
 Vue Lynx reuses 100% of Vue's reactivity core (`@vue/reactivity`). Every reactivity API works identically to standard Vue, with no Lynx-specific caveats or adaptations.
@@ -288,3 +242,17 @@ Some Vue built-in features are not yet adapted to the dual-thread native environ
 |---------|--------|-------------|
 | `<Transition>` auto-duration | `getComputedStyle()` is unavailable on the background thread | Always pass an explicit `:duration` prop |
 | `withKeys` key modifiers | No-op on native — Lynx's native runtime converts keyboard input to named events (e.g. `confirm`) before reaching JS, so `event.key` is never populated on iOS/Android. Works on web preview ([lynx-stack#2594](https://github.com/lynx-family/lynx-stack/pull/2594)). Native support requires an upstream runtime change. | Native: use `@confirm` directly on `<input>` |
+
+## Top-Level Nodes
+
+Every Lynx screen has one native [`<page>`](https://lynxjs.org/api/elements/built-in/page) root. Vue Lynx creates it automatically; write an explicit `<page>` only when you need to bind a class, style, event, or ref to the root:
+
+```vue
+<template>
+  <page class="app" :style="pageStyle" @tap="onPageTap">
+    <view>...</view>
+  </page>
+</template>
+```
+
+An explicit `<page>` compiles to a transparent built-in component that applies attributes to the existing native page — it does not create a second one. Use at most one per screen, as the outermost element. Prefer Lynx Engine **3.8.1+** when using an explicit `<page>`.

--- a/website/docs/zh/guide/vue-compatibility.mdx
+++ b/website/docs/zh/guide/vue-compatibility.mdx
@@ -234,16 +234,7 @@ export default defineComponent({
 
 `<Teleport>` 支持 `to="#id"` 字符串选择器。暂不支持直接传入元素 ref 或非 ID 选择器。
 
-## 不支持的特性
-
-部分 Vue 内置特性尚未适配双线程原生环境：
-
-| 特性 | 原因 | 替代方案 |
-|---------|--------|-------------|
-| `<Transition>` 自动时长 | 后台线程无法使用 `getComputedStyle()` | 始终传递显式的 `:duration` prop |
-| `withKeys` 按键修饰符 | 原生平台为 no-op —— Lynx 原生运行时在事件到达 JS 线程之前已将键盘输入转换为具名事件（如 `confirm`），iOS/Android 上的 `event.key` 始终为空。Web 预览在 [lynx-stack#2594](https://github.com/lynx-family/lynx-stack/pull/2594) 后可正常使用。原生端支持有赖于上游运行时变更。 | 原生端在 `<input>` 上直接使用 `@confirm` |
-
-## 顶层节点
+## `<page>` 顶层节点
 
 每个 Lynx 页面都有一个原生 [`<page>`](https://lynxjs.org/api/elements/built-in/page) 根节点。Vue Lynx 会自动创建它；只有需要直接给根节点绑定 class、样式、事件或 ref 时，才需要显式写出 `<page>`：
 
@@ -256,3 +247,12 @@ export default defineComponent({
 ```
 
 显式 `<page>` 会被编译成透明内置组件，属性作用在已有的原生 page 上，不会再创建第二个。每个页面只能有一个，且必须是最外层元素。使用显式 `<page>` 时建议 Lynx Engine **3.8.1+**。
+
+## 不支持的特性
+
+部分 Vue 内置特性尚未适配双线程原生环境：
+
+| 特性 | 原因 | 替代方案 |
+|---------|--------|-------------|
+| `<Transition>` 自动时长 | 后台线程无法使用 `getComputedStyle()` | 始终传递显式的 `:duration` prop |
+| `withKeys` 按键修饰符 | 原生平台为 no-op —— Lynx 原生运行时在事件到达 JS 线程之前已将键盘输入转换为具名事件（如 `confirm`），iOS/Android 上的 `event.key` 始终为空。Web 预览在 [lynx-stack#2594](https://github.com/lynx-family/lynx-stack/pull/2594) 后可正常使用。原生端支持有赖于上游运行时变更。 | 原生端在 `<input>` 上直接使用 `@confirm` |

--- a/website/docs/zh/guide/vue-compatibility.mdx
+++ b/website/docs/zh/guide/vue-compatibility.mdx
@@ -4,52 +4,6 @@ Vue Lynx 构建在官方 Vue 3 运行时核心（`@vue/runtime-core`）之上，
 
 下面是我们已在 Lynx 上验证的 Vue 特性的逐项说明。如果存在 Lynx 特有的注意事项，会在对应位置标注。关于双线程架构底层工作原理的详细信息，请参阅[理解双线程模型](/zh/guide/introduction#understanding-the-dual-thread-model)。
 
-## `<page>` 根节点
-
-每个 Lynx 页面都只有一个原生 [`<page>`](https://lynxjs.org/api/elements/built-in/page) 根节点。Vue Lynx 会在应用挂载前自动创建它，因此可以省略显式包装：
-
-```vue
-<template>
-  <view class="app">...</view>
-</template>
-
-<style>
-page,
-:root {
-  background-color: white;
-}
-</style>
-```
-
-当你需要直接给原生根节点绑定 class、内联样式、事件、ID 或模板 ref 时，可以显式使用 `<page>`：
-
-```vue
-<template>
-  <page class="app" :style="pageStyle" @tap="onPageTap">
-    <view>...</view>
-  </page>
-</template>
-```
-
-Vue Lynx 会把这个包装编译成透明的内置组件：属性和事件应用到已经创建的原生 page，子节点则直接挂载到该根节点下；它**不会**再创建第二个 `<page>`。渲染函数可以使用 `h('page', props, children)`，也可以直接使用导出的 `Page` 组件，行为相同。
-
-一个页面只能有一个 `<page>` 包装，并且它必须是表示整个页面的最外层元素。不要嵌套或同时渲染多个 `<page>`——嵌套在原生元素内部会在编译期报错，同时渲染多个则会在运行时报告错误。与 Lynx 本身一致，page 的尺寸由外层原生 View 决定，不能通过 `width`、`height`、`left` 或 `top` 直接改变 page 的大小或位置。
-
-由于 `<page>` 被编译成组件而非原生元素，有以下注意事项：
-
-- **指令** — `v-show` 和自定义指令作用在组件的子节点上，而不是原生根节点。请直接绑定 `:style` / `:class`。
-- **模板 ref** — `<page>` 上的 `ref` 解析为暴露出的 page 根节点：`.id`、`.invoke()`、`.setNativeProps()`、`.fields()` 都可用，但它不是普通的元素引用。
-- **在模板中**，请使用小写的 `<page>`（由编译器改写）。大写的 `<Page>` 形式需要在 `<script setup>` 中显式 `import { Page } from 'vue-lynx'`。
-- **所有权交接** — 当各路由组件分别渲染自己的 `<page>` 时，旧包装 unmount（或被 `<KeepAlive>` 停用）后，新包装会立即接管原生根节点。在没有 `mode="out-in"` 的 `<Transition>` 中，两个包装会短暂共存；新页面的根属性要等离场动画结束后才生效，因此当两个页面根节点样式不同时，建议使用 `out-in`。
-
-:::warning Lynx 引擎兼容性
-依赖显式 `<page>` 根节点的应用请使用 Lynx Engine **3.8.1 或更高版本**。这是根据 [HackerNews 引擎 bisect](/zh/guide/hackernews) 得出的保守兼容下限：3.8.1 是测试中能够完整渲染应用的最早引擎；3.6.0 和 3.7.0 虽然能加载数据，但当前路由不可见。修复后的显式根节点 bundle 已在源码构建的 Engine 4.1 上直接验证，但尚未在所有中间版本上重新测试。
-
-同一份修复前 CSS bundle 在 Engine 3.6.0、3.8.1 和 4.1 上都会产生 `990100` 错误。这说明崩溃来自 Vue Lynx 尝试创建第二个原生 page，而不是因为该功能要求 Engine 4.1。面向 3.6.x 或 3.7.x 时请省略显式包装，但需要注意，bisect 发现的路由渲染限制仍然独立存在。
-
-请使用 `SystemInfo.engineVersion` 判断引擎版本。在未定义 [`Lynx_POD_VERSION`](https://github.com/lynx-family/lynx/blob/develop/platform/darwin/common/lynx/base/LynxVersion.m) 的 iOS Lynx 源码构建中，DevTool 的 `sdkVersion` 字段以及错误报告中的 `sdk` 字段可能包含 fallback 值 `1.4.0`；该值不是 Lynx Engine 版本。
-:::
-
 ## 响应式系统 + 组合式函数
 
 Vue Lynx 100% 复用了 Vue 的响应式核心（`@vue/reactivity`）。每个响应式 API 的行为与标准 Vue 完全一致，没有任何 Lynx 特有的注意事项或适配。
@@ -288,3 +242,17 @@ export default defineComponent({
 |---------|--------|-------------|
 | `<Transition>` 自动时长 | 后台线程无法使用 `getComputedStyle()` | 始终传递显式的 `:duration` prop |
 | `withKeys` 按键修饰符 | 原生平台为 no-op —— Lynx 原生运行时在事件到达 JS 线程之前已将键盘输入转换为具名事件（如 `confirm`），iOS/Android 上的 `event.key` 始终为空。Web 预览在 [lynx-stack#2594](https://github.com/lynx-family/lynx-stack/pull/2594) 后可正常使用。原生端支持有赖于上游运行时变更。 | 原生端在 `<input>` 上直接使用 `@confirm` |
+
+## 顶层节点
+
+每个 Lynx 页面都有一个原生 [`<page>`](https://lynxjs.org/api/elements/built-in/page) 根节点。Vue Lynx 会自动创建它；只有需要直接给根节点绑定 class、样式、事件或 ref 时，才需要显式写出 `<page>`：
+
+```vue
+<template>
+  <page class="app" :style="pageStyle" @tap="onPageTap">
+    <view>...</view>
+  </page>
+</template>
+```
+
+显式 `<page>` 会被编译成透明内置组件，属性作用在已有的原生 page 上，不会再创建第二个。每个页面只能有一个，且必须是最外层元素。使用显式 `<page>` 时建议 Lynx Engine **3.8.1+**。


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Move the lengthy `<page>` root section off the top of the Vue compatibility guide and replace it with a short "顶层节点" / "Top-Level Nodes" section at the bottom.

- Drop the engine-bisect / discovery narrative — this is a minor caveat, not a headline topic
- Keep only the essentials: auto-created root, when to write explicit `<page>`, one-per-screen, Engine 3.8.1+
- Update both `zh` and `en` docs for parity

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-421f1ab3-b5ac-434b-8087-279ffb258693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-421f1ab3-b5ac-434b-8087-279ffb258693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

