### PR TITLE
fix(website): pre-gzip lynx.bundles so QR fetches stay under timeout

### DIFF
--- a/website/scripts/prepare-examples.mjs
+++ b/website/scripts/prepare-examples.mjs
@@ -9,12 +9,23 @@ import { execSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { gzipSync } from 'node:zlib';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '../..');
 const EXAMPLES_SRC = path.resolve(REPO_ROOT, 'examples');
 const EXAMPLES_DEST = path.resolve(__dirname, '../docs/public/examples');
 const EXAMPLE_GIT_BASE_URL = 'https://github.com/huxpro/vue-lynx/tree/main/examples';
+const PLUGIN_DIST = path.join(
+  REPO_ROOT,
+  'packages/vue-lynx/plugin/dist/index.js',
+);
+
+// On Vercel, pre-gzip *.lynx.bundle so QR/device fetches stay under LynxExplorer's
+// ~10s timeout. IFR roughly doubled uncompressed size; Vercel only auto-compresses
+// when the client sends Accept-Encoding, and some native fetchers do not.
+// vercel.json sets Content-Encoding: gzip for these paths.
+const PRE_GZIP_LYNX_BUNDLES = Boolean(process.env.VERCEL);
 
 // File extensions to skip (binary assets in src/)
 const BINARY_EXTENSIONS = new Set([
@@ -176,8 +187,12 @@ function processExample(exampleName) {
 
   // Copy entire dist/ (bundles + static assets referenced by bundles)
   const distSrcDir = path.join(srcDir, 'dist');
+  const distDestDir = path.join(destDir, 'dist');
   if (fs.existsSync(distSrcDir)) {
-    copyDirRecursive(distSrcDir, path.join(destDir, 'dist'));
+    copyDirRecursive(distSrcDir, distDestDir);
+    if (PRE_GZIP_LYNX_BUNDLES) {
+      gzipLynxBundlesInPlace(distDestDir);
+    }
   }
 
   // Copy preview image if it exists
@@ -188,6 +203,34 @@ function processExample(exampleName) {
   }
 
   console.info(`  -> ${textFiles.length} files, ${templateFiles.length} entries`);
+}
+
+/**
+ * Replace each *.lynx.bundle with its gzip payload (same filename).
+ * Paired with vercel.json Content-Encoding: gzip so HTTP clients inflate.
+ */
+function gzipLynxBundlesInPlace(dir) {
+  if (!fs.existsSync(dir)) return;
+
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      gzipLynxBundlesInPlace(fullPath);
+      continue;
+    }
+    if (!entry.name.endsWith('.lynx.bundle')) continue;
+
+    const raw = fs.readFileSync(fullPath);
+    // Already gzipped (magic 1f 8b) — leave as-is so re-runs are idempotent.
+    if (raw.length >= 2 && raw[0] === 0x1f && raw[1] === 0x8b) continue;
+
+    const compressed = gzipSync(raw, { level: 9 });
+    fs.writeFileSync(fullPath, compressed);
+    const ratio = raw.length === 0 ? 0 : compressed.length / raw.length;
+    console.info(
+      `  gzip ${entry.name}: ${raw.length} -> ${compressed.length} bytes (${(ratio * 100).toFixed(1)}%)`,
+    );
+  }
 }
 
 // Main
@@ -213,7 +256,7 @@ const needsBuild = examples.some((example) =>
 
 if (needsBuild) {
   // Examples depend on vue-lynx (workspace:*), so build the lib first if needed
-  const libBuilt = fs.existsSync(path.join(REPO_ROOT, 'plugin/dist/index.js'));
+  const libBuilt = fs.existsSync(PLUGIN_DIST);
   if (!libBuilt) {
     console.info('Building vue-lynx library (required by examples)...');
     execSync('pnpm build', { cwd: REPO_ROOT, stdio: 'inherit' });

--- a/website/vercel.json
+++ b/website/vercel.json
@@ -3,5 +3,41 @@
   "buildCommand": "pnpm run build",
   "outputDirectory": "doc_build",
   "cleanUrls": true,
-  "ignoreCommand": "node scripts/vercel-ignore.mjs"
+  "ignoreCommand": "node scripts/vercel-ignore.mjs",
+  "headers": [
+    {
+      "source": "/examples/(.*)\\.lynx\\.bundle",
+      "headers": [
+        {
+          "key": "Content-Type",
+          "value": "application/octet-stream"
+        },
+        {
+          "key": "Content-Encoding",
+          "value": "gzip"
+        },
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=86400, stale-while-revalidate=604800"
+        },
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "*"
+        }
+      ]
+    },
+    {
+      "source": "/examples/(.*)\\.web\\.bundle",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=86400, stale-while-revalidate=604800"
+        },
+        {
+          "key": "Access-Control-Allow-Origin",
+          "value": "*"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Since IFR was enabled on website examples (~Jul 15), scanning the docs QR code and loading `*.lynx.bundle` in LynxExplorer often **times out**.

Verified on production:
- QR encodes the correct URL, e.g. `https://vue.lynxjs.org/examples/hello-world/dist/main.lynx.bundle`
- The file is present (HTTP 200)
- Uncompressed size grew from ~80KiB (pre-IFR npm) to ~181KiB (live IFR)
- LynxExplorer aborts template fetches around **10s**
- Vercel only auto-compresses when the client sends `Accept-Encoding`; native fetchers that omit it pull the full raw bytes

At ~15–20KB/s (common on cross-border mobile links), the post-IFR hello-world bundle alone crosses that timeout; larger demos (Elk, HackerNews) fail even sooner.

## Fix

1. **`website/scripts/prepare-examples.mjs`** — on Vercel builds (`VERCEL=1`), gzip each `*.lynx.bundle` in place after copying `dist/` (idempotent via gzip magic check). hello-world: **181KiB → ~82KiB**.
2. **`website/vercel.json`** — send `Content-Encoding: gzip` for `/examples/**/*.lynx.bundle` so HTTP stacks inflate transparently, plus short cache + CORS headers. Also cache `.web.bundle`.
3. Fix the stale plugin dist path check (`packages/vue-lynx/plugin/dist/index.js` instead of `plugin/dist/index.js`).

Local / non-Vercel builds keep raw bundles so `rspress preview` stays unaffected.

## Follow-up

If phones still cannot *connect* to Vercel from mainland China (TCP timeout before any bytes), transfer compression will not be enough — consider mirroring example bundles to a China-friendly CDN (jsDelivr/npmmirror after publishing `@vue-lynx-example/*`, or Cloudflare/Bunny in front of `/examples/`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a94bda92-2091-4e3f-8186-3fa1b9d8920a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a94bda92-2091-4e3f-8186-3fa1b9d8920a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

