### PR TITLE
docs: merge v-once / v-memo compatibility section + example

### DIFF
--- a/.changeset/v-once-memo-example.md
+++ b/.changeset/v-once-memo-example.md
@@ -1,0 +1,5 @@
+---
+"@vue-lynx-example/v-once-memo": patch
+---
+
+Add `v-once` / `v-memo` compatibility demo for the docs playground.

--- a/examples/v-once-memo/CHANGELOG.md
+++ b/examples/v-once-memo/CHANGELOG.md
@@ -1,0 +1,7 @@
+# @vue-lynx-example/v-once-memo
+
+## 0.2.7
+
+### Patch Changes
+
+- Initial `v-once` / `v-memo` compatibility demo.

--- a/examples/v-once-memo/lynx.config.ts
+++ b/examples/v-once-memo/lynx.config.ts
@@ -1,0 +1,29 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from '@lynx-js/rspeedy';
+import { pluginVueLynx } from 'vue-lynx/plugin';
+
+const exampleName = path.basename(path.dirname(fileURLToPath(import.meta.url)));
+
+export default defineConfig({
+  environments: {
+    web: {},
+    lynx: {},
+  },
+  output: {
+    assetPrefix: `https://vue.lynxjs.org/examples/${exampleName}/dist/`,
+  },
+  source: {
+    entry: {
+      main: './src/index.ts',
+    },
+  },
+  plugins: [
+    pluginVueLynx({
+      // IFR: render the first screen on the main thread during
+      // loadTemplate, then hydrate when the background thread boots.
+      enableIFR: true,
+      optionsApi: false,
+    }),
+  ],
+});

--- a/examples/v-once-memo/package.json
+++ b/examples/v-once-memo/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@vue-lynx-example/v-once-memo",
+  "version": "0.2.7",
+  "private": false,
+  "description": "Vue-Lynx v-once and v-memo directive demo",
+  "license": "Apache-2.0",
+  "type": "module",
+  "files": [
+    "dist",
+    "src",
+    "lynx.config.ts",
+    "tsconfig.json"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Huxpro/vue-lynx",
+    "directory": "examples/v-once-memo"
+  },
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev"
+  },
+  "dependencies": {
+    "vue-lynx": "workspace:*"
+  },
+  "devDependencies": {
+    "@lynx-js/rspeedy": "^0.13.5",
+    "@rsbuild/plugin-vue": "^1.2.6",
+    "typescript": "^5.0.0"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/examples/v-once-memo/src/App.vue
+++ b/examples/v-once-memo/src/App.vue
@@ -1,0 +1,147 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const count = ref(0)
+
+type Item = { id: number; label: string; selected: boolean }
+const items = ref<Item[]>([
+  { id: 1, label: 'Apple', selected: false },
+  { id: 2, label: 'Banana', selected: true },
+  { id: 3, label: 'Cherry', selected: false },
+])
+
+function bump() {
+  count.value++
+}
+
+function toggle(id: number) {
+  const item = items.value.find((entry) => entry.id === id)
+  if (item) item.selected = !item.selected
+}
+
+function rename(id: number) {
+  const item = items.value.find((entry) => entry.id === id)
+  if (!item) return
+  item.label = item.label.endsWith('!') ? item.label.slice(0, -1) : `${item.label}!`
+}
+</script>
+
+<template>
+  <scroll-view
+    scroll-orientation="vertical"
+    :style="{ width: '100%', height: '100%', backgroundColor: '#f5f5f5', padding: '16px' }"
+  >
+    <text :style="{ fontSize: '20px', fontWeight: 'bold', marginBottom: '16px', color: '#111' }">
+      v-once / v-memo
+    </text>
+
+    <!-- 1. v-once -->
+    <view :style="{ marginBottom: '24px' }">
+      <text :style="{ fontSize: '14px', fontWeight: 'bold', marginBottom: '8px', color: '#111' }">
+        1. v-once — freeze after first render
+      </text>
+      <text :style="{ fontSize: '12px', color: '#666', marginBottom: '8px' }">
+        Tap Increment. The live value updates; the v-once value stays at the first render.
+      </text>
+
+      <view
+        :style="{
+          padding: '12px',
+          marginBottom: '8px',
+          backgroundColor: '#fff',
+          borderRadius: '8px',
+        }"
+      >
+        <text :style="{ fontSize: '13px', color: '#333', marginBottom: '4px' }">
+          Live: {{ count }}
+        </text>
+        <text v-once :style="{ fontSize: '13px', color: '#888' }">
+          Frozen (v-once): {{ count }}
+        </text>
+      </view>
+
+      <view
+        :style="{
+          alignSelf: 'flex-start',
+          padding: '8px 14px',
+          backgroundColor: '#4a90d9',
+          borderRadius: '4px',
+        }"
+        @tap="bump"
+      >
+        <text :style="{ color: '#fff', fontSize: '13px' }">Increment</text>
+      </view>
+    </view>
+
+    <!-- 2. v-memo -->
+    <view :style="{ marginBottom: '24px' }">
+      <text :style="{ fontSize: '14px', fontWeight: 'bold', marginBottom: '8px', color: '#111' }">
+        2. v-memo — skip when deps are unchanged
+      </text>
+      <text :style="{ fontSize: '12px', color: '#666', marginBottom: '8px' }">
+        Each row memos on `[selected, label]`. Bumping the shared count does not refresh a row;
+        toggling or renaming that row does — and the "saw count" value catches up.
+      </text>
+
+      <text :style="{ fontSize: '12px', color: '#555', marginBottom: '8px' }">
+        Shared count: {{ count }}
+      </text>
+
+      <view
+        v-for="item in items"
+        :key="item.id"
+        v-memo="[item.selected, item.label]"
+        :style="{
+          padding: '12px',
+          marginBottom: '8px',
+          backgroundColor: item.selected ? '#e8f1fb' : '#fff',
+          borderRadius: '8px',
+          borderWidth: '1px',
+          borderColor: item.selected ? '#4a90d9' : '#e0e0e0',
+        }"
+      >
+        <text :style="{ fontSize: '14px', fontWeight: 'bold', color: '#111', marginBottom: '4px' }">
+          {{ item.label }}
+        </text>
+        <text :style="{ fontSize: '12px', color: '#666', marginBottom: '8px' }">
+          selected={{ item.selected }} · saw count={{ count }}
+        </text>
+        <view :style="{ flexDirection: 'row' }">
+          <view
+            :style="{
+              padding: '6px 10px',
+              marginRight: '8px',
+              backgroundColor: '#4a90d9',
+              borderRadius: '4px',
+            }"
+            @tap="toggle(item.id)"
+          >
+            <text :style="{ color: '#fff', fontSize: '12px' }">Toggle</text>
+          </view>
+          <view
+            :style="{
+              padding: '6px 10px',
+              backgroundColor: '#555',
+              borderRadius: '4px',
+            }"
+            @tap="rename(item.id)"
+          >
+            <text :style="{ color: '#fff', fontSize: '12px' }">Rename</text>
+          </view>
+        </view>
+      </view>
+
+      <view
+        :style="{
+          alignSelf: 'flex-start',
+          padding: '8px 14px',
+          backgroundColor: '#27ae60',
+          borderRadius: '4px',
+        }"
+        @tap="bump"
+      >
+        <text :style="{ color: '#fff', fontSize: '13px' }">Bump shared count</text>
+      </view>
+    </view>
+  </scroll-view>
+</template>

--- a/examples/v-once-memo/src/index.ts
+++ b/examples/v-once-memo/src/index.ts
@@ -1,0 +1,6 @@
+import { createApp } from 'vue-lynx';
+
+import App from './App.vue';
+
+const app = createApp(App);
+app.mount();

--- a/examples/v-once-memo/src/shims-vue.d.ts
+++ b/examples/v-once-memo/src/shims-vue.d.ts
@@ -1,0 +1,6 @@
+declare module '*.vue' {
+  import type { Component } from 'vue-lynx';
+
+  const component: Component;
+  export default component;
+}

--- a/examples/v-once-memo/tsconfig.json
+++ b/examples/v-once-memo/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["src", "lynx.config.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,10 +26,10 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.8))
+        version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
-        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+        version: 1.2.7(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.8(@swc/helpers@0.5.19))
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -580,6 +580,22 @@ importers:
         version: 1.2.7(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.8(@swc/helpers@0.5.19))
       typescript:
         specifier: ~5.9.3
+        version: 5.9.3
+
+  examples/v-once-memo:
+    dependencies:
+      vue-lynx:
+        specifier: workspace:*
+        version: link:../../packages/vue-lynx
+    devDependencies:
+      '@lynx-js/rspeedy':
+        specifier: ^0.13.5
+        version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.8))
+      '@rsbuild/plugin-vue':
+        specifier: ^1.2.6
+        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+      typescript:
+        specifier: ^5.0.0
         version: 5.9.3
 
   examples/vue-router:
@@ -2708,11 +2724,6 @@ packages:
     resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
     engines: {node: '>=0.4.0'}
 
-  acorn@8.16.0:
-    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
   acorn@8.17.0:
     resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
     engines: {node: '>=0.4.0'}
@@ -2844,11 +2855,6 @@ packages:
     resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
     engines: {node: ^4.5.0 || >= 5.9}
 
-  baseline-browser-mapping@2.10.0:
-    resolution: {integrity: sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   baseline-browser-mapping@2.10.43:
     resolution: {integrity: sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==}
     engines: {node: '>=6.0.0'}
@@ -2897,11 +2903,6 @@ packages:
 
   browserslist-to-es-version@1.4.1:
     resolution: {integrity: sha512-1bYCrck5Qh5HUy7P+iDuK39v757/ry5PnQo20vf4sHGeUrYKL2N2OF05U9ARSGt06TpFDQiTv9MT+eitYgWWxA==}
-    hasBin: true
-
-  browserslist@4.28.1:
-    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
-    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
   browserslist@4.28.6:
@@ -3339,9 +3340,6 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.313:
-    resolution: {integrity: sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==}
-
   electron-to-chromium@1.5.392:
     resolution: {integrity: sha512-1yQq3VQCZRwsnYc67Oc+1fge6Lwtn0hzi6zmEVkB61Zx21kTbwJAW4dFLadl5Rc1tKhG/kSpYXnfiAhu0f0a1g==}
 
@@ -3586,10 +3584,6 @@ packages:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
-  fs-extra@11.3.4:
-    resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
-    engines: {node: '>=14.14'}
-
   fs-extra@11.3.6:
     resolution: {integrity: sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==}
     engines: {node: '>=14.14'}
@@ -3698,10 +3692,6 @@ packages:
 
   has-tostringtag@1.0.2:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
-    engines: {node: '>= 0.4'}
-
-  hasown@2.0.2:
-    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
   hasown@2.0.4:
@@ -4061,9 +4051,6 @@ packages:
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
-
-  jsonfile@6.2.0:
-    resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
 
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
@@ -4451,9 +4438,6 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
-
-  node-releases@2.0.36:
-    resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
 
   node-releases@2.0.51:
     resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
@@ -6694,7 +6678,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.5.0
+      '@types/node': 25.9.5
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -6905,11 +6889,11 @@ snapshots:
 
   '@mdx-js/mdx@3.1.1':
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdx': 2.0.13
-      acorn: 8.16.0
+      acorn: 8.17.0
       collapse-white-space: 2.1.0
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
@@ -6918,7 +6902,7 @@ snapshots:
       hast-util-to-jsx-runtime: 2.3.6
       markdown-extensions: 2.0.0
       recma-build-jsx: 1.0.0
-      recma-jsx: 1.0.1(acorn@8.16.0)
+      recma-jsx: 1.0.1(acorn@8.17.0)
       recma-stringify: 1.0.0
       rehype-recma: 1.0.0
       remark-mdx: 3.1.1
@@ -7217,7 +7201,7 @@ snapshots:
 
   '@rsbuild/plugin-check-syntax@1.3.0(@rsbuild/core@1.7.3)':
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
       browserslist-to-es-version: 1.4.1
       htmlparser2: 10.0.0
       picocolors: 1.1.1
@@ -7327,7 +7311,7 @@ snapshots:
       browserslist-load-config: 1.0.1
       enhanced-resolve: 5.12.0
       filesize: 10.1.6
-      fs-extra: 11.3.4
+      fs-extra: 11.3.6
       lodash: 4.17.23
       path-browserify: 1.0.1
       semver: 7.7.4
@@ -7352,7 +7336,7 @@ snapshots:
       browserslist-load-config: 1.0.1
       enhanced-resolve: 5.12.0
       filesize: 10.1.6
-      fs-extra: 11.3.4
+      fs-extra: 11.3.6
       lodash: 4.17.23
       path-browserify: 1.0.1
       semver: 7.7.4
@@ -7434,7 +7418,7 @@ snapshots:
       body-parser: 1.20.3
       cors: 2.8.5
       dayjs: 1.11.13
-      fs-extra: 11.3.4
+      fs-extra: 11.3.6
       json-cycle: 1.5.0
       open: 8.4.2
       sirv: 2.0.4
@@ -7458,7 +7442,7 @@ snapshots:
       body-parser: 1.20.3
       cors: 2.8.5
       dayjs: 1.11.13
-      fs-extra: 11.3.4
+      fs-extra: 11.3.6
       json-cycle: 1.5.0
       open: 8.4.2
       sirv: 2.0.4
@@ -7497,14 +7481,14 @@ snapshots:
       '@babel/code-frame': 7.26.2
       '@rsdoctor/types': 1.2.3(@rspack/core@1.7.8(@swc/helpers@0.5.19))(webpack@5.105.4(postcss@8.5.8))
       '@types/estree': 1.0.5
-      acorn: 8.16.0
-      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      acorn: 8.17.0
+      acorn-import-attributes: 1.9.5(acorn@8.17.0)
       acorn-walk: 8.3.4
       connect: 3.7.0
       deep-eql: 4.1.4
       envinfo: 7.14.0
       filesize: 10.1.6
-      fs-extra: 11.3.4
+      fs-extra: 11.3.6
       get-port: 5.1.1
       json-stream-stringify: 3.0.1
       lines-and-columns: 2.0.4
@@ -7521,14 +7505,14 @@ snapshots:
       '@babel/code-frame': 7.26.2
       '@rsdoctor/types': 1.2.3(@rspack/core@1.7.8(@swc/helpers@0.5.19))(webpack@5.105.4)
       '@types/estree': 1.0.5
-      acorn: 8.16.0
-      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      acorn: 8.17.0
+      acorn-import-attributes: 1.9.5(acorn@8.17.0)
       acorn-walk: 8.3.4
       connect: 3.7.0
       deep-eql: 4.1.4
       envinfo: 7.14.0
       filesize: 10.1.6
-      fs-extra: 11.3.4
+      fs-extra: 11.3.6
       get-port: 5.1.1
       json-stream-stringify: 3.0.1
       lines-and-columns: 2.0.4
@@ -8199,11 +8183,11 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.9.5
 
   '@types/cors@2.8.19':
     dependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.9.5
 
   '@types/debug@4.1.12':
     dependencies:
@@ -8223,7 +8207,7 @@ snapshots:
 
   '@types/estree-jsx@1.0.5':
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   '@types/estree@1.0.5': {}
 
@@ -8234,7 +8218,7 @@ snapshots:
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 25.5.0
+      '@types/node': 25.9.5
 
   '@types/hast@3.0.4':
     dependencies:
@@ -8256,7 +8240,7 @@ snapshots:
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.9.5
 
   '@types/linkify-it@5.0.0': {}
 
@@ -8299,7 +8283,7 @@ snapshots:
 
   '@types/tapable@2.2.7':
     dependencies:
-      tapable: 2.3.0
+      tapable: 2.3.3
 
   '@types/trusted-types@2.0.7':
     optional: true
@@ -8312,7 +8296,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.9.5
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -8536,23 +8520,21 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
-  acorn-import-attributes@1.9.5(acorn@8.16.0):
+  acorn-import-attributes@1.9.5(acorn@8.17.0):
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
 
   acorn-import-phases@1.0.4(acorn@8.17.0):
     dependencies:
       acorn: 8.17.0
 
-  acorn-jsx@5.3.2(acorn@8.16.0):
+  acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.17.0
 
   acorn-walk@8.3.4:
     dependencies:
-      acorn: 8.16.0
-
-  acorn@8.16.0: {}
+      acorn: 8.17.0
 
   acorn@8.17.0: {}
 
@@ -8663,8 +8645,6 @@ snapshots:
 
   base64id@2.0.0: {}
 
-  baseline-browser-mapping@2.10.0: {}
-
   baseline-browser-mapping@2.10.43: {}
 
   better-path-resolve@1.0.0:
@@ -8717,15 +8697,7 @@ snapshots:
 
   browserslist-to-es-version@1.4.1:
     dependencies:
-      browserslist: 4.28.1
-
-  browserslist@4.28.1:
-    dependencies:
-      baseline-browser-mapping: 2.10.0
-      caniuse-lite: 1.0.30001778
-      electron-to-chromium: 1.5.313
-      node-releases: 2.0.36
-      update-browserslist-db: 1.2.3(browserslist@4.28.1)
+      browserslist: 4.28.6
 
   browserslist@4.28.6:
     dependencies:
@@ -8764,8 +8736,8 @@ snapshots:
 
   caniuse-api@3.0.0:
     dependencies:
-      browserslist: 4.28.1
-      caniuse-lite: 1.0.30001778
+      browserslist: 4.28.6
+      caniuse-lite: 1.0.30001805
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
 
@@ -8948,7 +8920,7 @@ snapshots:
 
   cssnano-preset-default@7.0.11(postcss@8.5.8):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.6
       css-declaration-sorter: 7.3.1(postcss@8.5.8)
       cssnano-utils: 5.0.1(postcss@8.5.8)
       postcss: 8.5.8
@@ -9142,8 +9114,6 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.313: {}
-
   electron-to-chromium@1.5.392: {}
 
   emoji-regex-xs@1.0.0: {}
@@ -9157,7 +9127,7 @@ snapshots:
   engine.io@6.6.6:
     dependencies:
       '@types/cors': 2.8.19
-      '@types/node': 25.5.0
+      '@types/node': 25.9.5
       '@types/ws': 8.18.1
       accepts: 1.3.8
       base64id: 2.0.0
@@ -9174,7 +9144,7 @@ snapshots:
   enhanced-resolve@5.12.0:
     dependencies:
       graceful-fs: 4.2.11
-      tapable: 2.3.0
+      tapable: 2.3.3
 
   enhanced-resolve@5.24.2:
     dependencies:
@@ -9222,7 +9192,7 @@ snapshots:
       has-property-descriptors: 1.0.2
       has-proto: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       internal-slot: 1.1.0
       is-array-buffer: 3.0.5
       is-callable: 1.2.7
@@ -9272,7 +9242,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   es-to-primitive@1.3.0:
     dependencies:
@@ -9290,7 +9260,7 @@ snapshots:
   esast-util-from-js@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
-      acorn: 8.16.0
+      acorn: 8.17.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
 
@@ -9348,7 +9318,7 @@ snapshots:
 
   estree-util-attach-comments@3.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   estree-util-build-jsx@3.0.1:
     dependencies:
@@ -9361,7 +9331,7 @@ snapshots:
 
   estree-util-scope@1.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       devlop: 1.1.0
 
   estree-util-to-js@2.0.0:
@@ -9379,7 +9349,7 @@ snapshots:
 
   estree-walker@3.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
 
   eventemitter3@5.0.4: {}
 
@@ -9457,21 +9427,14 @@ snapshots:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       mime-types: 2.1.35
-
-  fs-extra@11.3.4:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.2.0
-      universalify: 2.0.1
 
   fs-extra@11.3.6:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.2.1
       universalify: 2.0.1
-    optional: true
 
   fs-extra@7.0.1:
     dependencies:
@@ -9496,7 +9459,7 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       functions-have-names: 1.2.3
-      hasown: 2.0.2
+      hasown: 2.0.4
       is-callable: 1.2.7
 
   functions-have-names@1.2.3: {}
@@ -9515,7 +9478,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-port@5.1.1: {}
@@ -9590,14 +9553,9 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
-  hasown@2.0.2:
-    dependencies:
-      function-bind: 1.1.2
-
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
-    optional: true
 
   hast-util-from-parse5@8.0.3:
     dependencies:
@@ -9640,7 +9598,7 @@ snapshots:
 
   hast-util-to-estree@3.1.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       comma-separated-tokens: 2.0.3
@@ -9675,7 +9633,7 @@ snapshots:
 
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/hast': 3.0.4
       '@types/unist': 3.0.3
       comma-separated-tokens: 2.0.3
@@ -9790,7 +9748,7 @@ snapshots:
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       side-channel: 1.1.0
 
   is-absolute-url@4.0.1: {}
@@ -9833,7 +9791,7 @@ snapshots:
 
   is-core-module@2.16.1:
     dependencies:
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   is-core-module@2.16.2:
     dependencies:
@@ -9897,7 +9855,7 @@ snapshots:
       call-bound: 1.0.4
       gopd: 1.2.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   is-set@2.0.3: {}
 
@@ -9954,7 +9912,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.5.0
+      '@types/node': 25.9.5
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -9968,7 +9926,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 25.5.0
+      '@types/node': 25.9.5
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -10064,18 +10022,11 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
-  jsonfile@6.2.0:
-    dependencies:
-      universalify: 2.0.1
-    optionalDependencies:
-      graceful-fs: 4.2.11
-
   jsonfile@6.2.1:
     dependencies:
       universalify: 2.0.1
     optionalDependencies:
       graceful-fs: 4.2.11
-    optional: true
 
   kind-of@6.0.3: {}
 
@@ -10456,7 +10407,7 @@ snapshots:
 
   micromark-extension-mdx-expression@3.0.1:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       devlop: 1.1.0
       micromark-factory-mdx-expression: 2.0.3
       micromark-factory-space: 2.0.1
@@ -10467,7 +10418,7 @@ snapshots:
 
   micromark-extension-mdx-jsx@3.0.2:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       micromark-factory-mdx-expression: 2.0.3
@@ -10484,7 +10435,7 @@ snapshots:
 
   micromark-extension-mdxjs-esm@3.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
       micromark-util-character: 2.1.1
@@ -10496,8 +10447,8 @@ snapshots:
 
   micromark-extension-mdxjs@3.0.0:
     dependencies:
-      acorn: 8.16.0
-      acorn-jsx: 5.3.2(acorn@8.16.0)
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
       micromark-extension-mdx-expression: 3.0.1
       micromark-extension-mdx-jsx: 3.0.2
       micromark-extension-mdx-md: 2.0.0
@@ -10520,7 +10471,7 @@ snapshots:
 
   micromark-factory-mdx-expression@2.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       devlop: 1.1.0
       micromark-factory-space: 2.0.1
       micromark-util-character: 2.1.1
@@ -10584,7 +10535,7 @@ snapshots:
 
   micromark-util-events-to-acorn@2.0.3:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/unist': 3.0.3
       devlop: 1.1.0
       estree-util-visit: 2.0.0
@@ -10699,8 +10650,6 @@ snapshots:
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
-
-  node-releases@2.0.36: {}
 
   node-releases@2.0.51: {}
 
@@ -10860,7 +10809,7 @@ snapshots:
 
   postcss-colormin@7.0.6(postcss@8.5.8):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.6
       caniuse-api: 3.0.0
       colord: 2.9.3
       postcss: 8.5.8
@@ -10868,7 +10817,7 @@ snapshots:
 
   postcss-convert-values@7.0.9(postcss@8.5.8):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.6
       postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
@@ -10918,7 +10867,7 @@ snapshots:
 
   postcss-merge-rules@7.0.8(postcss@8.5.8):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.6
       caniuse-api: 3.0.0
       cssnano-utils: 5.0.1(postcss@8.5.8)
       postcss: 8.5.8
@@ -10938,7 +10887,7 @@ snapshots:
 
   postcss-minify-params@7.0.6(postcss@8.5.8):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.6
       cssnano-utils: 5.0.1(postcss@8.5.8)
       postcss: 8.5.8
       postcss-value-parser: 4.2.0
@@ -10985,7 +10934,7 @@ snapshots:
 
   postcss-normalize-unicode@7.0.6(postcss@8.5.8):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.6
       postcss: 8.5.8
       postcss-value-parser: 4.2.0
 
@@ -11007,7 +10956,7 @@ snapshots:
 
   postcss-reduce-initial@7.0.6(postcss@8.5.8):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.6
       caniuse-api: 3.0.0
       postcss: 8.5.8
 
@@ -11287,14 +11236,14 @@ snapshots:
 
   recma-build-jsx@1.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       estree-util-build-jsx: 3.0.1
       vfile: 6.0.3
 
-  recma-jsx@1.0.1(acorn@8.16.0):
+  recma-jsx@1.0.1(acorn@8.17.0):
     dependencies:
-      acorn: 8.16.0
-      acorn-jsx: 5.3.2(acorn@8.16.0)
+      acorn: 8.17.0
+      acorn-jsx: 5.3.2(acorn@8.17.0)
       estree-util-to-js: 2.0.0
       recma-parse: 1.0.0
       recma-stringify: 1.0.0
@@ -11302,14 +11251,14 @@ snapshots:
 
   recma-parse@1.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       esast-util-from-js: 2.0.1
       unified: 11.0.5
       vfile: 6.0.3
 
   recma-stringify@1.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       estree-util-to-js: 2.0.0
       unified: 11.0.5
       vfile: 6.0.3
@@ -11377,7 +11326,7 @@ snapshots:
 
   rehype-recma@1.0.0:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/hast': 3.0.4
       hast-util-to-estree: 3.1.3
     transitivePeerDependencies:
@@ -11946,7 +11895,7 @@ snapshots:
 
   stylehacks@7.0.8(postcss@8.5.8):
     dependencies:
-      browserslist: 4.28.1
+      browserslist: 4.28.6
       postcss: 8.5.8
       postcss-selector-parser: 7.1.1
 
@@ -12262,12 +12211,6 @@ snapshots:
   universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
-
-  update-browserslist-db@1.2.3(browserslist@4.28.1):
-    dependencies:
-      browserslist: 4.28.1
-      escalade: 3.2.0
-      picocolors: 1.1.1
 
   update-browserslist-db@1.2.3(browserslist@4.28.6):
     dependencies:

--- a/website/docs/guide/vue-compatibility.mdx
+++ b/website/docs/guide/vue-compatibility.mdx
@@ -223,43 +223,14 @@ The example below uses `defineComponent` with `data()`, `computed`, `watch`, `me
 
 ## v-once / v-memo
 
-[`v-once`](https://vuejs.org/api/built-in-directives.html#v-once) and [`v-memo`](https://vuejs.org/api/built-in-directives.html#v-memo) work in Vue Lynx without any configuration. The SFC template compiler already emits the cache lookups (`setBlockTracking` / `_cache` for `v-once`, `withMemo()` for `v-memo`), and the runtime bails out before the patcher runs.
-
-On Lynx a cache hit is especially valuable: the whole cross-thread op batch for that subtree is skipped, not just DOM diffing. Prefer `v-once` for content that never changes after first render; use `v-memo` when a subtree should update only for a short dependency list (common in `v-for` rows):
-
-```vue
-<text v-once>{{ expensiveInitialValue }}</text>
-
-<view
-  v-for="item in list"
-  :key="item.id"
-  v-memo="[item.selected, item.label]"
->
-  <!-- Only re-renders when selected or label changes -->
-</view>
-```
-
-The example below freezes a value with `v-once`, then shows a memoized list whose rows keep a stale "saw count" until their deps change:
+[`v-once`](https://vuejs.org/api/built-in-directives.html#v-once) and [`v-memo`](https://vuejs.org/api/built-in-directives.html#v-memo) work in Vue Lynx without any configuration. On Lynx a cache hit skips the whole cross-thread op batch for that subtree — prefer `v-once` for never-changing content, and `v-memo` when a subtree should update only for a short dependency list (common in `v-for` rows).
 
 <Go
   example="v-once-memo"
   defaultFile="src/App.vue"
 />
 
-For render functions, `withMemo` is exported from `vue-lynx`:
-
-```ts
-import { defineComponent, h, ref } from 'vue'
-import { withMemo } from 'vue-lynx'
-
-export default defineComponent({
-  setup() {
-    const dep = ref('')
-    const cache: unknown[] = [] // per-instance, mirrors SFC _cache
-    return () => withMemo([dep.value], () => h('view', { content: dep.value }), cache, 0)
-  },
-})
-```
+For render functions, Vue's `withMemo` helper (what the compiler emits for [`v-memo`](https://vuejs.org/api/built-in-directives.html#v-memo)) is re-exported from `vue-lynx`.
 
 ## Teleport
 

--- a/website/docs/guide/vue-compatibility.mdx
+++ b/website/docs/guide/vue-compatibility.mdx
@@ -221,47 +221,32 @@ The example below uses `defineComponent` with `data()`, `computed`, `watch`, `me
   defaultFile="src/App.vue"
 />
 
-## v-once
+## v-once / v-memo
 
-[`v-once`](https://vuejs.org/api/built-in-directives.html#v-once) renders an element or component exactly once and skips all future updates. It works in Vue Lynx without any configuration — the SFC template compiler emits a cache lookup using `setBlockTracking` and the component's `_cache` array, and the runtime short-circuits on subsequent renders.
+[`v-once`](https://vuejs.org/api/built-in-directives.html#v-once) and [`v-memo`](https://vuejs.org/api/built-in-directives.html#v-memo) work in Vue Lynx without any configuration. The SFC template compiler already emits the cache lookups (`setBlockTracking` / `_cache` for `v-once`, `withMemo()` for `v-memo`), and the runtime bails out before the patcher runs.
 
-In Lynx, `v-once` is more impactful than in the browser because a cache hit eliminates the entire cross-thread op batch. After the initial mount:
-
-- The VNode patcher receives the same cached VNode object reference.
-- No `patchProp` calls are made, so no ops enter the buffer.
-- `doFlush` sees an empty buffer and skips `callLepusMethod` entirely — the main thread is never contacted for that subtree.
-
-Use `v-once` for genuinely static content that should never update after first render:
+On Lynx a cache hit is especially valuable: the whole cross-thread op batch for that subtree is skipped, not just DOM diffing. Prefer `v-once` for content that never changes after first render; use `v-memo` when a subtree should update only for a short dependency list (common in `v-for` rows):
 
 ```vue
 <text v-once>{{ expensiveInitialValue }}</text>
-```
 
-> `v-once` is a stronger guarantee than `v-memo` — it caches unconditionally, with no dependency array to check. Prefer it when content is truly static.
-
-## v-memo
-
-[`v-memo`](https://vuejs.org/api/built-in-directives.html#v-memo) skips a subtree re-render when its dependency array hasn't changed. It works in Vue Lynx without any configuration — the SFC template compiler already emits the correct `withMemo()` calls, and the runtime bails out before the patcher runs.
-
-In Lynx, `v-memo` is more impactful than in the browser because a cache hit eliminates the entire cross-thread op batch, not just DOM diffing. When deps are unchanged:
-
-- The VNode patcher short-circuits (same VNode object reference).
-- No `patchProp` calls are made, so no ops enter the buffer.
-- `doFlush` sees an empty buffer and skips `callLepusMethod` entirely — the main thread is never contacted for that subtree.
-
-The primary use case is `v-for` lists where only some items change on each update:
-
-```vue
-<list-item
+<view
   v-for="item in list"
   :key="item.id"
   v-memo="[item.selected, item.label]"
 >
   <!-- Only re-renders when selected or label changes -->
-</list-item>
+</view>
 ```
 
-For render functions written in JavaScript, `withMemo` is exported directly from `vue-lynx`:
+The example below freezes a value with `v-once`, then shows a memoized list whose rows keep a stale "saw count" until their deps change:
+
+<Go
+  example="v-once-memo"
+  defaultFile="src/App.vue"
+/>
+
+For render functions, `withMemo` is exported from `vue-lynx`:
 
 ```ts
 import { defineComponent, h, ref } from 'vue'

--- a/website/docs/zh/guide/vue-compatibility.mdx
+++ b/website/docs/zh/guide/vue-compatibility.mdx
@@ -223,43 +223,14 @@ pluginVueLynx({
 
 ## v-once / v-memo
 
-[`v-once`](https://vuejs.org/api/built-in-directives.html#v-once) 与 [`v-memo`](https://vuejs.org/api/built-in-directives.html#v-memo) 在 Vue Lynx 中无需任何配置即可使用。SFC 模板编译器已经会生成对应的缓存查找（`v-once` 使用 `setBlockTracking` / `_cache`，`v-memo` 使用 `withMemo()`），运行时会在 patcher 执行前短路。
-
-在 Lynx 上缓存命中尤其有价值：会跳过该子树的整批跨线程 op，而不仅仅是 DOM diff。内容在首次渲染后永不变化时优先用 `v-once`；当子树只应随一小段依赖更新时用 `v-memo`（常见于 `v-for` 列表项）：
-
-```vue
-<text v-once>{{ expensiveInitialValue }}</text>
-
-<view
-  v-for="item in list"
-  :key="item.id"
-  v-memo="[item.selected, item.label]"
->
-  <!-- 仅在 selected 或 label 变化时重新渲染 -->
-</view>
-```
-
-下面的示例用 `v-once` 冻结一个值，再用 memoized 列表展示：行内的 "saw count" 会保持旧值，直到该行的依赖发生变化：
+[`v-once`](https://vuejs.org/api/built-in-directives.html#v-once) 与 [`v-memo`](https://vuejs.org/api/built-in-directives.html#v-memo) 在 Vue Lynx 中无需任何配置即可使用。在 Lynx 上缓存命中会跳过该子树的整批跨线程 op——内容永不变化时用 `v-once`，子树只应随一小段依赖更新时用 `v-memo`（常见于 `v-for` 列表项）。
 
 <Go
   example="v-once-memo"
   defaultFile="src/App.vue"
 />
 
-对于用 JavaScript 编写的渲染函数，`withMemo` 可直接从 `vue-lynx` 导入：
-
-```ts
-import { defineComponent, h, ref } from 'vue'
-import { withMemo } from 'vue-lynx'
-
-export default defineComponent({
-  setup() {
-    const dep = ref('')
-    const cache: unknown[] = [] // 每实例独立，对应 SFC 编译产物中的 _cache
-    return () => withMemo([dep.value], () => h('view', { content: dep.value }), cache, 0)
-  },
-})
-```
+对于渲染函数，Vue 的 `withMemo` 辅助函数（编译器为 [`v-memo`](https://vuejs.org/api/built-in-directives.html#v-memo) 生成的运行时 API）已从 `vue-lynx` 重新导出。
 
 ## Teleport
 

--- a/website/docs/zh/guide/vue-compatibility.mdx
+++ b/website/docs/zh/guide/vue-compatibility.mdx
@@ -221,45 +221,30 @@ pluginVueLynx({
   defaultFile="src/App.vue"
 />
 
-## v-once
+## v-once / v-memo
 
-[`v-once`](https://vuejs.org/api/built-in-directives.html#v-once) 仅渲染元素或组件一次，并跳过所有后续更新。它在 Vue Lynx 中无需任何配置即可使用——SFC 模板编译器会生成使用 `setBlockTracking` 和组件 `_cache` 数组的缓存查找，运行时在后续渲染时短路。
+[`v-once`](https://vuejs.org/api/built-in-directives.html#v-once) 与 [`v-memo`](https://vuejs.org/api/built-in-directives.html#v-memo) 在 Vue Lynx 中无需任何配置即可使用。SFC 模板编译器已经会生成对应的缓存查找（`v-once` 使用 `setBlockTracking` / `_cache`，`v-memo` 使用 `withMemo()`），运行时会在 patcher 执行前短路。
 
-在 Lynx 中，`v-once` 比在浏览器中更有价值，因为缓存命中可以消除整个跨线程 op 批次。首次挂载后：
-
-- VNode patcher 接收到相同的缓存 VNode 对象引用。
-- 不会发生 `patchProp` 调用，因此没有 op 进入缓冲区。
-- `doFlush` 看到空缓冲区并完全跳过 `callLepusMethod`——该子树的主线程永远不会被联系。
-
-对于首次渲染后永远不需要更新的真正静态内容，使用 `v-once`：
+在 Lynx 上缓存命中尤其有价值：会跳过该子树的整批跨线程 op，而不仅仅是 DOM diff。内容在首次渲染后永不变化时优先用 `v-once`；当子树只应随一小段依赖更新时用 `v-memo`（常见于 `v-for` 列表项）：
 
 ```vue
 <text v-once>{{ expensiveInitialValue }}</text>
-```
 
-> `v-once` 是比 `v-memo` 更强的保证——它无条件缓存，无需检查依赖数组。当内容真正静态时优先使用它。
-
-## v-memo
-
-[`v-memo`](https://vuejs.org/api/built-in-directives.html#v-memo) 在依赖数组未发生变化时跳过子树的重新渲染。它在 Vue Lynx 中无需任何配置即可使用——SFC 模板编译器已经生成了正确的 `withMemo()` 调用，运行时会在 patcher 执行之前进行短路。
-
-在 Lynx 中，`v-memo` 比在浏览器中更有价值，因为缓存命中可以消除整个跨线程 op 批次，而不仅仅是 DOM diff。当依赖未变化时：
-
-- VNode patcher 立即短路（返回相同的 VNode 对象引用）。
-- 不会调用 `patchProp`，因此 ops 缓冲区保持为空。
-- `doFlush` 发现缓冲区为空，完全跳过 `callLepusMethod`——主线程对该子树不会有任何联系。
-
-主要使用场景是 `v-for` 列表，其中每次更新只有部分项目发生变化：
-
-```vue
-<list-item
+<view
   v-for="item in list"
   :key="item.id"
   v-memo="[item.selected, item.label]"
 >
   <!-- 仅在 selected 或 label 变化时重新渲染 -->
-</list-item>
+</view>
 ```
+
+下面的示例用 `v-once` 冻结一个值，再用 memoized 列表展示：行内的 "saw count" 会保持旧值，直到该行的依赖发生变化：
+
+<Go
+  example="v-once-memo"
+  defaultFile="src/App.vue"
+/>
 
 对于用 JavaScript 编写的渲染函数，`withMemo` 可直接从 `vue-lynx` 导入：
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Merges the separate `v-once` and `v-memo` sections in Vue Compatibility into one entry (EN + ZH), restyles them to match neighboring sections like KeepAlive / Suspense, and adds an interactive `examples/v-once-memo` Go playground demo.

## History (who / when / release)

| Feature | First verified & documented | Author | PR | Release |
|---------|----------------------------|--------|-----|---------|
| `v-memo` | 2026-04-17 | kealan (+ Huxpro co-author) | [#156](https://github.com/Huxpro/vue-lynx/pull/156) | **vue-lynx 0.4.0** |
| `v-once` | 2026-05-07 | kealan | [#176](https://github.com/Huxpro/vue-lynx/pull/176) | **vue-lynx 0.4.0** |

Both were added as separate `##` headings in `vue-compatibility`; this PR collapses them into a single short section with official Vue API links.

## Changes

- One short EN/ZH section linking [`v-once`](https://vuejs.org/api/built-in-directives.html#v-once) / [`v-memo`](https://vuejs.org/api/built-in-directives.html#v-memo)
- Note that `withMemo` is Vue's compiler helper for `v-memo`, re-exported from `vue-lynx` for render functions
- New `examples/v-once-memo` demo wired via `<Go example="v-once-memo" />`

## Test plan

- [x] `pnpm build` (vue-lynx)
- [x] `pnpm --filter @vue-lynx-example/v-once-memo build` (web + lynx bundles)
- [ ] Spot-check the Go playground: Increment freezes `v-once`; Bump shared count leaves memoized rows stale; Toggle/Rename refreshes that row's "saw count"

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ccbb6b13-383d-4d1f-87bd-d8dc0cccb125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ccbb6b13-383d-4d1f-87bd-d8dc0cccb125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

