### PR TITLE
Add epilogue chapter with fabric weave visualization

### DIFF
--- a/slides/AGENTS.md
+++ b/slides/AGENTS.md
@@ -1,0 +1,90 @@
+# Slides — Agent Guide
+
+HTML deck, zero runtime deps. One `<section class="slide">` in `index.html` =
+one step (no in-slide fragments). Everything is authored against a fixed
+1280×720 stage — **size in `cqw`/`cqh`, never `vw`/`vh`**. Depth: `README.md`.
+
+## Vocabulary
+
+| Term | Meaning |
+| ---- | ------- |
+| **stage slide** | `class="slide stage"` — centered one-idea slide (h-section / mega / chips) |
+| **divider** | chapter break: eyebrow + big serif numeral + title + tag |
+| **overlay** | `class="slide overlay"` — floats above its **base** (nearest previous non-overlay slide, kept visible via `is-under`); inherits the base's weave scene |
+| **magic move** | FLIP morph between **adjacent** slides: same `data-flip="id"` on both sides |
+| **`data-mm-fade`** | transient content that washes in behind a morph (first-appearance elements) |
+| **weave** | the epilogue's canvas thread field; a slide opts in with `data-weave="<scene>"` (`src/weave.js`) |
+| **`<vl-media>`** | universal embed: video / image / iframe with missing-file placeholders (`src/embeds.js`) |
+| **embed frame** | `.phone.phone--embed.no-deck-scroll` wrapper → drag-resize + preset chrome |
+| **flags** | per-slide `data-bg` (clean/beam) · `data-transition` (magic/fade/cut) · `data-chrome` (minimal/full/none) |
+
+## Adding a slide — the invariants
+
+1. Add the `<section>` **and** an `<aside class="notes">` (every slide has one).
+2. Add a ZH speaker note in `src/i18n.js` `ZH_NOTES` **at the same position** —
+   the array is indexed by document order. Check: `grep -c '<section class="slide'`
+   = `grep -c '<aside class="notes">'` = `ZH_NOTES.length`.
+3. Visible English text is translated by **normalized `textContent` lookup** in
+   the `ZH` map — new/changed on-screen text needs a matching key (exact
+   punctuation: `“ ” — · …`). Untranslated text silently stays English.
+   Only classes in `main.js` `I18N_SELECTOR` are swapped.
+4. Update the `data-counter` total in `index.html`.
+
+## Magic move rules
+
+- Same `data-flip` id on two **consecutive** slides = morph; ids are global, so
+  reuse across non-adjacent slides is fine but adjacent reuse must be intended.
+- FLIP preserves the element's own positioning scheme and transform (inline
+  transforms included) — don't change an element's `position` type between the
+  two sides of a pair.
+- `pnpm test:morph` drives every adjacent pair and fails on off-path or
+  landing-snap regressions. Run it after touching flips or `framework/magic-move.js`.
+
+## Overlays
+
+- Overlay slides keep the base rendered beneath — use them for media layers
+  that shouldn't interrupt a page's rhythm. Consecutive overlays share one base.
+- To "dismiss" back to the base look, follow the overlay run with a **verbatim
+  duplicate of the base slide** (this deck's normal idiom) — that also restores
+  the morph into the next slide.
+- Overlays default to `data-bg="clean" data-chrome="none"` and inherit the
+  base's `data-weave` unless they set their own.
+
+## `<vl-media>` embeds
+
+- `src` under `/media/embeds/` (drop-ins listed in `public/media/embeds/README.md`);
+  kind inferred from extension, `kind="iframe"` for URLs.
+- Videos: muted+loop+autoplay-on-arrival by default; reset (pause+rewind) on
+  every slide change. Opt-outs: `data-autoplay="false"`, `unmuted`, `no-loop`,
+  `controls`.
+- Iframes mount at distance ≤ 1, unload at ≥ 2 — never keep one always-live.
+- Missing files show a labeled placeholder (set `--ph-ar` for its aspect).
+- Resizable: wrap in `.phone.phone--embed.no-deck-scroll` with
+  `data-embed="wide|portrait|browser"`; seed size with `data-w`/`data-h`
+  (not inline `--phone-w`, which the preset would clobber).
+
+## Weave scenes
+
+Scene names: `fabric · fabric-dense · loom · loom-dim · compress ·
+panorama-left · panorama · finale`. Lane Y-fractions in `weave.js` are
+mirrored by `.wlab` label positions in HTML (`0.16` ↔ `top:16cqh`) — change
+them together. New scenes: add a builder to `SCENES`; keep geometry
+deterministic (seeded `rnd(i, salt)`, never `Math.random`).
+
+## Keyboard & focus (don't fight these)
+
+- Only slide navigation is on bare keys; every command lives in the palette
+  (`⌘K` / `/`). Never add global keydown shortcuts.
+- Demos only get the keyboard after a **deliberate click inside** them;
+  autofocus grabs are blurred (`demoEngaged` in `main.js`). Scroll/swipe
+  inside `.phone` / `.no-deck-scroll` never advances the deck.
+
+## Verify
+
+```bash
+pnpm build        # must stay green
+pnpm test:morph   # after touching data-flip usage or the framework
+```
+
+Plus a Playwright keyboard-walk over any slides you added (assert zero
+`pageerror`s) — see `README.md` for the deploy/preview URLs.

--- a/slides/AGENTS.md
+++ b/slides/AGENTS.md
@@ -39,6 +39,11 @@ one step (no in-slide fragments). Everything is authored against a fixed
   two sides of a pair.
 - `pnpm test:morph` drives every adjacent pair and fails on off-path or
   landing-snap regressions. Run it after touching flips or `framework/magic-move.js`.
+- Morphing elements are elevated to `z-index: 4` (`.is-flipping`) so they ride
+  above slide content. When overlapping elements have a meaningful stacking
+  order (a cascade: later on top), give each an explicit inline `z-index`
+  (1, 2, 3…) on **every** slide of the sequence — inline wins over the
+  elevation, so stacking stays stable mid-morph.
 
 ## Overlays
 

--- a/slides/README.md
+++ b/slides/README.md
@@ -133,6 +133,39 @@ flips black/white with the theme) and participates in magic move via
 `data-flip="weave-lynx"`. Reduced motion and embed previews render a single
 static frame instead of animating.
 
+## Overlay slides & media embeds
+
+An **overlay slide** (`<section class="slide overlay">`) keeps the nearest
+previous non-overlay slide rendered beneath it (`is-under`), so a media layer
+reads as "the same page, plus a layer" instead of a hard cut — consecutive
+overlays share one base, and an overlay inherits the base's `data-weave`
+unless it declares its own. To "dismiss" an overlay run back into the base
+look, follow it with a duplicate of the base slide (the deck's usual
+copy-the-markup idiom), which also restores magic-move continuity into the
+next slide.
+
+**`<vl-media src="…">`** (`src/embeds.js`) embeds a video, image, or iframe
+(kind inferred from the URL, or forced with `kind=`):
+
+- **Videos** reset on every slide change (pause + rewind — audio can never
+  leak across pages) and autoplay when their slide becomes current; opt out
+  with `data-autoplay="false"`, and use `unmuted` / `no-loop` / `controls`
+  to override the muted-loop defaults.
+- **Iframes** mount when their slide is one step away and unload two steps
+  out, so a heavy embedded page (e.g. the live PWA-talk deck) never taxes
+  the rest of the talk.
+- **Missing files** render as a labeled placeholder showing the exact path to
+  drop the asset at — author slides first, add media later. Expected files
+  are listed in `public/media/embeds/README.md`.
+
+For a **resizable** frame, wrap the `<vl-media>` in
+`.phone.phone--embed.no-deck-scroll` with `data-embed="wide|portrait|browser"`
+— it gets the demo mockups' drag grips + preset switcher (embed-shaped
+presets), and `data-w`/`data-h` seed a per-slide starting size (used by the
+cascade sequence). The tweet-reveal pair shows the other trick: a fixed
+`.crop` window whose inner `vl-media` carries `data-flip`, so magic move
+pans/zooms the image inside the crop.
+
 ## Deploy
 
 Two deploy shapes, chosen per branch by `website/vercel.json`:

--- a/slides/README.md
+++ b/slides/README.md
@@ -109,6 +109,30 @@ logo build (React → Chrome → Lynx), the landscape columns, and the two-threa
 build on the How-it-works slides are the worked examples. One `<section class="slide">` = one step (no in-slide
 fragments), which keeps speaker-view sync and deep-links simple.
 
+## The weave layer (epilogue)
+
+The epilogue's "fabrics" visual is a single persistent canvas
+(`src/weave.js`) mounted *under* the slides inside the frame. A slide opts in
+with `data-weave="<scene>"` and the engine tweens the whole thread field
+between scenes on navigation, so adjacent weave slides read as one continuous
+magic move of the threads themselves. Scenes:
+
+| Scene | Picture |
+| ----- | ------- |
+| `fabric` / `fabric-dense` | Vue alone — glowing green threads |
+| `loom` / `loom-dim`       | Vue pinches through the Lynx mark into iOS / Android / Web |
+| `compress`                | the model's gray choice space → the bright idiom |
+| `panorama-left`           | the whole web ecosystem weaves toward the waist |
+| `panorama`                | …and fans out into every platform |
+| `finale`                  | the panorama, dimmed to a backdrop |
+
+Lane fractions in `weave.js` are mirrored by the `.wlab` label positions in
+`index.html` (canvas fraction `0.16` ↔ `top:16cqh`) — keep them in sync when
+moving bundles. The Lynx mark at the waist is DOM (`.wlynx`, ink-colored so it
+flips black/white with the theme) and participates in magic move via
+`data-flip="weave-lynx"`. Reduced motion and embed previews render a single
+static frame instead of animating.
+
 ## Deploy
 
 Two deploy shapes, chosen per branch by `website/vercel.json`:

--- a/slides/index.html
+++ b/slides/index.html
@@ -24,7 +24,7 @@
     </button>
   </div>
   <div class="chrome chrome--bottom">
-    <span data-counter>01 / 70</span>
+    <span data-counter>01 / 106</span>
   </div>
   <div class="chrome chrome--bottom-right">
     <a href="https://vue.lynxjs.org" target="_blank" rel="noreferrer">vue.lynxjs.org</a>
@@ -2152,8 +2152,471 @@
       <a href="https://vue.lynxjs.org" target="_blank" rel="noreferrer">vue.lynxjs.org</a>
     </div>
     <aside class="notes">
-      <p><strong>Close.</strong> Thank them. Invite questions. Stay here for Q&amp;A.</p>
-      <p>"Is this production?" — pre-alpha, architecture solid, tested surface. "Android?" — Lynx is cross-platform, same bundle runs on both.</p>
+      <p><strong>The fake close.</strong> Play it completely straight: thank them, half a bow, reach for the water — hold until the room starts to applaud.</p>
+      <p>Then, deadpan: "啊——没有哈。这才过去十分钟。" Advance into the real second half.</p>
+    </aside>
+  </section>
+
+  <!-- ====================================================
+       Epilogue · The elephant in the room — AI, fabrics,
+       and the case for weaving. The (real) second half.
+       ==================================================== -->
+  <section class="slide divider">
+    <span class="eyebrow">Epilogue</span>
+    <div class="divider__row">
+      <span class="divider__num numeral--brand">&infin;</span>
+      <h2 class="divider__title">
+        The elephant<br/>in the room.
+      </h2>
+    </div>
+    <p class="divider__tag">
+      &ldquo;Vibe coding&rdquo; is barely eighteen months old &mdash; and it
+      already writes native apps. So why frameworks? Why Lynx? Why any of this?
+    </p>
+    <aside class="notes">
+      <p><strong>Reset the room.</strong> "So — with the ten minutes we saved, let's talk about the elephant." If AI can do everything, why not just prompt out N native apps and skip the framework, the cross-platform layer, all of it?</p>
+      <p>Tone shift: less product pitch, more thinking-out-loud. This half is the <em>why</em>, not the <em>what</em>.</p>
+    </aside>
+  </section>
+
+  <!-- E2 — the question, honestly -->
+  <section class="slide stage">
+    <span class="eyebrow">Epilogue · the question</span>
+    <h2 class="h-section" style="text-align:center;max-width:20ch">
+      Does AI obsolete <span class="brand-text">all of us</span>?
+    </h2>
+    <div class="demo__meta" style="justify-content:center">
+      <span class="chip">no frameworks?</span>
+      <span class="chip">no libraries?</span>
+      <span class="chip">no docs?</span>
+      <span class="chip">no us?</span>
+    </div>
+    <aside class="notes">
+      <p><strong>Be honest first: I don't know.</strong> What does AI mean for Lynx, for Vue — why do I even bother? Does documentation matter if no human reads it? Do libraries matter if the model can rebuild them from bare metal?</p>
+      <p>Datapoints to drop: React usage <em>spiked</em> in the AI era — models default to it — and yet React itself matters less than it used to; Anthropic just wrote about Claude building one-off internal tools in plain HTML, no framework at all. The ground is genuinely moving.</p>
+    </aside>
+  </section>
+
+  <!-- E3 — the claim / roadmap -->
+  <section class="slide stage">
+    <span class="eyebrow">Epilogue · a claim</span>
+    <h2 class="h-section" style="text-align:center;max-width:22ch">
+      What <span class="brand-text">survives</span> AI?
+    </h2>
+    <div class="tiles">
+      <span class="tile" style="--c:#8b93a3">infrastructure</span>
+      <span class="tilearr">&rarr;</span>
+      <span class="tile" style="--c:#E8B44A">enablers</span>
+      <span class="tilearr">&rarr;</span>
+      <span class="tile" style="--c:#56b8f0">platforms</span>
+      <span class="tilearr">&rarr;</span>
+      <span class="tile" style="--c:#9E86F0">ecosystems</span>
+      <span class="tilearr">&rarr;</span>
+      <span class="tile is-hero" style="--c:#42b883">people</span>
+    </div>
+    <p class="lead" data-mm-fade>Two lemmas, then an answer.</p>
+    <aside class="notes">
+      <p><strong>The thesis, stated up front so the chapter has a spine.</strong> What's "saved" from AI is everything that <em>enables</em> instead of merely produces: infrastructure, enablers, platforms, ecosystems — and, at the end of the chain, people. Note the progression: each one is saved <em>because</em> it feeds the next.</p>
+      <p>I'll argue it with two lemmas: (1) technology's role flips from interface to harness; (2) technology's real job is connecting ecosystems — and people.</p>
+    </aside>
+  </section>
+
+  <!-- E4 — Lemma 1 · the stack, rewritten -->
+  <section class="slide stage">
+    <span class="eyebrow">Epilogue · Lemma 1</span>
+    <div class="flow" style="height:56cqh;width:min(100%,880px)">
+      <div class="fb" data-flip="stk-human" style="--c:#8b93a3;left:44%;top:4%">human</div>
+      <div class="fb is-hero" data-flip="stk-nl" style="--c:#42b883;left:44%;top:22.4%">natural languages</div>
+      <div class="fb is-hero" data-flip="stk-agent" style="--c:#56b8f0;left:44%;top:40.8%">agent</div>
+      <div class="fb" data-flip="stk-code" style="--c:#8b93a3;left:44%;top:59.2%">code</div>
+      <div class="fb" data-flip="stk-fw" style="--c:#8b93a3;left:44%;top:77.6%">frameworks</div>
+      <div class="fb" data-flip="stk-sys" style="--c:#8b93a3;left:44%;top:96%">system</div>
+      <span class="farr" data-mm-fade style="--c:#42b883;left:71%;top:22.4%">&larr; the new source</span>
+      <span class="farr" data-mm-fade style="--c:#56b8f0;left:71.5%;top:40.8%">&larr; the new interface</span>
+      <span class="farr" data-mm-fade style="left:73%;top:77.6%">&larr; they stay &mdash; and evolve</span>
+    </div>
+    <p class="lead" data-mm-fade>The stack, rewritten.</p>
+    <aside class="notes">
+      <p><strong>Lemma 1 opens with the new stack.</strong> Natural language is the new source code; the agent is the new interface sitting where IDEs and GUIs used to. But look below the agent: code, frameworks, the system — they didn't vanish. They became what the agent <em>drives</em>.</p>
+      <p>Technology's job flipped: from serving humans directly to <em>harnessing</em> the thing that serves humans.</p>
+    </aside>
+  </section>
+
+  <!-- E5 — what makes a harness -->
+  <section class="slide stage">
+    <span class="eyebrow">Epilogue · Lemma 1 · harness</span>
+    <h2 class="h-section" style="text-align:center;max-width:24ch">
+      AI can do anything &mdash; <span class="brand-text">harnessed</span>.
+    </h2>
+    <div class="tiles">
+      <span class="tile" style="--c:#E8B44A">context <small>docs &middot; priors &middot; AGENTS.md</small></span>
+      <span class="tile" style="--c:#56b8f0">tools <small>functions &middot; capabilities</small></span>
+      <span class="tile" style="--c:#9E86F0">environment <small>runtime &middot; sandbox</small></span>
+      <span class="tile" style="--c:#42b883">feedback <small>render &middot; tests &middot; logs</small></span>
+    </div>
+    <aside class="notes">
+      <p><strong>Define the word, because the whole chapter leans on it.</strong> A harness is what turns raw capability into reliable work: context (what it knows going in), tools (what it can act with), an environment (where actions are safe and cheap), feedback (how it sees what it just did).</p>
+      <p>Chapter IV was secretly this slide: AGENTS.md was context, the toolchain was tools, LynxExplorer the environment, the upstream tests the feedback.</p>
+    </aside>
+  </section>
+
+  <!-- E6 — the browser is a great harness -->
+  <section class="slide stage">
+    <span class="eyebrow">Epilogue · Lemma 1 · platforms</span>
+    <div class="logo" style="position:static;width:8cqw;height:8cqw">
+      <svg viewBox="0 0 48 48" aria-label="Chrome logo"><circle cx="24" cy="24" r="12" fill="#fff"/><path fill="#EA4335" d="M24 12h20.78a23.99 23.99 0 0 0-41.56.003L13.61 30l.009-.002A11.99 11.99 0 0 1 24 12Z"/><path fill="#FBBC04" d="M34.39 30.003 24 48a23.99 23.99 0 0 0 20.78-35.997H24l-.003.009a11.99 11.99 0 0 1 10.393 17.991Z"/><path fill="#34A853" d="M13.61 30.003 3.22 12.006A23.99 23.99 0 0 0 24 48l10.39-17.997-.007-.007a11.99 11.99 0 0 1-20.773.007Z"/><circle cx="24" cy="24" r="9.5" fill="#1A73E8"/></svg>
+    </div>
+    <h2 class="h-section" style="text-align:center;max-width:22ch">
+      Nobody says AI will replace <span style="color:#4FB8F0">the browser</span>.
+    </h2>
+    <div class="demo__meta" style="justify-content:center">
+      <span class="chip">open by default</span>
+      <span class="chip">sandboxed</span>
+      <span class="chip">endlessly capable</span>
+      <span class="chip">fully observable</span>
+    </div>
+    <aside class="notes">
+      <p><strong>Platforms survive because platforms are great harnesses.</strong> The browser: open data and open docs (context), an enormous capability surface (tools), a natural sandbox (environment), and total transparency — the DOM, DevTools (feedback).</p>
+      <p>Nobody argues the Web gets obsoleted by AI. I'd go further: GUI itself won't be — humans still need to <em>see</em>.</p>
+    </aside>
+  </section>
+
+  <!-- E7 — frameworks were always harnesses -->
+  <section class="slide stage">
+    <span class="eyebrow">Epilogue · Lemma 1 · frameworks</span>
+    <h2 class="h-section" style="text-align:center;max-width:24ch">
+      Frameworks were always <span class="brand-text">harnesses</span>.
+    </h2>
+    <div class="tiles">
+      <span class="tile" style="--c:#8b93a3">then <small>architecting how humans reason</small></span>
+      <span class="tilearr">&rarr;</span>
+      <span class="tile is-hero" style="--c:#42b883">now <small>steering what models emit</small></span>
+    </div>
+    <aside class="notes">
+      <p><strong>The reframe that makes frameworks AI-relevant.</strong> On the web you could always mutate the DOM however you liked — React and Vue won because they <em>constrained</em> us: an architecture that harnessed human reasoning into emitting the next token of correct code.</p>
+      <p>We were the first token predictors being harnessed. The model is just the next one. Higher-level abstraction still helps — it helped us, it helps it.</p>
+    </aside>
+  </section>
+
+  <!-- E8 — FABRIC I · every technology is a fabric -->
+  <section class="slide weave" data-bg="clean" data-chrome="minimal" data-weave="fabric">
+    <p class="weave-kicker">Every technology is a fabric.</p>
+    <aside class="notes">
+      <p><strong>The chapter's image arrives.</strong> Let the threads breathe for a moment before speaking. In my "Frontend is Dead" talk I argued from first principles that we'll always need the UI/App abstraction — some woven layer between intent and pixels. Modern software is stitched, not carved.</p>
+      <p>So here's the metaphor that carries the rest of the talk: every technology is a fabric — with its own fibers, its own weave, its own feel.</p>
+    </aside>
+  </section>
+
+  <!-- E9 — FABRIC I · Vue's texture -->
+  <section class="slide weave" data-bg="clean" data-chrome="minimal" data-weave="fabric-dense">
+    <p class="weave-kicker">Vue &mdash; a weave you can feel.</p>
+    <div class="demo__meta" data-mm-fade
+         style="position:absolute;left:50%;bottom:11cqh;transform:translateX(-50%);justify-content:center;z-index:2">
+      <span class="chip chip--brand">templates</span>
+      <span class="chip chip--brand">reactivity</span>
+      <span class="chip chip--brand">mutable state</span>
+      <span class="chip chip--brand">SFC</span>
+    </div>
+    <aside class="notes">
+      <p><strong>The weave tightens.</strong> Different fabrics have different characteristics — and maybe Vue's is exactly the texture you want: templates, fine-grained reactivity, mutable state that just works, single-file components.</p>
+      <p>The point isn't Vue vs anything. It's that the <em>material</em> still matters — to humans choosing it, and to models trained on oceans of it.</p>
+    </aside>
+  </section>
+
+  <!-- E10 — intermission meme -->
+  <section class="slide stage" data-bg="clean">
+    <span class="eyebrow">Epilogue &middot; intermission</span>
+    <div class="meme">[ meme goes here ]</div>
+    <p class="kicker" style="text-align:center">&ldquo;Getting metaphysical again &mdash; &#38634;&#30887; is going to roast me.&rdquo;</p>
+    <aside class="notes">
+      <p><strong>Breather.</strong> Self-aware beat before Lemma 2 — drop the meme in, take the laugh, move on. (Placeholder frame: replace with the actual image in <code>public/media/</code>.)</p>
+    </aside>
+  </section>
+
+  <!-- E11 — FABRIC II · the loom -->
+  <section class="slide weave" data-bg="clean" data-chrome="minimal" data-weave="loom">
+    <p class="weave-kicker">Lynx &mdash; the loom.</p>
+    <span class="wlab" style="--c:#42b883;left:5cqw;top:50cqh">Vue <i></i></span>
+    <div class="wlynx" data-flip="weave-lynx">
+      <svg viewBox="0 0 27 28" aria-label="Lynx"><path fill-rule="evenodd" clip-rule="evenodd" d="M7.56542 6.19594L3.90642 8.7164C3.50877 8.99031 3.23346 9.40191 3.13675 9.86708L2.77902 11.5878C2.76005 11.679 2.71799 11.7642 2.65665 11.8355L0.996306 14.0121C0.772761 14.2722 0.778152 14.9632 1.39044 15.4057C1.62523 15.6103 1.93915 16.0691 2.29622 16.591C3.05224 17.6959 4.00169 19.0836 4.80312 18.9394C5.9372 18.541 7.32544 18.4135 8.39128 18.9394C10.4632 20.7282 9.95449 22.3775 9.22514 24.7421C8.93165 25.6936 8.60243 26.7609 8.39128 27.9997C9.38643 24.3777 11.6242 20.1711 15.6592 18.7437C14.9322 18.1498 13.4486 17.5981 12.1357 17.4653C12.1357 17.4653 16.1691 14.0121 21.1439 12.4254C17.671 4.16205 11.9386 0.213095 11.9386 0.213095C11.6465 -0.148197 11.0566 -0.0296711 10.9349 0.414774C10.8371 1.72112 10.675 2.60942 10.4074 3.44676L8.39128 1.12029C8.18068 0.866399 7.75965 1.013 7.76176 1.33949C8.10312 3.23719 8.05521 4.30239 7.56542 6.19594ZM8.9846 6.02248L8.99663 6.02171C9.02298 6.02002 9.0489 6.01659 9.07424 6.01153L8.9846 6.02248ZM11.7123 1.7617C13.094 4.1491 13.7199 5.5054 13.9322 8.03659C12.4625 7.2017 11.8221 6.98923 10.7413 6.99451C11.3718 5.0773 11.5644 3.92284 11.7123 1.7617Z"/><path d="M20.5916 19.4929C14.9639 20.7806 11.7672 22.7198 9.32227 28.0001C13.7111 20.6367 26.9966 21.9536 26.9966 21.9536C26.7484 20.7508 24.1069 18.4571 22.3696 17.0503C22.3696 17.0503 23.7712 15.3272 26.8697 14.455C26.8697 14.455 20.9125 14.8002 17.4445 16.6727C18.568 17.2656 20.0071 18.2663 20.5916 19.4929Z"/></svg>
+    </div>
+    <span class="wlab" data-mm-fade style="--c:#cdd6e4;right:5cqw;top:30cqh"><i></i> iOS</span>
+    <span class="wlab" data-mm-fade style="--c:#3ddc84;right:5cqw;top:50cqh"><i></i> Android</span>
+    <span class="wlab" data-mm-fade style="--c:#56b8f0;right:5cqw;top:70cqh"><i></i> Web</span>
+    <aside class="notes">
+      <p><strong>Lemma 2 opens as a picture, not a claim.</strong> The green fabric pulls through a single point — the loom — and comes out the other side woven into iOS, Android, the Web. Watch a thread: it keeps its color into the waist, and takes the platform's color out of it.</p>
+      <p>What makes Lynx able to be this? A web-friendly surface on one side, a serious native architecture on the other, and openness at every level in between.</p>
+    </aside>
+  </section>
+
+  <!-- E12 — own the patchwork -->
+  <section class="slide stage" data-bg="clean" data-weave="loom-dim">
+    <span class="eyebrow">Epilogue &middot; Lemma 2</span>
+    <h2 class="h-section" style="text-align:center;max-width:24ch">
+      &ldquo;A patchwork monster&rdquo;? <span class="brand-text">Exactly.</span>
+    </h2>
+    <div class="demo__meta" style="justify-content:center">
+      <span class="chip">web-friendly surface</span>
+      <span class="chip">strong native core</span>
+      <span class="chip">framework-agnostic</span>
+      <span class="chip">hybrid rendering</span>
+    </div>
+    <aside class="notes">
+      <p><strong>Own the insult.</strong> People call Lynx a 缝合怪 — a stitched-together monster. Yes! We just said code comes in fabrics — of course the thing that joins them is stitched. A loom is <em>supposed</em> to be a patchwork machine.</p>
+      <p>What the stitching buys: it absorbs the raw entropy of N platforms so it isn't re-paid in every app — and that's exactly the part AI is bad at amortizing on its own. The framework holds the translation contract; the agent writes against compressed semantics.</p>
+    </aside>
+  </section>
+
+  <!-- E13 — FABRIC · compression -->
+  <section class="slide weave" data-bg="clean" data-chrome="minimal" data-weave="compress">
+    <p class="weave-kicker">Frameworks compress the search space.</p>
+    <span class="wlab wlab--soft" style="left:5cqw;top:16cqh">everything the model could emit</span>
+    <span class="wlab" style="--c:#42b883;right:5cqw;top:38cqh">the idiom</span>
+    <aside class="notes">
+      <p><strong>The same loom, one abstraction up.</strong> On the left: the model's whole choice space — gray, wide, chaotic. Through the framework it comes out narrow, bright, aligned: the idiom. Steering, visualized.</p>
+      <p>This is why cross-platform frameworks are <em>semantic compression layers</em> for AI: fewer tokens, a denser region of the training distribution, less room to hallucinate. Correctness is a probability problem — compression moves the probability.</p>
+    </aside>
+  </section>
+
+  <!-- E14 — people -->
+  <section class="slide stage">
+    <span class="eyebrow">Epilogue &middot; Lemma 2 &middot; people</span>
+    <h2 class="h-section" style="text-align:center;max-width:24ch">
+      Technology is nothing without its <span class="brand-text">people</span>.
+    </h2>
+    <div class="demo__meta" style="justify-content:center">
+      <span class="chip">3D prints &middot; &#23567;&#38899;</span>
+      <span class="chip">a dinner in Fuzhou &middot; &#38634;&#30887;</span>
+      <span class="chip">Poland, then here &middot; Nector</span>
+      <span class="chip chip--brand">Evan &middot; Anthony &middot; you</span>
+    </div>
+    <aside class="notes">
+      <p><strong>The lemma lands on humans.</strong> If AI ultimately boils down to human taste, people become <em>more</em> important, not less — and connecting a community is connecting its people.</p>
+      <p>Make it concrete, name the room: 小音 who 3D-printed help for the demo; 雪碧 — last time we ate together was Fuzhou, and here we are; Nector — last time was Poland! You could say "I can only watch this idol on this platform" — well, Evan and Anthony are on this one.</p>
+    </aside>
+  </section>
+
+  <!-- E15 — not a framework, a connection -->
+  <section class="slide stage">
+    <span class="eyebrow">Epilogue &middot; Lemma 2</span>
+    <h2 class="h-section" style="text-align:center;max-width:26ch">
+      Vue Lynx isn't a framework. It's a <span class="brand-text">connection</span>.
+    </h2>
+    <div class="flow" style="height:22cqh;width:min(100%,780px)">
+      <div class="fb" style="--c:#4FB8F0;left:16%;top:50%">Web<small>DOM &middot; CSS &middot; JS</small></div>
+      <span class="farr" style="left:33.5%;top:50%">&harr;</span>
+      <div class="fb is-hero" style="--c:#5dd5a8;left:50%;top:50%">Lynx<small>the designed seam</small></div>
+      <span class="farr" style="left:66.5%;top:50%">&harr;</span>
+      <div class="fb" style="--c:#F27A9E;left:84%;top:50%">Native<small>iOS &middot; Android &middot; &hellip;</small></div>
+    </div>
+    <aside class="notes">
+      <p><strong>So what did I actually build?</strong> In the AI era you arguably don't <em>need</em> a framework — ten years ago I built an online editor for HTML slides; this deck is fully generated, zero libraries underneath. Vue Lynx is really a beginning: convincing the Vue community to build for native.</p>
+      <p>Here's the deeper reason it works: wherever a connection <em>exists</em>, AI multiplies the connections that happen. Porting between languages is easy because every language is Turing-complete with a runtime — the bridge exists. Web ↔ Native has no natural bridge. Lynx, as a project, IS the design of that bridge. (And when I pick what to work on: commercial value counts for one, but there'd better be some ideal in it too.)</p>
+    </aside>
+  </section>
+
+  <!-- E16 — connections compound -->
+  <section class="slide stage">
+    <span class="eyebrow">Epilogue &middot; Lemma 2 &middot; compounding</span>
+    <h2 class="h-section" style="text-align:center;max-width:22ch">
+      One connection <span class="brand-text">compounds</span>.
+    </h2>
+    <div class="wgrid">
+      <div class="wg"><b>Web</b><div class="demo__meta"><span class="chip">Motion</span><span class="chip">Pretext</span></div></div>
+      <div class="wg"><b>Electron</b><div class="demo__meta"><span class="chip">Node-API</span></div></div>
+      <div class="wg"><b>JSI</b><div class="demo__meta"><span class="chip">Expo Modules</span></div></div>
+      <div class="wg"><b>Rendering</b><div class="demo__meta"><span class="chip">native</span><span class="chip">custom</span><span class="chip">hybrid</span></div></div>
+      <div class="wg"><b>Agents</b><div class="demo__meta"><span class="chip">A2UI</span><span class="chip">OpenUI</span></div></div>
+      <div class="wg"><b>Lynx</b><div class="demo__meta"><span class="chip chip--brand">Sparkling</span><span class="chip chip--brand">Lynxtron</span></div></div>
+    </div>
+    <aside class="notes">
+      <p><strong>Connect to Lynx and you connect to everything Lynx connects.</strong> The web fabrics you already use — Motion, Pretext — carry over. Electron via Node-API; the JSI world, Expo Modules included; every rendering strategy; the agent-UI protocols taking shape. And Lynx's own ecosystem — Sparkling, Lynxtron.</p>
+      <p>The ecosystem and the community are what get carried over. That's the compounding.</p>
+    </aside>
+  </section>
+
+  <!-- E17 — a place to vibe -->
+  <section class="slide stage">
+    <span class="eyebrow">Epilogue &middot; Lemma 2</span>
+    <h2 class="h-section" style="text-align:center;max-width:26ch">
+      AI doesn't need mature libraries. It needs a place to <span class="brand-text">vibe</span>.
+    </h2>
+    <p class="lead">The Web was that place. Lynx carries it to native.</p>
+    <aside class="notes">
+      <p><strong>Sharpen the ecosystem point for the AI era.</strong> With an agent at the keyboard, what you need isn't even a mature library — it's a platform where trying things is cheap, observable, and safe. That's what made the Web the Web. Lynx's bet is carrying that property to native.</p>
+    </aside>
+  </section>
+
+  <!-- E18 — one more thing -->
+  <section class="slide stage" data-bg="clean" data-chrome="none">
+    <p class="kicker" style="font-size:clamp(44px,5.6cqw,80px);text-align:center;max-width:none">One more thing&hellip;</p>
+    <aside class="notes">
+      <p><strong>Hold it.</strong> Count two beats before advancing.</p>
+    </aside>
+  </section>
+
+  <!-- E19 — Vapor on Lynx -->
+  <section class="slide stage">
+    <span class="eyebrow">One more thing &middot; Vue Vapor</span>
+    <div class="flow" style="height:34cqh;width:min(100%,900px)">
+      <div class="fb is-hero" style="--c:#42b883;left:16%;top:34%">Vue Vapor<small>no VDOM &middot; signals</small></div>
+      <span class="farr" style="--c:#4FB8F0;left:34.5%;top:34%">&rarr;</span>
+      <div class="fb" style="--c:#4FB8F0;left:50%;top:34%">ops<small>flat array &middot; per tick</small></div>
+      <span class="farr" style="--c:#F27A9E;left:65.5%;top:34%">&rarr;</span>
+      <div class="fb" style="--c:#F27A9E;left:83%;top:34%">Element PAPI<small>__CreateView &middot; &hellip;</small></div>
+      <div class="fb is-dim" style="--c:#8b93a3;left:50%;top:82%">VDOM &middot; ShadowElement<small>the layer we get to drop</small></div>
+    </div>
+    <p class="lead" data-mm-fade>
+      Vapor on Lynx &mdash; no VDOM. Straight to <b style="color:#4FB8F0">ops</b>.
+    </p>
+    <aside class="notes">
+      <p><strong>Connecting innovation itself.</strong> Remember the chapter-IV pipeline: VDOM → ShadowElement → ops → PAPI. Vapor mode renders without a VDOM — so on Lynx, an entire layer of the pipeline simply falls away: signals drive effects that emit ops directly. Implementation-wise we get to <em>drop</em> abstraction, not add it.</p>
+      <p>Status honesty: this is the design sketch and early experiments, not a shipped mode — which is exactly why it's exciting: the seam is open, and this is the kind of innovation that a connection lets flow both ways.</p>
+    </aside>
+  </section>
+
+  <!-- E20 — the cradle -->
+  <section class="slide stage">
+    <span class="eyebrow">One more thing</span>
+    <h2 class="h-section" style="text-align:center;max-width:22ch">
+      A <span class="brand-text">cradle</span> for framework design.
+    </h2>
+    <p class="lead">A team that loves the Web &mdash; and dares to break it.</p>
+    <aside class="notes">
+      <p><strong>Why framework authors should care about Lynx.</strong> Lynx has made interesting — even controversial — design choices, and keeps making them: dual threads, MTS, a real CSS engine off the DOM. This is a team that loves the Web and has both the guts and the room to break it where it must.</p>
+      <p>For Vue specifically: a native platform with genuine room to run — the kind of space where a Vapor-native renderer is a weekend of vibing away.</p>
+    </aside>
+  </section>
+
+  <!-- E21 — FABRIC III · panorama, left half -->
+  <section class="slide weave" data-bg="clean" data-chrome="none" data-weave="panorama-left">
+    <p class="weave-kicker">Weave the whole Web&hellip;</p>
+    <span class="wlab" data-flip="wl-vue" style="--c:#42b883;left:4cqw;top:16cqh">Vue <i></i></span>
+    <span class="wlab" data-flip="wl-react" style="--c:#61dafb;left:4cqw;top:25cqh">React <i></i></span>
+    <span class="wlab" data-flip="wl-svelte" style="--c:#ff9a4d;left:4cqw;top:33cqh">Svelte <i></i></span>
+    <span class="wlab" data-flip="wl-solid" style="--c:#ffd166;left:4cqw;top:40cqh">Solid <i></i></span>
+    <span class="wlab" data-flip="wl-octane" style="--c:#ff5468;left:4cqw;top:47cqh">Octane <i></i></span>
+    <span class="wlab" data-flip="wl-css" style="--c:#8a63d2;left:4cqw;top:55cqh">CSS <i></i></span>
+    <span class="wlab" data-flip="wl-tailwind" style="--c:#38bdf8;left:4cqw;top:63cqh">Tailwind <i></i></span>
+    <span class="wlab" data-flip="wl-motion" style="--c:#f7e14d;left:4cqw;top:71cqh">Motion &middot; Pretext <i></i></span>
+    <span class="wlab" data-flip="wl-rspack" style="--c:#ff7a1a;left:4cqw;top:80cqh">Rspack <i></i></span>
+    <div class="wlynx" data-flip="weave-lynx">
+      <svg viewBox="0 0 27 28" aria-label="Lynx"><path fill-rule="evenodd" clip-rule="evenodd" d="M7.56542 6.19594L3.90642 8.7164C3.50877 8.99031 3.23346 9.40191 3.13675 9.86708L2.77902 11.5878C2.76005 11.679 2.71799 11.7642 2.65665 11.8355L0.996306 14.0121C0.772761 14.2722 0.778152 14.9632 1.39044 15.4057C1.62523 15.6103 1.93915 16.0691 2.29622 16.591C3.05224 17.6959 4.00169 19.0836 4.80312 18.9394C5.9372 18.541 7.32544 18.4135 8.39128 18.9394C10.4632 20.7282 9.95449 22.3775 9.22514 24.7421C8.93165 25.6936 8.60243 26.7609 8.39128 27.9997C9.38643 24.3777 11.6242 20.1711 15.6592 18.7437C14.9322 18.1498 13.4486 17.5981 12.1357 17.4653C12.1357 17.4653 16.1691 14.0121 21.1439 12.4254C17.671 4.16205 11.9386 0.213095 11.9386 0.213095C11.6465 -0.148197 11.0566 -0.0296711 10.9349 0.414774C10.8371 1.72112 10.675 2.60942 10.4074 3.44676L8.39128 1.12029C8.18068 0.866399 7.75965 1.013 7.76176 1.33949C8.10312 3.23719 8.05521 4.30239 7.56542 6.19594ZM8.9846 6.02248L8.99663 6.02171C9.02298 6.02002 9.0489 6.01659 9.07424 6.01153L8.9846 6.02248ZM11.7123 1.7617C13.094 4.1491 13.7199 5.5054 13.9322 8.03659C12.4625 7.2017 11.8221 6.98923 10.7413 6.99451C11.3718 5.0773 11.5644 3.92284 11.7123 1.7617Z"/><path d="M20.5916 19.4929C14.9639 20.7806 11.7672 22.7198 9.32227 28.0001C13.7111 20.6367 26.9966 21.9536 26.9966 21.9536C26.7484 20.7508 24.1069 18.4571 22.3696 17.0503C22.3696 17.0503 23.7712 15.3272 26.8697 14.455C26.8697 14.455 20.9125 14.8002 17.4445 16.6727C18.568 17.2656 20.0071 18.2663 20.5916 19.4929Z"/></svg>
+    </div>
+    <aside class="notes">
+      <p><strong>The panorama begins.</strong> Name the strands as they land: Vue green, React blue, the faint yellows of Svelte and Solid, Octane red — a brand-new fabric still being spun — CSS, Tailwind, Motion and Pretext, Rspack orange. The whole web ecosystem, as threads.</p>
+      <p>They all pull toward one thin, strong waist.</p>
+    </aside>
+  </section>
+
+  <!-- E22 — FABRIC III · the full panorama -->
+  <section class="slide weave" data-bg="clean" data-chrome="none" data-weave="panorama">
+    <p class="weave-kicker">&hellip;into every platform.</p>
+    <span class="wlab" data-flip="wl-vue" style="--c:#42b883;left:4cqw;top:16cqh">Vue <i></i></span>
+    <span class="wlab" data-flip="wl-react" style="--c:#61dafb;left:4cqw;top:25cqh">React <i></i></span>
+    <span class="wlab" data-flip="wl-svelte" style="--c:#ff9a4d;left:4cqw;top:33cqh">Svelte <i></i></span>
+    <span class="wlab" data-flip="wl-solid" style="--c:#ffd166;left:4cqw;top:40cqh">Solid <i></i></span>
+    <span class="wlab" data-flip="wl-octane" style="--c:#ff5468;left:4cqw;top:47cqh">Octane <i></i></span>
+    <span class="wlab" data-flip="wl-css" style="--c:#8a63d2;left:4cqw;top:55cqh">CSS <i></i></span>
+    <span class="wlab" data-flip="wl-tailwind" style="--c:#38bdf8;left:4cqw;top:63cqh">Tailwind <i></i></span>
+    <span class="wlab" data-flip="wl-motion" style="--c:#f7e14d;left:4cqw;top:71cqh">Motion &middot; Pretext <i></i></span>
+    <span class="wlab" data-flip="wl-rspack" style="--c:#ff7a1a;left:4cqw;top:80cqh">Rspack <i></i></span>
+    <div class="wlynx" data-flip="weave-lynx">
+      <svg viewBox="0 0 27 28" aria-label="Lynx"><path fill-rule="evenodd" clip-rule="evenodd" d="M7.56542 6.19594L3.90642 8.7164C3.50877 8.99031 3.23346 9.40191 3.13675 9.86708L2.77902 11.5878C2.76005 11.679 2.71799 11.7642 2.65665 11.8355L0.996306 14.0121C0.772761 14.2722 0.778152 14.9632 1.39044 15.4057C1.62523 15.6103 1.93915 16.0691 2.29622 16.591C3.05224 17.6959 4.00169 19.0836 4.80312 18.9394C5.9372 18.541 7.32544 18.4135 8.39128 18.9394C10.4632 20.7282 9.95449 22.3775 9.22514 24.7421C8.93165 25.6936 8.60243 26.7609 8.39128 27.9997C9.38643 24.3777 11.6242 20.1711 15.6592 18.7437C14.9322 18.1498 13.4486 17.5981 12.1357 17.4653C12.1357 17.4653 16.1691 14.0121 21.1439 12.4254C17.671 4.16205 11.9386 0.213095 11.9386 0.213095C11.6465 -0.148197 11.0566 -0.0296711 10.9349 0.414774C10.8371 1.72112 10.675 2.60942 10.4074 3.44676L8.39128 1.12029C8.18068 0.866399 7.75965 1.013 7.76176 1.33949C8.10312 3.23719 8.05521 4.30239 7.56542 6.19594ZM8.9846 6.02248L8.99663 6.02171C9.02298 6.02002 9.0489 6.01659 9.07424 6.01153L8.9846 6.02248ZM11.7123 1.7617C13.094 4.1491 13.7199 5.5054 13.9322 8.03659C12.4625 7.2017 11.8221 6.98923 10.7413 6.99451C11.3718 5.0773 11.5644 3.92284 11.7123 1.7617Z"/><path d="M20.5916 19.4929C14.9639 20.7806 11.7672 22.7198 9.32227 28.0001C13.7111 20.6367 26.9966 21.9536 26.9966 21.9536C26.7484 20.7508 24.1069 18.4571 22.3696 17.0503C22.3696 17.0503 23.7712 15.3272 26.8697 14.455C26.8697 14.455 20.9125 14.8002 17.4445 16.6727C18.568 17.2656 20.0071 18.2663 20.5916 19.4929Z"/></svg>
+    </div>
+    <span class="wlab" data-mm-fade style="--c:#cdd6e4;right:4cqw;top:16cqh"><i></i> iOS</span>
+    <span class="wlab" data-mm-fade style="--c:#3ddc84;right:4cqw;top:25.7cqh"><i></i> Android</span>
+    <span class="wlab" data-mm-fade style="--c:#56b8f0;right:4cqw;top:35.4cqh"><i></i> Web</span>
+    <span class="wlab" data-mm-fade style="--c:#ff6f61;right:4cqw;top:45.1cqh"><i></i> HarmonyOS</span>
+    <span class="wlab" data-mm-fade style="--c:#aab4c8;right:4cqw;top:54.9cqh"><i></i> macOS</span>
+    <span class="wlab" data-mm-fade style="--c:#2f7fe0;right:4cqw;top:64.6cqh"><i></i> Windows</span>
+    <span class="wlab" data-mm-fade style="--c:#f5c04a;right:4cqw;top:74.3cqh"><i></i> Linux</span>
+    <span class="wlab" data-mm-fade style="--c:#8b93a3;right:4cqw;top:84cqh"><i></i> more&hellip;</span>
+    <aside class="notes">
+      <p><strong>The money shot — don't talk over its first second.</strong> The waist blossoms: every fabric on the left re-emerges woven into iOS, Android, Web, HarmonyOS, macOS, Windows, Linux, and whatever comes next.</p>
+      <p>One thin, strong loom in the middle. That's the whole argument in one picture: harness on the left half, connection on the right half. Hold it, then quietly: "Lynx is giving you the right skills — and the right harness — to weave any of these fabrics."</p>
+    </aside>
+  </section>
+
+  <!-- E23 — coda · Germany, part 1 -->
+  <section class="slide stage">
+    <span class="eyebrow">Epilogue &middot; coda</span>
+    <p class="wquote">&ldquo;AI took away the fun.&rdquo;</p>
+    <span class="wattr">&mdash; a workshop attendee &middot; Germany, last week</span>
+    <p class="lead" data-mm-fade>Find a new dopamine.</p>
+    <aside class="notes">
+      <p><strong>Story time — drop the slides-per-minute, slow the voice.</strong> Last week I ran a workshop in Germany. One attendee told me AI took the "fun" of development away from him. My answer was blunt: you need to find a new dopamine.</p>
+    </aside>
+  </section>
+
+  <!-- E24 — the frontend died. again. -->
+  <section class="slide stage" data-bg="clean">
+    <h2 class="h-section" style="text-align:center;max-width:24ch">
+      The frontend is dead. <em style="font-family:var(--serif);font-weight:400">Again.</em>
+    </h2>
+    <aside class="notes">
+      <p><strong>The callback.</strong> Some of you know I once gave a talk called "The Frontend Is Dead." Well — in the old sense of the word, it really did die again. Let that sit; the reversal is two slides away.</p>
+    </aside>
+  </section>
+
+  <!-- E25 — coda · Germany, part 2 -->
+  <section class="slide stage">
+    <span class="eyebrow">Epilogue &middot; coda</span>
+    <p class="wquote">&ldquo;But prompting <em>is</em> the dopamine.&rdquo;</p>
+    <span class="wattr">&mdash; another attendee &middot; he vibed a Pok&eacute;mon game that night</span>
+    <p class="lead" data-mm-fade>
+      I know AI makes it easy. I'm glad it's easy &mdash; I haven't been this excited in years.
+    </p>
+    <aside class="notes">
+      <p><strong>The counter-story.</strong> Another attendee pushed back: prompting IS the dopamine — and that night he vibed a whole Pokémon game. I know that with AI, that's not hard. And I'm <em>glad</em> it's not hard — I haven't been this excited in years.</p>
+      <p>Confess the AI-psychosis bit: I can't sleep without kicking off a few <code>/goal</code> <code>/loop</code> runs; when Fable or Codex goes down it feels like withdrawal. The room has felt it too.</p>
+    </aside>
+  </section>
+
+  <!-- E26 — ten years, renewed -->
+  <section class="slide stage">
+    <span class="eyebrow">Epilogue &middot; coda</span>
+    <h2 class="h-section" style="text-align:center;max-width:24ch">
+      I rebuilt everything <span class="brand-text">ten-years-ago me</span> dreamed of.
+    </h2>
+    <div class="demo__meta" style="justify-content:center">
+      <span class="chip">hux.pro &mdash; untouched for 10 years</span>
+      <span class="chip">my first Vue app &mdash; v0.12</span>
+      <span class="chip chip--brand">this deck &mdash; zero libraries, vibed</span>
+    </div>
+    <aside class="notes">
+      <p><strong>Personal receipts.</strong> This past year I went back and renewed every project ten-years-ago me dreamed of: my personal site that sat untouched for a decade; my very first Vue project, on Vue 0.12; and this deck — hand-vibed HTML, no slide library underneath, the direct descendant of the slide editor I built back then.</p>
+    </aside>
+  </section>
+
+  <!-- E27 — still frontend -->
+  <section class="slide stage" data-bg="clean">
+    <h2 class="h-section" style="text-align:center;max-width:24ch">
+      I just changed languages &mdash; to <span class="brand-text">natural language</span>.
+    </h2>
+    <p class="lead">I'm still doing frontend.</p>
+    <aside class="notes">
+      <p><strong>The turn.</strong> So what am I actually doing all day, prompting instead of typing? I just switched languages one more time — assembly to C to JS to… natural language. The source changed. The work didn't: I'm still translating human intent into something people can see and touch.</p>
+      <p>That has always been the job. That <em>is</em> frontend.</p>
+    </aside>
+  </section>
+
+  <!-- E28 — finale · long live the frontend -->
+  <section class="slide thankyou" data-bg="clean" data-chrome="minimal" data-weave="finale">
+    <span class="eyebrow">Fin. &mdash; for real</span>
+    <p class="fin-dead">The frontend is dead.</p>
+    <h1>Long live <span class="brand-text">the frontend</span>.</h1>
+    <p class="sig">
+      Thank you &mdash; for real this time.
+    </p>
+    <div class="handles">
+      <a href="https://x.com/Huxpro" target="_blank" rel="noreferrer">@Huxpro</a>
+      <a href="https://github.com/Huxpro/vue-lynx" target="_blank" rel="noreferrer">huxpro/vue-lynx</a>
+      <a href="https://vue.lynxjs.org" target="_blank" rel="noreferrer">vue.lynxjs.org</a>
+    </div>
+    <aside class="notes">
+      <p><strong>The real close.</strong> Small print struck through: the frontend is dead. Big print: long live the frontend. 前端永生. Thank them — for real this time — and stay for Q&amp;A.</p>
+      <p>Q&amp;A ammo: "Is this production?" — pre-alpha, architecture solid, tested surface. "Android?" — same bundle, both platforms. "Will AI replace Vue?" — you just watched the whole answer.</p>
     </aside>
   </section>
 

--- a/slides/index.html
+++ b/slides/index.html
@@ -24,7 +24,7 @@
     </button>
   </div>
   <div class="chrome chrome--bottom">
-    <span data-counter>01 / 106</span>
+    <span data-counter>01 / 116</span>
   </div>
   <div class="chrome chrome--bottom-right">
     <a href="https://vue.lynxjs.org" target="_blank" rel="noreferrer">vue.lynxjs.org</a>
@@ -78,6 +78,72 @@
   </section>
 
   <!-- ====================================================
+       2a–2d — OVERLAYS over the two marks · the years
+       (media drop-in: slides/public/media/embeds/)
+       ==================================================== -->
+  <section class="slide overlay" data-bg="clean" data-chrome="none">
+    <div class="phone phone--embed no-deck-scroll" data-embed="wide" data-flip="em-02a"
+         data-w="min(56cqw, 700px)"
+         style="position:absolute;left:50%;top:47%;transform:translate(-50%,-50%)">
+      <div class="phone__inner"><vl-media src="/media/embeds/02-video-1.mp4" label="02-video-1.mp4 · landscape"></vl-media></div>
+    </div>
+    <aside class="notes">
+      <p><strong>First clip fades in over the two marks</strong> — the React-era years. Muted and looping; talk over it, the logos stay visible behind.</p>
+      <p>Drop the file at <code>slides/public/media/embeds/02-video-1.mp4</code> — until then this shows a labeled placeholder.</p>
+    </aside>
+  </section>
+
+  <section class="slide overlay" data-bg="clean" data-chrome="none">
+    <div class="phone phone--embed no-deck-scroll" data-embed="wide" data-flip="em-02a"
+         data-w="min(36cqw, 450px)"
+         style="position:absolute;left:30%;top:32%;transform:translate(-50%,-50%)">
+      <div class="phone__inner"><vl-media src="/media/embeds/02-video-1.mp4" data-autoplay="false" label="02-video-1.mp4 · landscape"></vl-media></div>
+    </div>
+    <div class="phone phone--embed no-deck-scroll" data-embed="wide" data-flip="em-02b"
+         data-w="min(42cqw, 530px)" data-mm-fade
+         style="position:absolute;left:67%;top:63%;transform:translate(-50%,-50%)">
+      <div class="phone__inner"><vl-media src="/media/embeds/02-video-2.mp4" label="02-video-2.mp4 · landscape"></vl-media></div>
+    </div>
+    <aside class="notes">
+      <p><strong>Second clip joins</strong> — the first shrinks into the corner (frozen), the new one plays. A cascade building up, Keynote-style.</p>
+      <p>File: <code>02-video-2.mp4</code>.</p>
+    </aside>
+  </section>
+
+  <section class="slide overlay" data-bg="clean" data-chrome="none">
+    <div class="phone phone--embed no-deck-scroll" data-embed="wide" data-flip="em-02a"
+         data-w="min(30cqw, 380px)"
+         style="position:absolute;left:25%;top:26%;transform:translate(-50%,-50%)">
+      <div class="phone__inner"><vl-media src="/media/embeds/02-video-1.mp4" data-autoplay="false" label="02-video-1.mp4 · landscape"></vl-media></div>
+    </div>
+    <div class="phone phone--embed no-deck-scroll" data-embed="wide" data-flip="em-02b"
+         data-w="min(32cqw, 400px)"
+         style="position:absolute;left:74%;top:30%;transform:translate(-50%,-50%)">
+      <div class="phone__inner"><vl-media src="/media/embeds/02-video-2.mp4" data-autoplay="false" label="02-video-2.mp4 · landscape"></vl-media></div>
+    </div>
+    <vl-media class="snap" data-mm-fade src="/media/embeds/02-image.png" label="02-image.png · photo"
+              style="position:absolute;left:49%;top:64%;width:34cqw;transform:translate(-50%,-50%) rotate(-1.5deg);--ph-ar:4/3"></vl-media>
+    <aside class="notes">
+      <p><strong>The photo lands</strong> — both clips freeze small, the snapshot drops center-stage. The collage of that era, complete.</p>
+      <p>File: <code>02-image.png</code>.</p>
+    </aside>
+  </section>
+
+  <section class="slide logos" data-bg="clean" data-chrome="none">
+    <div class="logo logo--react" data-flip="brand-react"
+         style="left:calc(37% - 8cqw);top:calc(50% - 8cqw)">
+      <svg viewBox="-11.5 -10.232 23 20.464" fill="none" aria-label="React logo"><circle r="2.05" fill="#61dafb"/><g stroke="#61dafb" stroke-width="1" fill="none"><ellipse rx="11" ry="4.2"/><ellipse rx="11" ry="4.2" transform="rotate(60)"/><ellipse rx="11" ry="4.2" transform="rotate(120)"/></g></svg>
+    </div>
+    <div class="logo logo--vue" data-flip="brand-vue"
+         style="left:calc(63% - 8cqw);top:calc(50% - 8cqw)">
+      <svg viewBox="0 0 256 221" fill="none" aria-label="Vue logo"><path fill="#41b883" d="M204.8 0H256L128 220.8 0 0h97.92L128 51.2 157.44 0z"/><path fill="#41b883" d="M0 0l128 220.8L256 0h-51.2L128 132.48 50.56 0z"/><path fill="#35495e" d="M50.56 0L128 133.12 204.8 0h-47.36L128 51.2 97.92 0z"/></svg>
+    </div>
+    <aside class="notes">
+      <p><strong>The overlay clears</strong> — back to the two marks alone. A beat, then on into the Web triangle.</p>
+    </aside>
+  </section>
+
+  <!-- ====================================================
        3 — Logo build-up · + Chrome (triangle)
        ==================================================== -->
   <section class="slide logos" data-bg="clean" data-chrome="none">
@@ -96,6 +162,39 @@
     <aside class="notes">
       <p><strong>Chrome rises from below</strong> — React and Vue lift into the top corners, and the three settle into a triangle with the Web underneath, carrying both.</p>
       <p>"先聊 Web。" React and Vue were the vehicles — the ground we all actually stood on was the Web: its DX, its reach, its openness.</p>
+    </aside>
+  </section>
+
+  <!-- ====================================================
+       3a–3b — OVERLAY over the triangle · the PWA talk, live
+       ==================================================== -->
+  <section class="slide overlay" data-bg="clean" data-chrome="none">
+    <div class="phone phone--embed no-deck-scroll" data-embed="browser" data-flip="em-03"
+         data-w="min(64cqw, 820px)"
+         style="position:absolute;left:50%;top:50%;transform:translate(-50%,-50%)">
+      <div class="phone__inner"><vl-media kind="iframe" src="https://huangxuan.me/pwa-qcon2016/#/" label="huangxuan.me/pwa-qcon2016 · live iframe"></vl-media></div>
+    </div>
+    <aside class="notes">
+      <p><strong>The receipts for "先聊 Web":</strong> the 2016 PWA talk, embedded <em>live</em> over the triangle. Click inside the frame to drive that deck; wheel/keys outside it drive this one. The corner grip resizes; the switcher has desktop/tablet/phone shapes; the ↗ button opens it in a new tab.</p>
+      <p>The iframe loads one slide before you arrive and unloads two slides after you leave — it never taxes the rest of the talk. (Needs venue network; the ↗ fallback is your plan B.)</p>
+    </aside>
+  </section>
+
+  <section class="slide logos" data-bg="clean" data-chrome="none">
+    <div class="logo logo--react" data-flip="brand-react"
+         style="left:calc(34% - 8cqw);top:calc(31% - 8cqw)">
+      <svg viewBox="-11.5 -10.232 23 20.464" fill="none" aria-label="React logo"><circle r="2.05" fill="#61dafb"/><g stroke="#61dafb" stroke-width="1" fill="none"><ellipse rx="11" ry="4.2"/><ellipse rx="11" ry="4.2" transform="rotate(60)"/><ellipse rx="11" ry="4.2" transform="rotate(120)"/></g></svg>
+    </div>
+    <div class="logo logo--vue" data-flip="brand-vue"
+         style="left:calc(66% - 8cqw);top:calc(31% - 8cqw)">
+      <svg viewBox="0 0 256 221" fill="none" aria-label="Vue logo"><path fill="#41b883" d="M204.8 0H256L128 220.8 0 0h97.92L128 51.2 157.44 0z"/><path fill="#41b883" d="M0 0l128 220.8L256 0h-51.2L128 132.48 50.56 0z"/><path fill="#35495e" d="M50.56 0L128 133.12 204.8 0h-47.36L128 51.2 97.92 0z"/></svg>
+    </div>
+    <div class="logo logo--chrome" data-flip="brand-chrome"
+         style="left:calc(50% - 8cqw);top:calc(60% - 8cqw)">
+      <svg viewBox="0 0 48 48" aria-label="Chrome logo"><circle cx="24" cy="24" r="12" fill="#fff"/><path fill="#EA4335" d="M24 12h20.78a23.99 23.99 0 0 0-41.56.003L13.61 30l.009-.002A11.99 11.99 0 0 1 24 12Z"/><path fill="#FBBC04" d="M34.39 30.003 24 48a23.99 23.99 0 0 0 20.78-35.997H24l-.003.009a11.99 11.99 0 0 1 10.393 17.991Z"/><path fill="#34A853" d="M13.61 30.003 3.22 12.006A23.99 23.99 0 0 0 24 48l10.39-17.997-.007-.007a11.99 11.99 0 0 1-20.773.007Z"/><circle cx="24" cy="24" r="9.5" fill="#1A73E8"/></svg>
+    </div>
+    <aside class="notes">
+      <p><strong>Close the PWA window</strong> — the triangle returns, and the story continues on this ground: the Web carried us.</p>
     </aside>
   </section>
 
@@ -2179,6 +2278,33 @@
     </aside>
   </section>
 
+  <!-- ====================================================
+       ∞a–∞b — OVERLAY over the divider · the tweet
+       (top half → pan to the bottom half → fade out)
+       ==================================================== -->
+  <section class="slide overlay" data-chrome="none">
+    <div class="crop" data-flip="k-frame" style="width:44cqw;height:54cqh">
+      <vl-media data-flip="k-img" src="/media/embeds/79-vibe-coding.png"
+                label="79-vibe-coding.png · full tweet screenshot"
+                style="top:0;--ph-ar:842/1000"></vl-media>
+    </div>
+    <aside class="notes">
+      <p><strong>The tweet itself, over the divider.</strong> Feb 2, 2025 — Karpathy coins "vibe coding". Top half first: <em>"fully give in to the vibes, embrace exponentials, and forget that the code even exists."</em></p>
+      <p>File: <code>slides/public/media/embeds/79-vibe-coding.png</code> — one full-height screenshot; this window crops it.</p>
+    </aside>
+  </section>
+
+  <section class="slide overlay" data-chrome="none">
+    <div class="crop" data-flip="k-frame" style="width:44cqw;height:54cqh">
+      <vl-media data-flip="k-img" src="/media/embeds/79-vibe-coding.png"
+                label="79-vibe-coding.png · full tweet screenshot"
+                style="bottom:0;left:-3%;width:106%;--ph-ar:842/1000"></vl-media>
+    </div>
+    <aside class="notes">
+      <p><strong>Pan down, slight zoom</strong> — the bottom half: <em>"It's not too bad for throwaway weekend projects…"</em> Eighteen months later, it writes native apps. Let that land, advance — the tweet fades out into the question.</p>
+    </aside>
+  </section>
+
   <!-- E2 — the question, honestly -->
   <section class="slide stage">
     <span class="eyebrow">Epilogue · the question</span>
@@ -2326,10 +2452,11 @@
   <!-- E10 — intermission meme -->
   <section class="slide stage" data-bg="clean">
     <span class="eyebrow">Epilogue &middot; intermission</span>
-    <div class="meme">[ meme goes here ]</div>
+    <vl-media class="meme" src="/media/embeds/88-meme.png" label="88-meme.png · the roast"
+              style="--ph-ar:4/3"></vl-media>
     <p class="kicker" style="text-align:center">&ldquo;Getting metaphysical again &mdash; &#38634;&#30887; is going to roast me.&rdquo;</p>
     <aside class="notes">
-      <p><strong>Breather.</strong> Self-aware beat before Lemma 2 — drop the meme in, take the laugh, move on. (Placeholder frame: replace with the actual image in <code>public/media/</code>.)</p>
+      <p><strong>Breather.</strong> Self-aware beat before Lemma 2 — drop the meme in, take the laugh, move on. File: <code>slides/public/media/embeds/88-meme.png</code>; until it exists this shows the labeled placeholder.</p>
     </aside>
   </section>
 
@@ -2570,6 +2697,35 @@
     <aside class="notes">
       <p><strong>The counter-story.</strong> Another attendee pushed back: prompting IS the dopamine — and that night he vibed a whole Pokémon game. I know that with AI, that's not hard. And I'm <em>glad</em> it's not hard — I haven't been this excited in years.</p>
       <p>Confess the AI-psychosis bit: I can't sleep without kicking off a few <code>/goal</code> <code>/loop</code> runs; when Fable or Codex goes down it feels like withdrawal. The room has felt it too.</p>
+    </aside>
+  </section>
+
+  <!-- ====================================================
+       coda-a/b — OVERLAYS over the quote · Germany receipts
+       ==================================================== -->
+  <section class="slide overlay" data-bg="clean" data-chrome="none">
+    <vl-media class="snap" data-mm-fade src="/media/embeds/103-photo-1.png" label="103-photo-1.png"
+              style="position:absolute;left:22%;top:48%;width:24cqw;transform:translate(-50%,-50%) rotate(-2.5deg)"></vl-media>
+    <div class="phone phone--embed no-deck-scroll" data-embed="portrait" data-flip="em-103v"
+         style="position:absolute;left:50%;top:50%;transform:translate(-50%,-50%)">
+      <div class="phone__inner"><vl-media src="/media/embeds/103-video-portrait.mp4" label="103-video-portrait.mp4 · vertical"></vl-media></div>
+    </div>
+    <vl-media class="snap" data-mm-fade src="/media/embeds/103-photo-2.png" label="103-photo-2.png"
+              style="position:absolute;left:78%;top:54%;width:24cqw;transform:translate(-50%,-50%) rotate(2deg)"></vl-media>
+    <aside class="notes">
+      <p><strong>Receipts, tossed on the table</strong> — two photos flanking the vertical clip, dropped over the quote. The center video autoplays muted; the photos tilt like snapshots.</p>
+      <p>Files: <code>103-photo-1.png</code>, <code>103-video-portrait.mp4</code>, <code>103-photo-2.png</code> under <code>slides/public/media/embeds/</code>.</p>
+    </aside>
+  </section>
+
+  <section class="slide overlay" data-bg="clean" data-chrome="none">
+    <div class="phone phone--embed no-deck-scroll" data-embed="wide" data-flip="em-103w"
+         data-w="min(60cqw, 760px)"
+         style="position:absolute;left:50%;top:50%;transform:translate(-50%,-50%)">
+      <div class="phone__inner"><vl-media src="/media/embeds/103-video-wide.mp4" label="103-video-wide.mp4 · landscape"></vl-media></div>
+    </div>
+    <aside class="notes">
+      <p><strong>One more click — the Pokémon, full width.</strong> The three-up clears, the landscape video takes the stage. File: <code>103-video-wide.mp4</code>.</p>
     </aside>
   </section>
 

--- a/slides/index.html
+++ b/slides/index.html
@@ -84,7 +84,7 @@
   <section class="slide overlay" data-bg="clean" data-chrome="none">
     <div class="phone phone--embed no-deck-scroll" data-embed="wide" data-flip="em-02a"
          data-w="min(56cqw, 700px)"
-         style="position:absolute;left:50%;top:47%;transform:translate(-50%,-50%)">
+         style="position:absolute;z-index:1;left:50%;top:47%;transform:translate(-50%,-50%)">
       <div class="phone__inner"><vl-media src="/media/embeds/02-video-1.mp4" label="02-video-1.mp4 · landscape"></vl-media></div>
     </div>
     <aside class="notes">
@@ -96,12 +96,12 @@
   <section class="slide overlay" data-bg="clean" data-chrome="none">
     <div class="phone phone--embed no-deck-scroll" data-embed="wide" data-flip="em-02a"
          data-w="min(36cqw, 450px)"
-         style="position:absolute;left:30%;top:32%;transform:translate(-50%,-50%)">
+         style="position:absolute;z-index:1;left:30%;top:32%;transform:translate(-50%,-50%)">
       <div class="phone__inner"><vl-media src="/media/embeds/02-video-1.mp4" data-autoplay="false" label="02-video-1.mp4 · landscape"></vl-media></div>
     </div>
     <div class="phone phone--embed no-deck-scroll" data-embed="wide" data-flip="em-02b"
          data-w="min(42cqw, 530px)" data-mm-fade
-         style="position:absolute;left:67%;top:63%;transform:translate(-50%,-50%)">
+         style="position:absolute;z-index:2;left:67%;top:63%;transform:translate(-50%,-50%)">
       <div class="phone__inner"><vl-media src="/media/embeds/02-video-2.mp4" label="02-video-2.mp4 · landscape"></vl-media></div>
     </div>
     <aside class="notes">
@@ -113,16 +113,16 @@
   <section class="slide overlay" data-bg="clean" data-chrome="none">
     <div class="phone phone--embed no-deck-scroll" data-embed="wide" data-flip="em-02a"
          data-w="min(30cqw, 380px)"
-         style="position:absolute;left:25%;top:26%;transform:translate(-50%,-50%)">
+         style="position:absolute;z-index:1;left:25%;top:26%;transform:translate(-50%,-50%)">
       <div class="phone__inner"><vl-media src="/media/embeds/02-video-1.mp4" data-autoplay="false" label="02-video-1.mp4 · landscape"></vl-media></div>
     </div>
     <div class="phone phone--embed no-deck-scroll" data-embed="wide" data-flip="em-02b"
          data-w="min(32cqw, 400px)"
-         style="position:absolute;left:74%;top:30%;transform:translate(-50%,-50%)">
+         style="position:absolute;z-index:2;left:74%;top:30%;transform:translate(-50%,-50%)">
       <div class="phone__inner"><vl-media src="/media/embeds/02-video-2.mp4" data-autoplay="false" label="02-video-2.mp4 · landscape"></vl-media></div>
     </div>
     <vl-media class="snap" data-mm-fade src="/media/embeds/02-image.png" label="02-image.png · photo"
-              style="position:absolute;left:49%;top:64%;width:34cqw;transform:translate(-50%,-50%) rotate(-1.5deg);--ph-ar:4/3"></vl-media>
+              style="position:absolute;z-index:3;left:49%;top:64%;width:34cqw;transform:translate(-50%,-50%) rotate(-1.5deg);--ph-ar:4/3"></vl-media>
     <aside class="notes">
       <p><strong>The photo lands</strong> — both clips freeze small, the snapshot drops center-stage. The collage of that era, complete.</p>
       <p>File: <code>02-image.png</code>.</p>
@@ -2705,13 +2705,13 @@
        ==================================================== -->
   <section class="slide overlay" data-bg="clean" data-chrome="none">
     <vl-media class="snap" data-mm-fade src="/media/embeds/103-photo-1.png" label="103-photo-1.png"
-              style="position:absolute;left:22%;top:48%;width:24cqw;transform:translate(-50%,-50%) rotate(-2.5deg)"></vl-media>
+              style="position:absolute;z-index:1;left:22%;top:48%;width:24cqw;transform:translate(-50%,-50%) rotate(-2.5deg)"></vl-media>
     <div class="phone phone--embed no-deck-scroll" data-embed="portrait" data-flip="em-103v"
-         style="position:absolute;left:50%;top:50%;transform:translate(-50%,-50%)">
+         style="position:absolute;z-index:2;left:50%;top:50%;transform:translate(-50%,-50%)">
       <div class="phone__inner"><vl-media src="/media/embeds/103-video-portrait.mp4" label="103-video-portrait.mp4 · vertical"></vl-media></div>
     </div>
     <vl-media class="snap" data-mm-fade src="/media/embeds/103-photo-2.png" label="103-photo-2.png"
-              style="position:absolute;left:78%;top:54%;width:24cqw;transform:translate(-50%,-50%) rotate(2deg)"></vl-media>
+              style="position:absolute;z-index:1;left:78%;top:54%;width:24cqw;transform:translate(-50%,-50%) rotate(2deg)"></vl-media>
     <aside class="notes">
       <p><strong>Receipts, tossed on the table</strong> — two photos flanking the vertical clip, dropped over the quote. The center video autoplays muted; the photos tilt like snapshots.</p>
       <p>Files: <code>103-photo-1.png</code>, <code>103-video-portrait.mp4</code>, <code>103-photo-2.png</code> under <code>slides/public/media/embeds/</code>.</p>

--- a/slides/public/media/embeds/README.md
+++ b/slides/public/media/embeds/README.md
@@ -1,0 +1,26 @@
+# Embed media drop-ins
+
+Drop the files below into this directory (exact names). Every slot renders a
+labeled placeholder until its file exists — no HTML edits needed, just refresh.
+Names are anchored to the slide numbers used while authoring.
+
+| File | Where | Shape |
+| ---- | ----- | ----- |
+| `02-video-1.mp4` | over the React + Vue marks — first clip of the cascade | landscape, muted loop |
+| `02-video-2.mp4` | second clip of the cascade | landscape, muted loop |
+| `02-image.png` | the snapshot that completes the cascade | photo, ~4:3 |
+| `88-meme.png` | the "getting metaphysical" intermission | ~4:3 |
+| `79-vibe-coding.png` | the Karpathy vibe-coding tweet over the ∞ divider | ONE full-height screenshot — the slide crops top half, then pans to the bottom half |
+| `103-photo-1.png` | Germany three-up, left snapshot | portrait-ish |
+| `103-video-portrait.mp4` | Germany three-up, center | vertical (9:16), muted loop |
+| `103-photo-2.png` | Germany three-up, right snapshot | portrait-ish |
+| `103-video-wide.mp4` | the Pokémon clip, full width | landscape, muted loop |
+
+The PWA-talk slide embeds `https://huangxuan.me/pwa-qcon2016/#/` live — no
+file needed, but it wants venue network (its frame has an ↗ open-in-new-tab
+fallback).
+
+Video defaults: muted + looping + autoplay-on-arrival, reset (paused, rewound)
+on every slide change. Add `unmuted` / `no-loop` / `controls` attributes or
+`data-autoplay="false"` on the `<vl-media>` in `index.html` to change that
+per embed.

--- a/slides/src/embeds.js
+++ b/slides/src/embeds.js
@@ -1,0 +1,168 @@
+// =========================================================
+// Media embeds — <vl-media> + the embed device frames.
+//
+// A universal way to drop a video / image / iframe onto a
+// slide (usually an *overlay* slide — see main.js). The
+// element owns its media lifecycle around deck navigation:
+//
+//   · videos reset on every slide change (pause + rewind, so
+//     audio can never leak across pages) and autoplay when
+//     their slide becomes current — opt out per element with
+//     data-autoplay="false".
+//   · iframes are mounted only when their slide is at most
+//     one step away and unloaded again two steps out, so a
+//     heavy embedded page never taxes the rest of the talk.
+//   · a missing file renders as a labeled placeholder frame
+//     showing the exact path to drop the asset at — author
+//     slides first, add media later.
+//
+// Sizing: a bare <vl-media> is laid out by the slide (width
+// in, height from the media). For a resizable frame, wrap it
+// in `.phone.phone--embed` — the same chrome as the demo
+// mockups, de-phoned — and it gets the drag grips + preset
+// switcher from framework/device.js.
+// =========================================================
+import { attachDeviceControls } from './framework/device.js';
+
+const EXT_VIDEO = /\.(mp4|webm|mov|m4v)(\?|#|$)/i;
+const EXT_IMAGE = /\.(png|jpe?g|webp|gif|avif|svg)(\?|#|$)/i;
+
+// Presets for embed frames, per data-embed kind. Named after the
+// stock device icons (monitor / tablet / smartphone) so the preset
+// switcher stays legible.
+const EMBED_PRESETS = {
+  desktop: { ar: '16 / 9', w: 'min(62cqw, 800px)', h: 'auto' },
+  tablet: { ar: '4 / 3', w: 'min(46cqw, 560px)', h: 'auto' },
+  phone: { ar: '9 / 16', w: 'auto', h: 'min(78cqh, 580px)' },
+};
+const EMBED_DEVICES = {
+  wide: { devices: ['desktop', 'tablet'], initial: 'desktop' },
+  portrait: { devices: ['phone', 'tablet'], initial: 'phone' },
+  browser: { devices: ['desktop', 'tablet', 'phone'], initial: 'desktop' },
+};
+
+function inferKind(src) {
+  if (EXT_VIDEO.test(src)) return 'video';
+  if (EXT_IMAGE.test(src)) return 'image';
+  return 'iframe';
+}
+
+class VlMedia extends HTMLElement {
+  connectedCallback() {
+    if (this._wired) return;
+    this._wired = true;
+    this.src = this.getAttribute('src') || '';
+    this.kind = this.getAttribute('kind') || inferKind(this.src);
+    this.autoplay = this.dataset.autoplay !== 'false';
+
+    const ph = document.createElement('div');
+    ph.className = 'vl-ph';
+    ph.innerHTML =
+      `<span class="vl-ph__kind">${this.kind}</span>` +
+      `<span>${this.getAttribute('label') || this.src}</span>`;
+    this.appendChild(ph);
+
+    if (this.kind === 'image') {
+      const img = document.createElement('img');
+      img.alt = this.getAttribute('alt') || '';
+      img.addEventListener('error', () => this.classList.add('is-missing'));
+      img.addEventListener('load', () => this.classList.remove('is-missing'));
+      img.src = this.src;
+      this.appendChild(img);
+    } else if (this.kind === 'video') {
+      const v = document.createElement('video');
+      v.playsInline = true;
+      v.muted = !this.hasAttribute('unmuted');
+      v.loop = !this.hasAttribute('no-loop');
+      if (this.hasAttribute('controls')) v.controls = true;
+      v.preload = 'metadata';
+      v.addEventListener('error', () => this.classList.add('is-missing'));
+      v.addEventListener('loadedmetadata', () => this.classList.remove('is-missing'));
+      v.src = this.src;
+      this.appendChild(v);
+      this._video = v;
+    }
+    // iframes mount lazily in setDistance().
+  }
+
+  _mountFrame() {
+    if (this._iframe) return;
+    const f = document.createElement('iframe');
+    f.src = this.src;
+    f.allow = 'autoplay; fullscreen';
+    f.title = this.getAttribute('label') || this.src;
+    this.appendChild(f);
+    this._iframe = f;
+    this.classList.add('is-live');
+  }
+
+  _unmountFrame() {
+    if (!this._iframe) return;
+    this._iframe.remove();
+    this._iframe = null;
+    this.classList.remove('is-live');
+  }
+
+  /** Called on every deck:change with (mySlide - currentSlide). */
+  setDistance(d, { still = false } = {}) {
+    if (this.kind === 'video' && this._video) {
+      const v = this._video;
+      if (d === 0 && this.autoplay && !still) {
+        try { v.currentTime = 0; } catch { /* not seekable yet */ }
+        const p = v.play?.();
+        if (p?.catch) p.catch(() => {});
+      } else {
+        v.pause?.();
+        if (d !== 0) {
+          try { v.currentTime = 0; } catch { /* not seekable yet */ }
+        }
+      }
+    } else if (this.kind === 'iframe') {
+      // Live only in the immediate neighborhood; embed previews (the
+      // speaker view's iframes) never mount nested third-party pages.
+      if (Math.abs(d) <= 1 && !still) this._mountFrame();
+      else if (Math.abs(d) >= 2) this._unmountFrame();
+    }
+  }
+}
+
+export function registerVlMedia() {
+  if (!customElements.get('vl-media')) customElements.define('vl-media', VlMedia);
+}
+
+export function initEmbeds({ getScale, reducedMotion = false, embed = false } = {}) {
+  registerVlMedia();
+  const still = reducedMotion || embed;
+
+  // Resizable embed frames — same chrome as the demo phones, with
+  // embed-shaped presets. Inline data-w/data-h re-apply after the
+  // initial preset so a slide can seed its own size (the cascade).
+  document.querySelectorAll('.phone--embed').forEach((frame) => {
+    const conf = EMBED_DEVICES[frame.dataset.embed] || EMBED_DEVICES.wide;
+    const media = frame.querySelector('vl-media');
+    attachDeviceControls(frame, {
+      getScale,
+      presets: EMBED_PRESETS,
+      devices: conf.devices,
+      initial: frame.dataset.device || conf.initial,
+      corners: ['nw', 'ne', 'sw', 'se'],
+      anchor: 'center',
+      externalUrl: () =>
+        (media && (media.getAttribute('kind') === 'iframe' ||
+          inferKind(media.getAttribute('src') || '') === 'iframe')
+          ? media.getAttribute('src') : null),
+    });
+    if (frame.dataset.w) frame.style.setProperty('--phone-w', frame.dataset.w);
+    if (frame.dataset.h) frame.style.setProperty('--phone-h', frame.dataset.h);
+  });
+
+  // Drive media lifecycle from deck navigation.
+  const slides = Array.from(document.querySelectorAll('.slide'));
+  const medias = Array.from(document.querySelectorAll('vl-media')).map((el) => ({
+    el,
+    idx: slides.indexOf(el.closest('.slide')),
+  }));
+  document.addEventListener('deck:change', (e) => {
+    medias.forEach((m) => m.el.setDistance?.(m.idx - e.detail.index, { still }));
+  });
+}

--- a/slides/src/framework/magic-move.js
+++ b/slides/src/framework/magic-move.js
@@ -73,6 +73,11 @@ export function createMagicMove({ deck, getScale, reducedMotion = false, embed =
       // were measured with the own transform applied, so prepending the
       // delta and releasing back to the own matrix is exact.
       p.own = cs.transform === 'none' ? '' : cs.transform;
+      // The own transform may live in the element's INLINE style (the embed
+      // frames center with an inline translate(-50%,-50%)) — the morph is
+      // about to overwrite that inline slot, so remember it and put it back
+      // at cleanup. Clearing to '' only restores class-based transforms.
+      p.prevInline = toEl.style.transform;
       toEl.style.transformOrigin = 'top left';
       toEl.style.transition = 'none';
       toEl.style.transform =
@@ -94,9 +99,9 @@ export function createMagicMove({ deck, getScale, reducedMotion = false, embed =
     // 6. Cleanup.
     const cleanup = () => {
       clearTimeout(timer);
-      pairs.forEach(({ toEl, promoted }) => {
+      pairs.forEach(({ toEl, promoted, prevInline }) => {
         toEl.classList.remove('is-flipping');
-        toEl.style.transform = '';
+        toEl.style.transform = prevInline || '';
         toEl.style.transition = '';
         toEl.style.transformOrigin = '';
         if (promoted) toEl.style.position = '';

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -296,6 +296,119 @@ export const ZH = {
   'Fin.': '完。',
   'Thank you.': '<span class="brand-text">谢</span>谢。',
   'Questions, PRs, opinions — all welcome.': '提问、PR、想法 —— 都欢迎。',
+
+  // ---- Epilogue · the elephant / fabrics ----
+  'Epilogue': '终章',
+  'The elephant in the room.': '聊聊房间里的<br/>大象。',
+  '“Vibe coding” is barely eighteen months old — and it already writes native apps. So why frameworks? Why Lynx? Why any of this?':
+    '"vibe coding" 这个词诞生至今不过一年半 —— 它已经能直接写出原生应用了。那,还要框架干嘛?还要 Lynx 干嘛?这一切还有什么意义?',
+  'Epilogue · the question': '终章 · 问题',
+  'Does AI obsolete all of us?':
+    'AI 会让<span class="brand-text">我们所有人</span>都过时吗?',
+  'no frameworks?': '不要框架?',
+  'no libraries?': '不要类库?',
+  'no docs?': '不要文档?',
+  'no us?': '不要我们?',
+  'Epilogue · a claim': '终章 · 一个论断',
+  'What survives AI?':
+    '什么能在 AI 之后<span class="brand-text">留下来</span>?',
+  'infrastructure': '基础设施',
+  'enablers': '使能者',
+  'platforms': '平台',
+  'ecosystems': '生态',
+  'people': '人',
+  'Two lemmas, then an answer.': '两个引理,一个答案。',
+  'Epilogue · Lemma 1': '终章 · 引理一',
+  'The stack, rewritten.': '技术栈,被重写了。',
+  'Epilogue · Lemma 1 · harness': '终章 · 引理一 · Harness',
+  'AI can do anything — harnessed.':
+    'AI 什么都能做 —— 只要有好的 <span class="brand-text">harness</span>。',
+  'context docs · priors · AGENTS.md': '上下文 <small>文档 · 先验 · AGENTS.md</small>',
+  'tools functions · capabilities': '工具 <small>函数 · 能力</small>',
+  'environment runtime · sandbox': '环境 <small>运行时 · 沙箱</small>',
+  'feedback render · tests · logs': '反馈 <small>渲染 · 测试 · 日志</small>',
+  'Epilogue · Lemma 1 · platforms': '终章 · 引理一 · 平台',
+  'Nobody says AI will replace the browser.':
+    '没人会说,AI 要取代<span style="color:#4FB8F0">浏览器</span>。',
+  'open by default': '天生开放',
+  'sandboxed': '天然沙箱',
+  'endlessly capable': '能力无穷',
+  'fully observable': '完全可观测',
+  'Epilogue · Lemma 1 · frameworks': '终章 · 引理一 · 框架',
+  'Frameworks were always harnesses.':
+    '框架,从来都是 <span class="brand-text">harness</span>。',
+  'then architecting how humans reason': '过去 <small>规训人类如何推理</small>',
+  'now steering what models emit': '现在 <small>引导模型吐出什么</small>',
+  'Every technology is a fabric.': '每一种技术,都是一种织物。',
+  'Vue — a weave you can feel.': 'Vue —— 一种你能触到的织法。',
+  'templates': '模板',
+  'reactivity': '响应式',
+  'mutable state': '可变状态',
+  'Epilogue · intermission': '终章 · 幕间',
+  '“Getting metaphysical again — 雪碧 is going to roast me.”':
+    '"又开始形而上了 —— 雪碧又要批评我了。"',
+  'Lynx — the loom.': 'Lynx —— 织机。',
+  'Epilogue · Lemma 2': '终章 · 引理二',
+  '“A patchwork monster”? Exactly.':
+    '"缝合怪"?—— <span class="brand-text">正是。</span>',
+  'web-friendly surface': 'Web 亲和的表面',
+  'strong native core': '扎实的原生内核',
+  'hybrid rendering': '混合渲染',
+  'Frameworks compress the search space.': '框架,压缩了搜索空间。',
+  'everything the model could emit': '模型可能吐出的一切',
+  'the idiom': '惯用法',
+  'Epilogue · Lemma 2 · people': '终章 · 引理二 · 人',
+  'Technology is nothing without its people.':
+    '技术若没有<span class="brand-text">人</span>,什么都不是。',
+  '3D prints · 小音': '帮忙 3D 打印 · 小音',
+  'a dinner in Fuzhou · 雪碧': '上一顿饭在福州 · 雪碧',
+  'Poland, then here · Nector': '上一面在波兰 · Nector',
+  'Evan · Anthony · you': 'Evan · Anthony · 还有你',
+  "Vue Lynx isn't a framework. It's a connection.":
+    'Vue Lynx 不是一个框架,而是一次<span class="brand-text">连接</span>。',
+  'Epilogue · Lemma 2 · compounding': '终章 · 引理二 · 复利',
+  'One connection compounds.':
+    '一次连接,产生<span class="brand-text">复利</span>。',
+  'Rendering': '渲染',
+  'Agents': '智能体',
+  'native': '原生元件',
+  'custom': '自渲染',
+  'hybrid': '混合',
+  "AI doesn't need mature libraries. It needs a place to vibe.":
+    'AI 要的不是成熟的类库,而是一个能 <span class="brand-text">vibe</span> 的地方。',
+  'The Web was that place. Lynx carries it to native.':
+    'Web 曾经就是那个地方。Lynx 把它带到原生。',
+  'Vapor on Lynx — no VDOM. Straight to ops.':
+    'Vapor on Lynx —— 没有 VDOM,直达 <b style="color:#4FB8F0">ops</b>。',
+  'A cradle for framework design.':
+    '框架设计的<span class="brand-text">摇篮</span>。',
+  'A team that loves the Web — and dares to break it.':
+    '一支深爱 Web、也敢于打破 Web 的团队。',
+  'Weave the whole Web…': '把整个 Web 织进来……',
+  '…into every platform.': '……再织向每一个平台。',
+  'more…': '<i></i> 更多……',
+  'Epilogue · coda': '终章 · 尾声',
+  '“AI took away the fun.”': '"AI 把乐趣拿走了。"',
+  '— a workshop attendee · Germany, last week': '—— 一位 workshop 学员 · 上周,德国',
+  'Find a new dopamine.': '去找新的多巴胺。',
+  'The frontend is dead. Again.': '前端,确实又死了。',
+  '“But prompting is the dopamine.”': '"可 prompt 本身,就是多巴胺。"',
+  '— another attendee · he vibed a Pokémon game that night':
+    '—— 另一位学员 · 他当晚 vibe 出了一个宝可梦',
+  "I know AI makes it easy. I'm glad it's easy — I haven't been this excited in years.":
+    '我知道有 AI 这不难。我很高兴这不难 —— 我好久没这么兴奋过了。',
+  'I rebuilt everything ten-years-ago me dreamed of.':
+    '我把 <span class="brand-text">10 年前的自己</span>想做的东西,全部翻新了一遍。',
+  'hux.pro — untouched for 10 years': 'hux.pro —— 十年没动过',
+  'my first Vue app — v0.12': '我的第一个 Vue 应用 —— v0.12',
+  'this deck — zero libraries, vibed': '这套 deck —— 零依赖,纯 vibe',
+  'I just changed languages — to natural language.':
+    '我只是又换了一门语言 —— <span class="brand-text">自然语言</span>。',
+  "I'm still doing frontend.": '可我做的,还是前端。',
+  'Fin. — for real': '终 · 这次是真的',
+  'The frontend is dead.': '前端已死。',
+  'Long live the frontend.': '前端<span class="brand-text">永生</span>。',
+  'Thank you — for real this time.': '谢谢 —— 这次是真的。',
 };
 
 // Speaker-view chrome labels.
@@ -477,6 +590,62 @@ export const ZH_NOTES = [
   `<p>左边 = 今天就能用、可以做生产探索的。右边 = 贡献者能发力的地方 —— 第三章里 Elk 的 view pager,就在这个清单上。</p>`,
   // 69 Try
   `<p><strong>行动号召。</strong>一行命令 —— <code>npm create vue-lynx@latest</code>。"给 Agent"按钮会复制一段引导 prompt。承诺:"今晚回家的公交上,你就能让一个 Vue 应用跑在 iPhone 上。"</p>`,
-  // 70 Thank you
-  `<p><strong>收尾。</strong>感谢,邀请提问,停在这页做 Q&amp;A。</p><p>"能上生产吗?" —— pre-alpha,架构稳,已覆盖的部分测试充分。"Android?" —— Lynx 跨平台,同一产物两端都跑。</p>`,
+  // 70 Thank you (the FAKE close)
+  `<p><strong>假收尾。</strong>演得越真越好:道谢、微微鞠躬、伸手去拿水 —— 停住,等掌声起来。</p><p>然后面无表情:"啊——没有哈。这才过去十分钟。"翻页,进入真正的后半场。</p>`,
+  // 71 Epilogue divider · 大象
+  `<p><strong>重置全场。</strong>"那,用省下来的十分钟,聊聊房间里的大象。"如果 AI 什么都能做,为什么不直接 prompt 出 N 个原生应用,跳过框架、跳过跨端、跳过这一切?</p><p>语气转变:少一点产品推介,多一点自言自语。这半场讲的是 <em>why</em>,不是 <em>what</em>。</p>`,
+  // 72 E2 · 诚实的问题
+  `<p><strong>先诚实:我不知道。</strong>AI 对 Lynx、对 Vue 意味着什么,我为什么还要费这个劲?如果没有人类会读,文档还重要吗?如果模型能从裸金属重建,类库还重要吗?</p><p>可以丢的数据点:AI 时代 React 的使用量反而<em>暴涨</em> —— 模型默认写 React —— 但 React 本身却没有过去那么重要了;Anthropic 刚写过 Claude 用纯 HTML 搓一次性内部工具、什么框架都不用。地面真的在动。</p>`,
+  // 73 E3 · 论断
+  `<p><strong>先把论点立起来,这一章才有脊柱。</strong>从 AI 手里"幸存"下来的,是所有<em>使能</em>而非仅仅产出的东西:基础设施、使能者、平台、生态 —— 以及链条尽头的,人。注意这是递进:每一环都因为喂养下一环而幸存。</p><p>我用两个引理来论证:(1) 技术的角色从 interface 翻转为 harness;(2) 技术真正的工作,是连接生态 —— 和人。</p>`,
+  // 74 E4 · 新的栈
+  `<p><strong>引理一,从新的技术栈开始。</strong>自然语言是新的源代码;agent 是新的 interface,坐在 IDE 和 GUI 曾经的位置上。但看 agent 下面:code、frameworks、system —— 它们没有消失,它们变成了 agent <em>驾驭的对象</em>。</p><p>技术的工作翻转了:从直接服务人,变成 harness 那个服务人的东西。</p>`,
+  // 75 E5 · harness 是什么
+  `<p><strong>把这个词定义清楚,整章都压在它上面。</strong>Harness 是把原始能力变成可靠工作的东西:上下文(它带着什么进来)、工具(它能用什么行动)、环境(行动在哪里既安全又便宜)、反馈(它如何看见自己刚做了什么)。</p><p>第四章其实偷偷讲的就是这页:AGENTS.md 是上下文,工具链是工具,LynxExplorer 是环境,上游测试是反馈。</p>`,
+  // 76 E6 · 浏览器是个好 harness
+  `<p><strong>平台之所以幸存,是因为平台是极好的 harness。</strong>浏览器:开放的数据与文档(上下文)、巨大的能力表面(工具)、天然的沙箱(环境)、彻底的透明 —— DOM、DevTools(反馈)。</p><p>没有人argue Web 会被 AI 淘汰。我甚至更进一步:GUI 本身都不会 —— 人类总要<em>看</em>。</p>`,
+  // 77 E7 · 框架一直是 harness
+  `<p><strong>让框架与 AI 相关的那次重构。</strong>在 Web 上你本来爱怎么改 DOM 都行 —— React 和 Vue 赢,是因为它们<em>约束</em>了我们:一种架构,把人类的推理 harness 成吐出下一个正确 token 的过程。</p><p>我们才是第一批被 harness 的 token 预测器。模型只是下一批。高层抽象仍然有用 —— 它帮过我们,也会帮它。</p>`,
+  // 78 E8 · FABRIC I
+  `<p><strong>本章的意象登场。</strong>先让线呼吸一会儿再开口。在我"前端已死"的演讲里,我试着从第一性原理论证:UI/App 抽象永远都需要 —— 意图与像素之间,总要有一层织物。现代软件是缝出来的,不是凿出来的。</p><p>于是,贯穿后半场的比喻:每一种技术都是一种织物 —— 有自己的纤维、自己的织法、自己的手感。</p>`,
+  // 79 E9 · Vue 的质地
+  `<p><strong>织得更密了。</strong>不同的织物有不同的特性 —— 而 Vue 的质地也许正是你想要的:模板、细粒度响应式、"直接改就行"的可变状态、单文件组件。</p><p>重点不是 Vue 对谁。重点是<em>材质</em>依然重要 —— 对选择它的人重要,对在它的海洋里训练出来的模型也重要。</p>`,
+  // 80 E10 · meme 幕间
+  `<p><strong>喘口气。</strong>进入引理二之前的自嘲一拍 —— 把 meme 放进来,收下笑声,继续。(占位框:把真图放进 <code>public/media/</code> 后替换。)</p>`,
+  // 81 E11 · FABRIC II · 织机
+  `<p><strong>引理二用画面开场,不用论断。</strong>绿色的织物穿过一个点 —— 织机 —— 在另一侧被织进 iOS、Android、Web。盯住一根线:进腰身之前它保持自己的颜色,出来时带上了平台的颜色。</p><p>Lynx 凭什么能当这台织机?一侧是 Web 亲和的表面,另一侧是扎实的原生架构,中间是每一层的开放。</p>`,
+  // 82 E12 · 认领"缝合怪"
+  `<p><strong>把这个"骂名"认下来。</strong>有人叫 Lynx 缝合怪 —— 对!我们刚说了,代码本来就是一块块织物 —— 把它们接起来的东西,当然是缝起来的。织机<em>本来</em>就该是台缝合机器。</p><p>缝合换来的:它吸收了 N 个平台的原始熵,让每个应用不必重新支付 —— 而这恰恰是 AI 自己最难摊销的部分。框架持有翻译合同,agent 只对压缩后的语义写作。</p>`,
+  // 83 E13 · 压缩
+  `<p><strong>同一台织机,抽象上移一层。</strong>左边:模型的整个选择空间 —— 灰、宽、混沌。穿过框架,出来时又窄又亮又齐:惯用法。所谓 steering,画出来就是这样。</p><p>这就是为什么跨端框架是 AI 的<em>语义压缩层</em>:更少的 token、训练分布里更密的区域、更小的幻觉空间。正确性是个概率问题 —— 压缩,挪动的就是概率。</p>`,
+  // 84 E14 · 人
+  `<p><strong>引理落在人身上。</strong>如果 AI 最终 boil down 到人的品味,那人只会更重要 —— 连接一个社区,就是连接一群人。</p><p>点名现场:帮忙 3D 打印的小音,非常感谢;雪碧 —— 上一顿饭还在福州,没想到今天在这里遇见;Nector —— 上一面还在波兰!你可以说"这个平台才有我想追的偶像" —— 那,Evan 和 Anthony 就在这个平台上。</p>`,
+  // 85 E15 · 不是框架,是连接
+  `<p><strong>那我到底做了个什么?</strong>AI 时代你理论上并不<em>需要</em>框架 —— 十年前我做过一个在线 HTML slides 编辑器;今天这套 deck 完全是生成的,底下什么库都没有。Vue Lynx 真正是一个开端:说服 Vue 社区,来给原生做点东西。</p><p>更深一层的道理:只要连接<em>存在</em>,AI 就会放大发生的连接。编程语言之间移植容易,因为大家都图灵完备、都有 runtime —— 桥本来就在。Web ↔ Native 之间没有天然的桥。Lynx 这个开源项目的命题,就是那座桥的<em>设计</em>。(顺带:我选择投身的技术,商业价值是一,理想也总要有一点。)</p>`,
+  // 86 E16 · 连接复利
+  `<p><strong>连上 Lynx,就连上了 Lynx 连接的一切。</strong>你已经在用的 Web 织物 —— Motion、Pretext —— 直接带过来;经 Node-API 连 Electron;JSI 世界连 Expo Modules;每一种渲染策略;正在成形的 agent-UI 协议。还有 Lynx 自己的生态 —— Sparkling、Lynxtron。</p><p>被带过来的,是生态和社区本身。这就是复利。</p>`,
+  // 87 E17 · 能 vibe 的地方
+  `<p><strong>把生态论点按 AI 时代磨尖。</strong>键盘前坐着 agent 的时候,你需要的甚至不是成熟的类库 —— 而是一个试错便宜、可观测、够安全的平台。Web 之所以是 Web,靠的就是这个。Lynx 的赌注,是把这个性质带到原生。</p>`,
+  // 88 E18 · One more thing
+  `<p><strong>停住。</strong>数两拍,再翻页。</p>`,
+  // 89 E19 · Vapor on Lynx
+  `<p><strong>连接创新本身。</strong>回想第四章的流水线:VDOM → ShadowElement → ops → PAPI。Vapor 模式不需要 VDOM —— 于是在 Lynx 上,整整一层直接消失:signal 驱动 effect,effect 直接吐 ops。在实现上我们做的是<em>删掉</em>抽象,不是增加抽象。</p><p>诚实交代进度:这是设计草图和早期实验,不是已发布的模式 —— 而这正是它令人兴奋的地方:缝是开着的,创新可以沿着连接双向流动。</p>`,
+  // 90 E20 · 摇篮
+  `<p><strong>框架作者为什么该关心 Lynx。</strong>Lynx 做过很多有趣甚至有争议的设计决定,而且还在继续:双线程、MTS、一台不在 DOM 上的真 CSS 引擎。这是一支深爱 Web、也有胆量和空间在必要处打破 Web 的团队。</p><p>对 Vue 而言:一个真正有奔跑空间的原生平台 —— 在这种空间里,一个 Vapor 原生渲染器,就是一个周末的 vibe 量。</p>`,
+  // 91 E21 · 全景 · 左半
+  `<p><strong>全景开始。</strong>线落下时逐一点名:Vue 的绿、React 的蓝、Svelte 和 Solid 隐约的黄、Octane 的红 —— 一种还在纺的新织物 —— CSS、Tailwind、Motion 和 Pretext、Rspack 的橘。整个 Web 生态,化作丝线。</p><p>它们全都收向同一个又细又有力的腰身。</p>`,
+  // 92 E22 · 全景
+  `<p><strong>压轴画面 —— 头一秒别说话。</strong>腰身绽开:左侧的每一种织物,重新织进 iOS、Android、Web、HarmonyOS、macOS、Windows、Linux,以及接下来的任何平台。</p><p>中间是那台又细又强的织机。整个论证浓缩成一张图:左半是 harness,右半是连接。停住,然后轻轻说:"Lynx 给你的,是织任何一种织物所需要的技艺 —— 和 harness。"</p>`,
+  // 93 E23 · 德国 · 上
+  `<p><strong>讲故事的时间 —— 降低翻页速度,放慢声音。</strong>上周我在德国带 workshop。一位学员说,AI 把开发的"乐趣"从他手里拿走了。我的回答很直接:你需要找到新的多巴胺。</p>`,
+  // 94 E24 · 又死了
+  `<p><strong>callback。</strong>有些朋友知道,我讲过一场"前端已死"。嗯 —— 按旧的定义,它确实又死了一次。让这句话悬着;反转在两页之后。</p>`,
+  // 95 E25 · 德国 · 下
+  `<p><strong>反例来了。</strong>另一位学员不同意:prompt 本身就是多巴胺 —— 那天晚上他 vibe 出了一整个宝可梦游戏。我知道有 AI 这不难。而我<em>很高兴</em>这不难 —— 我好久没这么兴奋过了。</p><p>坦白 AI 精神病环节:不睡前跑几个 <code>/goal</code> <code>/loop</code> 就睡不着;Fable 或 Codex 一挂就像戒断。在座的应该也有同感。</p>`,
+  // 96 E26 · 十年翻新
+  `<p><strong>个人的证据。</strong>这一年我回头把 10 年前的自己想做的项目全都翻新了一遍:十年没动过的个人网站;我的第一个 Vue 项目,Vue 0.12;还有这套 deck —— 手 vibe 的 HTML,底下没有任何 slide 库,正是当年那个 slides 编辑器的直系后代。</p>`,
+  // 97 E27 · 还是前端
+  `<p><strong>转折。</strong>那我整天在做什么呢,从敲代码变成 prompt?我只是又换了一门语言 —— 汇编到 C 到 JS 到……自然语言。源变了,工作没变:我仍然在把人的意图,翻译成人能看见、能触摸的东西。</p><p>这从来就是这份工作。这<em>就是</em>前端。</p>`,
+  // 98 E28 · 前端永生
+  `<p><strong>真正的收尾。</strong>小字划掉:前端已死。大字:前端永生。谢谢 —— 这次是真的 —— 然后留在这页做 Q&amp;A。</p><p>Q&amp;A 弹药:"能上生产吗?" —— pre-alpha,架构稳,已覆盖的部分测试充分。"Android?" —— 同一份产物,两端都跑。"AI 会取代 Vue 吗?" —— 你刚看完整个答案。</p>`,
 ];

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -440,8 +440,20 @@ export const ZH_NOTES = [
   `<p><strong>冷开场 —— 屏幕上没有一个字。</strong>"Hey what's up guys —— 我是 Hux 黄玄,前 React 团队成员。"让 logo 单独停一拍。</p>`,
   // 2 Logo · +Vue
   `<p><strong>Vue 入场。</strong>React 让到一侧,Vue 落在旁边 —— 组件模型时代的两大基石。</p><p>抖包袱:React 一直没有一个自己的中文会议 —— 所以,很高兴来到 VueConf!(真心的)</p>`,
+  // 2a Overlay · 第一段视频
+  `<p><strong>第一段视频淡入,浮在两个 logo 之上</strong> —— React 岁月的影像。静音循环,人声压在上面讲;logo 在背后一直可见。</p><p>文件放到 <code>slides/public/media/embeds/02-video-1.mp4</code> —— 放进去之前这里显示带路径的占位框。</p>`,
+  // 2b Overlay · 第二段视频
+  `<p><strong>第二段视频加入</strong> —— 第一段缩进角落(定格),新的一段播放。Keynote 式的层层堆叠。</p><p>文件:<code>02-video-2.mp4</code>。</p>`,
+  // 2c Overlay · 照片
+  `<p><strong>照片落下</strong> —— 两段视频定格缩小,快照落在正中。那个时代的拼贴,完成。</p><p>文件:<code>02-image.png</code>。</p>`,
+  // 2d 回归 · 两个 logo
+  `<p><strong>图层散去</strong> —— 回到两个 logo 本身。停一拍,进入 Web 三角。</p>`,
   // 3 Logo · +Chrome(三角)
   `<p><strong>Chrome 从下方升起</strong> —— React 和 Vue 抬到上方两角,三个 logo 落成三角,Web 在底下托着它们。</p><p>"先聊 Web。"React 和 Vue 只是载体 —— 我们真正共同站立的地面,是 Web:它的开发体验、它的开放性、它的可达性。</p>`,
+  // 3a Overlay · PWA 演讲 iframe
+  `<p><strong>"先聊 Web"的实证:</strong>2016 年的 PWA 演讲,以 <em>live iframe</em> 浮在三角之上。点进框内可以翻那套 deck;在框外滚轮/按键才翻这套。角上的把手可拖拽缩放;切换器有桌面/平板/手机三档;↗ 按钮在新标签页打开。</p><p>iframe 在到达前一页时才加载、离开两页后卸载 —— 不拖累整场演讲。(需要会场网络;↗ 是 plan B。)</p>`,
+  // 3b 回归 · Web 三角
+  `<p><strong>关掉 PWA 窗口</strong> —— 三角回来,故事继续踩在这块地面上:是 Web 载着我们。</p>`,
   // 4 Logo · Lynx 取代 Chrome
   `<p><strong>Lynx 顶掉 Chrome</strong>,落在三角的同一个位置 —— 同一个位置,换了引擎。我在解的问题没变;脚下的地面变了。</p><p>快速给事实:Lynx 是字节跳动的跨平台引擎 —— TikTok 的界面就在跑 —— 而且已经开源。</p>`,
   // 5 一排候选人
@@ -594,6 +606,10 @@ export const ZH_NOTES = [
   `<p><strong>假收尾。</strong>演得越真越好:道谢、微微鞠躬、伸手去拿水 —— 停住,等掌声起来。</p><p>然后面无表情:"啊——没有哈。这才过去十分钟。"翻页,进入真正的后半场。</p>`,
   // 71 Epilogue divider · 大象
   `<p><strong>重置全场。</strong>"那,用省下来的十分钟,聊聊房间里的大象。"如果 AI 什么都能做,为什么不直接 prompt 出 N 个原生应用,跳过框架、跳过跨端、跳过这一切?</p><p>语气转变:少一点产品推介,多一点自言自语。这半场讲的是 <em>why</em>,不是 <em>what</em>。</p>`,
+  // 71a Overlay · 推文上半
+  `<p><strong>推文本尊,浮在 divider 之上。</strong>2025 年 2 月 2 日 —— Karpathy 造出 "vibe coding" 这个词。先露上半截:<em>"fully give in to the vibes, embrace exponentials, and forget that the code even exists."</em></p><p>文件:<code>slides/public/media/embeds/79-vibe-coding.png</code> —— 一整张全高截图,由这个窗口裁切。</p>`,
+  // 71b Overlay · 推文下半
+  `<p><strong>下移 + 轻微放大</strong> —— 下半截:<em>"It's not too bad for throwaway weekend projects…"</em> 十八个月后,它已经在写原生应用了。让这句落地,翻页 —— 推文淡出,进入提问。</p>`,
   // 72 E2 · 诚实的问题
   `<p><strong>先诚实:我不知道。</strong>AI 对 Lynx、对 Vue 意味着什么,我为什么还要费这个劲?如果没有人类会读,文档还重要吗?如果模型能从裸金属重建,类库还重要吗?</p><p>可以丢的数据点:AI 时代 React 的使用量反而<em>暴涨</em> —— 模型默认写 React —— 但 React 本身却没有过去那么重要了;Anthropic 刚写过 Claude 用纯 HTML 搓一次性内部工具、什么框架都不用。地面真的在动。</p>`,
   // 73 E3 · 论断
@@ -642,6 +658,10 @@ export const ZH_NOTES = [
   `<p><strong>callback。</strong>有些朋友知道,我讲过一场"前端已死"。嗯 —— 按旧的定义,它确实又死了一次。让这句话悬着;反转在两页之后。</p>`,
   // 95 E25 · 德国 · 下
   `<p><strong>反例来了。</strong>另一位学员不同意:prompt 本身就是多巴胺 —— 那天晚上他 vibe 出了一整个宝可梦游戏。我知道有 AI 这不难。而我<em>很高兴</em>这不难 —— 我好久没这么兴奋过了。</p><p>坦白 AI 精神病环节:不睡前跑几个 <code>/goal</code> <code>/loop</code> 就睡不着;Fable 或 Codex 一挂就像戒断。在座的应该也有同感。</p>`,
+  // 95a Overlay · 德国现场三连
+  `<p><strong>证据甩上桌</strong> —— 两张照片夹着中间的竖屏视频,压在 quote 之上。中间的视频静音自动播放;照片带一点快照式的倾斜。</p><p>文件:<code>103-photo-1.png</code>、<code>103-video-portrait.mp4</code>、<code>103-photo-2.png</code>,放在 <code>slides/public/media/embeds/</code>。</p>`,
+  // 95b Overlay · 宝可梦横屏
+  `<p><strong>再点一下 —— 宝可梦,全宽登场。</strong>三连散去,横屏视频占满舞台。文件:<code>103-video-wide.mp4</code>。</p>`,
   // 96 E26 · 十年翻新
   `<p><strong>个人的证据。</strong>这一年我回头把 10 年前的自己想做的项目全都翻新了一遍:十年没动过的个人网站;我的第一个 Vue 项目,Vue 0.12;还有这套 deck —— 手 vibe 的 HTML,底下没有任何 slide 库,正是当年那个 slides 编辑器的直系后代。</p>`,
   // 97 E27 · 还是前端

--- a/slides/src/main.js
+++ b/slides/src/main.js
@@ -1,6 +1,7 @@
 import './styles.css';
 import { mountMeteors } from './meteors.js';
 import { initArch } from './arch.js';
+import { initWeave } from './weave.js';
 import { ZH, ZH_VERBS, ZH_NOTES, normalizeKey } from './i18n.js';
 import { readFlags, expandChrome } from './framework/flags.js';
 import { initCommand } from './framework/command.js';
@@ -55,6 +56,19 @@ const mm = createMagicMove({
   getScale: stage.getScale,
   reducedMotion: REDUCED_MOTION,
   embed: embedMode,
+});
+
+// The epilogue's "fabrics" canvas — one persistent layer under the
+// slides; scenes are declared per-slide via data-weave and tweened
+// across navigations (see src/weave.js). Embed iframes render a
+// single static frame so speaker previews stay cheap.
+const weave = initWeave(frame, {
+  getScale: stage.getScale,
+  reducedMotion: REDUCED_MOTION,
+  embed: embedMode,
+});
+document.addEventListener('deck:change', (e) => {
+  weave.setScene(slides[e.detail.index]?.dataset.weave || null);
 });
 
 let current = 0;
@@ -534,6 +548,7 @@ const I18N_SELECTOR = [
   '.arrow', '.cta__link', '.agent', '.mega', '.label',
   '.flane__label', '.fcenter', '.lgtag',
   '.demo__caption', '.videopair figcaption',
+  '.tile', '.wlab', '.wattr', '.wg b',
 ].map((s) => `.slide ${s}`).join(', ') + ', .gate-legend span';
 
 let i18nEls = [];

--- a/slides/src/main.js
+++ b/slides/src/main.js
@@ -10,6 +10,7 @@ import { createStage } from './framework/stage.js';
 import { createMagicMove } from './framework/magic-move.js';
 import { attachDeviceControls, DECK_PRESETS } from './framework/device.js';
 import { registerVlDemo } from './demo.js';
+import { initEmbeds } from './embeds.js';
 import { initQRCodes } from './qrcodes.js';
 
 // =========================================================
@@ -68,7 +69,20 @@ const weave = initWeave(frame, {
   embed: embedMode,
 });
 document.addEventListener('deck:change', (e) => {
-  weave.setScene(slides[e.detail.index]?.dataset.weave || null);
+  // Overlay slides float above their base slide (see setSlide) — unless
+  // they declare their own scene, they inherit the base's weave so the
+  // canvas doesn't blink out under a media layer.
+  let i = e.detail.index;
+  while (i > 0 && slides[i].classList.contains('overlay') && !slides[i].dataset.weave) i--;
+  weave.setScene(slides[i]?.dataset.weave || null);
+});
+
+// Media embeds — <vl-media> lifecycle (video reset/autoplay, iframe
+// proximity mount/unload) + resizable .phone--embed frames.
+initEmbeds({
+  getScale: stage.getScale,
+  reducedMotion: REDUCED_MOTION,
+  embed: embedMode,
 });
 
 let current = 0;
@@ -156,9 +170,19 @@ function setSlide(index, opts = {}) {
   const cut = flags.transition === 'cut';
   if (cut) deck.classList.add('is-cut'); // disables .slide transition for this change
 
+  // Overlay slides keep their base slide visible beneath them: the
+  // nearest previous non-overlay slide stays rendered (`is-under`), so
+  // a media layer reads as "the same page, plus a layer" instead of a
+  // hard cut. Consecutive overlays share one base.
+  let under = -1;
+  if (slides[current]?.classList.contains('overlay')) {
+    under = current - 1;
+    while (under >= 0 && slides[under].classList.contains('overlay')) under--;
+  }
   slides.forEach((s, i) => {
     s.classList.toggle('is-active', i === current);
-    s.classList.toggle('is-prev', i < current);
+    s.classList.toggle('is-under', i === under);
+    s.classList.toggle('is-prev', i < current && i !== under);
   });
   applyChromeAndBg(flags);
 
@@ -463,7 +487,9 @@ initQRCodes();
 // framework/device.js. The play page reuses the same component.
 function initPhoneControls() {
   if (embedMode) return;
-  document.querySelectorAll('.phone').forEach((phone) =>
+  // (embed frames wire their own controls in initEmbeds, with
+  // embed-shaped presets — skip them here)
+  document.querySelectorAll('.phone:not(.phone--embed)').forEach((phone) =>
     attachDeviceControls(phone, {
       getScale: stage.getScale,
       presets: DECK_PRESETS,

--- a/slides/src/main.js
+++ b/slides/src/main.js
@@ -357,6 +357,42 @@ if (!embedMode) {
 }
 
 // =========================================================
+// Demo focus containment — live demos are real apps, and some
+// autofocus an input the moment they load (TodoMVC), which
+// would silently swallow the arrow keys via the .phone guard
+// below. Policy: only a deliberate pointer/touch INTO a demo
+// hands it the keyboard. Programmatic focus grabs are blurred
+// on the spot, navigation reclaims focus on every slide
+// change, and clicking anywhere outside a demo takes the
+// keyboard back.
+// =========================================================
+let demoEngaged = false;
+const inDemo = (el) => !!el?.closest?.('.phone, .no-deck-scroll');
+
+if (!embedMode) {
+  document.addEventListener('pointerdown', (e) => {
+    const inside = inDemo(e.target);
+    // Clicking outside a demo also releases any focus it still holds,
+    // so arrows never double-drive a demo input AND the deck.
+    if (!inside && inDemo(document.activeElement)) {
+      document.activeElement.blur?.();
+    }
+    demoEngaged = inside;
+  }, true);
+
+  document.addEventListener('focusin', (e) => {
+    // Focus landed inside a demo without a user gesture → an autofocus
+    // grab. Refuse it; the deck keeps the keyboard.
+    if (inDemo(e.target) && !demoEngaged) e.target.blur?.();
+  });
+
+  document.addEventListener('deck:change', () => {
+    demoEngaged = false;
+    if (inDemo(document.activeElement)) document.activeElement.blur?.();
+  });
+}
+
+// =========================================================
 // Keyboard
 // =========================================================
 // In embed mode the deck is read-only — the iframe is just a preview surface
@@ -366,8 +402,10 @@ if (!embedMode) {
   document.addEventListener('keydown', (e) => {
     if (e.target.matches?.('input, textarea, [contenteditable]')) return;
     // Typing inside a live demo (native inputs live in the lynx-view shadow, so
-    // the event retargets to the .phone host) must not drive the deck.
-    if (e.target?.closest?.('.phone, .no-deck-scroll')) return;
+    // the event retargets to the .phone host) must not drive the deck — but
+    // only when the user deliberately clicked into the demo (demoEngaged).
+    // An app that autofocused itself doesn't get to eat the arrow keys.
+    if (demoEngaged && e.target?.closest?.('.phone, .no-deck-scroll')) return;
     if (document.querySelector('.cmdk')) return; // command palette owns the keyboard
 
     // Only slide navigation is bound to bare keys. Every discrete action

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -3060,22 +3060,13 @@ body.is-blackout::after {
   color: var(--ink-mute);
 }
 
-/* Meme placeholder — a dashed frame ready for the actual image. */
-.meme {
-  width: min(52cqw, 500px);
-  aspect-ratio: 4 / 3;
-  border: 1.6px dashed var(--line);
+/* Meme slot — a <vl-media> wearing this class; the missing-file
+   placeholder chrome comes from .vl-ph. */
+.meme { width: min(52cqw, 500px); }
+.meme img {
   border-radius: var(--radius);
-  display: grid;
-  place-items: center;
-  font-family: var(--mono);
-  font-size: 12px;
-  letter-spacing: 0.12em;
-  color: var(--ink-faint);
-  background: var(--paper-elev);
-  overflow: hidden;
+  box-shadow: 0 18px 60px -22px rgba(0, 0, 0, 0.55);
 }
-.meme img { width: 100%; height: 100%; object-fit: cover; }
 
 /* The finale's struck first line. */
 .fin-dead {
@@ -3088,3 +3079,123 @@ body.is-blackout::after {
   text-decoration-color: color-mix(in srgb, #ff5468 70%, transparent);
   text-decoration-thickness: 1.5px;
 }
+
+/* =========================================================
+   Overlay slides + media embeds (<vl-media>, see embeds.js).
+   An .overlay slide keeps its base slide rendered beneath it
+   (main.js marks the nearest non-overlay predecessor
+   `is-under`), so media reads as a layer over the same page.
+   ========================================================= */
+.slide.is-under {
+  opacity: 1;
+  transform: none;
+  pointer-events: none;
+  z-index: 1;
+}
+
+/* Embed frame — the demo phone chrome, de-phoned: slim dark bezel,
+   same drag grips + preset switcher (wired in embeds.js). */
+.phone--embed {
+  --phone-ar: 16 / 9;
+  --phone-w: min(62cqw, 800px);
+  --phone-h: auto;
+  padding: 3px;
+  border-radius: 14px;
+}
+.phone--embed .phone__inner {
+  width: 100%;
+  height: 100%;
+  border-radius: 11px;
+  overflow: hidden;
+  background: #0b0d10;
+}
+
+/* <vl-media> — block host; media fills the width, height follows.
+   Inside a .phone__inner it fills the frame instead. */
+vl-media {
+  display: block;
+  position: relative;
+}
+vl-media img,
+vl-media video,
+vl-media iframe {
+  display: block;
+  width: 100%;
+  height: auto;
+  border: 0;
+}
+.phone__inner vl-media { width: 100%; height: 100%; }
+.phone__inner vl-media img,
+.phone__inner vl-media video { height: 100%; object-fit: contain; }
+.phone__inner vl-media iframe { height: 100%; background: #fff; }
+
+/* Missing-file placeholder — shows the exact path to drop the
+   asset at, so slides can be authored before media exists. */
+vl-media .vl-ph { display: none; }
+vl-media.is-missing > img,
+vl-media.is-missing > video { display: none; }
+vl-media.is-missing .vl-ph {
+  display: grid;
+  place-content: center;
+  gap: 8px;
+  width: 100%;
+  aspect-ratio: var(--ph-ar, 16 / 9);
+  border: 1.6px dashed var(--line);
+  border-radius: 12px;
+  background: var(--paper-elev);
+  color: var(--ink-faint);
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-align: center;
+  padding: 14px;
+  box-sizing: border-box;
+}
+vl-media .vl-ph__kind {
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: var(--ink-mute);
+}
+.phone__inner vl-media.is-missing .vl-ph {
+  aspect-ratio: auto;
+  height: 100%;
+  border: 0;
+  border-radius: 0;
+}
+
+/* Crop window — a fixed viewport a tall image pans inside via
+   magic move (the vibe-coding tweet reveal). */
+.crop {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  overflow: hidden;
+  border-radius: 14px;
+  border: 1px solid var(--line);
+  background: var(--paper-elev);
+  box-shadow: 0 24px 70px -24px rgba(0, 0, 0, 0.6);
+}
+.crop vl-media {
+  position: absolute;
+  left: 0;
+  width: 100%;
+}
+
+/* Snapshot look for bare photo embeds (the coda three-up). */
+.snap {
+  padding: 6px 6px 10px;
+  background: #f4f5f7;
+  border-radius: 6px;
+  box-shadow: 0 18px 48px -16px rgba(0, 0, 0, 0.55);
+}
+.snap img { border-radius: 2px; }
+/* The polaroid card is light in both themes — the missing-file
+   placeholder must re-ink dark-on-light or it vanishes into the card. */
+.snap .vl-ph { --ph-ar: 4 / 5; }
+vl-media.snap.is-missing .vl-ph {
+  background: rgba(15, 18, 22, 0.05);
+  border-color: rgba(15, 18, 22, 0.3);
+  color: rgba(15, 18, 22, 0.5);
+}
+vl-media.snap.is-missing .vl-ph__kind { color: rgba(15, 18, 22, 0.65); }

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -2892,3 +2892,199 @@ body.is-blackout::after {
 .profilemock__badge.page { bottom: 10px; right: 8px; color: #E8B44A; border: 1px solid color-mix(in srgb, #E8B44A 50%, transparent); }
 .profilemock__badge.scroll { top: 50%; left: 8px; transform: translateY(-50%); color: #E8B44A; border: 1px solid color-mix(in srgb, #E8B44A 45%, transparent); }
 .profilemock__tabwrap { position: relative; }
+
+/* =========================================================
+   Epilogue — the weave layer & fabric-chapter components.
+   The canvas (mounted by src/weave.js) sits UNDER the slides
+   inside the frame; slides opt in with data-weave="…".
+   ========================================================= */
+.weave-canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 0;
+  pointer-events: none;
+}
+.deck.overview .weave-canvas { display: none; }
+
+/* Serif caption floating over the weave. */
+.weave-kicker {
+  position: absolute;
+  left: 50%;
+  top: 9cqh;
+  transform: translateX(-50%);
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: clamp(30px, 3.6cqw, 52px);
+  letter-spacing: -0.01em;
+  color: var(--ink);
+  text-align: center;
+  white-space: nowrap;
+  text-shadow: 0 0 18px var(--paper), 0 0 6px var(--paper);
+  z-index: 2;
+}
+.weave-kicker--bottom { top: auto; bottom: 9cqh; }
+
+/* Thread-bundle label — a mono tag with a glowing dot, positioned
+   on the lane fractions mirrored from weave.js. */
+.wlab {
+  position: absolute;
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--mono);
+  font-size: clamp(12px, 1.15cqw, 15px);
+  letter-spacing: 0.08em;
+  color: color-mix(in srgb, var(--c, #5dd5a8) 78%, var(--ink));
+  text-shadow: 0 0 12px var(--paper), 0 0 4px var(--paper);
+  white-space: nowrap;
+  z-index: 2;
+}
+.wlab i {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--c, #5dd5a8);
+  box-shadow: 0 0 10px var(--c, #5dd5a8);
+}
+.wlab--soft { color: var(--ink-mute); }
+
+/* The loom itself — the Lynx mark at the waist. Ink-colored (black
+   or white with the theme), with a paper halo so threads read as
+   passing *through* it. */
+.wlynx {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: clamp(56px, 6.4cqw, 84px);
+  color: var(--ink);
+  filter: drop-shadow(0 0 20px color-mix(in srgb, var(--brand-teal) 45%, transparent));
+  z-index: 2;
+}
+.wlynx::before {
+  content: '';
+  position: absolute;
+  inset: -30%;
+  border-radius: 50%;
+  background: radial-gradient(circle, var(--paper) 0 36%, transparent 72%);
+  opacity: 0.92;
+  z-index: -1;
+}
+.wlynx svg { width: 100%; height: auto; display: block; fill: currentColor; }
+
+/* Weave slides own the full stage — labels position against the
+   frame edges, not the text padding. */
+.slide.weave { padding: 0; }
+
+/* Static concept tiles — the flex sibling of the absolutely-
+   positioned .fb, for rows/grids that need no diagram geometry. */
+.tiles {
+  display: flex;
+  gap: clamp(14px, 1.6cqw, 22px);
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+}
+.tile {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: clamp(14px, 2cqh, 20px) clamp(20px, 2.4cqw, 30px);
+  border-radius: 14px;
+  border: 1.5px solid color-mix(in srgb, var(--c, #5dd5a8) 55%, transparent);
+  background: color-mix(in srgb, var(--c, #5dd5a8) 8%, transparent);
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: clamp(17px, 1.5cqw, 22px);
+  letter-spacing: -0.01em;
+  color: var(--ink);
+  white-space: nowrap;
+}
+.tile small {
+  font-family: var(--mono);
+  font-weight: 400;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: var(--ink-mute);
+}
+.tile.is-hero { box-shadow: 0 0 22px -4px var(--c, #5dd5a8); }
+.tilearr {
+  font-family: var(--mono);
+  font-size: clamp(15px, 1.4cqw, 19px);
+  color: var(--ink-faint);
+}
+
+/* Big serif pull-quote + mono attribution (the coda stories). */
+.wquote {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: clamp(40px, 4.8cqw, 68px);
+  line-height: 1.12;
+  letter-spacing: -0.015em;
+  color: var(--ink);
+  max-width: 24ch;
+}
+.wattr {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+
+/* Ecosystem groups — label + chips columns (the "connections
+   compound" grid). */
+.wgrid {
+  display: grid;
+  grid-template-columns: repeat(3, auto);
+  gap: clamp(18px, 2.6cqh, 28px) clamp(32px, 4cqw, 56px);
+  text-align: left;
+}
+.wg {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.wg b {
+  font-family: var(--mono);
+  font-weight: 500;
+  font-size: 11.5px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+
+/* Meme placeholder — a dashed frame ready for the actual image. */
+.meme {
+  width: min(52cqw, 500px);
+  aspect-ratio: 4 / 3;
+  border: 1.6px dashed var(--line);
+  border-radius: var(--radius);
+  display: grid;
+  place-items: center;
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 0.12em;
+  color: var(--ink-faint);
+  background: var(--paper-elev);
+  overflow: hidden;
+}
+.meme img { width: 100%; height: 100%; object-fit: cover; }
+
+/* The finale's struck first line. */
+.fin-dead {
+  font-family: var(--mono);
+  font-size: clamp(13px, 1.2cqw, 16px);
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  text-decoration: line-through;
+  text-decoration-color: color-mix(in srgb, #ff5468 70%, transparent);
+  text-decoration-thickness: 1.5px;
+}

--- a/slides/src/weave.js
+++ b/slides/src/weave.js
@@ -1,0 +1,422 @@
+// =========================================================
+// Weave — the "fabrics" canvas layer for the epilogue.
+//
+// The chapter's central image: every technology is a fabric,
+// and Lynx is the loom that weaves them into the platforms.
+// One persistent canvas lives *under* the slides inside the
+// fixed 1280×720 frame; a slide opts in with data-weave="…"
+// and the engine TWEENS the whole thread field between
+// scenes, so adjacent weave slides read as one continuous
+// magic move of the threads themselves:
+//
+//   fabric         Vue alone — glowing green threads
+//   fabric-dense   the same fabric, tighter weave
+//   loom           Vue pinches through Lynx → iOS/Android/Web
+//   loom-dim       the loom, faded to a backdrop
+//   compress       the model's wide choice space → the idiom
+//   panorama-left  the whole web ecosystem weaves in
+//   panorama       …and fans out into every platform
+//   finale         the panorama as a quiet backdrop
+//
+// Geometry is authored in the 1280×720 design space (same as
+// the slides); lane fractions are MIRRORED by .wlab positions
+// in index.html, so DOM labels sit exactly on their bundles.
+// The backing store scales with devicePixelRatio × stage
+// scale so threads stay crisp on any screen.
+// =========================================================
+
+const W = 1280;
+const H = 720;
+const XW = 0.5; // the waist — where the Lynx mark sits
+const YW = 0.5;
+const SAMPLES = 44;
+const TWEEN_MS = 1150;
+const FADE_MS = 450;
+const TAU = Math.PI * 2;
+
+// Deterministic per-thread jitter — no Math.random, so every
+// run (and both speaker/audience windows) draws the same weave.
+const rnd = (i, salt = 0) => {
+  const x = Math.sin(i * 127.1 + salt * 311.7 + 17.13) * 43758.5453;
+  return x - Math.floor(x);
+};
+const lerp = (a, b, u) => a + (b - a) * u;
+const clamp01 = (u) => Math.max(0, Math.min(1, u));
+const smooth = (u) => {
+  const v = clamp01(u);
+  return v * v * (3 - 2 * v);
+};
+const easeInOut = (u) => (u < 0.5 ? 4 * u * u * u : 1 - ((-2 * u + 2) ** 3) / 2);
+const hex = (h) => [1, 3, 5].map((k) => Number.parseInt(h.slice(k, k + 2), 16));
+
+const PAL = {
+  vue: '#42b883', teal: '#3deae7',
+  react: '#61dafb', svelte: '#ff9a4d', solid: '#ffd166', octane: '#ff5468',
+  css: '#8a63d2', tailwind: '#38bdf8', motion: '#f7e14d', rspack: '#ff7a1a',
+  ios: '#cdd6e4', android: '#3ddc84', web: '#56b8f0', harmony: '#ff6f61',
+  macos: '#aab4c8', windows: '#2f7fe0', linux: '#f5c04a', more: '#8b93a3',
+};
+
+// Lane fractions — keep in sync with the .wlab tops in index.html.
+const ECO = [
+  { c: 'vue', y: 0.16, n: 6, a: 1 },
+  { c: 'react', y: 0.25, n: 5, a: 0.95 },
+  { c: 'svelte', y: 0.33, n: 3, a: 0.55 },
+  { c: 'solid', y: 0.40, n: 3, a: 0.5 },
+  { c: 'octane', y: 0.47, n: 3, a: 0.85 },
+  { c: 'css', y: 0.55, n: 4, a: 0.9 },
+  { c: 'tailwind', y: 0.63, n: 3, a: 0.85 },
+  { c: 'motion', y: 0.71, n: 3, a: 0.7 },
+  { c: 'rspack', y: 0.80, n: 4, a: 0.9 },
+];
+const PLAT = [
+  { c: 'ios', y: 0.16 }, { c: 'android', y: 0.257 }, { c: 'web', y: 0.354 },
+  { c: 'harmony', y: 0.451 }, { c: 'macos', y: 0.549 }, { c: 'windows', y: 0.646 },
+  { c: 'linux', y: 0.743 }, { c: 'more', y: 0.84 },
+];
+
+const inkColor = () =>
+  document.documentElement.classList.contains('light') ? [42, 48, 58] : [214, 222, 232];
+
+// A thread's tweenable state is a flat numeric record — colors are
+// split into channels so one generic lerp covers everything.
+function mk(o) {
+  const [sr, sg, sb] = o.src;
+  const [dr, dg, db] = o.dst || o.src;
+  return {
+    alpha: 1, width: 1.5, yL: 0.5, yR: 0.5, ampL: 22, ampR: 22,
+    waist: 0, aL: 0.3, aR: 0.3, braid: 0, shim: 0,
+    ...o, src: undefined, dst: undefined,
+    sr, sg, sb, dr, dg, db,
+  };
+}
+
+function fabricScene(n, band) {
+  const g = hex(PAL.vue);
+  const t = hex(PAL.teal);
+  const out = [];
+  for (let i = 0; i < n; i++) {
+    const mix = rnd(i, 9) * 0.45;
+    const c = g.map((v, k) => Math.round(lerp(v, t[k], mix)));
+    out.push(mk({
+      src: c, dst: c,
+      yL: lerp(band[0], band[1], rnd(i, 1)),
+      yR: lerp(band[0], band[1], rnd(i, 2)),
+      ampL: 16 + rnd(i, 3) * 22, ampR: 16 + rnd(i, 4) * 22,
+      alpha: 0.55 + rnd(i, 5) * 0.4,
+      width: 1.3 + rnd(i, 6) * 0.9,
+      aL: 0.1, aR: 0.1,
+      shim: rnd(i, 7) < 0.6 ? 1 : 0,
+    }));
+  }
+  return out;
+}
+
+function loomScene(dim) {
+  const src = hex(PAL.vue);
+  const lanes = ['ios', 'android', 'web'];
+  const laneY = [0.30, 0.50, 0.70];
+  const out = [];
+  for (let i = 0; i < 12; i++) {
+    const li = i % 3;
+    out.push(mk({
+      src, dst: hex(PAL[lanes[li]]),
+      yL: lerp(0.34, 0.66, (i + 0.5) / 12) + (rnd(i, 1) - 0.5) * 0.02,
+      yR: laneY[li] + (rnd(i, 2) - 0.5) * 0.05,
+      waist: 1, braid: 7,
+      ampL: 8 + rnd(i, 3) * 9, ampR: 5 + rnd(i, 4) * 5,
+      alpha: (0.7 + rnd(i, 5) * 0.3) * dim,
+      width: 1.5, aL: 0.55, aR: 0.75,
+      shim: rnd(i, 7) < 0.7 ? 1 : 0,
+    }));
+  }
+  return out;
+}
+
+// The steering image: a wide, gray, chaotic left half — everything
+// the model *could* emit — pulled through the waist into a narrow
+// bright idiom. Ink is resolved at build time; the theme observer
+// re-issues the scene so a mid-slide theme flip re-inks the noise.
+function compressScene() {
+  const ink = inkColor();
+  const dst = hex(PAL.vue);
+  const out = [];
+  for (let i = 0; i < 30; i++) {
+    out.push(mk({
+      src: ink, dst,
+      yL: 0.5 + (rnd(i, 1) - 0.5) * 0.82,
+      yR: 0.5 + ((i % 6) - 2.5) * 0.016 + (rnd(i, 2) - 0.5) * 0.008,
+      waist: 0.9, braid: 4,
+      ampL: 26 + rnd(i, 3) * 26, ampR: 3,
+      alpha: 0.4 + rnd(i, 5) * 0.3,
+      width: 1.2, aL: 0.08, aR: 0.9,
+      shim: rnd(i, 7) < 0.25 ? 1 : 0,
+    }));
+  }
+  return out;
+}
+
+function panoramaScene({ rightA = 1, dim = 1 }) {
+  const out = [];
+  let i = 0;
+  for (const g of ECO) {
+    const src = hex(PAL[g.c]);
+    for (let k = 0; k < g.n; k++, i++) {
+      const pl = PLAT[Math.floor(rnd(i, 11) * PLAT.length) % PLAT.length];
+      out.push(mk({
+        src,
+        // Before the right side "blossoms", threads trail off dim and
+        // uncommitted near the waist line instead of claiming a platform.
+        dst: rightA < 0.5 ? src : hex(PAL[pl.c]),
+        yL: g.y + (k - (g.n - 1) / 2) * 0.014 + (rnd(i, 1) - 0.5) * 0.006,
+        yR: rightA < 0.5
+          ? 0.5 + (rnd(i, 2) - 0.5) * 0.10
+          : pl.y + (rnd(i, 2) - 0.5) * 0.05,
+        waist: 1, braid: 6,
+        ampL: 6 + rnd(i, 3) * 9, ampR: 5 + rnd(i, 4) * 7,
+        alpha: g.a * dim * (0.75 + rnd(i, 5) * 0.25),
+        width: 1.35, aL: 0.5, aR: rightA * 0.7 + 0.04,
+        shim: rnd(i, 7) < (dim < 0.5 ? 0.2 : 0.5) ? 1 : 0,
+      }));
+    }
+  }
+  return out;
+}
+
+// Built lazily per setScene call (cheap, deterministic) so theme-
+// dependent colors resolve against the *current* theme.
+const SCENES = {
+  fabric: () => fabricScene(10, [0.32, 0.68]),
+  'fabric-dense': () => fabricScene(22, [0.26, 0.74]),
+  loom: () => loomScene(1),
+  'loom-dim': () => loomScene(0.22),
+  compress: () => compressScene(),
+  'panorama-left': () => panoramaScene({ rightA: 0, dim: 1 }),
+  panorama: () => panoramaScene({ rightA: 1, dim: 1 }),
+  finale: () => panoramaScene({ rightA: 1, dim: 0.3 }),
+};
+
+const POOL_N = Math.max(...Object.keys(SCENES).map((k) => SCENES[k]().length));
+const TWEEN_KEYS = [
+  'alpha', 'width', 'yL', 'yR', 'ampL', 'ampR', 'waist',
+  'aL', 'aR', 'braid', 'shim', 'sr', 'sg', 'sb', 'dr', 'dg', 'db',
+];
+
+export function initWeave(frame, { getScale, reducedMotion = false, embed = false } = {}) {
+  const canvas = document.createElement('canvas');
+  canvas.className = 'weave-canvas';
+  canvas.setAttribute('aria-hidden', 'true');
+  frame.prepend(canvas);
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return { setScene: () => {}, destroy: () => {} };
+
+  const still = reducedMotion || embed;
+
+  // Per-thread motion constants (never tweened).
+  const motion = Array.from({ length: POOL_N }, (_, i) => ({
+    phase: rnd(i, 20) * TAU,
+    speed: 0.5 + rnd(i, 21) * 0.9,
+    freq: TAU * (1.1 + rnd(i, 22) * 1.6),
+    braidHz: 1.1 + rnd(i, 23) * 0.7,
+    shimSpeed: 0.10 + rnd(i, 24) * 0.10,
+    shimOff: rnd(i, 25),
+  }));
+
+  const hidden = (base) => ({ ...base, alpha: 0 });
+  const seed = SCENES.fabric();
+  const pool = Array.from({ length: POOL_N }, (_, i) => ({
+    cur: hidden(seed[i % seed.length]),
+    from: null,
+    to: null,
+  }));
+
+  let scene = null;
+  let tweenT0 = 0;
+  let tweening = false;
+  let fade = 0;
+  let fadeFrom = 0;
+  let fadeTo = 0;
+  let fadeT0 = 0;
+  let raf = 0;
+
+  function resize() {
+    const scale = Math.max(0.4, getScale?.() || 1);
+    const q = Math.min(2.4, (window.devicePixelRatio || 1) * scale);
+    canvas.width = Math.round(W * q);
+    canvas.height = Math.round(H * q);
+    ctx.setTransform(q, 0, 0, q, 0, 0);
+    if (still) draw(4.2);
+  }
+  // fitStage also runs on resize — defer one frame so getScale()
+  // reads the post-fit value.
+  const onResize = () => requestAnimationFrame(resize);
+  window.addEventListener('resize', onResize);
+  resize();
+
+  // Theme flips re-ink theme-dependent scenes (compress) and, in
+  // reduced-motion mode, trigger the one static redraw.
+  const themeObs = new MutationObserver(() => {
+    if (scene) setScene(scene, true);
+  });
+  themeObs.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+
+  const pts = new Float64Array((SAMPLES + 1) * 2);
+
+  function samplePts(th, m, t) {
+    for (let s = 0; s <= SAMPLES; s++) {
+      const xn = -0.02 + (1.04 * s) / SAMPLES;
+      const u = clamp01(xn);
+      const line = lerp(th.yL, th.yR, smooth(u));
+      let y = line;
+      if (th.waist > 0.002) {
+        const pin = u < XW
+          ? lerp(th.yL, YW, smooth(u / XW))
+          : lerp(YW, th.yR, smooth((u - XW) / (1 - XW)));
+        y = lerp(line, pin, th.waist);
+      }
+      y *= H;
+      const pinchG = Math.exp(-((u - XW) ** 2) / (2 * 0.055 ** 2));
+      const env = smooth(u / 0.10) * smooth((1 - u) / 0.10)
+        * (1 - th.waist * pinchG * 0.85);
+      const amp = lerp(th.ampL, th.ampR, smooth(u));
+      y += amp * Math.sin(xn * m.freq + m.phase + t * m.speed) * env;
+      // Interlace right at the waist — the threads visibly cross each
+      // other as they pass through the loom.
+      y += th.braid * Math.sin(t * m.braidHz + m.phase * 7.31) * pinchG;
+      pts[s * 2] = xn * W;
+      pts[s * 2 + 1] = y;
+    }
+  }
+
+  function strokePts(a, b) {
+    ctx.beginPath();
+    ctx.moveTo(pts[a * 2], pts[a * 2 + 1]);
+    for (let s = a + 1; s <= b; s++) ctx.lineTo(pts[s * 2], pts[s * 2 + 1]);
+    ctx.stroke();
+  }
+
+  function draw(t) {
+    ctx.clearRect(0, 0, W, H);
+    if (fade <= 0.004) return;
+    const light = document.documentElement.classList.contains('light');
+    // Bright neon washes out on paper — pull colors toward ink instead.
+    const cf = light ? 0.68 : 1;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+
+    for (let i = 0; i < POOL_N; i++) {
+      const th = pool[i].cur;
+      const m = motion[i];
+      const a = th.alpha * fade;
+      if (a <= 0.004) continue;
+      samplePts(th, m, t);
+
+      const sc = `${Math.round(th.sr * cf)},${Math.round(th.sg * cf)},${Math.round(th.sb * cf)}`;
+      const dc = `${Math.round(th.dr * cf)},${Math.round(th.dg * cf)},${Math.round(th.db * cf)}`;
+      const grad = ctx.createLinearGradient(0, 0, W, 0);
+      grad.addColorStop(0, `rgba(${sc},${th.aL})`);
+      grad.addColorStop(0.4, `rgba(${sc},1)`);
+      grad.addColorStop(0.6, `rgba(${dc},1)`);
+      grad.addColorStop(1, `rgba(${dc},${th.aR})`);
+      ctx.strokeStyle = grad;
+
+      if (!light) {
+        // Additive glow pass, dark theme only.
+        ctx.globalCompositeOperation = 'lighter';
+        ctx.globalAlpha = a * 0.14;
+        ctx.lineWidth = th.width * 3.6;
+        strokePts(0, SAMPLES);
+      }
+      ctx.globalCompositeOperation = light ? 'source-over' : 'lighter';
+      ctx.globalAlpha = light ? a * 0.9 : a;
+      ctx.lineWidth = th.width;
+      strokePts(0, SAMPLES);
+
+      // Traveling shimmer — a short bright run pulled along the thread,
+      // the "being woven" motion.
+      if (th.shim > 0.05 && !still) {
+        const hs = ((t * m.shimSpeed + m.shimOff) % 1.3) - 0.15;
+        const a0 = Math.max(0, Math.ceil(((hs + 0.02) / 1.04) * SAMPLES));
+        const b0 = Math.min(SAMPLES, Math.floor(((hs + 0.12) / 1.04) * SAMPLES));
+        if (b0 > a0) {
+          const edge = smooth((hs + 0.1) / 0.2) * smooth((1.1 - hs) / 0.2);
+          const c = hs < 0.5 ? [th.sr, th.sg, th.sb] : [th.dr, th.dg, th.db];
+          const bright = c.map((v) => Math.round(lerp(v * cf, light ? 30 : 255, 0.6)));
+          ctx.strokeStyle = `rgb(${bright.join(',')})`;
+          ctx.globalAlpha = a * th.shim * edge * 0.9;
+          ctx.lineWidth = th.width * 1.8;
+          strokePts(a0, b0);
+        }
+      }
+    }
+    ctx.globalAlpha = 1;
+    ctx.globalCompositeOperation = 'source-over';
+  }
+
+  function tick(nowMs) {
+    raf = 0;
+    const now = nowMs / 1000;
+    if (tweening) {
+      const p = clamp01((nowMs - tweenT0) / TWEEN_MS);
+      const e = easeInOut(p);
+      for (const th of pool) {
+        for (const k of TWEEN_KEYS) th.cur[k] = lerp(th.from[k], th.to[k], e);
+      }
+      if (p >= 1) tweening = false;
+    }
+    if (fade !== fadeTo) {
+      const p = clamp01((nowMs - fadeT0) / FADE_MS);
+      fade = lerp(fadeFrom, fadeTo, smooth(p));
+      if (p >= 1) fade = fadeTo;
+    }
+    draw(now);
+    const alive = tweening || fade !== fadeTo || (fade > 0.004 && !still);
+    if (alive) raf = requestAnimationFrame(tick);
+  }
+
+  function kick() {
+    if (!raf) raf = requestAnimationFrame(tick);
+  }
+
+  function setScene(name, force = false) {
+    if (name === scene && !force) return;
+    scene = SCENES[name] ? name : null;
+    const now = performance.now();
+
+    if (scene) {
+      const target = SCENES[scene]();
+      for (let i = 0; i < POOL_N; i++) {
+        pool[i].from = { ...pool[i].cur };
+        pool[i].to = target[i] ? { ...target[i] } : hidden(pool[i].cur);
+      }
+      tweenT0 = now;
+      tweening = true;
+      fadeFrom = fade;
+      fadeTo = 1;
+      fadeT0 = now;
+    } else {
+      fadeFrom = fade;
+      fadeTo = 0;
+      fadeT0 = now;
+    }
+
+    if (still) {
+      // Reduced motion / embed previews: snap and paint one frame.
+      for (const th of pool) if (th.to) th.cur = { ...th.to };
+      tweening = false;
+      fade = fadeTo;
+      draw(4.2);
+      return;
+    }
+    kick();
+  }
+
+  function destroy() {
+    if (raf) cancelAnimationFrame(raf);
+    window.removeEventListener('resize', onResize);
+    themeObs.disconnect();
+    canvas.remove();
+  }
+
+  return { setScene, destroy };
+}


### PR DESCRIPTION
## Summary

Extends the deck with the real second half — a 28-slide epilogue chapter on AI, fabrics, and the case for weaving — plus a universal overlay/media-embed system used to layer videos, photos, and live iframes over existing slides. The pre-existing thank-you slide becomes a fake close; advancing past it opens the chapter. Deck grows 78 → 116 slides.

## Key Changes

**Epilogue content**: "The elephant in the room" — why frameworks and cross-platform tech matter in the AI era. Two lemmas: (1) technology's role flips from interface to harness; (2) technology's real job is connecting ecosystems and people (frameworks as semantic compression layers for models). One-more-thing beat on Vapor-on-Lynx, then a personal coda ending on 前端永生 ("Long live the frontend").

**Weave visualization system** (`slides/src/weave.js`): persistent canvas layer under the slides; slides opt in via `data-weave="…"`. 8 scenes (fabric, fabric-dense, loom, loom-dim, compress, panorama-left, panorama, finale) with deterministic seeded geometry — the whole thread field tweens between scenes on navigation (~1.15s), so adjacent weave slides read as one continuous magic move. Sine-based drift + traveling shimmer, interlacing at the "waist" where the ink-colored Lynx mark sits, threads gradient from source color (Vue, React, …) to platform color (iOS, Android, …). Theme-aware (additive glow in dark, ink-pulled colors in light, compress re-inks on theme flip); reduced-motion/embed render one static frame.

**Overlay slides + `<vl-media>` embeds** (`slides/src/embeds.js`): an `.overlay` slide keeps its base slide rendered beneath (`is-under`) and inherits its weave scene — media reads as "the same page, plus a layer". `<vl-media>` embeds video/image/iframe with: video reset on every slide change (pause + rewind; autoplay on arrival, `data-autoplay="false"` opt-out; muted/loop defaults with `unmuted`/`no-loop`/`controls` overrides), iframes mounted at distance ≤ 1 and unloaded at ≥ 2, and labeled missing-file placeholders so slides are authored before assets exist (`public/media/embeds/README.md` lists the drop-ins). `.phone--embed` reuses the demo mockups' drag-to-resize grips + preset switcher with embed-shaped presets.

Inserted media sequences: a three-step cascade (two clips + photo) over the React + Vue marks; the 2016 PWA talk as a live resizable iframe over the Web triangle; the Karpathy vibe-coding tweet crop-panned (top half → bottom half, slight zoom via FLIP) over the ∞ divider; the Germany three-up (photos + vertical clip) and Pokémon clip over the coda quote.

**Styling** (`slides/src/styles.css`): weave layer (`.weave-canvas`, `.weave-kicker`, `.wlab`, `.wlynx`), epilogue components (`.tiles`, `.wquote`, `.wgrid`, `.fin-dead`), overlay/embed chrome (`.slide.is-under`, `.phone--embed`, `vl-media` + `.vl-ph` placeholder, `.crop` pan window, `.snap` polaroids).

**Internationalization** (`slides/src/i18n.js`): ZH strings for every new surface; speaker notes inserted/appended in document order — verified 116 sections = 116 asides = 116 ZH_NOTES.

**Integration** (`slides/src/main.js`): weave engine + embeds init, `deck:change` wiring, overlay `is-under` logic, I18N selector extensions.

**Docs** (`slides/README.md`): "The weave layer" and "Overlay slides & media embeds" sections.

## Verification

- `pnpm build` green; Playwright keyboard-walks of every new transition (epilogue 78→106 pre-shift, overlay sequences 1→11 / 84→89 / 110→115) with zero page errors
- iframe proximity behavior asserted (mounted on its slide, unloaded two slides later)
- All new layouts screenshot-reviewed in dark; loom verified in light; panorama + finale verified in Chinese

## Open items

- Drop the actual media files into `slides/public/media/embeds/` (exact names + shapes listed in that directory's README; every slot shows a labeled placeholder until then)
- The PWA-talk iframe needs venue network; its frame has an ↗ open-in-new-tab fallback
- Vapor-on-Lynx speaker notes describe it as design sketch / early experiments; adjust if further along

https://claude.ai/code/session_017PfEoLVhtqJM122yw7emE8