### PR TITLE
feat(slides): add Teleport coverage slide (@sentomk, 0.4.0)

### DIFF
--- a/examples/teleport/lynx.config.ts
+++ b/examples/teleport/lynx.config.ts
@@ -1,0 +1,29 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from '@lynx-js/rspeedy';
+import { pluginVueLynx } from 'vue-lynx/plugin';
+
+const exampleName = path.basename(path.dirname(fileURLToPath(import.meta.url)));
+
+export default defineConfig({
+  environments: {
+    web: {},
+    lynx: {},
+  },
+  output: {
+    assetPrefix: `https://vue.lynxjs.org/examples/${exampleName}/dist/`,
+  },
+  source: {
+    entry: {
+      main: './src/index.ts',
+    },
+  },
+  plugins: [
+    pluginVueLynx({
+      // IFR: render the first screen on the main thread during
+      // loadTemplate, then hydrate when the background thread boots.
+      enableIFR: true,
+      optionsApi: false,
+    }),
+  ],
+});

--- a/examples/teleport/package.json
+++ b/examples/teleport/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@vue-lynx-example/teleport",
+  "version": "0.0.0",
+  "private": false,
+  "description": "Vue-Lynx Teleport demo — render content to a remote #id target",
+  "license": "Apache-2.0",
+  "type": "module",
+  "files": [
+    "dist",
+    "src",
+    "lynx.config.ts",
+    "tsconfig.json"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Huxpro/vue-lynx",
+    "directory": "examples/teleport"
+  },
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev"
+  },
+  "dependencies": {
+    "vue-lynx": "workspace:*"
+  },
+  "devDependencies": {
+    "@lynx-js/rspeedy": "^0.13.5",
+    "@rsbuild/plugin-vue": "^1.2.6",
+    "typescript": "^5.0.0"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/examples/teleport/src/App.vue
+++ b/examples/teleport/src/App.vue
@@ -1,0 +1,178 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const showModal = ref(false)
+const teleportDisabled = ref(false)
+const count = ref(0)
+</script>
+
+<template>
+  <!--
+    Teleport targets must appear earlier in the tree than their <Teleport>
+    consumers so querySelector can resolve them at mount time.
+  -->
+  <view
+    :style="{
+      width: '100%',
+      height: '100%',
+      position: 'relative',
+      backgroundColor: '#f0f2f5',
+    }"
+  >
+    <!--
+      Full-screen overlay host. Styles live on the target itself so
+      teleported children do not depend on absolute positioning inside
+      an empty zero-size mount point (which collapses on Lynx).
+    -->
+    <view
+      id="overlay-root"
+      :style="{
+        position: 'absolute',
+        top: '0px',
+        left: '0px',
+        right: '0px',
+        bottom: '0px',
+        zIndex: 1000,
+        display: showModal ? 'flex' : 'none',
+        justifyContent: 'center',
+        alignItems: 'center',
+        backgroundColor: 'rgba(0,0,0,0.45)',
+      }"
+      @tap="showModal = false"
+    />
+
+    <scroll-view
+      scroll-orientation="vertical"
+      :style="{ width: '100%', height: '100%', padding: '16px' }"
+    >
+      <text :style="{ fontSize: '20px', fontWeight: 'bold', marginBottom: '8px' }">
+        Teleport Demo
+      </text>
+      <text :style="{ fontSize: '12px', color: '#666', marginBottom: '20px' }">
+        Content inside &lt;Teleport to="#id"&gt; is rendered into the target by
+        id — useful for modals and overlays.
+      </text>
+
+      <!-- 1. Modal via Teleport -->
+      <view :style="{ marginBottom: '24px' }">
+        <text :style="{ fontSize: '14px', fontWeight: 'bold', marginBottom: '8px' }">
+          1. Modal Overlay
+        </text>
+        <text :style="{ fontSize: '12px', color: '#666', marginBottom: '8px' }">
+          Tap Open Modal — the dialog is teleported to #overlay-root, outside
+          this scroll-view's stacking context.
+        </text>
+
+        <view
+          :style="{
+            padding: '10px 16px',
+            backgroundColor: '#4a90d9',
+            borderRadius: '8px',
+            alignSelf: 'flex-start',
+          }"
+          @tap="showModal = true"
+        >
+          <text :style="{ color: '#fff', fontSize: '14px' }">Open Modal</text>
+        </view>
+
+        <Teleport v-if="showModal" to="#overlay-root">
+          <view
+            :style="{
+              width: '280px',
+              padding: '20px',
+              backgroundColor: '#fff',
+              borderRadius: '12px',
+            }"
+            @tap.stop
+          >
+            <text :style="{ fontSize: '16px', fontWeight: 'bold', marginBottom: '8px' }">
+              Teleported Modal
+            </text>
+            <text :style="{ fontSize: '13px', color: '#555', marginBottom: '16px' }">
+              This content was rendered under #overlay-root via
+              &lt;Teleport to="#overlay-root"&gt;.
+            </text>
+            <view
+              :style="{
+                padding: '8px 14px',
+                backgroundColor: '#4a90d9',
+                borderRadius: '6px',
+                alignSelf: 'flex-end',
+              }"
+              @tap="showModal = false"
+            >
+              <text :style="{ color: '#fff', fontSize: '13px' }">Close</text>
+            </view>
+          </view>
+        </Teleport>
+      </view>
+
+      <!-- 2. Reactive content + disabled -->
+      <view :style="{ marginBottom: '24px' }">
+        <text :style="{ fontSize: '14px', fontWeight: 'bold', marginBottom: '8px' }">
+          2. Reactive Content + disabled
+        </text>
+        <text :style="{ fontSize: '12px', color: '#666', marginBottom: '8px' }">
+          Teleported content stays reactive. With :disabled="true", it renders
+          in place instead of at the target.
+        </text>
+
+        <view :style="{ flexDirection: 'row', marginBottom: '8px' }">
+          <view
+            :style="{
+              padding: '8px 12px',
+              marginRight: '8px',
+              backgroundColor: '#27ae60',
+              borderRadius: '6px',
+            }"
+            @tap="count++"
+          >
+            <text :style="{ color: '#fff', fontSize: '13px' }">Count: {{ count }}</text>
+          </view>
+          <view
+            :style="{
+              padding: '8px 12px',
+              backgroundColor: teleportDisabled ? '#e67e22' : '#95a5a6',
+              borderRadius: '6px',
+            }"
+            @tap="teleportDisabled = !teleportDisabled"
+          >
+            <text :style="{ color: '#fff', fontSize: '13px' }">
+              disabled: {{ teleportDisabled }}
+            </text>
+          </view>
+        </view>
+
+        <view
+          id="badge-target"
+          :style="{
+            minHeight: '48px',
+            padding: '8px',
+            backgroundColor: '#e8f0fe',
+            borderRadius: '8px',
+            marginBottom: '8px',
+          }"
+        >
+          <text :style="{ fontSize: '11px', color: '#666' }">#badge-target</text>
+        </view>
+
+        <view
+          :style="{
+            padding: '8px',
+            backgroundColor: '#fff3e0',
+            borderRadius: '8px',
+          }"
+        >
+          <text :style="{ fontSize: '11px', color: '#666', marginBottom: '4px' }">
+            Teleport source (in-tree when disabled)
+          </text>
+          <Teleport to="#badge-target" :disabled="teleportDisabled">
+            <text :style="{ fontSize: '14px', fontWeight: 'bold', color: '#1565c0' }">
+              Badge count: {{ count }}
+            </text>
+          </Teleport>
+        </view>
+      </view>
+    </scroll-view>
+  </view>
+</template>

--- a/examples/teleport/src/index.ts
+++ b/examples/teleport/src/index.ts
@@ -1,0 +1,6 @@
+import { createApp } from 'vue-lynx';
+
+import App from './App.vue';
+
+const app = createApp(App);
+app.mount();

--- a/examples/teleport/src/shims-vue.d.ts
+++ b/examples/teleport/src/shims-vue.d.ts
@@ -1,0 +1,6 @@
+declare module '*.vue' {
+  import type { Component } from 'vue-lynx';
+
+  const component: Component;
+  export default component;
+}

--- a/examples/teleport/tsconfig.json
+++ b/examples/teleport/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["src", "lynx.config.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
-        version: 1.2.7(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -459,6 +459,22 @@ importers:
         specifier: ~5.9.3
         version: 5.9.3
 
+  examples/teleport:
+    dependencies:
+      vue-lynx:
+        specifier: workspace:*
+        version: link:../../packages/vue-lynx
+    devDependencies:
+      '@lynx-js/rspeedy':
+        specifier: ^0.13.5
+        version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
+      '@rsbuild/plugin-vue':
+        specifier: ^1.2.6
+        version: 1.2.7(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
   examples/todomvc:
     dependencies:
       vue-lynx:
@@ -553,7 +569,7 @@ importers:
         version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
-        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+        version: 1.2.7(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.8(@swc/helpers@0.5.19))
       typescript:
         specifier: ^5.0.0
         version: 5.9.3

--- a/slides/index.html
+++ b/slides/index.html
@@ -308,7 +308,7 @@
        ==================================================== -->
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 1/12</span>
+      <span class="eyebrow">II · Vue coverage · 1/13</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><code class="brand-text">ref()</code></h2>
         <span class="ver-badge">0.2.0</span>
@@ -346,7 +346,7 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 2/12</span>
+      <span class="eyebrow">II · Vue coverage · 2/13</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><code class="brand-text">reactive()</code> + composables</h2>
         <span class="ver-badge">0.2.0</span>
@@ -380,7 +380,7 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 3/12</span>
+      <span class="eyebrow">II · Vue coverage · 3/13</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><code class="brand-text">v-model</code></h2>
         <span class="ver-badge">0.2.0</span>
@@ -419,7 +419,7 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 4/12</span>
+      <span class="eyebrow">II · Vue coverage · 4/13</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><code class="brand-text">&lt;slot&gt;</code></h2>
         <span class="ver-badge">0.2.0</span>
@@ -455,7 +455,7 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 5/12</span>
+      <span class="eyebrow">II · Vue coverage · 5/13</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><code class="brand-text">provide / inject</code></h2>
         <span class="ver-badge">0.2.0</span>
@@ -487,7 +487,7 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 6/12</span>
+      <span class="eyebrow">II · Vue coverage · 6/13</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><code class="brand-text">&lt;Suspense&gt;</code></h2>
         <span class="ver-badge">0.2.0</span>
@@ -522,7 +522,7 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 7/12</span>
+      <span class="eyebrow">II · Vue coverage · 7/13</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><code class="brand-text">&lt;Transition&gt;</code></h2>
         <span class="ver-badge">0.2.0</span>
@@ -555,7 +555,7 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 8/12</span>
+      <span class="eyebrow">II · Vue coverage · 8/13</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><span class="brand-text">CSS</span> features</h2>
         <span class="ver-badge">0.3.0</span>
@@ -598,7 +598,7 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 9/12</span>
+      <span class="eyebrow">II · Vue coverage · 9/13</span>
       <div class="demo__title-row">
         <h2 class="demo__title">Event <span class="brand-text">modifiers</span></h2>
         <span class="ver-badge">0.4.0</span>
@@ -636,7 +636,7 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 10/12</span>
+      <span class="eyebrow">II · Vue coverage · 10/13</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><code class="brand-text">&lt;KeepAlive&gt;</code></h2>
         <span class="ver-badge">0.4.0</span>
@@ -672,7 +672,44 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 11/12</span>
+      <span class="eyebrow">II · Vue coverage · 11/13</span>
+      <div class="demo__title-row">
+        <h2 class="demo__title"><code class="brand-text">&lt;Teleport&gt;</code></h2>
+        <span class="ver-badge">0.4.0</span>
+      </div>
+      <a class="gh-badge" href="https://github.com/sentomk" target="_blank" rel="noopener noreferrer">
+        <img class="gh-badge__avatar" src="https://github.com/sentomk.png?size=48" alt="" width="18" height="18" loading="lazy" decoding="async" />
+        <span>@sentomk</span>
+      </a>
+      <div class="codeframe">
+        <div class="codeframe__head">
+          <span class="dots"><span></span><span></span><span></span></span>
+          <span>App.vue</span>
+        </div>
+<pre><span class="code-tag">&lt;view</span> <span class="code-attr">id</span>=<span class="code-str">"overlay-root"</span> <span class="code-tag">/&gt;</span>
+
+<span class="code-tag">&lt;Teleport</span> <span class="code-attr">to</span>=<span class="code-str">"#overlay-root"</span><span class="code-tag">&gt;</span>
+  <span class="code-tag">&lt;view</span> <span class="code-attr">class</span>=<span class="code-str">"modal"</span><span class="code-tag">&gt;</span>…<span class="code-tag">&lt;/view&gt;</span>
+<span class="code-tag">&lt;/Teleport&gt;</span>
+
+<span class="code-com">// to="#id" only — reactive + :disabled</span></pre>
+      </div>
+    </div>
+    <div class="demo__stage">
+      <div class="phone">
+        <div class="phone__inner">
+          <vl-demo bundle="teleport/dist/main.web.bundle"></vl-demo>
+        </div>
+      </div>
+    </div>
+    <aside class="notes">
+      <p>Render into a target by id — modals and overlays without fighting scroll stacking. BG-side <code>idRegistry</code> resolves <code>to="#id"</code>; content stays reactive, and <code>:disabled</code> renders in place. Shipped by @sentomk (#161) in <code>0.4.0</code>.</p>
+    </aside>
+  </section>
+
+  <section class="slide demo demo--api">
+    <div class="demo__body">
+      <span class="eyebrow">II · Vue coverage · 12/13</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><code class="brand-text">v-once</code></h2>
         <span class="ver-badge">0.4.0</span>
@@ -707,7 +744,7 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 12/12</span>
+      <span class="eyebrow">II · Vue coverage · 13/13</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><code class="brand-text">v-memo</code></h2>
         <span class="ver-badge">0.4.0</span>
@@ -740,7 +777,7 @@
       </div>
     </div>
     <aside class="notes">
-      <p><code>v-memo</code> skips a subtree when its deps are unchanged — same cross-thread win as <code>v-once</code>, but keyed on a dependency list. Common in <code>v-for</code> rows. <code>isMemoSame</code> export + tests from @KealanAU (#156 / #181) in <code>0.4.0</code>. Twelve features, twelve live apps. That's the API story. Now — whole applications.</p>
+      <p><code>v-memo</code> skips a subtree when its deps are unchanged — same cross-thread win as <code>v-once</code>, but keyed on a dependency list. Common in <code>v-for</code> rows. <code>isMemoSame</code> export + tests from @KealanAU (#156 / #181) in <code>0.4.0</code>. Thirteen features, thirteen live apps. That's the API story. Now — whole applications.</p>
     </aside>
   </section>
 
@@ -2083,7 +2120,7 @@
         <span class="eyebrow" style="margin-bottom:8px">What's there</span>
         <ul class="web__list">
           <li><b>Composition API &amp; SFCs</b></li>
-          <li><b>Transition, Suspense, KeepAlive</b></li>
+          <li><b>Transition, Suspense, KeepAlive, Teleport</b></li>
           <li><b>Pinia, Router, Query, Tailwind</b></li>
           <li><b>Main-Thread Script</b></li>
         </ul>
@@ -2091,7 +2128,6 @@
       <div class="stack-y gap-sm">
         <span class="eyebrow" style="margin-bottom:8px">What's open</span>
         <ul class="web__list">
-          <li><b>Teleport example &amp; polish</b></li>
           <li><b>View pager &amp; more gestures</b></li>
           <li><b>Vue DevTools integration</b></li>
           <li><b>The ecosystem you'd port</b></li>

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -64,18 +64,19 @@ export const ZH = {
     '来自 Vue core 上游的测试,在我们的渲染器上直接通过。',
 
   // ---- API coverage ----
-  'II · Vue coverage · 1/12': 'II · Vue 覆盖度 · 1/12',
-  'II · Vue coverage · 2/12': 'II · Vue 覆盖度 · 2/12',
-  'II · Vue coverage · 3/12': 'II · Vue 覆盖度 · 3/12',
-  'II · Vue coverage · 4/12': 'II · Vue 覆盖度 · 4/12',
-  'II · Vue coverage · 5/12': 'II · Vue 覆盖度 · 5/12',
-  'II · Vue coverage · 6/12': 'II · Vue 覆盖度 · 6/12',
-  'II · Vue coverage · 7/12': 'II · Vue 覆盖度 · 7/12',
-  'II · Vue coverage · 8/12': 'II · Vue 覆盖度 · 8/12',
-  'II · Vue coverage · 9/12': 'II · Vue 覆盖度 · 9/12',
-  'II · Vue coverage · 10/12': 'II · Vue 覆盖度 · 10/12',
-  'II · Vue coverage · 11/12': 'II · Vue 覆盖度 · 11/12',
-  'II · Vue coverage · 12/12': 'II · Vue 覆盖度 · 12/12',
+  'II · Vue coverage · 1/13': 'II · Vue 覆盖度 · 1/13',
+  'II · Vue coverage · 2/13': 'II · Vue 覆盖度 · 2/13',
+  'II · Vue coverage · 3/13': 'II · Vue 覆盖度 · 3/13',
+  'II · Vue coverage · 4/13': 'II · Vue 覆盖度 · 4/13',
+  'II · Vue coverage · 5/13': 'II · Vue 覆盖度 · 5/13',
+  'II · Vue coverage · 6/13': 'II · Vue 覆盖度 · 6/13',
+  'II · Vue coverage · 7/13': 'II · Vue 覆盖度 · 7/13',
+  'II · Vue coverage · 8/13': 'II · Vue 覆盖度 · 8/13',
+  'II · Vue coverage · 9/13': 'II · Vue 覆盖度 · 9/13',
+  'II · Vue coverage · 10/13': 'II · Vue 覆盖度 · 10/13',
+  'II · Vue coverage · 11/13': 'II · Vue 覆盖度 · 11/13',
+  'II · Vue coverage · 12/13': 'II · Vue 覆盖度 · 12/13',
+  'II · Vue coverage · 13/13': 'II · Vue 覆盖度 · 13/13',
   'reactive() + composables':
     '<code class="brand-text">reactive()</code> + 组合式函数',
   'Event modifiers': '事件<span class="brand-text">修饰符</span>',
@@ -280,10 +281,9 @@ export const ZH = {
   "What's there": '已经有的',
   "What's open": '还缺的',
   'Composition API & SFCs': '<b>Composition API 与 SFC</b>',
-  'Transition, Suspense, KeepAlive': '<b>Transition、Suspense、KeepAlive</b>',
+  'Transition, Suspense, KeepAlive, Teleport': '<b>Transition、Suspense、KeepAlive、Teleport</b>',
   'Pinia, Router, Query, Tailwind': '<b>Pinia、Router、Query、Tailwind</b>',
   'Main-Thread Script': '<b>Main-Thread Script</b>',
-  'Teleport example & polish': '<b>Teleport example 与打磨</b>',
   'View pager & more gestures': '<b>View pager 与更多手势</b>',
   'Vue DevTools integration': '<b>Vue DevTools 集成</b>',
   "The ecosystem you'd port": '<b>等你来移植的生态</b>',
@@ -371,13 +371,15 @@ export const ZH_NOTES = [
   `<p>Vue 的事件修饰符映射到 Lynx 事件系统:<code>.once</code>、<code>.stop</code>、<code>.self</code>、链式组合 —— @KealanAU 落地(#155), <code>0.4.0</code>。demo 里每个都和"不加修饰符"的孪生版本并排对照。(<code>.prevent</code> 是兼容性 no-op —— 原生没有默认行为可阻止。)</p>`,
   // 24 KeepAlive
   `<p>原生树上的组件实例缓存 —— 切 tab 再回来,状态还在。<code>include</code> / <code>exclude</code> / <code>max</code>,加上 <code>onActivated</code> / <code>onDeactivated</code>。@jynxbt 贡献(#153),落在 <code>0.4.0</code>。</p>`,
-  // 25 v-once
+  // 25 Teleport
+  `<p>按 id 渲染到目标节点 —— modal / overlay,不用和滚动层叠硬刚。BG 侧 <code>idRegistry</code> 解析 <code>to="#id"</code>;内容保持响应式,<code>:disabled</code> 则就地渲染。@sentomk 贡献(#161),落在 <code>0.4.0</code>。</p>`,
+  // 26 v-once
   `<p><code>v-once</code> 首次渲染后冻结。在 Lynx 上缓存命中会跳过该子树的<strong>整批跨线程 ops</strong> —— 比浏览器更值钱。@KealanAU 验证并文档化(#176), <code>0.4.0</code>。点 Increment:live 会变,frozen 不动。</p>`,
-  // 26 v-memo
-  `<p><code>v-memo</code> 在依赖未变时跳过子树 —— 和 <code>v-once</code> 一样有跨线程收益,但按依赖列表判定。常见于 <code>v-for</code> 行。<code>isMemoSame</code> 导出与测试来自 @KealanAU(#156 / #181), <code>0.4.0</code>。十二个特性、十二个现场应用。API 讲完了 —— 接下来,整个应用。</p>`,
-  // 27 Whole apps
+  // 27 v-memo
+  `<p><code>v-memo</code> 在依赖未变时跳过子树 —— 和 <code>v-once</code> 一样有跨线程收益,但按依赖列表判定。常见于 <code>v-for</code> 行。<code>isMemoSame</code> 导出与测试来自 @KealanAU(#156 / #181), <code>0.4.0</code>。十三个特性、十三个现场应用。API 讲完了 —— 接下来,整个应用。</p>`,
+  // 28 Whole apps
   `<p>API 逐个通过只是入场券。"Web DX 是基线"真正的考验,是把一整个 Vue 代码库 —— 状态、路由、样式、数据请求 —— 整体落到原生上。来两个经典。</p>`,
-  // 25 TodoMVC
+  // 29 TodoMVC
   `<p><strong>TodoMVC</strong> —— 每个框架的成人礼。和写 Web 一模一样的 Composition API;输入框是<em>原生</em>的,滚动是<em>原生</em>的,点击延迟不到一帧。</p><p><strong>现场:</strong>加一条、勾几条、清除已完成。</p>`,
   // 26 HackerNews
   `<p><strong>HackerNews</strong> —— 社区公认的"真应用"基准:网络、分页、嵌套评论。数据 TanStack Vue Query,样式 Tailwind,滚动跑在带复用的原生 <code>&lt;list&gt;</code> 上。<strong>跟着过来的不只是框架,是生态。</strong></p>`,

--- a/website/docs/guide/vue-compatibility.mdx
+++ b/website/docs/guide/vue-compatibility.mdx
@@ -124,7 +124,11 @@ The example below provides a reactive `theme` ref and a static `appName` string 
 
 ## Suspense
 
-Vue's [`<Suspense>`](https://vuejs.org/guide/built-ins/suspense.html) displays fallback content while waiting for async components to resolve. On Lynx, `<Suspense>` works with both async `setup()` (top-level `await` in `<script setup>`) and `defineAsyncComponent` for lazy-loading.
+Vue's [`<Suspense>`](https://vuejs.org/guide/built-ins/suspense.html) displays fallback content while waiting for async components to resolve. On Lynx, `<Suspense>` works with both async `setup()` (top-level `await` in `<script setup>`) and `defineAsyncComponent` for deferred loading.
+
+:::tip Code-splitting
+`defineAsyncComponent(() => import('./X.vue'))` emits webpack async chunks that need Lynx's lazy-bundle runtime (`lynx.requireModuleAsync` / `lynx.loadLazyBundle`). Those APIs are not available in Lynx Web Preview, so the docs example uses delayed promises over statically imported components instead — the Suspense fallback path is the same.
+:::
 
 <Go
   example="suspense"
@@ -188,7 +192,20 @@ For render functions, Vue's `withMemo` helper (what the compiler emits for [`v-m
 
 ## Teleport
 
-`<Teleport>` is supported for `to="#id"` string selectors. Direct element refs and non-ID selectors are not yet supported.
+Vue's [`<Teleport>`](https://vuejs.org/guide/built-ins/teleport.html) moves a template fragment to a different place in the UI tree. Vue Lynx supports it for `to="#id"` string selectors via a background-thread `idRegistry` lookup — the same pattern as a modal rendered at the page root while its trigger lives deeper in the component tree.
+
+:::warning Caveats
+Direct element refs and non-ID selectors (e.g. `to=".class"` or `to="body"`) are not yet supported. Give the destination an `id` and target it with `to="#that-id"`.
+
+The target element must already exist when `<Teleport>` mounts — place the `id` host earlier in the tree than the `<Teleport>` (or outside the component that owns it). Vue cannot resolve a target that is created by the same render as the teleport.
+:::
+
+The example below shows a modal teleported to `#overlay-root`, plus reactive content with the `disabled` prop:
+
+<Go
+  example="teleport"
+  defaultFile="src/App.vue"
+/>
 
 ## The `<page>` Top-Level Node
 

--- a/website/docs/zh/guide/vue-compatibility.mdx
+++ b/website/docs/zh/guide/vue-compatibility.mdx
@@ -124,7 +124,11 @@ Vue 的 [`provide`](https://vuejs.org/guide/components/provide-inject.html) 和 
 
 ## Suspense
 
-Vue 的 [`<Suspense>`](https://vuejs.org/guide/built-ins/suspense.html) 在等待异步组件解析时显示后备内容。在 Lynx 上，`<Suspense>` 支持异步 `setup()`（`<script setup>` 中的顶层 `await`）和用于懒加载的 `defineAsyncComponent`。
+Vue 的 [`<Suspense>`](https://vuejs.org/guide/built-ins/suspense.html) 在等待异步组件解析时显示后备内容。在 Lynx 上，`<Suspense>` 支持异步 `setup()`（`<script setup>` 中的顶层 `await`）和用于延迟加载的 `defineAsyncComponent`。
+
+:::tip 关于代码分割
+`defineAsyncComponent(() => import('./X.vue'))` 会产出依赖 Lynx lazy-bundle 运行时（`lynx.requireModuleAsync` / `lynx.loadLazyBundle`）的 webpack 异步 chunk。这些 API 在 Lynx Web Preview 中不可用，因此文档示例改用静态导入组件 + 延迟 Promise——Suspense 的 fallback 路径与真正的懒加载相同。
+:::
 
 <Go
   example="suspense"
@@ -188,7 +192,20 @@ pluginVueLynx({
 
 ## Teleport
 
-`<Teleport>` 支持 `to="#id"` 字符串选择器。暂不支持直接传入元素 ref 或非 ID 选择器。
+Vue 的 [`<Teleport>`](https://cn.vuejs.org/guide/built-ins/teleport.html) 可以将模板片段渲染到 UI 树中的另一处。Vue Lynx 通过后台线程的 `idRegistry` 查找支持 `to="#id"` 字符串选择器——典型用法是触发器在组件树深处，弹层却渲染到页面根节点。
+
+:::warning 注意事项
+暂不支持直接传入元素 ref，以及非 ID 选择器（例如 `to=".class"` 或 `to="body"`）。请给目标节点设置 `id`，并用 `to="#that-id"` 指向它。
+
+`<Teleport>` 挂载时目标元素必须已经存在——把带 `id` 的宿主放在 `<Teleport>` 之前（或放在拥有它的组件之外）。Vue 无法解析与 teleport 同一次渲染才创建出来的目标。
+:::
+
+下面的示例演示了传送到 `#overlay-root` 的弹层，以及带 `disabled` prop 的响应式内容：
+
+<Go
+  example="teleport"
+  defaultFile="src/App.vue"
+/>
 
 ## `<page>` 顶层节点
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `<Teleport>` to Chapter II Vue coverage now that the example landed in #256.

- Pulls `examples/teleport` (+ compat `<Go>` docs) from `main`
- Inserts as **11/13** in `0.4.0` order (after KeepAlive, before v-once/v-memo)
- Version chip `0.4.0` + contributor badge **@sentomk** (#161)
- Roadmap: Teleport moves to **What's there**

Coverage is now 13 slides.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-962e37b2-b337-44cd-a910-6f4389fbe1ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-962e37b2-b337-44cd-a910-6f4389fbe1ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

