### PR TITLE
chore(examples): turn off enableIFR to match plugin default

### DIFF
--- a/examples/7guis/lynx.config.ts
+++ b/examples/7guis/lynx.config.ts
@@ -26,9 +26,6 @@ export default defineConfig({
   },
   plugins: [
     pluginVueLynx({
-      // IFR: render the first screen on the main thread during
-      // loadTemplate, then hydrate when the background thread boots.
-      enableIFR: true,
       optionsApi: false,
     }),
   ],

--- a/examples/basic/lynx.config.ts
+++ b/examples/basic/lynx.config.ts
@@ -21,9 +21,6 @@ export default defineConfig({
   },
   plugins: [
     pluginVueLynx({
-      // IFR: render the first screen on the main thread during
-      // loadTemplate, then hydrate when the background thread boots.
-      enableIFR: true,
       optionsApi: false,
     }),
   ],

--- a/examples/css-features/lynx.config.ts
+++ b/examples/css-features/lynx.config.ts
@@ -20,9 +20,6 @@ export default defineConfig({
   },
   plugins: [
     pluginVueLynx({
-      // IFR: render the first screen on the main thread during
-      // loadTemplate, then hydrate when the background thread boots.
-      enableIFR: true,
       optionsApi: false,
       enableCSSInlineVariables: true,
       enableCSSInheritance: true,

--- a/examples/event-modifiers/lynx.config.ts
+++ b/examples/event-modifiers/lynx.config.ts
@@ -20,9 +20,6 @@ export default defineConfig({
   },
   plugins: [
     pluginVueLynx({
-      // IFR: render the first screen on the main thread during
-      // loadTemplate, then hydrate when the background thread boots.
-      enableIFR: true,
     }),
   ],
 });

--- a/examples/gallery/lynx.config.ts
+++ b/examples/gallery/lynx.config.ts
@@ -26,9 +26,6 @@ export default defineConfig({
   },
   plugins: [
     pluginVueLynx({
-      // IFR: render the first screen on the main thread during
-      // loadTemplate, then hydrate when the background thread boots.
-      enableIFR: true,
       optionsApi: false,
       enableCSSSelector: true,
     }),

--- a/examples/hackernews-css/lynx.config.ts
+++ b/examples/hackernews-css/lynx.config.ts
@@ -28,9 +28,6 @@ export default defineConfig({
     }),
     pluginSass(),
     pluginVueLynx({
-      // IFR: render the first screen on the main thread during
-      // loadTemplate, then hydrate when the background thread boots.
-      enableIFR: true,
       optionsApi: false,
       enableCSSInheritance: true,
       enableCSSInlineVariables: true,

--- a/examples/hackernews-tailwind/lynx.config.ts
+++ b/examples/hackernews-tailwind/lynx.config.ts
@@ -27,9 +27,6 @@ export default defineConfig({
       },
     }),
     pluginVueLynx({
-      // IFR: render the first screen on the main thread during
-      // loadTemplate, then hydrate when the background thread boots.
-      enableIFR: true,
       optionsApi: false,
       enableCSSInheritance: true,
       enableCSSInlineVariables: true,

--- a/examples/hello-world/lynx.config.ts
+++ b/examples/hello-world/lynx.config.ts
@@ -21,9 +21,6 @@ export default defineConfig({
   plugins: [
     pluginVueLynx({
       optionsApi: false,
-      // IFR: render the first screen on the main thread during loadTemplate,
-      // then hydrate when the background thread boots.
-      enableIFR: true,
     }),
   ],
 });

--- a/examples/keep-alive/lynx.config.ts
+++ b/examples/keep-alive/lynx.config.ts
@@ -20,9 +20,6 @@ export default defineConfig({
   },
   plugins: [
     pluginVueLynx({
-      // IFR: render the first screen on the main thread during
-      // loadTemplate, then hydrate when the background thread boots.
-      enableIFR: true,
       optionsApi: false,
     }),
   ],

--- a/examples/main-thread/lynx.config.ts
+++ b/examples/main-thread/lynx.config.ts
@@ -21,9 +21,6 @@ export default defineConfig({
   },
   plugins: [
     pluginVueLynx({
-      // IFR: render the first screen on the main thread during
-      // loadTemplate, then hydrate when the background thread boots.
-      enableIFR: true,
       optionsApi: false,
       enableCSSSelector: true,
     }),

--- a/examples/networking/lynx.config.ts
+++ b/examples/networking/lynx.config.ts
@@ -13,9 +13,6 @@ export default defineConfig({
   },
   plugins: [
     pluginVueLynx({
-      // IFR: render the first screen on the main thread during
-      // loadTemplate, then hydrate when the background thread boots.
-      enableIFR: true,
       optionsApi: false,
       enableCSSSelector: true,
     }),

--- a/examples/option-api/lynx.config.ts
+++ b/examples/option-api/lynx.config.ts
@@ -20,9 +20,6 @@ export default defineConfig({
   },
   plugins: [
     pluginVueLynx({
-      // IFR: render the first screen on the main thread during
-      // loadTemplate, then hydrate when the background thread boots.
-      enableIFR: true,
       optionsApi: true,
       enableCSSSelector: true,
     }),

--- a/examples/pinia/lynx.config.ts
+++ b/examples/pinia/lynx.config.ts
@@ -20,9 +20,6 @@ export default defineConfig({
   },
   plugins: [
     pluginVueLynx({
-      // IFR: render the first screen on the main thread during
-      // loadTemplate, then hydrate when the background thread boots.
-      enableIFR: true,
       optionsApi: false,
       enableCSSSelector: true,
     }),

--- a/examples/provide-inject/lynx.config.ts
+++ b/examples/provide-inject/lynx.config.ts
@@ -20,9 +20,6 @@ export default defineConfig({
   },
   plugins: [
     pluginVueLynx({
-      // IFR: render the first screen on the main thread during
-      // loadTemplate, then hydrate when the background thread boots.
-      enableIFR: true,
       optionsApi: false,
     }),
   ],

--- a/examples/reactivity/lynx.config.ts
+++ b/examples/reactivity/lynx.config.ts
@@ -20,9 +20,6 @@ export default defineConfig({
   },
   plugins: [
     pluginVueLynx({
-      // IFR: render the first screen on the main thread during
-      // loadTemplate, then hydrate when the background thread boots.
-      enableIFR: true,
       optionsApi: false,
     }),
   ],

--- a/examples/slots/lynx.config.ts
+++ b/examples/slots/lynx.config.ts
@@ -20,9 +20,6 @@ export default defineConfig({
   },
   plugins: [
     pluginVueLynx({
-      // IFR: render the first screen on the main thread during
-      // loadTemplate, then hydrate when the background thread boots.
-      enableIFR: true,
       optionsApi: false,
     }),
   ],

--- a/examples/suspense/lynx.config.ts
+++ b/examples/suspense/lynx.config.ts
@@ -20,9 +20,6 @@ export default defineConfig({
   },
   plugins: [
     pluginVueLynx({
-      // IFR: render the first screen on the main thread during
-      // loadTemplate, then hydrate when the background thread boots.
-      enableIFR: true,
       enableCSSSelector: true,
     }),
   ],

--- a/examples/swiper/lynx.config.ts
+++ b/examples/swiper/lynx.config.ts
@@ -22,9 +22,6 @@ export default defineConfig({
   },
   plugins: [
     pluginVueLynx({
-      // IFR: render the first screen on the main thread during
-      // loadTemplate, then hydrate when the background thread boots.
-      enableIFR: true,
       optionsApi: false,
       enableCSSSelector: true,
     }),

--- a/examples/tailwindcss/lynx.config.ts
+++ b/examples/tailwindcss/lynx.config.ts
@@ -27,9 +27,6 @@ export default defineConfig({
       },
     }),
     pluginVueLynx({
-      // IFR: render the first screen on the main thread during
-      // loadTemplate, then hydrate when the background thread boots.
-      enableIFR: true,
       optionsApi: false,
       enableCSSInheritance: true,
       enableCSSInlineVariables: true,

--- a/examples/todomvc-codex/lynx.config.ts
+++ b/examples/todomvc-codex/lynx.config.ts
@@ -20,9 +20,6 @@ export default defineConfig({
   },
   plugins: [
     pluginVueLynx({
-      // IFR: render the first screen on the main thread during
-      // loadTemplate, then hydrate when the background thread boots.
-      enableIFR: true,
       optionsApi: false,
       enableCSSSelector: true,
     }),

--- a/examples/todomvc-day1/lynx.config.ts
+++ b/examples/todomvc-day1/lynx.config.ts
@@ -20,9 +20,6 @@ export default defineConfig({
   },
   plugins: [
     pluginVueLynx({
-      // IFR: render the first screen on the main thread during
-      // loadTemplate, then hydrate when the background thread boots.
-      enableIFR: true,
       optionsApi: false,
       enableCSSSelector: true,
     }),

--- a/examples/todomvc/lynx.config.ts
+++ b/examples/todomvc/lynx.config.ts
@@ -20,9 +20,6 @@ export default defineConfig({
   },
   plugins: [
     pluginVueLynx({
-      // IFR: render the first screen on the main thread during
-      // loadTemplate, then hydrate when the background thread boots.
-      enableIFR: true,
       optionsApi: false,
       enableCSSSelector: true,
     }),

--- a/examples/transition/lynx.config.ts
+++ b/examples/transition/lynx.config.ts
@@ -20,9 +20,6 @@ export default defineConfig({
   },
   plugins: [
     pluginVueLynx({
-      // IFR: render the first screen on the main thread during
-      // loadTemplate, then hydrate when the background thread boots.
-      enableIFR: true,
       optionsApi: false,
       enableCSSSelector: true,
     }),

--- a/examples/v-model/lynx.config.ts
+++ b/examples/v-model/lynx.config.ts
@@ -20,9 +20,6 @@ export default defineConfig({
   },
   plugins: [
     pluginVueLynx({
-      // IFR: render the first screen on the main thread during
-      // loadTemplate, then hydrate when the background thread boots.
-      enableIFR: true,
       optionsApi: false,
     }),
   ],

--- a/examples/v-once-memo/lynx.config.ts
+++ b/examples/v-once-memo/lynx.config.ts
@@ -20,9 +20,6 @@ export default defineConfig({
   },
   plugins: [
     pluginVueLynx({
-      // IFR: render the first screen on the main thread during
-      // loadTemplate, then hydrate when the background thread boots.
-      enableIFR: true,
       optionsApi: false,
     }),
   ],

--- a/examples/vue-router/lynx.config.ts
+++ b/examples/vue-router/lynx.config.ts
@@ -20,9 +20,6 @@ export default defineConfig({
   },
   plugins: [
     pluginVueLynx({
-      // IFR: render the first screen on the main thread during
-      // loadTemplate, then hydrate when the background thread boots.
-      enableIFR: true,
       optionsApi: false,
       enableCSSSelector: true,
     }),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #257. `pluginVueLynx` defaults `enableIFR` to `false`, but 26 examples still forced `enableIFR: true` from the IFR rollout. That put docs demos (including Suspense) on the IFR path unexpectedly.

Remove the `enableIFR: true` overrides (and the accompanying comments) so example/docs builds follow the library default again. Opt in per example when intentionally showcasing IFR.

Already default-off (unchanged): `ai-chat`, `elk`, `elk-viewpager`.

## Test plan

- [x] `rg 'enableIFR: true' examples` → no matches
- [ ] Spot-check docs preview for suspense / hello-world after deploy

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-846771cf-6f41-464b-a653-b57e19f3aa77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-846771cf-6f41-464b-a653-b57e19f3aa77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

