### PR TITLE
docs(examples): add Teleport demo to vue-compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ pnpm dev
 - [`provide-inject`](examples/provide-inject) — `provide()` / `inject()`
 - [`suspense`](examples/suspense) — Suspense and async components
 - [`transition`](examples/transition) — `<Transition>` and `<TransitionGroup>`
+- [`teleport`](examples/teleport) — `<Teleport to="#id">`
 - [`css-features`](examples/css-features) — CSS selectors and features
 - [`main-thread`](examples/main-thread) — Main thread script
 - [`networking`](examples/networking) — Network requests and data fetching

--- a/examples/teleport/lynx.config.ts
+++ b/examples/teleport/lynx.config.ts
@@ -1,0 +1,29 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from '@lynx-js/rspeedy';
+import { pluginVueLynx } from 'vue-lynx/plugin';
+
+const exampleName = path.basename(path.dirname(fileURLToPath(import.meta.url)));
+
+export default defineConfig({
+  environments: {
+    web: {},
+    lynx: {},
+  },
+  output: {
+    assetPrefix: `https://vue.lynxjs.org/examples/${exampleName}/dist/`,
+  },
+  source: {
+    entry: {
+      main: './src/index.ts',
+    },
+  },
+  plugins: [
+    pluginVueLynx({
+      // IFR: render the first screen on the main thread during
+      // loadTemplate, then hydrate when the background thread boots.
+      enableIFR: true,
+      optionsApi: false,
+    }),
+  ],
+});

--- a/examples/teleport/package.json
+++ b/examples/teleport/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@vue-lynx-example/teleport",
+  "version": "0.0.0",
+  "private": false,
+  "description": "Vue-Lynx Teleport demo — render content to a remote #id target",
+  "license": "Apache-2.0",
+  "type": "module",
+  "files": [
+    "dist",
+    "src",
+    "lynx.config.ts",
+    "tsconfig.json"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Huxpro/vue-lynx",
+    "directory": "examples/teleport"
+  },
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev"
+  },
+  "dependencies": {
+    "vue-lynx": "workspace:*"
+  },
+  "devDependencies": {
+    "@lynx-js/rspeedy": "^0.13.5",
+    "@rsbuild/plugin-vue": "^1.2.6",
+    "typescript": "^5.0.0"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/examples/teleport/src/App.vue
+++ b/examples/teleport/src/App.vue
@@ -1,0 +1,172 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const showModal = ref(false)
+const teleportDisabled = ref(false)
+const count = ref(0)
+</script>
+
+<template>
+  <view
+    :style="{
+      width: '100%',
+      height: '100%',
+      position: 'relative',
+      backgroundColor: '#f0f2f5',
+    }"
+  >
+    <scroll-view
+      scroll-orientation="vertical"
+      :style="{ width: '100%', height: '100%', padding: '16px' }"
+    >
+      <text :style="{ fontSize: '20px', fontWeight: 'bold', marginBottom: '8px' }">
+        Teleport Demo
+      </text>
+      <text :style="{ fontSize: '12px', color: '#666', marginBottom: '20px' }">
+        Content inside &lt;Teleport to="#id"&gt; is rendered into the target by
+        id — useful for modals and overlays.
+      </text>
+
+      <!-- 1. Modal via Teleport -->
+      <view :style="{ marginBottom: '24px' }">
+        <text :style="{ fontSize: '14px', fontWeight: 'bold', marginBottom: '8px' }">
+          1. Modal Overlay
+        </text>
+        <text :style="{ fontSize: '12px', color: '#666', marginBottom: '8px' }">
+          Tap Open Modal — the dialog is teleported to #overlay-root, outside
+          this scroll-view's stacking context.
+        </text>
+
+        <view
+          :style="{
+            padding: '10px 16px',
+            backgroundColor: '#4a90d9',
+            borderRadius: '8px',
+            alignSelf: 'flex-start',
+          }"
+          @tap="showModal = true"
+        >
+          <text :style="{ color: '#fff', fontSize: '14px' }">Open Modal</text>
+        </view>
+
+        <Teleport to="#overlay-root">
+          <view
+            v-if="showModal"
+            :style="{
+              position: 'absolute',
+              top: '0px',
+              left: '0px',
+              right: '0px',
+              bottom: '0px',
+              backgroundColor: 'rgba(0,0,0,0.45)',
+              display: 'flex',
+              justifyContent: 'center',
+              alignItems: 'center',
+              zIndex: 1000,
+            }"
+            @tap="showModal = false"
+          >
+            <view
+              :style="{
+                width: '280px',
+                padding: '20px',
+                backgroundColor: '#fff',
+                borderRadius: '12px',
+              }"
+              @tap.stop
+            >
+              <text :style="{ fontSize: '16px', fontWeight: 'bold', marginBottom: '8px' }">
+                Teleported Modal
+              </text>
+              <text :style="{ fontSize: '13px', color: '#555', marginBottom: '16px' }">
+                This content was rendered under #overlay-root via
+                &lt;Teleport to="#overlay-root"&gt;.
+              </text>
+              <view
+                :style="{
+                  padding: '8px 14px',
+                  backgroundColor: '#4a90d9',
+                  borderRadius: '6px',
+                  alignSelf: 'flex-end',
+                }"
+                @tap="showModal = false"
+              >
+                <text :style="{ color: '#fff', fontSize: '13px' }">Close</text>
+              </view>
+            </view>
+          </view>
+        </Teleport>
+      </view>
+
+      <!-- 2. Reactive content + disabled -->
+      <view :style="{ marginBottom: '24px' }">
+        <text :style="{ fontSize: '14px', fontWeight: 'bold', marginBottom: '8px' }">
+          2. Reactive Content + disabled
+        </text>
+        <text :style="{ fontSize: '12px', color: '#666', marginBottom: '8px' }">
+          Teleported content stays reactive. With :disabled="true", it renders
+          in place instead of at the target.
+        </text>
+
+        <view :style="{ flexDirection: 'row', marginBottom: '8px' }">
+          <view
+            :style="{
+              padding: '8px 12px',
+              marginRight: '8px',
+              backgroundColor: '#27ae60',
+              borderRadius: '6px',
+            }"
+            @tap="count++"
+          >
+            <text :style="{ color: '#fff', fontSize: '13px' }">Count: {{ count }}</text>
+          </view>
+          <view
+            :style="{
+              padding: '8px 12px',
+              backgroundColor: teleportDisabled ? '#e67e22' : '#ddd',
+              borderRadius: '6px',
+            }"
+            @tap="teleportDisabled = !teleportDisabled"
+          >
+            <text :style="{ color: teleportDisabled ? '#fff' : '#333', fontSize: '13px' }">
+              disabled: {{ teleportDisabled }}
+            </text>
+          </view>
+        </view>
+
+        <view
+          id="badge-target"
+          :style="{
+            minHeight: '48px',
+            padding: '8px',
+            backgroundColor: '#e8f0fe',
+            borderRadius: '8px',
+            marginBottom: '8px',
+          }"
+        >
+          <text :style="{ fontSize: '11px', color: '#666' }">#badge-target</text>
+        </view>
+
+        <view
+          :style="{
+            padding: '8px',
+            backgroundColor: '#fff3e0',
+            borderRadius: '8px',
+          }"
+        >
+          <text :style="{ fontSize: '11px', color: '#666', marginBottom: '4px' }">
+            Teleport source (in-tree when disabled)
+          </text>
+          <Teleport to="#badge-target" :disabled="teleportDisabled">
+            <text :style="{ fontSize: '14px', fontWeight: 'bold', color: '#1565c0' }">
+              Badge count: {{ count }}
+            </text>
+          </Teleport>
+        </view>
+      </view>
+    </scroll-view>
+
+    <!-- Mount point for the modal Teleport — keep it empty so it does not block taps -->
+    <view id="overlay-root" />
+  </view>
+</template>

--- a/examples/teleport/src/App.vue
+++ b/examples/teleport/src/App.vue
@@ -7,6 +7,10 @@ const count = ref(0)
 </script>
 
 <template>
+  <!--
+    Teleport targets must appear earlier in the tree than their <Teleport>
+    consumers so querySelector can resolve them at mount time.
+  -->
   <view
     :style="{
       width: '100%',
@@ -15,6 +19,28 @@ const count = ref(0)
       backgroundColor: '#f0f2f5',
     }"
   >
+    <!--
+      Full-screen overlay host. Styles live on the target itself so
+      teleported children do not depend on absolute positioning inside
+      an empty zero-size mount point (which collapses on Lynx).
+    -->
+    <view
+      id="overlay-root"
+      :style="{
+        position: 'absolute',
+        top: '0px',
+        left: '0px',
+        right: '0px',
+        bottom: '0px',
+        zIndex: 1000,
+        display: showModal ? 'flex' : 'none',
+        justifyContent: 'center',
+        alignItems: 'center',
+        backgroundColor: 'rgba(0,0,0,0.45)',
+      }"
+      @tap="showModal = false"
+    />
+
     <scroll-view
       scroll-orientation="vertical"
       :style="{ width: '100%', height: '100%', padding: '16px' }"
@@ -49,50 +75,33 @@ const count = ref(0)
           <text :style="{ color: '#fff', fontSize: '14px' }">Open Modal</text>
         </view>
 
-        <Teleport to="#overlay-root">
+        <Teleport v-if="showModal" to="#overlay-root">
           <view
-            v-if="showModal"
             :style="{
-              position: 'absolute',
-              top: '0px',
-              left: '0px',
-              right: '0px',
-              bottom: '0px',
-              backgroundColor: 'rgba(0,0,0,0.45)',
-              display: 'flex',
-              justifyContent: 'center',
-              alignItems: 'center',
-              zIndex: 1000,
+              width: '280px',
+              padding: '20px',
+              backgroundColor: '#fff',
+              borderRadius: '12px',
             }"
-            @tap="showModal = false"
+            @tap.stop
           >
+            <text :style="{ fontSize: '16px', fontWeight: 'bold', marginBottom: '8px' }">
+              Teleported Modal
+            </text>
+            <text :style="{ fontSize: '13px', color: '#555', marginBottom: '16px' }">
+              This content was rendered under #overlay-root via
+              &lt;Teleport to="#overlay-root"&gt;.
+            </text>
             <view
               :style="{
-                width: '280px',
-                padding: '20px',
-                backgroundColor: '#fff',
-                borderRadius: '12px',
+                padding: '8px 14px',
+                backgroundColor: '#4a90d9',
+                borderRadius: '6px',
+                alignSelf: 'flex-end',
               }"
-              @tap.stop
+              @tap="showModal = false"
             >
-              <text :style="{ fontSize: '16px', fontWeight: 'bold', marginBottom: '8px' }">
-                Teleported Modal
-              </text>
-              <text :style="{ fontSize: '13px', color: '#555', marginBottom: '16px' }">
-                This content was rendered under #overlay-root via
-                &lt;Teleport to="#overlay-root"&gt;.
-              </text>
-              <view
-                :style="{
-                  padding: '8px 14px',
-                  backgroundColor: '#4a90d9',
-                  borderRadius: '6px',
-                  alignSelf: 'flex-end',
-                }"
-                @tap="showModal = false"
-              >
-                <text :style="{ color: '#fff', fontSize: '13px' }">Close</text>
-              </view>
+              <text :style="{ color: '#fff', fontSize: '13px' }">Close</text>
             </view>
           </view>
         </Teleport>
@@ -123,12 +132,12 @@ const count = ref(0)
           <view
             :style="{
               padding: '8px 12px',
-              backgroundColor: teleportDisabled ? '#e67e22' : '#ddd',
+              backgroundColor: teleportDisabled ? '#e67e22' : '#95a5a6',
               borderRadius: '6px',
             }"
             @tap="teleportDisabled = !teleportDisabled"
           >
-            <text :style="{ color: teleportDisabled ? '#fff' : '#333', fontSize: '13px' }">
+            <text :style="{ color: '#fff', fontSize: '13px' }">
               disabled: {{ teleportDisabled }}
             </text>
           </view>
@@ -165,8 +174,5 @@ const count = ref(0)
         </view>
       </view>
     </scroll-view>
-
-    <!-- Mount point for the modal Teleport — keep it empty so it does not block taps -->
-    <view id="overlay-root" />
   </view>
 </template>

--- a/examples/teleport/src/index.ts
+++ b/examples/teleport/src/index.ts
@@ -1,0 +1,6 @@
+import { createApp } from 'vue-lynx';
+
+import App from './App.vue';
+
+const app = createApp(App);
+app.mount();

--- a/examples/teleport/src/shims-vue.d.ts
+++ b/examples/teleport/src/shims-vue.d.ts
@@ -1,0 +1,6 @@
+declare module '*.vue' {
+  import type { Component } from 'vue-lynx';
+
+  const component: Component;
+  export default component;
+}

--- a/examples/teleport/tsconfig.json
+++ b/examples/teleport/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["src", "lynx.config.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -499,6 +499,22 @@ importers:
         specifier: ~5.9.3
         version: 5.9.3
 
+  examples/teleport:
+    dependencies:
+      vue-lynx:
+        specifier: workspace:*
+        version: link:../../packages/vue-lynx
+    devDependencies:
+      '@lynx-js/rspeedy':
+        specifier: ^0.13.5
+        version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
+      '@rsbuild/plugin-vue':
+        specifier: ^1.2.6
+        version: 1.2.7(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
   examples/todomvc:
     dependencies:
       vue-lynx:

--- a/website/docs/guide/vue-compatibility.mdx
+++ b/website/docs/guide/vue-compatibility.mdx
@@ -278,7 +278,18 @@ export default defineComponent({
 
 ## Teleport
 
-`<Teleport>` is supported for `to="#id"` string selectors. Direct element refs and non-ID selectors are not yet supported.
+Vue's [`<Teleport>`](https://vuejs.org/guide/built-ins/teleport.html) moves a template fragment to a different place in the UI tree. Vue Lynx supports it for `to="#id"` string selectors via a background-thread `idRegistry` lookup — the same pattern as a modal rendered at the page root while its trigger lives deeper in the component tree.
+
+:::warning Caveats
+Direct element refs and non-ID selectors (e.g. `to=".class"` or `to="body"`) are not yet supported. Give the destination an `id` and target it with `to="#that-id"`.
+:::
+
+The example below shows a modal teleported to `#overlay-root`, plus reactive content with the `disabled` prop:
+
+<Go
+  example="teleport"
+  defaultFile="src/App.vue"
+/>
 
 ## Unsupported Features
 

--- a/website/docs/guide/vue-compatibility.mdx
+++ b/website/docs/guide/vue-compatibility.mdx
@@ -281,8 +281,9 @@ export default defineComponent({
 Vue's [`<Teleport>`](https://vuejs.org/guide/built-ins/teleport.html) moves a template fragment to a different place in the UI tree. Vue Lynx supports it for `to="#id"` string selectors via a background-thread `idRegistry` lookup — the same pattern as a modal rendered at the page root while its trigger lives deeper in the component tree.
 
 :::warning Caveats
-- Direct element refs and non-ID selectors (e.g. `to=".class"` or `to="body"`) are not yet supported. Give the destination an `id` and target it with `to="#that-id"`.
-- The target element must already exist when `<Teleport>` mounts — place the `id` host earlier in the tree than the `<Teleport>` (or outside the component that owns it). Vue cannot resolve a target that is created by the same render as the teleport.
+Direct element refs and non-ID selectors (e.g. `to=".class"` or `to="body"`) are not yet supported. Give the destination an `id` and target it with `to="#that-id"`.
+
+The target element must already exist when `<Teleport>` mounts — place the `id` host earlier in the tree than the `<Teleport>` (or outside the component that owns it). Vue cannot resolve a target that is created by the same render as the teleport.
 :::
 
 The example below shows a modal teleported to `#overlay-root`, plus reactive content with the `disabled` prop:

--- a/website/docs/guide/vue-compatibility.mdx
+++ b/website/docs/guide/vue-compatibility.mdx
@@ -281,7 +281,8 @@ export default defineComponent({
 Vue's [`<Teleport>`](https://vuejs.org/guide/built-ins/teleport.html) moves a template fragment to a different place in the UI tree. Vue Lynx supports it for `to="#id"` string selectors via a background-thread `idRegistry` lookup — the same pattern as a modal rendered at the page root while its trigger lives deeper in the component tree.
 
 :::warning Caveats
-Direct element refs and non-ID selectors (e.g. `to=".class"` or `to="body"`) are not yet supported. Give the destination an `id` and target it with `to="#that-id"`.
+- Direct element refs and non-ID selectors (e.g. `to=".class"` or `to="body"`) are not yet supported. Give the destination an `id` and target it with `to="#that-id"`.
+- The target element must already exist when `<Teleport>` mounts — place the `id` host earlier in the tree than the `<Teleport>` (or outside the component that owns it). Vue cannot resolve a target that is created by the same render as the teleport.
 :::
 
 The example below shows a modal teleported to `#overlay-root`, plus reactive content with the `disabled` prop:

--- a/website/docs/zh/guide/vue-compatibility.mdx
+++ b/website/docs/zh/guide/vue-compatibility.mdx
@@ -281,7 +281,8 @@ export default defineComponent({
 Vue 的 [`<Teleport>`](https://cn.vuejs.org/guide/built-ins/teleport.html) 可以将模板片段渲染到 UI 树中的另一处。Vue Lynx 通过后台线程的 `idRegistry` 查找支持 `to="#id"` 字符串选择器——典型用法是触发器在组件树深处，弹层却渲染到页面根节点。
 
 :::warning 注意事项
-暂不支持直接传入元素 ref，以及非 ID 选择器（例如 `to=".class"` 或 `to="body"`）。请给目标节点设置 `id`，并用 `to="#that-id"` 指向它。
+- 暂不支持直接传入元素 ref，以及非 ID 选择器（例如 `to=".class"` 或 `to="body"`）。请给目标节点设置 `id`，并用 `to="#that-id"` 指向它。
+- `<Teleport>` 挂载时目标元素必须已经存在——把带 `id` 的宿主放在 `<Teleport>` 之前（或放在拥有它的组件之外）。Vue 无法解析与 teleport 同一次渲染才创建出来的目标。
 :::
 
 下面的示例演示了传送到 `#overlay-root` 的弹层，以及带 `disabled` prop 的响应式内容：

--- a/website/docs/zh/guide/vue-compatibility.mdx
+++ b/website/docs/zh/guide/vue-compatibility.mdx
@@ -281,8 +281,9 @@ export default defineComponent({
 Vue 的 [`<Teleport>`](https://cn.vuejs.org/guide/built-ins/teleport.html) 可以将模板片段渲染到 UI 树中的另一处。Vue Lynx 通过后台线程的 `idRegistry` 查找支持 `to="#id"` 字符串选择器——典型用法是触发器在组件树深处，弹层却渲染到页面根节点。
 
 :::warning 注意事项
-- 暂不支持直接传入元素 ref，以及非 ID 选择器（例如 `to=".class"` 或 `to="body"`）。请给目标节点设置 `id`，并用 `to="#that-id"` 指向它。
-- `<Teleport>` 挂载时目标元素必须已经存在——把带 `id` 的宿主放在 `<Teleport>` 之前（或放在拥有它的组件之外）。Vue 无法解析与 teleport 同一次渲染才创建出来的目标。
+暂不支持直接传入元素 ref，以及非 ID 选择器（例如 `to=".class"` 或 `to="body"`）。请给目标节点设置 `id`，并用 `to="#that-id"` 指向它。
+
+`<Teleport>` 挂载时目标元素必须已经存在——把带 `id` 的宿主放在 `<Teleport>` 之前（或放在拥有它的组件之外）。Vue 无法解析与 teleport 同一次渲染才创建出来的目标。
 :::
 
 下面的示例演示了传送到 `#overlay-root` 的弹层，以及带 `disabled` prop 的响应式内容：

--- a/website/docs/zh/guide/vue-compatibility.mdx
+++ b/website/docs/zh/guide/vue-compatibility.mdx
@@ -278,7 +278,18 @@ export default defineComponent({
 
 ## Teleport
 
-`<Teleport>` 支持 `to="#id"` 字符串选择器。暂不支持直接传入元素 ref 或非 ID 选择器。
+Vue 的 [`<Teleport>`](https://cn.vuejs.org/guide/built-ins/teleport.html) 可以将模板片段渲染到 UI 树中的另一处。Vue Lynx 通过后台线程的 `idRegistry` 查找支持 `to="#id"` 字符串选择器——典型用法是触发器在组件树深处，弹层却渲染到页面根节点。
+
+:::warning 注意事项
+暂不支持直接传入元素 ref，以及非 ID 选择器（例如 `to=".class"` 或 `to="body"`）。请给目标节点设置 `id`，并用 `to="#that-id"` 指向它。
+:::
+
+下面的示例演示了传送到 `#overlay-root` 的弹层，以及带 `disabled` prop 的响应式内容：
+
+<Go
+  example="teleport"
+  defaultFile="src/App.vue"
+/>
 
 ## 不支持的特性
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`<Teleport>` was added in [#161](https://github.com/Huxpro/vue-lynx/pull/161) (merged **2026-05-06**). The vue-compatibility doc already documented support for `to="#id"`, but had no interactive `<Go>` playground.

This PR adds:

- `examples/teleport` — modal overlay teleported to `#overlay-root`, plus reactive content with the `disabled` prop
- `<Go example="teleport">` on both EN and ZH vue-compatibility docs
- README listing for the new example

## Test plan

- [x] `pnpm --filter @vue-lynx-example/teleport run build` succeeds (web + lynx bundles)
- [ ] Open vue-compatibility Teleport section and confirm the Go playground loads
- [ ] Open Modal teleports content to `#overlay-root`; Close / backdrop dismiss works
- [ ] Count updates inside `#badge-target`; toggling `disabled` moves content back in-tree

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eb3bb78d-2e84-452d-9061-302fe43c7506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eb3bb78d-2e84-452d-9061-302fe43c7506"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

