### PR TITLE
fix(ifr): seal first-screen snapshot so Suspense demos stay visible

### DIFF
--- a/.changeset/ifr-seal-first-screen-snapshot.md
+++ b/.changeset/ifr-seal-first-screen-snapshot.md
@@ -1,0 +1,5 @@
+---
+"vue-lynx": patch
+---
+
+Seal the IFR first-screen ops snapshot when the sync mount returns, so Suspense / `defineAsyncComponent` resolves on the main thread cannot extend the hydration stream and wipe the tree on mismatch.

--- a/examples/suspense/README.md
+++ b/examples/suspense/README.md
@@ -5,7 +5,10 @@ Tests Vue's `<Suspense>` API with vue-lynx.
 ## Features Exercised
 
 - `<Suspense>` with `#default` / `#fallback` slots
-- `defineAsyncComponent` with dynamic import (triggers Suspense fallback)
-- Code-splitting via lazy-loaded components
+- `defineAsyncComponent` with delayed / microtask resolution (triggers Suspense fallback)
+- Async `setup()` via top-level `await` in `<script setup>` (requires `withAsyncContext`)
 
-> **Note:** `async setup()` (top-level `await` in `<script setup>`) is **not** supported because vue-lynx does not export `withAsyncContext`. This example focuses on `defineAsyncComponent` which does trigger the Suspense fallback.
+> **Note:** This example avoids dynamic `import()` code-splitting. Webpack async
+> chunks rely on `lynx.requireModuleAsync` / `lynx.loadLazyBundle`, which are not
+> available in Lynx Web Preview's iframe runtime. Use delayed promises (or a
+> dedicated lazy-bundle setup) when you need Suspense without native chunk loading.

--- a/examples/suspense/src/App.vue
+++ b/examples/suspense/src/App.vue
@@ -1,15 +1,21 @@
 <script setup lang="ts">
 import { ref, defineAsyncComponent, Suspense } from 'vue-lynx'
 import AsyncSetup from './AsyncSetup.vue'
+import LazyCounterComp from './LazyCounter.vue'
+import SlowContent from './SlowContent.vue'
 
-// Lazy-loaded component — triggers Suspense fallback during chunk loading
-const LazyCounter = defineAsyncComponent(() => import('./LazyCounter.vue'))
+// Eager component wrapped in defineAsyncComponent — resolves on a microtask
+// so Suspense still shows the fallback briefly. Avoids dynamic `import()`,
+// which emits webpack async chunks that Lynx Web Preview cannot load
+// (`lynx.requireModuleAsync` is unavailable in the iframe runtime).
+const LazyCounter = defineAsyncComponent(() => Promise.resolve(LazyCounterComp))
 
-// Simulated slow async component — 1.5s artificial delay
+// Simulated slow async component — 1.5s artificial delay, same Suspense
+// path as a lazy chunk load without requiring code-splitting support.
 const SlowComponent = defineAsyncComponent(
   () =>
-    new Promise<typeof import('./SlowContent.vue')>((resolve) => {
-      setTimeout(() => resolve(import('./SlowContent.vue')), 1500)
+    new Promise<typeof SlowContent>((resolve) => {
+      setTimeout(() => resolve(SlowContent), 1500)
     }),
 )
 
@@ -53,10 +59,10 @@ function toggleAsync() {
       </Suspense>
     </view>
 
-    <!-- 2. defineAsyncComponent (dynamic import, instant after chunk load) -->
+    <!-- 2. defineAsyncComponent (eager module, microtask resolve) -->
     <view v-if="showAsync" :style="{ margin: '0 16px 12px' }">
       <text :style="{ fontSize: 14, fontWeight: 'bold', color: '#333', marginBottom: 6 }">
-        2. Lazy-loaded counter (dynamic import)
+        2. Async component (defineAsyncComponent)
       </text>
       <Suspense>
         <template #default>
@@ -64,7 +70,7 @@ function toggleAsync() {
         </template>
         <template #fallback>
           <view :style="{ padding: 12, backgroundColor: '#fff3cd', borderRadius: 6 }">
-            <text :style="{ color: '#856404', fontSize: 13 }">⏳ Loading chunk...</text>
+            <text :style="{ color: '#856404', fontSize: 13 }">⏳ Loading async component...</text>
           </view>
         </template>
       </Suspense>

--- a/packages/testing-library/src/__tests__/ifr.test.ts
+++ b/packages/testing-library/src/__tests__/ifr.test.ts
@@ -25,6 +25,8 @@ import {
   ref,
   createApp,
   onMounted,
+  Suspense,
+  defineAsyncComponent,
   registerElementTemplate,
   resetForTesting,
 } from 'vue-lynx';
@@ -288,6 +290,80 @@ describe('IFR + element templates', () => {
     await waitForUpdate();
     env().switchToMainThread();
     expect(doc.querySelector('.label')?.textContent).toBe('n:1');
+  });
+});
+
+describe('IFR + Suspense', () => {
+  it('keeps the tree when async components resolve around hydration', async () => {
+    // Reproduces the docs suspense regression: setup-time async work runs on
+    // the IFR main-thread Vue app after the sync first paint. If those resolve
+    // batches are recorded, BG hydration can structurally mismatch, tear down
+    // the IFR tree, and apply only an incremental swap → blank page.
+    //
+    // Build separate component trees for MT vs BG so each thread gets its own
+    // defineAsyncComponent cache (real devices are separate JS contexts; this
+    // shared-globalThis harness would otherwise reuse a resolved loader).
+    function makeComp() {
+      const Child = defineComponent({
+        setup() {
+          return () => h('text', null, 'resolved');
+        },
+      });
+      const AsyncChild = defineAsyncComponent(
+        () =>
+          new Promise<typeof Child>((resolve) => {
+            setTimeout(() => resolve(Child), 30);
+          }),
+      );
+      return defineComponent({
+        setup() {
+          return () =>
+            h(Suspense, null, {
+              default: () => h(AsyncChild),
+              fallback: () => h('text', null, 'loading'),
+            });
+        },
+      });
+    }
+
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(' '));
+      origWarn.apply(console, args as []);
+    };
+
+    try {
+      const doc = mtFirstScreenRender(makeComp());
+      env().switchToMainThread();
+      expect(doc.querySelector('text')?.textContent).toBe('loading');
+      expect(getIfrPhase()).toBe('rendered');
+
+      // Let the MT async loader resolve *before* BG hydrates — the race that
+      // used to append a second recorded batch and wipe the tree on mismatch.
+      await new Promise((r) => setTimeout(r, 50));
+      env().switchToMainThread();
+      // Snapshot is frozen: still showing the sync first-screen fallback.
+      expect(doc.querySelector('text')?.textContent).toBe('loading');
+      expect(getIfrPhase()).toBe('rendered');
+
+      bgHydrate(makeComp());
+      await waitForUpdate();
+      // BG's initial fallback batch hydrates against the sealed snapshot.
+      expect(getIfrPhase()).toBe('hydrated');
+      expect(
+        warnings.some((w) => w.includes('IFR hydration mismatch')),
+      ).toBe(false);
+
+      await new Promise((r) => setTimeout(r, 50));
+      await waitForUpdate();
+
+      env().switchToMainThread();
+      expect(doc.querySelectorAll('text').length).toBe(1);
+      expect(doc.querySelector('text')?.textContent).toBe('resolved');
+    } finally {
+      console.warn = origWarn;
+    }
   });
 });
 

--- a/packages/vue-lynx/main-thread/src/ifr.ts
+++ b/packages/vue-lynx/main-thread/src/ifr.ts
@@ -28,6 +28,11 @@
  *      Either way the background thread ends up owning the tree, and all
  *      subsequent updates flow through the normal ops pipeline.
  *
+ * The recorded stream is sealed when the synchronous first-screen mount
+ * returns. Later main-thread Vue updates (Suspense resolves, timers, etc.)
+ * are dropped so they cannot extend the hydration stream or desync the
+ * tree from the background thread.
+ *
  * Events bound during the IFR render use the same sign strings the
  * background thread will register (`vue:N`), so taps that happen after the
  * background thread boots are routed correctly with no re-binding.  Worklet
@@ -137,20 +142,26 @@ let warnedPostHydrationOps = false;
 let inSyncRender = false;
 
 function recordAndApply(ops: unknown[]): void {
-  // After hydration the background thread owns the tree (matching
-  // ReactLynx, where the main thread stops responding to updates once it
-  // hands over control). Ops produced by the main-thread Vue app past that
-  // point — e.g. a timer-driven effect, or buffered leftovers from a failed
-  // render — would desync the tree from the background thread's view, so
-  // they are dropped.
-  if (phase === 'hydrated') {
+  // The IFR snapshot is sealed once the synchronous first-screen render
+  // finishes (`phase === 'rendered'`), and the background thread owns the
+  // tree after hydration (`phase === 'hydrated'`).
+  //
+  // Setup-time async work (Suspense / defineAsyncComponent / top-level
+  // await) still runs on the main-thread Vue app after paint — if those
+  // resolve batches were recorded and applied, hydration would compare
+  // against a stream the background thread cannot reproduce in the same
+  // order. A structural mismatch then tears the IFR tree down and applies
+  // only the incremental BG batch onto an empty page (blank UI). Drop
+  // post-snapshot MT ops so the recorded stream stays the sync first
+  // screen; BG Suspense resolutions apply normally after hydration.
+  if (phase === 'rendered' || phase === 'hydrated') {
     if (__DEV__ && !warnedPostHydrationOps) {
       warnedPostHydrationOps = true;
       console.warn(
         '[vue-lynx] IFR: dropping main-thread render ops produced after '
-          + 'hydration. First-screen code must not keep updating on the '
-          + 'main thread (side effects belong in onMounted / watchers, '
-          + 'which only run on the background thread).',
+          + 'the first-screen snapshot. First-screen code must not keep '
+          + 'updating on the main thread (side effects belong in onMounted '
+          + '/ watchers, which only run on the background thread).',
       );
     }
     return;

--- a/website/docs/guide/vue-compatibility.mdx
+++ b/website/docs/guide/vue-compatibility.mdx
@@ -170,7 +170,11 @@ The example below provides a reactive `theme` ref and a static `appName` string 
 
 ## Suspense
 
-Vue's [`<Suspense>`](https://vuejs.org/guide/built-ins/suspense.html) displays fallback content while waiting for async components to resolve. On Lynx, `<Suspense>` works with both async `setup()` (top-level `await` in `<script setup>`) and `defineAsyncComponent` for lazy-loading.
+Vue's [`<Suspense>`](https://vuejs.org/guide/built-ins/suspense.html) displays fallback content while waiting for async components to resolve. On Lynx, `<Suspense>` works with both async `setup()` (top-level `await` in `<script setup>`) and `defineAsyncComponent` for deferred loading.
+
+:::tip Code-splitting
+`defineAsyncComponent(() => import('./X.vue'))` emits webpack async chunks that need Lynx's lazy-bundle runtime (`lynx.requireModuleAsync` / `lynx.loadLazyBundle`). Those APIs are not available in Lynx Web Preview, so the docs example uses delayed promises over statically imported components instead — the Suspense fallback path is the same.
+:::
 
 <Go
   example="suspense"

--- a/website/docs/zh/guide/vue-compatibility.mdx
+++ b/website/docs/zh/guide/vue-compatibility.mdx
@@ -170,7 +170,11 @@ Vue 的 [`provide`](https://vuejs.org/guide/components/provide-inject.html) 和 
 
 ## Suspense
 
-Vue 的 [`<Suspense>`](https://vuejs.org/guide/built-ins/suspense.html) 在等待异步组件解析时显示后备内容。在 Lynx 上，`<Suspense>` 支持异步 `setup()`（`<script setup>` 中的顶层 `await`）和用于懒加载的 `defineAsyncComponent`。
+Vue 的 [`<Suspense>`](https://vuejs.org/guide/built-ins/suspense.html) 在等待异步组件解析时显示后备内容。在 Lynx 上，`<Suspense>` 支持异步 `setup()`（`<script setup>` 中的顶层 `await`）和用于延迟加载的 `defineAsyncComponent`。
+
+:::tip 关于代码分割
+`defineAsyncComponent(() => import('./X.vue'))` 会产出依赖 Lynx lazy-bundle 运行时（`lynx.requireModuleAsync` / `lynx.loadLazyBundle`）的 webpack 异步 chunk。这些 API 在 Lynx Web Preview 中不可用，因此文档示例改用静态导入组件 + 延迟 Promise——Suspense 的 fallback 路径与真正的懒加载相同。
+:::
 
 <Go
   example="suspense"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The docs Suspense example ([vue-compatibility#suspense](https://vue.lynxjs.org/zh/guide/vue-compatibility#suspense)) went blank / stuck after first paint with browser errors. Two stacked regressions:

1. **Async chunks fail in Web Preview** — `defineAsyncComponent(() => import(...))` emits webpack async chunks that call `lynx.requireModuleAsync`. That API is not available in the Lynx Web Preview iframe, so loaders reject (`TypeError: lynx.requireModuleAsync is not a function`) and resolved content never appears.
2. **IFR recorded post-paint Suspense resolves** — with `enableIFR: true`, setup-time async work still runs on the main-thread Vue app after the sync first screen. Those resolve batches were recorded + applied; BG hydration could then structurally mismatch, `teardownIfrTree()`, and apply only the incremental BG batch onto an empty page.

## Fix

- **Seal the IFR snapshot** when the sync `renderPage` mount returns (`phase === 'rendered'`): drop further main-thread ops (same as post-hydration), so hydration only compares against the sync first screen.
- **Rewrite `examples/suspense`** to use statically imported components + delayed / microtask promises instead of dynamic `import()`, so the demo no longer depends on lazy-bundle APIs in Web Preview.
- **Docs tip** (en + zh) explaining the code-splitting limitation.
- **Regression test** `IFR + Suspense` in `ifr.test.ts`.

## Test plan

- [x] `pnpm test` in `packages/testing-library` — 198 tests pass, including new Suspense IFR case
- [x] `examples/suspense` build produces no `static/js/async/*` chunks
- [x] Local web preview: all three Suspense sections resolve; counter increments; no `requireModuleAsync` errors

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-846771cf-6f41-464b-a653-b57e19f3aa77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-846771cf-6f41-464b-a653-b57e19f3aa77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

