### PR TITLE
feat(slides): epilogue design-space — static/dynamic spectrum + the async cut

### DIFF
--- a/slides/index.html
+++ b/slides/index.html
@@ -2651,6 +2651,104 @@
     </aside>
   </section>
 
+  <!-- E20b — design space · the static/dynamic spectrum -->
+  <section class="slide stage dspace">
+    <span class="eyebrow">One more thing &middot; the design space</span>
+    <h2 class="h-section" style="text-align:center;max-width:22ch">
+      A template is part <span style="color:#5dd5a8">static</span>, part <span style="color:#E8B44A">dynamic</span>.
+    </h2>
+    <div class="dsplit">
+      <div>
+        <div class="codeframe" style="width:100%">
+          <div class="codeframe__head">
+            <span class="dots"><span></span><span></span><span></span></span>
+            <span>card.vue · by binding time</span>
+          </div>
+<pre><span class="code-static">&lt;view class="card"&gt;</span>
+<span class="code-static">  &lt;image class="icon" src="…" /&gt;</span>
+<span class="code-static">  &lt;view class="body"&gt;</span>
+<span class="code-static">    &lt;text&gt;</span><span class="code-dyn">{{ title }}</span><span class="code-static">&lt;/text&gt;</span>
+<span class="code-static">    &lt;text&gt;Static description&lt;/text&gt;</span>
+<span class="code-static">  &lt;/view&gt;</span>
+<span class="code-static">&lt;/view&gt;</span></pre>
+        </div>
+        <div class="ds-legend" data-mm-fade>
+          <span class="k"><span class="sw" style="background:#5dd5a8"></span>static &middot; known when you write it</span>
+          <span class="k"><span class="sw" style="background:#E8B44A"></span>dynamic &middot; known only at runtime</span>
+        </div>
+      </div>
+      <div class="track" data-mm-fade>
+        <div class="track__line"></div>
+        <div class="track__stops">
+          <div class="stop">
+            <span class="stop__dot" style="border-color:#4FB8F0"></span>
+            <span class="stop__name">VDOM</span>
+            <span class="stop__sub">interpret + diff · re-discover each update</span>
+          </div>
+          <div class="stop">
+            <span class="stop__dot" style="border-color:#42b883"></span>
+            <span class="stop__name">Vapor</span>
+            <span class="stop__sub">wire it into create-time · O(1) update</span>
+          </div>
+          <div class="stop">
+            <span class="stop__dot" style="border-color:#8a63d2"></span>
+            <span class="stop__name">Element Templates</span>
+            <span class="stop__sub">bake the static shell to code</span>
+          </div>
+        </div>
+        <div class="track__ends">
+          <span>resolve at runtime</span>
+          <span>resolve at compile time</span>
+        </div>
+      </div>
+    </div>
+    <p class="lead" data-mm-fade style="text-align:center;max-width:52ch">
+      One question splits every renderer: <b>when</b> is &ldquo;what changes&rdquo; resolved?
+    </p>
+    <aside class="notes">
+      <p><strong>The design space, in one picture.</strong> A template is a mixed-stage program: the green parts (tags, classes, static text) are fixed the moment you write them; only <code>{{ title }}</code> waits for a runtime value. This is binding-time analysis — coloring = annotating.</p>
+      <p>Every renderer holds the <em>same</em> knowledge; they differ only in <em>when</em> they resolve the dynamic part. VDOM re-discovers it each update by diffing. Vapor wires it into create-time so updates are O(1). Element Templates bake the static shell all the way down to code. Same spectrum, different coordinates — VDOM, Vapor, and ET aren't rival inventions, they're points in one space.</p>
+    </aside>
+  </section>
+
+  <!-- E20c — design space · the async cut (thread boundary) -->
+  <section class="slide stage dspace">
+    <span class="eyebrow">One more thing &middot; the design space</span>
+    <h2 class="h-section" style="text-align:center;max-width:24ch">
+      Cut a thread — what can cross the wire?
+    </h2>
+    <div class="dboundary">
+      <div class="drealm">
+        <div class="drealm__t">BG · background thread · the program</div>
+        <ul class="xfer">
+          <li><span class="ok">✓</span><span class="lbl"><b>first-order data</b> — numbers, strings, plain objects</span></li>
+          <li><span class="ok">✓</span><span class="lbl"><b>names</b> — ids, template no., event signs</span></li>
+          <li><span class="no">✗</span><span class="lbl"><b>pointers</b> — <code>nthChild(root,1)</code>, only local</span></li>
+          <li><span class="no">✗</span><span class="lbl"><b>closures</b> — <code>effect(fn)</code> captures the heap</span></li>
+        </ul>
+      </div>
+      <div class="dwall"><span>serialization boundary</span></div>
+      <div class="drealm">
+        <div class="drealm__t">MT · main thread · the tree</div>
+        <div class="opstream">
+          <span class="op">CREATE 2 view</span>
+          <span class="op">SET_CLASS 2 "card"</span>
+          <span class="op dyn">SET_TEXT 6 "Hello"</span>
+          <span class="op">INSERT 1 2 -1</span>
+          <span class="op">…</span>
+        </div>
+        <p class="dboundary__cap">one flat <b>ops stream</b> crosses &mdash; and that stream <em>is</em> a display list.</p>
+      </div>
+    </div>
+    <p class="lead" data-mm-fade style="text-align:center;max-width:56ch">
+      Only closed, first-order terms survive the cut. Pointers and closures don&rsquo;t.
+    </p>
+    <aside class="notes">
+      <p><strong>The async cut.</strong> The dual-thread split is architected async — like the browser handing compositing to its own thread. The catch: the tree (MT) and the program that drives it (BG) no longer share an address space. So what can cross the serialization boundary? Only closed, first-order terms — data and names. Pointers are meaningful only in the local heap; closures capture an environment the other side doesn't have.</p>
+      <p>That leaves exactly one shape for what crosses: a flat, closed, first-order <strong>ops stream</strong> — which is precisely a <em>display list</em>. It's not an implementation detail; it's the constitution of the whole architecture (and why Vapor-on-Lynx emits ops directly).</p>
+    </aside>
+  </section>
+
   <!-- E21 — FABRIC III · panorama, left half -->
   <section class="slide weave" data-bg="clean" data-chrome="none" data-weave="panorama-left">
     <p class="weave-kicker">Weave the whole Web&hellip;</p>

--- a/slides/index.html
+++ b/slides/index.html
@@ -3301,10 +3301,20 @@ app.<span class="code-fn">use</span>(router)</pre>
       <div class="node" data-flip="vx-bg">
         <span class="node__label"><span class="dot"></span>Background · Vapor</span>
         <h3 class="node__title">template()</h3>
-        <ul class="node__list">
-          <li>parse the static shape</li>
-          <li>walk pre-order &rarr; uids</li>
-        </ul>
+        <svg class="dtree" viewBox="0 0 300 170" role="img" aria-label="card template walked pre-order, uid 2 to 7">
+          <line class="edge" x1="150" y1="28" x2="46" y2="60"/>
+          <line class="edge" x1="150" y1="28" x2="212" y2="60"/>
+          <line class="edge" x1="212" y1="82" x2="156" y2="114"/>
+          <line class="edge" x1="212" y1="82" x2="254" y2="114"/>
+          <line class="edge" x1="157" y1="136" x2="157" y2="148"/>
+          <g><rect class="nodebox st" x="120" y="6" width="60" height="22" rx="5"/><text class="tag" x="131" y="21">card</text><rect class="uidbg" x="158" y="0" width="20" height="14" rx="6"/><text class="uid" x="164" y="11">2</text></g>
+          <g><rect class="nodebox st" x="16" y="60" width="60" height="22" rx="5"/><text class="tag" x="30" y="75">icon</text><rect class="uidbg" x="54" y="54" width="20" height="14" rx="6"/><text class="uid" x="60" y="65">3</text></g>
+          <g><rect class="nodebox st" x="182" y="60" width="60" height="22" rx="5"/><text class="tag" x="194" y="75">body</text><rect class="uidbg" x="220" y="54" width="20" height="14" rx="6"/><text class="uid" x="226" y="65">4</text></g>
+          <g><rect class="nodebox st" x="126" y="114" width="60" height="22" rx="5"/><text class="tag" x="137" y="129">title</text><rect class="uidbg" x="164" y="108" width="20" height="14" rx="6"/><text class="uid" x="170" y="119">5</text></g>
+          <g><rect class="nodebox dy" x="133" y="148" width="48" height="18" rx="5"/><text class="tag" x="140" y="161" style="font-size:9px">#text</text><rect class="uidbg" x="185" y="147" width="20" height="14" rx="6"/><text class="uid" x="191" y="158">6</text></g>
+          <g><rect class="nodebox st" x="224" y="114" width="60" height="22" rx="5"/><text class="tag" x="236" y="129">desc</text><rect class="uidbg" x="262" y="108" width="20" height="14" rx="6"/><text class="uid" x="268" y="119">7</text></g>
+        </svg>
+        <span class="node__cap">parse &amp; walk pre-order &rarr; <b>uids</b></span>
       </div>
       <div class="xwire">
         <div class="xwire__op">
@@ -3317,14 +3327,24 @@ app.<span class="code-fn">use</span>(router)</pre>
       <div class="node node--main" data-flip="vx-mt">
         <span class="node__label"><span class="dot"></span>Main · interpreter</span>
         <h3 class="node__title">inert prototype</h3>
-        <ul class="node__list">
-          <li>cache the structure</li>
-          <li>same pre-order &rarr; uids</li>
-        </ul>
+        <svg class="dtree" viewBox="0 0 300 170" role="img" aria-label="cached prototype, same pre-order uids 2 to 7">
+          <line class="edge" x1="150" y1="28" x2="46" y2="60"/>
+          <line class="edge" x1="150" y1="28" x2="212" y2="60"/>
+          <line class="edge" x1="212" y1="82" x2="156" y2="114"/>
+          <line class="edge" x1="212" y1="82" x2="254" y2="114"/>
+          <line class="edge" x1="157" y1="136" x2="157" y2="148"/>
+          <g><rect class="nodebox st" x="120" y="6" width="60" height="22" rx="5"/><text class="tag" x="131" y="21">card</text><rect class="uidbg" x="158" y="0" width="20" height="14" rx="6"/><text class="uid" x="164" y="11">2</text></g>
+          <g><rect class="nodebox st" x="16" y="60" width="60" height="22" rx="5"/><text class="tag" x="30" y="75">icon</text><rect class="uidbg" x="54" y="54" width="20" height="14" rx="6"/><text class="uid" x="60" y="65">3</text></g>
+          <g><rect class="nodebox st" x="182" y="60" width="60" height="22" rx="5"/><text class="tag" x="194" y="75">body</text><rect class="uidbg" x="220" y="54" width="20" height="14" rx="6"/><text class="uid" x="226" y="65">4</text></g>
+          <g><rect class="nodebox st" x="126" y="114" width="60" height="22" rx="5"/><text class="tag" x="137" y="129">title</text><rect class="uidbg" x="164" y="108" width="20" height="14" rx="6"/><text class="uid" x="170" y="119">5</text></g>
+          <g><rect class="nodebox dy" x="133" y="148" width="48" height="18" rx="5"/><text class="tag" x="140" y="161" style="font-size:9px">#text</text><rect class="uidbg" x="185" y="147" width="20" height="14" rx="6"/><text class="uid" x="191" y="158">6</text></g>
+          <g><rect class="nodebox st" x="224" y="114" width="60" height="22" rx="5"/><text class="tag" x="236" y="129">desc</text><rect class="uidbg" x="262" y="108" width="20" height="14" rx="6"/><text class="uid" x="268" y="119">7</text></g>
+        </svg>
+        <span class="node__cap">same walk &rarr; <b>same uids</b></span>
       </div>
     </div>
     <p class="lead" data-mm-fade>
-      The static structure crosses <em>once</em> — not one op per element.
+      Pointers can&rsquo;t cross the boundary — so both sides <em>walk the same pre-order</em> and name every node alike. No id map is ever sent.
     </p>
     <aside class="notes">
       <p><strong>The problem first.</strong> Vapor's primitive is "clone a template, then bind." Naively, every cloned element would be its own create/append op — Vapor's cross-thread traffic would be <em>worse</em> than vdom's.</p>
@@ -3339,10 +3359,20 @@ app.<span class="code-fn">use</span>(router)</pre>
       <div class="node" data-flip="vx-bg">
         <span class="node__label"><span class="dot"></span>Background · Vapor</span>
         <h3 class="node__title">clone &times; 1,000</h3>
-        <ul class="node__list">
-          <li>one op per row</li>
-          <li>base uid only</li>
-        </ul>
+        <svg class="dtree" viewBox="0 0 300 170" role="img" aria-label="clone from base uid 2">
+          <line class="edge" x1="150" y1="28" x2="46" y2="60"/>
+          <line class="edge" x1="150" y1="28" x2="212" y2="60"/>
+          <line class="edge" x1="212" y1="82" x2="156" y2="114"/>
+          <line class="edge" x1="212" y1="82" x2="254" y2="114"/>
+          <line class="edge" x1="157" y1="136" x2="157" y2="148"/>
+          <g><rect class="nodebox st" x="120" y="6" width="60" height="22" rx="5" style="stroke:var(--ds-name);stroke-width:2"/><text class="tag" x="131" y="21">card</text><rect class="uidbg" x="150" y="0" width="30" height="14" rx="6"/><text class="uid" x="156" y="11">2</text></g>
+          <g class="ghost"><rect class="nodebox st" x="16" y="60" width="60" height="22" rx="5"/><text class="tag" x="30" y="75">icon</text></g>
+          <g class="ghost"><rect class="nodebox st" x="182" y="60" width="60" height="22" rx="5"/><text class="tag" x="194" y="75">body</text></g>
+          <g class="ghost"><rect class="nodebox st" x="126" y="114" width="60" height="22" rx="5"/><text class="tag" x="137" y="129">title</text></g>
+          <g class="ghost"><rect class="nodebox dy" x="133" y="148" width="48" height="18" rx="5"/><text class="tag" x="140" y="161" style="font-size:9px">#text</text></g>
+          <g class="ghost"><rect class="nodebox st" x="224" y="114" width="60" height="22" rx="5"/><text class="tag" x="236" y="129">desc</text></g>
+        </svg>
+        <span class="node__cap">one op per row &middot; <b>base uid 2</b></span>
       </div>
       <div class="xwire">
         <div class="xwire__op" style="opacity:.4">
@@ -3359,10 +3389,20 @@ app.<span class="code-fn">use</span>(router)</pre>
       <div class="node node--main" data-flip="vx-mt">
         <span class="node__label"><span class="dot"></span>Main · interpreter</span>
         <h3 class="node__title">clone &rarr; native</h3>
-        <ul class="node__list">
-          <li>re-walk from base uid</li>
-          <li>materialize real elements</li>
-        </ul>
+        <svg class="dtree" viewBox="0 0 300 170" role="img" aria-label="re-walk from base uid to materialize native elements">
+          <line class="edge" x1="150" y1="28" x2="46" y2="60"/>
+          <line class="edge" x1="150" y1="28" x2="212" y2="60"/>
+          <line class="edge" x1="212" y1="82" x2="156" y2="114"/>
+          <line class="edge" x1="212" y1="82" x2="254" y2="114"/>
+          <line class="edge" x1="157" y1="136" x2="157" y2="148"/>
+          <g><rect class="nodebox st" x="120" y="6" width="60" height="22" rx="5"/><text class="tag" x="131" y="21">card</text><rect class="uidbg" x="158" y="0" width="20" height="14" rx="6"/><text class="uid" x="164" y="11">2</text></g>
+          <g><rect class="nodebox st" x="16" y="60" width="60" height="22" rx="5"/><text class="tag" x="30" y="75">icon</text><rect class="uidbg" x="54" y="54" width="20" height="14" rx="6"/><text class="uid" x="60" y="65">3</text></g>
+          <g><rect class="nodebox st" x="182" y="60" width="60" height="22" rx="5"/><text class="tag" x="194" y="75">body</text><rect class="uidbg" x="220" y="54" width="20" height="14" rx="6"/><text class="uid" x="226" y="65">4</text></g>
+          <g><rect class="nodebox st" x="126" y="114" width="60" height="22" rx="5"/><text class="tag" x="137" y="129">title</text><rect class="uidbg" x="164" y="108" width="20" height="14" rx="6"/><text class="uid" x="170" y="119">5</text></g>
+          <g><rect class="nodebox dy" x="133" y="148" width="48" height="18" rx="5"/><text class="tag" x="140" y="161" style="font-size:9px">#text</text><rect class="uidbg" x="185" y="147" width="20" height="14" rx="6"/><text class="uid" x="191" y="158">6</text></g>
+          <g><rect class="nodebox st" x="224" y="114" width="60" height="22" rx="5"/><text class="tag" x="236" y="129">desc</text><rect class="uidbg" x="262" y="108" width="20" height="14" rx="6"/><text class="uid" x="268" y="119">7</text></g>
+        </svg>
+        <span class="node__cap">re-walk from base &rarr; <b>native</b></span>
       </div>
     </div>
     <p class="lead" data-mm-fade>
@@ -3567,118 +3607,7 @@ app.<span class="code-fn">use</span>(router)</pre>
     </aside>
   </section>
 
-  <!-- E20 — the cradle -->
-  <section class="slide stage">
-    <span class="eyebrow">One more thing</span>
-    <h2 class="h-section" style="text-align:center;max-width:22ch">
-      A <span class="brand-text">cradle</span> for framework design.
-    </h2>
-    <p class="lead">A team that loves the Web &mdash; and dares to break it.</p>
-    <aside class="notes">
-      <p><strong>Why framework authors should care about Lynx.</strong> Lynx has made interesting — even controversial — design choices, and keeps making them: dual threads, MTS, a real CSS engine off the DOM. This is a team that loves the Web and has both the guts and the room to break it where it must.</p>
-      <p>For Vue specifically: a native platform with genuine room to run — the kind of space where a Vapor-native renderer is a weekend of vibing away.</p>
-    </aside>
-  </section>
-
-  <!-- E20b — design space · the retained→immediate spectrum -->
-  <section class="slide stage dspace">
-    <span class="eyebrow">One more thing &middot; the design space</span>
-    <h2 class="h-section" style="text-align:center;max-width:26ch">
-      One template — a whole <span class="brand-text">spectrum</span> of renderers.
-    </h2>
-    <div class="spectrum">
-      <div class="spectrum__bar">
-        <span class="spectrum__end left">retained mode<i>address &amp; mutate at runtime · needs pointers</i></span>
-        <span class="spectrum__end right">write-only<i>emit names · a display list</i></span>
-        <span class="spectrum__dot" style="left:12.5%;--c:#4FB8F0"></span>
-        <span class="spectrum__dot" style="left:37.5%;--c:#42b883"></span>
-        <span class="spectrum__dot" style="left:62.5%;--c:#8bd6a0"></span>
-        <span class="spectrum__dot" style="left:87.5%;--c:#a78fff"></span>
-      </div>
-      <div class="spectrum__stops">
-        <div class="sstop" style="--c:#4FB8F0">
-          <span class="sstop__name">React · VDOM</span>
-          <span class="sstop__sub">fully dynamic — interpret + diff</span>
-        </div>
-        <div class="sstop" style="--c:#42b883">
-          <span class="sstop__name">Vue · Block VDOM</span>
-          <span class="sstop__sub">compiler-hinted — skip the statics</span>
-        </div>
-        <div class="sstop" style="--c:#8bd6a0">
-          <span class="sstop__name">Vapor</span>
-          <span class="sstop__sub">compiled — <b>but keeps pointers</b> to address nodes</span>
-        </div>
-        <div class="sstop hot" style="--c:#a78fff">
-          <span class="sstop__name">Element Templates</span>
-          <span class="sstop__sub">write-only — paint it, then let go</span>
-        </div>
-      </div>
-      <div class="spectrum__braces">
-        <span class="brace ret">still retained — holds runtime pointers</span>
-        <span class="brace imm">write-only — names, not pointers</span>
-      </div>
-    </div>
-    <p class="lead" data-mm-fade style="text-align:center;max-width:60ch">
-      Even <b>Vapor</b> stays retained — it keeps pointers. But cross a thread up front and pointers can&rsquo;t follow — so Lynx lives at the write-only end.
-    </p>
-    <aside class="notes">
-      <p><strong>The design space is one wide spectrum</strong> — from fully retained to fully immediate. <strong>React VDOM</strong> is fully dynamic: interpret a tree and diff it every update. <strong>Vue</strong>'s compiler-hinted, block-based VDOM does better — blocks let it skip the static subtrees. <strong>Vapor</strong> looks like it compiled everything away, but it still reserves a slice for the in-browser runtime: pointers, used to <em>read</em> / address live nodes. So Vapor is still <em>retained mode</em>.</p>
-      <p><strong>Why that matters at a thread boundary.</strong> Retained pointers only survive a thread hop if the tree itself is shared: RN's Fabric keeps pointers in a C++ shadow tree that both sides reach. Lynx can't — we cross threads from the very first frame. <strong>Element Templates</strong> go the other way: write-only, one direction, much closer to an immediate-mode <em>display list</em>. That crosses threads beautifully — but the price is giving up dynamism on the MT side. Like a painting: you draw it once, then let the canvas go.</p>
-    </aside>
-  </section>
-
-  <!-- E20c — design space · the async cut (schematic) -->
-  <section class="slide stage dspace">
-    <span class="eyebrow">One more thing &middot; the design space</span>
-    <h2 class="h-section" style="text-align:center;max-width:24ch">
-      Cut a thread — what can cross the wire?
-    </h2>
-    <div class="dschem">
-      <svg viewBox="0 0 900 268" role="img" aria-label="What crosses the BG/MT serialization boundary: data and names cross as an ops stream; pointers and closures are blocked.">
-        <defs>
-          <marker id="dsArrow" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
-            <path d="M0,0 L9,4.5 L0,9 Z" fill="#5dd5a8"/>
-          </marker>
-        </defs>
-        <!-- BG realm -->
-        <rect class="box" x="28" y="40" width="326" height="196" rx="14"/>
-        <text class="lane" x="52" y="72">BG · the program</text>
-        <text class="ok" x="52" y="114" font-size="16">✓</text><text class="chip-t" x="76" y="114">first-order data</text>
-        <text class="ok" x="52" y="150" font-size="16">✓</text><text class="chip-t" x="76" y="150">names · ids, signs</text>
-        <text class="no" x="52" y="186" font-size="16">✗</text><text class="chip-t" x="76" y="186">pointers</text><text class="chip-s" x="212" y="186">local heap only</text>
-        <text class="no" x="52" y="222" font-size="16">✗</text><text class="chip-t" x="76" y="222">closures</text><text class="chip-s" x="212" y="222">capture the heap</text>
-        <!-- wall -->
-        <line class="wall" x1="452" y1="34" x2="452" y2="244"/>
-        <text class="walltag" x="452" y="139" transform="rotate(90 452 139)" text-anchor="middle">serialization boundary</text>
-        <!-- data + names cross as an ops stream -->
-        <path class="flow-ok" d="M356 108 L600 108"/>
-        <path class="flow-ok" d="M356 150 L600 150"/>
-        <text class="streamlbl" x="474" y="98">ops stream</text>
-        <!-- pointers + closures blocked at the wall -->
-        <path class="flow-no" d="M356 186 L438 186"/>
-        <text class="no" x="446" y="191" font-size="15">✗</text>
-        <path class="flow-no" d="M356 222 L438 222"/>
-        <text class="no" x="446" y="227" font-size="15">✗</text>
-        <!-- MT realm: the native tree it builds -->
-        <rect class="box" x="612" y="58" width="260" height="160" rx="14"/>
-        <text class="lane" x="636" y="90">MT · the tree</text>
-        <line class="edge" x1="742" y1="132" x2="686" y2="166"/>
-        <line class="edge" x1="742" y1="132" x2="800" y2="166"/>
-        <rect class="opnode" x="702" y="110" width="80" height="24" rx="6"/><text class="optext" x="718" y="126">view</text>
-        <rect class="opnode" x="648" y="164" width="76" height="22" rx="6"/><text class="optext" x="662" y="179">text</text>
-        <rect class="opnode dyn" x="764" y="164" width="76" height="22" rx="6"/><text class="optext" x="778" y="179">{{…}}</text>
-      </svg>
-    </div>
-    <p class="lead" data-mm-fade style="text-align:center;max-width:58ch">
-      Only closed, first-order terms survive the cut — a flat ops stream, i.e. a <b>display list</b>.
-    </p>
-    <aside class="notes">
-      <p><strong>The async cut.</strong> The dual-thread split is architected async — like the browser handing compositing to its own thread. The catch: the tree (MT) and the program that drives it (BG) no longer share an address space. So what can cross the serialization boundary? Only closed, first-order terms — data and names. Pointers are meaningful only in the local heap; closures capture an environment the other side doesn't have.</p>
-      <p>That leaves exactly one shape for what crosses: a flat, closed, first-order <strong>ops stream</strong> — which is precisely a <em>display list</em>. It's not an implementation detail; it's the constitution of the whole architecture (and why Vapor-on-Lynx emits ops directly).</p>
-    </aside>
-  </section>
-
-  <!-- E20d — design space · dense vs sparse naming -->
+  <!-- E20a — design space · Vapor tree vs ET (naming) -->
   <section class="slide stage dspace">
     <span class="eyebrow">One more thing &middot; the design space</span>
     <h2 class="h-section" style="text-align:center;max-width:24ch">
@@ -3736,6 +3665,93 @@ app.<span class="code-fn">use</span>(router)</pre>
     </aside>
   </section>
 
+  <!-- E20b — design space · the retained→write-only spectrum -->
+  <section class="slide stage dspace">
+    <span class="eyebrow">One more thing &middot; the design space</span>
+    <h2 class="h-section" style="text-align:center;max-width:26ch">
+      One template — a whole <span class="brand-text">spectrum</span> of renderers.
+    </h2>
+    <div class="spectrum">
+      <div class="spectrum__bar">
+        <span class="spectrum__end left">retained mode<i>address &amp; mutate at runtime · needs pointers</i></span>
+        <span class="spectrum__end right">write-only<i>emit names · a display list</i></span>
+        <span class="spectrum__dot" style="left:12.5%;--c:#4FB8F0"></span>
+        <span class="spectrum__dot" style="left:37.5%;--c:#42b883"></span>
+        <span class="spectrum__dot" style="left:62.5%;--c:#8bd6a0"></span>
+        <span class="spectrum__dot" style="left:87.5%;--c:#a78fff"></span>
+      </div>
+      <div class="spectrum__stops">
+        <div class="sstop" style="--c:#4FB8F0">
+          <span class="sstop__name">React · VDOM</span>
+          <span class="sstop__sub">fully dynamic — interpret + diff</span>
+        </div>
+        <div class="sstop" style="--c:#42b883">
+          <span class="sstop__name">Vue · Block VDOM</span>
+          <span class="sstop__sub">compiler-hinted — skip the statics</span>
+        </div>
+        <div class="sstop" style="--c:#8bd6a0">
+          <span class="sstop__name">Vapor</span>
+          <span class="sstop__sub">compiled — <b>but keeps pointers</b> to address nodes</span>
+        </div>
+        <div class="sstop hot" style="--c:#a78fff">
+          <span class="sstop__name">Element Templates</span>
+          <span class="sstop__sub">write-only — paint it, then let go</span>
+        </div>
+      </div>
+      <div class="spectrum__braces">
+        <span class="brace ret">still retained — holds runtime pointers</span>
+        <span class="brace imm">write-only — names, not pointers</span>
+      </div>
+    </div>
+    <p class="lead" data-mm-fade style="text-align:center;max-width:60ch">
+      Even <b>Vapor</b> stays retained — it keeps pointers. But cross a thread up front and pointers can&rsquo;t follow — so Lynx lives at the write-only end.
+    </p>
+    <aside class="notes">
+      <p><strong>The design space is one wide spectrum</strong> — from fully retained to fully immediate. <strong>React VDOM</strong> is fully dynamic: interpret a tree and diff it every update. <strong>Vue</strong>'s compiler-hinted, block-based VDOM does better — blocks let it skip the static subtrees. <strong>Vapor</strong> looks like it compiled everything away, but it still reserves a slice for the in-browser runtime: pointers, used to <em>read</em> / address live nodes. So Vapor is still <em>retained mode</em>.</p>
+      <p><strong>Why that matters at a thread boundary.</strong> Retained pointers only survive a thread hop if the tree itself is shared: RN's Fabric keeps pointers in a C++ shadow tree that both sides reach. Lynx can't — we cross threads from the very first frame. <strong>Element Templates</strong> go the other way: write-only, one direction, much closer to an immediate-mode <em>display list</em>. That crosses threads beautifully — but the price is giving up dynamism on the MT side. Like a painting: you draw it once, then let the canvas go.</p>
+    </aside>
+  </section>
+
+  <!-- E20c — the cradle · closes the design-space arc -->
+  <section class="slide stage">
+    <span class="eyebrow">One more thing</span>
+    <h2 class="h-section" style="text-align:center;max-width:22ch">
+      A <span class="brand-text">cradle</span> for framework design.
+    </h2>
+    <p class="lead">A team that loves the Web &mdash; and dares to break it.</p>
+    <aside class="notes">
+      <p><strong>Why framework authors should care about Lynx.</strong> Lynx has made interesting — even controversial — design choices, and keeps making them: dual threads, MTS, a real CSS engine off the DOM. This is a team that loves the Web and has both the guts and the room to break it where it must.</p>
+      <p>For Vue specifically: a native platform with genuine room to run — the kind of space where a Vapor-native renderer is a weekend of vibing away.</p>
+    </aside>
+  </section>
+
+  <!-- E21·a — panorama seed · React first -->
+  <section class="slide weave" data-bg="clean" data-chrome="none" data-weave="panorama-r">
+    <p class="weave-kicker">Weave the whole Web&hellip;</p>
+    <span class="wlab" data-flip="wl-react" style="--c:#61dafb;left:4cqw;top:25cqh">React <i></i></span>
+    <div class="wlynx" data-flip="weave-lynx">
+      <svg viewBox="0 0 27 28" aria-label="Lynx"><path fill-rule="evenodd" clip-rule="evenodd" d="M7.56542 6.19594L3.90642 8.7164C3.50877 8.99031 3.23346 9.40191 3.13675 9.86708L2.77902 11.5878C2.76005 11.679 2.71799 11.7642 2.65665 11.8355L0.996306 14.0121C0.772761 14.2722 0.778152 14.9632 1.39044 15.4057C1.62523 15.6103 1.93915 16.0691 2.29622 16.591C3.05224 17.6959 4.00169 19.0836 4.80312 18.9394C5.9372 18.541 7.32544 18.4135 8.39128 18.9394C10.4632 20.7282 9.95449 22.3775 9.22514 24.7421C8.93165 25.6936 8.60243 26.7609 8.39128 27.9997C9.38643 24.3777 11.6242 20.1711 15.6592 18.7437C14.9322 18.1498 13.4486 17.5981 12.1357 17.4653C12.1357 17.4653 16.1691 14.0121 21.1439 12.4254C17.671 4.16205 11.9386 0.213095 11.9386 0.213095C11.6465 -0.148197 11.0566 -0.0296711 10.9349 0.414774C10.8371 1.72112 10.675 2.60942 10.4074 3.44676L8.39128 1.12029C8.18068 0.866399 7.75965 1.013 7.76176 1.33949C8.10312 3.23719 8.05521 4.30239 7.56542 6.19594ZM8.9846 6.02248L8.99663 6.02171C9.02298 6.02002 9.0489 6.01659 9.07424 6.01153L8.9846 6.02248ZM11.7123 1.7617C13.094 4.1491 13.7199 5.5054 13.9322 8.03659C12.4625 7.2017 11.8221 6.98923 10.7413 6.99451C11.3718 5.0773 11.5644 3.92284 11.7123 1.7617Z"/><path d="M20.5916 19.4929C14.9639 20.7806 11.7672 22.7198 9.32227 28.0001C13.7111 20.6367 26.9966 21.9536 26.9966 21.9536C26.7484 20.7508 24.1069 18.4571 22.3696 17.0503C22.3696 17.0503 23.7712 15.3272 26.8697 14.455C26.8697 14.455 20.9125 14.8002 17.4445 16.6727C18.568 17.2656 20.0071 18.2663 20.5916 19.4929Z"/></svg>
+    </div>
+    <aside class="notes">
+      <p><strong>The weave starts with one strand.</strong> React was the first to prove the pattern at scale — declarative UI, a runtime that reconciles. Name it, let it settle onto the loom.</p>
+      <p>Start here so the build reads as a story: one thread, then two, then the whole web.</p>
+    </aside>
+  </section>
+
+  <!-- E21·b — panorama seed · React + Vue -->
+  <section class="slide weave" data-bg="clean" data-chrome="none" data-weave="panorama-rv">
+    <p class="weave-kicker">Weave the whole Web&hellip;</p>
+    <span class="wlab" data-flip="wl-vue" style="--c:#42b883;left:4cqw;top:16cqh">Vue <i></i></span>
+    <span class="wlab" data-flip="wl-react" style="--c:#61dafb;left:4cqw;top:25cqh">React <i></i></span>
+    <div class="wlynx" data-flip="weave-lynx">
+      <svg viewBox="0 0 27 28" aria-label="Lynx"><path fill-rule="evenodd" clip-rule="evenodd" d="M7.56542 6.19594L3.90642 8.7164C3.50877 8.99031 3.23346 9.40191 3.13675 9.86708L2.77902 11.5878C2.76005 11.679 2.71799 11.7642 2.65665 11.8355L0.996306 14.0121C0.772761 14.2722 0.778152 14.9632 1.39044 15.4057C1.62523 15.6103 1.93915 16.0691 2.29622 16.591C3.05224 17.6959 4.00169 19.0836 4.80312 18.9394C5.9372 18.541 7.32544 18.4135 8.39128 18.9394C10.4632 20.7282 9.95449 22.3775 9.22514 24.7421C8.93165 25.6936 8.60243 26.7609 8.39128 27.9997C9.38643 24.3777 11.6242 20.1711 15.6592 18.7437C14.9322 18.1498 13.4486 17.5981 12.1357 17.4653C12.1357 17.4653 16.1691 14.0121 21.1439 12.4254C17.671 4.16205 11.9386 0.213095 11.9386 0.213095C11.6465 -0.148197 11.0566 -0.0296711 10.9349 0.414774C10.8371 1.72112 10.675 2.60942 10.4074 3.44676L8.39128 1.12029C8.18068 0.866399 7.75965 1.013 7.76176 1.33949C8.10312 3.23719 8.05521 4.30239 7.56542 6.19594ZM8.9846 6.02248L8.99663 6.02171C9.02298 6.02002 9.0489 6.01659 9.07424 6.01153L8.9846 6.02248ZM11.7123 1.7617C13.094 4.1491 13.7199 5.5054 13.9322 8.03659C12.4625 7.2017 11.8221 6.98923 10.7413 6.99451C11.3718 5.0773 11.5644 3.92284 11.7123 1.7617Z"/><path d="M20.5916 19.4929C14.9639 20.7806 11.7672 22.7198 9.32227 28.0001C13.7111 20.6367 26.9966 21.9536 26.9966 21.9536C26.7484 20.7508 24.1069 18.4571 22.3696 17.0503C22.3696 17.0503 23.7712 15.3272 26.8697 14.455C26.8697 14.455 20.9125 14.8002 17.4445 16.6727C18.568 17.2656 20.0071 18.2663 20.5916 19.4929Z"/></svg>
+    </div>
+    <aside class="notes">
+      <p><strong>Vue joins — now two strands.</strong> The whole argument is that neither is special: React and Vue are two coordinates in one design space, both weavable onto the same loom.</p>
+      <p>Beat here, then let the rest of the web pour in.</p>
+    </aside>
+  </section>
+
   <!-- E21 — FABRIC III · panorama, left half -->
   <section class="slide weave" data-bg="clean" data-chrome="none" data-weave="panorama-left">
     <p class="weave-kicker">Weave the whole Web&hellip;</p>
@@ -3746,13 +3762,13 @@ app.<span class="code-fn">use</span>(router)</pre>
     <span class="wlab" data-flip="wl-octane" style="--c:#ff5468;left:4cqw;top:47cqh">Octane <i></i></span>
     <span class="wlab" data-flip="wl-css" style="--c:#8a63d2;left:4cqw;top:55cqh">CSS <i></i></span>
     <span class="wlab" data-flip="wl-tailwind" style="--c:#38bdf8;left:4cqw;top:63cqh">Tailwind <i></i></span>
-    <span class="wlab" data-flip="wl-motion" style="--c:#f7e14d;left:4cqw;top:71cqh">Motion &middot; Pretext <i></i></span>
-    <span class="wlab" data-flip="wl-rspack" style="--c:#ff7a1a;left:4cqw;top:80cqh">Rspack <i></i></span>
+    <span class="wlab" data-flip="wl-motion" style="--c:#f7e14d;left:4cqw;top:71cqh">Motion <i></i></span>
+    <span class="wlab" data-flip="wl-pretext" style="--c:#ffc24d;left:4cqw;top:80cqh">Pretext <i></i></span>
     <div class="wlynx" data-flip="weave-lynx">
       <svg viewBox="0 0 27 28" aria-label="Lynx"><path fill-rule="evenodd" clip-rule="evenodd" d="M7.56542 6.19594L3.90642 8.7164C3.50877 8.99031 3.23346 9.40191 3.13675 9.86708L2.77902 11.5878C2.76005 11.679 2.71799 11.7642 2.65665 11.8355L0.996306 14.0121C0.772761 14.2722 0.778152 14.9632 1.39044 15.4057C1.62523 15.6103 1.93915 16.0691 2.29622 16.591C3.05224 17.6959 4.00169 19.0836 4.80312 18.9394C5.9372 18.541 7.32544 18.4135 8.39128 18.9394C10.4632 20.7282 9.95449 22.3775 9.22514 24.7421C8.93165 25.6936 8.60243 26.7609 8.39128 27.9997C9.38643 24.3777 11.6242 20.1711 15.6592 18.7437C14.9322 18.1498 13.4486 17.5981 12.1357 17.4653C12.1357 17.4653 16.1691 14.0121 21.1439 12.4254C17.671 4.16205 11.9386 0.213095 11.9386 0.213095C11.6465 -0.148197 11.0566 -0.0296711 10.9349 0.414774C10.8371 1.72112 10.675 2.60942 10.4074 3.44676L8.39128 1.12029C8.18068 0.866399 7.75965 1.013 7.76176 1.33949C8.10312 3.23719 8.05521 4.30239 7.56542 6.19594ZM8.9846 6.02248L8.99663 6.02171C9.02298 6.02002 9.0489 6.01659 9.07424 6.01153L8.9846 6.02248ZM11.7123 1.7617C13.094 4.1491 13.7199 5.5054 13.9322 8.03659C12.4625 7.2017 11.8221 6.98923 10.7413 6.99451C11.3718 5.0773 11.5644 3.92284 11.7123 1.7617Z"/><path d="M20.5916 19.4929C14.9639 20.7806 11.7672 22.7198 9.32227 28.0001C13.7111 20.6367 26.9966 21.9536 26.9966 21.9536C26.7484 20.7508 24.1069 18.4571 22.3696 17.0503C22.3696 17.0503 23.7712 15.3272 26.8697 14.455C26.8697 14.455 20.9125 14.8002 17.4445 16.6727C18.568 17.2656 20.0071 18.2663 20.5916 19.4929Z"/></svg>
     </div>
     <aside class="notes">
-      <p><strong>The panorama begins.</strong> Name the strands as they land: Vue green, React blue, the faint yellows of Svelte and Solid, Octane red — a brand-new fabric still being spun — CSS, Tailwind, Motion and Pretext, Rspack orange. The whole web ecosystem, as threads.</p>
+      <p><strong>The panorama begins.</strong> Name the strands as they land: Vue green, React blue, the faint yellows of Svelte and Solid, Octane red — a brand-new fabric still being spun — CSS, Tailwind, Motion, Pretext. The whole web ecosystem, as threads.</p>
       <p>They all pull toward one thin, strong waist.</p>
     </aside>
   </section>
@@ -3767,8 +3783,8 @@ app.<span class="code-fn">use</span>(router)</pre>
     <span class="wlab" data-flip="wl-octane" style="--c:#ff5468;left:4cqw;top:47cqh">Octane <i></i></span>
     <span class="wlab" data-flip="wl-css" style="--c:#8a63d2;left:4cqw;top:55cqh">CSS <i></i></span>
     <span class="wlab" data-flip="wl-tailwind" style="--c:#38bdf8;left:4cqw;top:63cqh">Tailwind <i></i></span>
-    <span class="wlab" data-flip="wl-motion" style="--c:#f7e14d;left:4cqw;top:71cqh">Motion &middot; Pretext <i></i></span>
-    <span class="wlab" data-flip="wl-rspack" style="--c:#ff7a1a;left:4cqw;top:80cqh">Rspack <i></i></span>
+    <span class="wlab" data-flip="wl-motion" style="--c:#f7e14d;left:4cqw;top:71cqh">Motion <i></i></span>
+    <span class="wlab" data-flip="wl-pretext" style="--c:#ffc24d;left:4cqw;top:80cqh">Pretext <i></i></span>
     <div class="wlynx" data-flip="weave-lynx">
       <svg viewBox="0 0 27 28" aria-label="Lynx"><path fill-rule="evenodd" clip-rule="evenodd" d="M7.56542 6.19594L3.90642 8.7164C3.50877 8.99031 3.23346 9.40191 3.13675 9.86708L2.77902 11.5878C2.76005 11.679 2.71799 11.7642 2.65665 11.8355L0.996306 14.0121C0.772761 14.2722 0.778152 14.9632 1.39044 15.4057C1.62523 15.6103 1.93915 16.0691 2.29622 16.591C3.05224 17.6959 4.00169 19.0836 4.80312 18.9394C5.9372 18.541 7.32544 18.4135 8.39128 18.9394C10.4632 20.7282 9.95449 22.3775 9.22514 24.7421C8.93165 25.6936 8.60243 26.7609 8.39128 27.9997C9.38643 24.3777 11.6242 20.1711 15.6592 18.7437C14.9322 18.1498 13.4486 17.5981 12.1357 17.4653C12.1357 17.4653 16.1691 14.0121 21.1439 12.4254C17.671 4.16205 11.9386 0.213095 11.9386 0.213095C11.6465 -0.148197 11.0566 -0.0296711 10.9349 0.414774C10.8371 1.72112 10.675 2.60942 10.4074 3.44676L8.39128 1.12029C8.18068 0.866399 7.75965 1.013 7.76176 1.33949C8.10312 3.23719 8.05521 4.30239 7.56542 6.19594ZM8.9846 6.02248L8.99663 6.02171C9.02298 6.02002 9.0489 6.01659 9.07424 6.01153L8.9846 6.02248ZM11.7123 1.7617C13.094 4.1491 13.7199 5.5054 13.9322 8.03659C12.4625 7.2017 11.8221 6.98923 10.7413 6.99451C11.3718 5.0773 11.5644 3.92284 11.7123 1.7617Z"/><path d="M20.5916 19.4929C14.9639 20.7806 11.7672 22.7198 9.32227 28.0001C13.7111 20.6367 26.9966 21.9536 26.9966 21.9536C26.7484 20.7508 24.1069 18.4571 22.3696 17.0503C22.3696 17.0503 23.7712 15.3272 26.8697 14.455C26.8697 14.455 20.9125 14.8002 17.4445 16.6727C18.568 17.2656 20.0071 18.2663 20.5916 19.4929Z"/></svg>
     </div>

--- a/slides/index.html
+++ b/slides/index.html
@@ -2660,7 +2660,7 @@
     <div class="spectrum">
       <div class="spectrum__bar">
         <span class="spectrum__end left">retained mode<i>address &amp; mutate at runtime · needs pointers</i></span>
-        <span class="spectrum__end right">immediate mode<i>write once · a display list</i></span>
+        <span class="spectrum__end right">write-only<i>emit names · a display list</i></span>
         <span class="spectrum__dot" style="left:12.5%;--c:#4FB8F0"></span>
         <span class="spectrum__dot" style="left:37.5%;--c:#42b883"></span>
         <span class="spectrum__dot" style="left:62.5%;--c:#8bd6a0"></span>
@@ -2686,7 +2686,7 @@
       </div>
       <div class="spectrum__braces">
         <span class="brace ret">still retained — holds runtime pointers</span>
-        <span class="brace imm">immediate — nothing to address</span>
+        <span class="brace imm">write-only — names, not pointers</span>
       </div>
     </div>
     <p class="lead" data-mm-fade style="text-align:center;max-width:60ch">

--- a/slides/index.html
+++ b/slides/index.html
@@ -2651,101 +2651,112 @@
     </aside>
   </section>
 
-  <!-- E20b — design space · the static/dynamic spectrum -->
-  <section class="slide stage dspace">
-    <span class="eyebrow">One more thing &middot; the design space</span>
-    <h2 class="h-section" style="text-align:center;max-width:22ch">
-      A template is part <span style="color:#5dd5a8">static</span>, part <span style="color:#E8B44A">dynamic</span>.
-    </h2>
-    <div class="dsplit">
-      <div>
-        <div class="codeframe" style="width:100%">
-          <div class="codeframe__head">
-            <span class="dots"><span></span><span></span><span></span></span>
-            <span>card.vue · by binding time</span>
-          </div>
-<pre><span class="code-static">&lt;view class="card"&gt;</span>
-<span class="code-static">  &lt;image class="icon" src="…" /&gt;</span>
-<span class="code-static">  &lt;view class="body"&gt;</span>
-<span class="code-static">    &lt;text&gt;</span><span class="code-dyn">{{ title }}</span><span class="code-static">&lt;/text&gt;</span>
-<span class="code-static">    &lt;text&gt;Static description&lt;/text&gt;</span>
-<span class="code-static">  &lt;/view&gt;</span>
-<span class="code-static">&lt;/view&gt;</span></pre>
-        </div>
-        <div class="ds-legend" data-mm-fade>
-          <span class="k"><span class="sw" style="background:#5dd5a8"></span>static &middot; known when you write it</span>
-          <span class="k"><span class="sw" style="background:#E8B44A"></span>dynamic &middot; known only at runtime</span>
-        </div>
-      </div>
-      <div class="track" data-mm-fade>
-        <div class="track__line"></div>
-        <div class="track__stops">
-          <div class="stop">
-            <span class="stop__dot" style="border-color:#4FB8F0"></span>
-            <span class="stop__name">VDOM</span>
-            <span class="stop__sub">interpret + diff · re-discover each update</span>
-          </div>
-          <div class="stop">
-            <span class="stop__dot" style="border-color:#42b883"></span>
-            <span class="stop__name">Vapor</span>
-            <span class="stop__sub">wire it into create-time · O(1) update</span>
-          </div>
-          <div class="stop">
-            <span class="stop__dot" style="border-color:#8a63d2"></span>
-            <span class="stop__name">Element Templates</span>
-            <span class="stop__sub">bake the static shell to code</span>
-          </div>
-        </div>
-        <div class="track__ends">
-          <span>resolve at runtime</span>
-          <span>resolve at compile time</span>
-        </div>
-      </div>
-    </div>
-    <p class="lead" data-mm-fade style="text-align:center;max-width:52ch">
-      One question splits every renderer: <b>when</b> is &ldquo;what changes&rdquo; resolved?
-    </p>
-    <aside class="notes">
-      <p><strong>The design space, in one picture.</strong> A template is a mixed-stage program: the green parts (tags, classes, static text) are fixed the moment you write them; only <code>{{ title }}</code> waits for a runtime value. This is binding-time analysis — coloring = annotating.</p>
-      <p>Every renderer holds the <em>same</em> knowledge; they differ only in <em>when</em> they resolve the dynamic part. VDOM re-discovers it each update by diffing. Vapor wires it into create-time so updates are O(1). Element Templates bake the static shell all the way down to code. Same spectrum, different coordinates — VDOM, Vapor, and ET aren't rival inventions, they're points in one space.</p>
-    </aside>
-  </section>
-
-  <!-- E20c — design space · the async cut (thread boundary) -->
+  <!-- E20b — design space · the async cut (schematic) -->
   <section class="slide stage dspace">
     <span class="eyebrow">One more thing &middot; the design space</span>
     <h2 class="h-section" style="text-align:center;max-width:24ch">
       Cut a thread — what can cross the wire?
     </h2>
-    <div class="dboundary">
-      <div class="drealm">
-        <div class="drealm__t">BG · background thread · the program</div>
-        <ul class="xfer">
-          <li><span class="ok">✓</span><span class="lbl"><b>first-order data</b> — numbers, strings, plain objects</span></li>
-          <li><span class="ok">✓</span><span class="lbl"><b>names</b> — ids, template no., event signs</span></li>
-          <li><span class="no">✗</span><span class="lbl"><b>pointers</b> — <code>nthChild(root,1)</code>, only local</span></li>
-          <li><span class="no">✗</span><span class="lbl"><b>closures</b> — <code>effect(fn)</code> captures the heap</span></li>
-        </ul>
-      </div>
-      <div class="dwall"><span>serialization boundary</span></div>
-      <div class="drealm">
-        <div class="drealm__t">MT · main thread · the tree</div>
-        <div class="opstream">
-          <span class="op">CREATE 2 view</span>
-          <span class="op">SET_CLASS 2 "card"</span>
-          <span class="op dyn">SET_TEXT 6 "Hello"</span>
-          <span class="op">INSERT 1 2 -1</span>
-          <span class="op">…</span>
-        </div>
-        <p class="dboundary__cap">one flat <b>ops stream</b> crosses &mdash; and that stream <em>is</em> a display list.</p>
-      </div>
+    <div class="dschem">
+      <svg viewBox="0 0 900 268" role="img" aria-label="What crosses the BG/MT serialization boundary: data and names cross as an ops stream; pointers and closures are blocked.">
+        <defs>
+          <marker id="dsArrow" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+            <path d="M0,0 L9,4.5 L0,9 Z" fill="#5dd5a8"/>
+          </marker>
+        </defs>
+        <!-- BG realm -->
+        <rect class="box" x="28" y="40" width="326" height="196" rx="14"/>
+        <text class="lane" x="52" y="72">BG · the program</text>
+        <text class="ok" x="52" y="114" font-size="16">✓</text><text class="chip-t" x="76" y="114">first-order data</text>
+        <text class="ok" x="52" y="150" font-size="16">✓</text><text class="chip-t" x="76" y="150">names · ids, signs</text>
+        <text class="no" x="52" y="186" font-size="16">✗</text><text class="chip-t" x="76" y="186">pointers</text><text class="chip-s" x="212" y="186">local heap only</text>
+        <text class="no" x="52" y="222" font-size="16">✗</text><text class="chip-t" x="76" y="222">closures</text><text class="chip-s" x="212" y="222">capture the heap</text>
+        <!-- wall -->
+        <line class="wall" x1="452" y1="34" x2="452" y2="244"/>
+        <text class="walltag" x="452" y="139" transform="rotate(90 452 139)" text-anchor="middle">serialization boundary</text>
+        <!-- data + names cross as an ops stream -->
+        <path class="flow-ok" d="M356 108 L600 108"/>
+        <path class="flow-ok" d="M356 150 L600 150"/>
+        <text class="streamlbl" x="474" y="98">ops stream</text>
+        <!-- pointers + closures blocked at the wall -->
+        <path class="flow-no" d="M356 186 L438 186"/>
+        <text class="no" x="446" y="191" font-size="15">✗</text>
+        <path class="flow-no" d="M356 222 L438 222"/>
+        <text class="no" x="446" y="227" font-size="15">✗</text>
+        <!-- MT realm: the native tree it builds -->
+        <rect class="box" x="612" y="58" width="260" height="160" rx="14"/>
+        <text class="lane" x="636" y="90">MT · the tree</text>
+        <line class="edge" x1="742" y1="132" x2="686" y2="166"/>
+        <line class="edge" x1="742" y1="132" x2="800" y2="166"/>
+        <rect class="opnode" x="702" y="110" width="80" height="24" rx="6"/><text class="optext" x="718" y="126">view</text>
+        <rect class="opnode" x="648" y="164" width="76" height="22" rx="6"/><text class="optext" x="662" y="179">text</text>
+        <rect class="opnode dyn" x="764" y="164" width="76" height="22" rx="6"/><text class="optext" x="778" y="179">{{…}}</text>
+      </svg>
     </div>
-    <p class="lead" data-mm-fade style="text-align:center;max-width:56ch">
-      Only closed, first-order terms survive the cut. Pointers and closures don&rsquo;t.
+    <p class="lead" data-mm-fade style="text-align:center;max-width:58ch">
+      Only closed, first-order terms survive the cut — a flat ops stream, i.e. a <b>display list</b>.
     </p>
     <aside class="notes">
       <p><strong>The async cut.</strong> The dual-thread split is architected async — like the browser handing compositing to its own thread. The catch: the tree (MT) and the program that drives it (BG) no longer share an address space. So what can cross the serialization boundary? Only closed, first-order terms — data and names. Pointers are meaningful only in the local heap; closures capture an environment the other side doesn't have.</p>
       <p>That leaves exactly one shape for what crosses: a flat, closed, first-order <strong>ops stream</strong> — which is precisely a <em>display list</em>. It's not an implementation detail; it's the constitution of the whole architecture (and why Vapor-on-Lynx emits ops directly).</p>
+    </aside>
+  </section>
+
+  <!-- E20c — design space · dense vs sparse naming -->
+  <section class="slide stage dspace">
+    <span class="eyebrow">One more thing &middot; the design space</span>
+    <h2 class="h-section" style="text-align:center;max-width:24ch">
+      Pointers die — <span class="brand-text">names</span> take over.
+    </h2>
+    <div class="dtrees">
+      <figure>
+        <figcaption><b>Vapor · dense</b> — every node gets a name</figcaption>
+        <svg class="dtree" viewBox="0 0 460 246" role="img" aria-label="Dense naming: preorder assigns uid 2 to 7 to every node.">
+          <line class="edge" x1="230" y1="52" x2="110" y2="102"/>
+          <line class="edge" x1="230" y1="52" x2="290" y2="102"/>
+          <line class="edge" x1="290" y1="130" x2="180" y2="178"/>
+          <line class="edge" x1="290" y1="130" x2="380" y2="178"/>
+          <line class="edge" x1="180" y1="206" x2="180" y2="218"/>
+          <g><rect class="nodebox st" x="178" y="26" width="104" height="28" rx="6"/><text class="tag" x="192" y="45">view.card</text></g>
+          <g><rect class="nodebox st" x="56" y="102" width="108" height="28" rx="6"/><text class="tag" x="70" y="121">image.icon</text></g>
+          <g><rect class="nodebox st" x="238" y="102" width="104" height="28" rx="6"/><text class="tag" x="252" y="121">view.body</text></g>
+          <g><rect class="nodebox st" x="126" y="178" width="108" height="28" rx="6"/><text class="tag" x="140" y="197">text.title</text></g>
+          <g><rect class="nodebox dy" x="146" y="212" width="68" height="22" rx="5"/><text class="tag" x="154" y="227" style="font-size:10px">#text ✎</text></g>
+          <g><rect class="nodebox st" x="326" y="178" width="106" height="28" rx="6"/><text class="tag" x="340" y="197">text.desc</text></g>
+          <g><rect class="uidbg" x="260" y="20" width="26" height="16" rx="7"/><text class="uid" x="268" y="32">2</text></g>
+          <g><rect class="uidbg" x="142" y="96" width="26" height="16" rx="7"/><text class="uid" x="150" y="108">3</text></g>
+          <g><rect class="uidbg" x="320" y="96" width="26" height="16" rx="7"/><text class="uid" x="328" y="108">4</text></g>
+          <g><rect class="uidbg" x="212" y="172" width="26" height="16" rx="7"/><text class="uid" x="220" y="184">5</text></g>
+          <g><rect class="uidbg" x="192" y="206" width="26" height="16" rx="7"/><text class="uid" x="200" y="218">6</text></g>
+          <g><rect class="uidbg" x="410" y="172" width="26" height="16" rx="7"/><text class="uid" x="418" y="184">7</text></g>
+        </svg>
+      </figure>
+      <figure>
+        <figcaption><b>Element Templates · sparse</b> — only the <span class="hot">holes</span> are named</figcaption>
+        <svg class="dtree" viewBox="0 0 460 246" role="img" aria-label="Sparse naming: only the root and the hole get ids; the static nodes are ghosted.">
+          <line class="edge ghost" x1="230" y1="52" x2="110" y2="102"/>
+          <line class="edge ghost" x1="230" y1="52" x2="290" y2="102"/>
+          <line class="edge ghost" x1="290" y1="130" x2="180" y2="178"/>
+          <line class="edge ghost" x1="290" y1="130" x2="380" y2="178"/>
+          <g><rect class="nodebox st" x="178" y="26" width="104" height="28" rx="6"/><text class="tag" x="192" y="45">view.card</text>
+             <rect class="uidbg" x="258" y="20" width="60" height="16" rx="7"/><text class="uid" x="264" y="32">root=2</text></g>
+          <g class="ghost"><rect class="nodebox" x="56" y="102" width="108" height="28" rx="6"/><text class="tag" x="70" y="121">image.icon</text></g>
+          <g class="ghost"><rect class="nodebox" x="238" y="102" width="104" height="28" rx="6"/><text class="tag" x="252" y="121">view.body</text></g>
+          <g><rect class="nodebox dy" x="126" y="178" width="108" height="28" rx="6"/><text class="tag" x="140" y="197">text.title</text>
+             <rect class="uidbg" x="212" y="172" width="64" height="16" rx="7"/><text class="uid" x="218" y="184">hole=3</text>
+             <text class="holelbl" x="126" y="224">the one dynamic point → the one hole</text></g>
+          <g class="ghost"><rect class="nodebox" x="326" y="178" width="106" height="28" rx="6"/><text class="tag" x="340" y="197">text.desc</text></g>
+        </svg>
+      </figure>
+    </div>
+    <div class="ds-legend" data-mm-fade>
+      <span class="k"><span class="sw" style="background:#5dd5a8"></span>static</span>
+      <span class="k"><span class="sw" style="background:#E8B44A"></span>dynamic (the hole)</span>
+      <span class="k"><span class="sw name"></span>a name that crosses the wire</span>
+    </div>
+    <aside class="notes">
+      <p><strong>Once pointers can't cross, names take over — and there are two ways to hand them out.</strong> Vapor names <em>densely</em>: a preorder walk gives every node a uid (2–7). Both threads run the same walk, so they agree on every name with zero bytes transferred — the addressable set is open (anything might get touched by an effect, event, or ref).</p>
+      <p>Element Templates name <em>sparsely</em>: the VDOM compiler already proved a closed set of dynamic points (the holes), and diffing guarantees the static nodes are never addressed — so only the holes get names and the grey nodes are invisible to the protocol. Sparse isn't saved, it's <em>proven</em>. Same template, two coordinates on the design space.</p>
     </aside>
   </section>
 

--- a/slides/index.html
+++ b/slides/index.html
@@ -2651,7 +2651,54 @@
     </aside>
   </section>
 
-  <!-- E20b — design space · the async cut (schematic) -->
+  <!-- E20b — design space · the retained→immediate spectrum -->
+  <section class="slide stage dspace">
+    <span class="eyebrow">One more thing &middot; the design space</span>
+    <h2 class="h-section" style="text-align:center;max-width:26ch">
+      One template — a whole <span class="brand-text">spectrum</span> of renderers.
+    </h2>
+    <div class="spectrum">
+      <div class="spectrum__bar">
+        <span class="spectrum__end left">retained mode<i>address &amp; mutate at runtime · needs pointers</i></span>
+        <span class="spectrum__end right">immediate mode<i>write once · a display list</i></span>
+        <span class="spectrum__dot" style="left:12.5%;--c:#4FB8F0"></span>
+        <span class="spectrum__dot" style="left:37.5%;--c:#42b883"></span>
+        <span class="spectrum__dot" style="left:62.5%;--c:#8bd6a0"></span>
+        <span class="spectrum__dot" style="left:87.5%;--c:#a78fff"></span>
+      </div>
+      <div class="spectrum__stops">
+        <div class="sstop" style="--c:#4FB8F0">
+          <span class="sstop__name">React · VDOM</span>
+          <span class="sstop__sub">fully dynamic — interpret + diff</span>
+        </div>
+        <div class="sstop" style="--c:#42b883">
+          <span class="sstop__name">Vue · Block VDOM</span>
+          <span class="sstop__sub">compiler-hinted — skip the statics</span>
+        </div>
+        <div class="sstop" style="--c:#8bd6a0">
+          <span class="sstop__name">Vapor</span>
+          <span class="sstop__sub">compiled — <b>but keeps pointers</b> to address nodes</span>
+        </div>
+        <div class="sstop hot" style="--c:#a78fff">
+          <span class="sstop__name">Element Templates</span>
+          <span class="sstop__sub">write-only — paint it, then let go</span>
+        </div>
+      </div>
+      <div class="spectrum__braces">
+        <span class="brace ret">still retained — holds runtime pointers</span>
+        <span class="brace imm">immediate — nothing to address</span>
+      </div>
+    </div>
+    <p class="lead" data-mm-fade style="text-align:center;max-width:60ch">
+      Even <b>Vapor</b> stays retained — it keeps pointers. But cross a thread up front and pointers can&rsquo;t follow — so Lynx lives at the write-only end.
+    </p>
+    <aside class="notes">
+      <p><strong>The design space is one wide spectrum</strong> — from fully retained to fully immediate. <strong>React VDOM</strong> is fully dynamic: interpret a tree and diff it every update. <strong>Vue</strong>'s compiler-hinted, block-based VDOM does better — blocks let it skip the static subtrees. <strong>Vapor</strong> looks like it compiled everything away, but it still reserves a slice for the in-browser runtime: pointers, used to <em>read</em> / address live nodes. So Vapor is still <em>retained mode</em>.</p>
+      <p><strong>Why that matters at a thread boundary.</strong> Retained pointers only survive a thread hop if the tree itself is shared: RN's Fabric keeps pointers in a C++ shadow tree that both sides reach. Lynx can't — we cross threads from the very first frame. <strong>Element Templates</strong> go the other way: write-only, one direction, much closer to an immediate-mode <em>display list</em>. That crosses threads beautifully — but the price is giving up dynamism on the MT side. Like a painting: you draw it once, then let the canvas go.</p>
+    </aside>
+  </section>
+
+  <!-- E20c — design space · the async cut (schematic) -->
   <section class="slide stage dspace">
     <span class="eyebrow">One more thing &middot; the design space</span>
     <h2 class="h-section" style="text-align:center;max-width:24ch">
@@ -2702,7 +2749,7 @@
     </aside>
   </section>
 
-  <!-- E20c — design space · dense vs sparse naming -->
+  <!-- E20d — design space · dense vs sparse naming -->
   <section class="slide stage dspace">
     <span class="eyebrow">One more thing &middot; the design space</span>
     <h2 class="h-section" style="text-align:center;max-width:24ch">

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -384,14 +384,12 @@ export const ZH = {
     '框架设计的<span class="brand-text">摇篮</span>。',
   'A team that loves the Web — and dares to break it.':
     '一支深爱 Web、也敢于打破 Web 的团队。',
-  'A template is part static, part dynamic.':
-    '模板,一半<span style="color:#5dd5a8">静态</span>,一半<span style="color:#E8B44A">动态</span>。',
-  'One question splits every renderer: when is “what changes” resolved?':
-    '所有渲染器的分歧只有一个问题:<b>何时</b>求解“哪里会变”?',
   'Cut a thread — what can cross the wire?':
     '切一刀线程 —— 什么能过桥?',
-  'Only closed, first-order terms survive the cut. Pointers and closures don’t.':
-    '只有封闭的一阶项能扛过这一刀;指针与闭包过不去。',
+  'Only closed, first-order terms survive the cut — a flat ops stream, i.e. a display list.':
+    '只有封闭的一阶项能扛过这一刀 —— 一串扁平的 ops,也就是一份 display list。',
+  'Pointers die — names take over.':
+    '指针死去 —— <span class="brand-text">名字</span>接管。',
   'Weave the whole Web…': '把整个 Web 织进来……',
   '…into every platform.': '……再织向每一个平台。',
   'more…': '<i></i> 更多……',
@@ -658,10 +656,10 @@ export const ZH_NOTES = [
   `<p><strong>连接创新本身。</strong>回想第四章的流水线:VDOM → ShadowElement → ops → PAPI。Vapor 模式不需要 VDOM —— 于是在 Lynx 上,整整一层直接消失:signal 驱动 effect,effect 直接吐 ops。在实现上我们做的是<em>删掉</em>抽象,不是增加抽象。</p><p>诚实交代进度:这是设计草图和早期实验,不是已发布的模式 —— 而这正是它令人兴奋的地方:缝是开着的,创新可以沿着连接双向流动。</p>`,
   // 90 E20 · 摇篮
   `<p><strong>框架作者为什么该关心 Lynx。</strong>Lynx 做过很多有趣甚至有争议的设计决定,而且还在继续:双线程、MTS、一台不在 DOM 上的真 CSS 引擎。这是一支深爱 Web、也有胆量和空间在必要处打破 Web 的团队。</p><p>对 Vue 而言:一个真正有奔跑空间的原生平台 —— 在这种空间里,一个 Vapor 原生渲染器,就是一个周末的 vibe 量。</p>`,
-  // 90b E20b · 动静光谱
-  `<p><strong>把设计空间浓缩成一张图。</strong>模板是一段混合阶段的程序:绿色部分(标签、类名、静态文案)在你写下的那一刻就定了;只有 <code>{{ title }}</code> 要等运行期才有值。这就是绑定时间分析 —— 着色即标注。</p><p>每个渲染器持有的是<em>同一份</em>知识,分歧只在<em>何时</em>求解动态部分:VDOM 每次更新用 diff 重新发现;Vapor 把它接线进创建期,换来 O(1) 更新;Element Templates 把静态壳一路特化成代码。同一条光谱、不同坐标 —— VDOM、Vapor、ET 不是三个孤立发明,而是同一空间里的三个点。</p>`,
-  // 90c E20c · 异步的那一刀
+  // 90b E20b · 异步的那一刀
   `<p><strong>异步的那一刀。</strong>双线程是"架构化的异步" —— 就像浏览器把合成交给独立线程。代价是:树(MT)和驱动它的程序(BG)不再共享地址空间。那什么能穿过序列化边界?只有封闭的一阶项 —— 数据与名字。指针只在本地堆有意义;闭包捕获了对面不存在的环境。</p><p>于是过桥的形态只剩一种:一条扁平、封闭、一阶的 <strong>ops 流</strong> —— 这正是 display list。它不是实现细节,是整套架构的宪法(也是为什么 Vapor-on-Lynx 直接吐 ops)。</p>`,
+  // 90c E20c · 稠密 vs 稀疏命名
+  `<p><strong>指针过不去,名字就得接管 —— 而发名字有两种发法。</strong>Vapor <em>稠密</em>地发:一趟前序遍历给每个节点一个 uid(2–7)。两条线程跑的是同一趟遍历,于是无需传一个字节就能对齐每个名字 —— 可寻址集合是开放的(任何节点都可能被 effect、事件或 ref 摸到)。</p><p>Element Templates <em>稀疏</em>地发:VDOM 编译器早已证明了一个封闭的动态点集合(holes),diff 又保证静态节点永远不会被寻址 —— 于是只有 hole 拿到名字,灰色节点对协议完全隐形。稀疏不是省出来的,是<em>证出来的</em>。同一份模板,设计空间上的两个坐标。</p>`,
   // 91 E21 · 全景 · 左半
   `<p><strong>全景开始。</strong>线落下时逐一点名:Vue 的绿、React 的蓝、Svelte 和 Solid 隐约的黄、Octane 的红 —— 一种还在纺的新织物 —— CSS、Tailwind、Motion 和 Pretext、Rspack 的橘。整个 Web 生态,化作丝线。</p><p>它们全都收向同一个又细又有力的腰身。</p>`,
   // 92 E22 · 全景

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -384,6 +384,14 @@ export const ZH = {
     '框架设计的<span class="brand-text">摇篮</span>。',
   'A team that loves the Web — and dares to break it.':
     '一支深爱 Web、也敢于打破 Web 的团队。',
+  'A template is part static, part dynamic.':
+    '模板,一半<span style="color:#5dd5a8">静态</span>,一半<span style="color:#E8B44A">动态</span>。',
+  'One question splits every renderer: when is “what changes” resolved?':
+    '所有渲染器的分歧只有一个问题:<b>何时</b>求解“哪里会变”?',
+  'Cut a thread — what can cross the wire?':
+    '切一刀线程 —— 什么能过桥?',
+  'Only closed, first-order terms survive the cut. Pointers and closures don’t.':
+    '只有封闭的一阶项能扛过这一刀;指针与闭包过不去。',
   'Weave the whole Web…': '把整个 Web 织进来……',
   '…into every platform.': '……再织向每一个平台。',
   'more…': '<i></i> 更多……',
@@ -650,6 +658,10 @@ export const ZH_NOTES = [
   `<p><strong>连接创新本身。</strong>回想第四章的流水线:VDOM → ShadowElement → ops → PAPI。Vapor 模式不需要 VDOM —— 于是在 Lynx 上,整整一层直接消失:signal 驱动 effect,effect 直接吐 ops。在实现上我们做的是<em>删掉</em>抽象,不是增加抽象。</p><p>诚实交代进度:这是设计草图和早期实验,不是已发布的模式 —— 而这正是它令人兴奋的地方:缝是开着的,创新可以沿着连接双向流动。</p>`,
   // 90 E20 · 摇篮
   `<p><strong>框架作者为什么该关心 Lynx。</strong>Lynx 做过很多有趣甚至有争议的设计决定,而且还在继续:双线程、MTS、一台不在 DOM 上的真 CSS 引擎。这是一支深爱 Web、也有胆量和空间在必要处打破 Web 的团队。</p><p>对 Vue 而言:一个真正有奔跑空间的原生平台 —— 在这种空间里,一个 Vapor 原生渲染器,就是一个周末的 vibe 量。</p>`,
+  // 90b E20b · 动静光谱
+  `<p><strong>把设计空间浓缩成一张图。</strong>模板是一段混合阶段的程序:绿色部分(标签、类名、静态文案)在你写下的那一刻就定了;只有 <code>{{ title }}</code> 要等运行期才有值。这就是绑定时间分析 —— 着色即标注。</p><p>每个渲染器持有的是<em>同一份</em>知识,分歧只在<em>何时</em>求解动态部分:VDOM 每次更新用 diff 重新发现;Vapor 把它接线进创建期,换来 O(1) 更新;Element Templates 把静态壳一路特化成代码。同一条光谱、不同坐标 —— VDOM、Vapor、ET 不是三个孤立发明,而是同一空间里的三个点。</p>`,
+  // 90c E20c · 异步的那一刀
+  `<p><strong>异步的那一刀。</strong>双线程是"架构化的异步" —— 就像浏览器把合成交给独立线程。代价是:树(MT)和驱动它的程序(BG)不再共享地址空间。那什么能穿过序列化边界?只有封闭的一阶项 —— 数据与名字。指针只在本地堆有意义;闭包捕获了对面不存在的环境。</p><p>于是过桥的形态只剩一种:一条扁平、封闭、一阶的 <strong>ops 流</strong> —— 这正是 display list。它不是实现细节,是整套架构的宪法(也是为什么 Vapor-on-Lynx 直接吐 ops)。</p>`,
   // 91 E21 · 全景 · 左半
   `<p><strong>全景开始。</strong>线落下时逐一点名:Vue 的绿、React 的蓝、Svelte 和 Solid 隐约的黄、Octane 的红 —— 一种还在纺的新织物 —— CSS、Tailwind、Motion 和 Pretext、Rspack 的橘。整个 Web 生态,化作丝线。</p><p>它们全都收向同一个又细又有力的腰身。</p>`,
   // 92 E22 · 全景

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -519,8 +519,8 @@ export const ZH = {
   'base uid only': '只传 base uid',
   're-walk from base uid': '从 base uid 重走一遍',
   'materialize real elements': '生成真实元素',
-  'The static structure crosses once — not one op per element.':
-    '静态结构只跨越<em>一次</em> —— 不是每个元素一个 op。',
+  'Pointers can’t cross the boundary — so both sides walk the same pre-order and name every node alike. No id map is ever sent.':
+    '指针过不了边界 —— 两侧于是各走<em>同一趟前序遍历</em>,给每个节点起一样的名字。从不传一张 id 映射表。',
   'create-1k across the boundary: 17,000 ops · 327 KB → 7,000 ops · 160 KB':
     'create-1k 跨越边界:<span style="color:var(--ink-mute);text-decoration:line-through">17,000 ops · 327 KB</span> → <b class="brand-text">7,000 ops · 160 KB</b>',
 
@@ -846,16 +846,18 @@ export const ZH_NOTES = [
   `<p><strong>压轴数字。</strong>跨框架套件(ReactLynx vs Vue VDOM vs Vue Vapor),真实点击到 composed-DOM 终态。Vue 对 Vue 的头条:10k select 风暴上 Vapor 7.0× VDOM,update 风暴 1.9×。</p><p>让它悬一会儿。然后最后一页。</p>`,
   // 47 收束 · 拨一下开关
   `<p><strong>收尾返场。</strong>Vapor 是按应用、构建期的开关:插件选项、入口 import、<code>vapor</code> 属性。两个纯入口 —— <code>vue-lynx</code> 与 <code>vue-lynx/vapor</code> —— 于是 vdom 专属 API 在 Vapor 应用里会在构建期报错,而不是在运行时出乱子。</p><p>落地:“还是你早就在写的那套 Vue —— 只是多了一条编译期的快路。这就是那‘还有一件事’。”</p>`,
-  // 90 E20 · 摇篮
-  `<p><strong>框架作者为什么该关心 Lynx。</strong>Lynx 做过很多有趣甚至有争议的设计决定,而且还在继续:双线程、MTS、一台不在 DOM 上的真 CSS 引擎。这是一支深爱 Web、也有胆量和空间在必要处打破 Web 的团队。</p><p>对 Vue 而言:一个真正有奔跑空间的原生平台 —— 在这种空间里,一个 Vapor 原生渲染器,就是一个周末的 vibe 量。</p>`,
-  // 90b E20b · 动静光谱 · retained → immediate
-  `<p><strong>设计空间是一条很宽的光谱</strong> —— 从完全 retained 到完全 immediate。<strong>React VDOM</strong> 完全动态:解释一棵树,每次更新再 diff。<strong>Vue</strong> 的 compiler-hinted、block-based VDOM 好一些 —— block 让它跳过静态子树。<strong>Vapor</strong> 看似把一切都编译掉了,其实仍给浏览器内的运行时留了一块:指针,用来<em>读</em> / 寻址活节点。所以 Vapor 依然是 <em>retained mode</em>。</p><p><strong>为什么这在线程边界上要命。</strong>retained 的指针只有在整棵树本身共享时才能扛过一次线程跳转:RN 的 Fabric 把指针留在一棵两侧都能碰到的 C++ 影子树里。Lynx 做不到 —— 我们从第一帧就跨线程。<strong>Element Templates</strong> 走了反方向:只写、单向,更接近 immediate mode 的 <em>display list</em>。它跨线程极其漂亮 —— 代价是放弃 MT 侧的动态性。就像画一幅画:画一次,然后把画布撒手。</p>`,
-  // 90c E20c · 异步的那一刀
-  `<p><strong>异步的那一刀。</strong>双线程是"架构化的异步" —— 就像浏览器把合成交给独立线程。代价是:树(MT)和驱动它的程序(BG)不再共享地址空间。那什么能穿过序列化边界?只有封闭的一阶项 —— 数据与名字。指针只在本地堆有意义;闭包捕获了对面不存在的环境。</p><p>于是过桥的形态只剩一种:一条扁平、封闭、一阶的 <strong>ops 流</strong> —— 这正是 display list。它不是实现细节,是整套架构的宪法(也是为什么 Vapor-on-Lynx 直接吐 ops)。</p>`,
-  // 90d E20d · 稠密 vs 稀疏命名
+  // 90a E20a · 稠密 vs 稀疏 (Vapor tree vs ET)
   `<p><strong>指针过不去,名字就得接管 —— 而发名字有两种发法。</strong>Vapor <em>稠密</em>地发:一趟前序遍历给每个节点一个 uid(2–7)。两条线程跑的是同一趟遍历,于是无需传一个字节就能对齐每个名字 —— 可寻址集合是开放的(任何节点都可能被 effect、事件或 ref 摸到)。</p><p>Element Templates <em>稀疏</em>地发:VDOM 编译器早已证明了一个封闭的动态点集合(holes),diff 又保证静态节点永远不会被寻址 —— 于是只有 hole 拿到名字,灰色节点对协议完全隐形。稀疏不是省出来的,是<em>证出来的</em>。同一份模板,设计空间上的两个坐标。</p>`,
+  // 90b E20b · 动静光谱 · retained → write-only
+  `<p><strong>设计空间是一条很宽的光谱</strong> —— 从完全 retained 到完全 immediate。<strong>React VDOM</strong> 完全动态:解释一棵树,每次更新再 diff。<strong>Vue</strong> 的 compiler-hinted、block-based VDOM 好一些 —— block 让它跳过静态子树。<strong>Vapor</strong> 看似把一切都编译掉了,其实仍给浏览器内的运行时留了一块:指针,用来<em>读</em> / 寻址活节点。所以 Vapor 依然是 <em>retained mode</em>。</p><p><strong>为什么这在线程边界上要命。</strong>retained 的指针只有在整棵树本身共享时才能扛过一次线程跳转:RN 的 Fabric 把指针留在一棵两侧都能碰到的 C++ 影子树里。Lynx 做不到 —— 我们从第一帧就跨线程。<strong>Element Templates</strong> 走了反方向:只写、单向,更接近 immediate mode 的 <em>display list</em>。它跨线程极其漂亮 —— 代价是放弃 MT 侧的动态性。就像画一幅画:画一次,然后把画布撒手。</p>`,
+  // 90c E20c · 摇篮 · 收束设计空间
+  `<p><strong>框架作者为什么该关心 Lynx。</strong>Lynx 做过很多有趣甚至有争议的设计决定,而且还在继续:双线程、MTS、一台不在 DOM 上的真 CSS 引擎。这是一支深爱 Web、也有胆量和空间在必要处打破 Web 的团队。</p><p>对 Vue 而言:一个真正有奔跑空间的原生平台 —— 在这种空间里,一个 Vapor 原生渲染器,就是一个周末的 vibe 量。</p>`,
+  // 91a E21·a · 全景种子 · 先 React
+  `<p><strong>织物从一根线开始。</strong>React 最先把这套模式跑通 —— 声明式 UI、一个做 reconcile 的运行时。先点它的名,让它落到织机上。</p><p>从这里起步,是为了让"生长"读起来像一个故事:一根线,然后两根,然后整张 Web。</p>`,
+  // 91b E21·b · 全景种子 · React + Vue
+  `<p><strong>Vue 加入 —— 现在是两根线。</strong>整场论证的核心就是:谁都不特殊。React 与 Vue 是同一设计空间里的两个坐标,都能织上同一台织机。</p><p>在这里停一拍,再让整张 Web 涌进来。</p>`,
   // 91 E21 · 全景 · 左半
-  `<p><strong>全景开始。</strong>线落下时逐一点名:Vue 的绿、React 的蓝、Svelte 和 Solid 隐约的黄、Octane 的红 —— 一种还在纺的新织物 —— CSS、Tailwind、Motion 和 Pretext、Rspack 的橘。整个 Web 生态,化作丝线。</p><p>它们全都收向同一个又细又有力的腰身。</p>`,
+  `<p><strong>全景开始。</strong>线落下时逐一点名:Vue 的绿、React 的蓝、Svelte 和 Solid 隐约的黄、Octane 的红 —— 一种还在纺的新织物 —— CSS、Tailwind、Motion、Pretext。整个 Web 生态,化作丝线。</p><p>它们全都收向同一个又细又有力的腰身。</p>`,
   // 92 E22 · 全景
   `<p><strong>压轴画面 —— 头一秒别说话。</strong>腰身绽开:左侧的每一种织物,重新织进 iOS、Android、Web、HarmonyOS、macOS、Windows、Linux,以及接下来的任何平台。</p><p>中间是那台又细又强的织机。整个论证浓缩成一张图:左半是 harness,右半是连接。停住,然后轻轻说:"Lynx 给你的,是织任何一种织物所需要的技艺 —— 和 harness。"</p>`,
   // 93 E23 · 德国 · 上

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -384,6 +384,10 @@ export const ZH = {
     '框架设计的<span class="brand-text">摇篮</span>。',
   'A team that loves the Web — and dares to break it.':
     '一支深爱 Web、也敢于打破 Web 的团队。',
+  'One template — a whole spectrum of renderers.':
+    '一份模板 —— 一整条渲染器的<span class="brand-text">光谱</span>。',
+  'Even Vapor stays retained — it keeps pointers. But cross a thread up front and pointers can’t follow — so Lynx lives at the write-only end.':
+    '连 <b>Vapor</b> 也仍是 retained —— 它保留着指针。可一旦上来就跨线程,指针跟不过去 —— 于是 Lynx 落在只写的那一端。',
   'Cut a thread — what can cross the wire?':
     '切一刀线程 —— 什么能过桥?',
   'Only closed, first-order terms survive the cut — a flat ops stream, i.e. a display list.':
@@ -656,9 +660,11 @@ export const ZH_NOTES = [
   `<p><strong>连接创新本身。</strong>回想第四章的流水线:VDOM → ShadowElement → ops → PAPI。Vapor 模式不需要 VDOM —— 于是在 Lynx 上,整整一层直接消失:signal 驱动 effect,effect 直接吐 ops。在实现上我们做的是<em>删掉</em>抽象,不是增加抽象。</p><p>诚实交代进度:这是设计草图和早期实验,不是已发布的模式 —— 而这正是它令人兴奋的地方:缝是开着的,创新可以沿着连接双向流动。</p>`,
   // 90 E20 · 摇篮
   `<p><strong>框架作者为什么该关心 Lynx。</strong>Lynx 做过很多有趣甚至有争议的设计决定,而且还在继续:双线程、MTS、一台不在 DOM 上的真 CSS 引擎。这是一支深爱 Web、也有胆量和空间在必要处打破 Web 的团队。</p><p>对 Vue 而言:一个真正有奔跑空间的原生平台 —— 在这种空间里,一个 Vapor 原生渲染器,就是一个周末的 vibe 量。</p>`,
-  // 90b E20b · 异步的那一刀
+  // 90b E20b · 动静光谱 · retained → immediate
+  `<p><strong>设计空间是一条很宽的光谱</strong> —— 从完全 retained 到完全 immediate。<strong>React VDOM</strong> 完全动态:解释一棵树,每次更新再 diff。<strong>Vue</strong> 的 compiler-hinted、block-based VDOM 好一些 —— block 让它跳过静态子树。<strong>Vapor</strong> 看似把一切都编译掉了,其实仍给浏览器内的运行时留了一块:指针,用来<em>读</em> / 寻址活节点。所以 Vapor 依然是 <em>retained mode</em>。</p><p><strong>为什么这在线程边界上要命。</strong>retained 的指针只有在整棵树本身共享时才能扛过一次线程跳转:RN 的 Fabric 把指针留在一棵两侧都能碰到的 C++ 影子树里。Lynx 做不到 —— 我们从第一帧就跨线程。<strong>Element Templates</strong> 走了反方向:只写、单向,更接近 immediate mode 的 <em>display list</em>。它跨线程极其漂亮 —— 代价是放弃 MT 侧的动态性。就像画一幅画:画一次,然后把画布撒手。</p>`,
+  // 90c E20c · 异步的那一刀
   `<p><strong>异步的那一刀。</strong>双线程是"架构化的异步" —— 就像浏览器把合成交给独立线程。代价是:树(MT)和驱动它的程序(BG)不再共享地址空间。那什么能穿过序列化边界?只有封闭的一阶项 —— 数据与名字。指针只在本地堆有意义;闭包捕获了对面不存在的环境。</p><p>于是过桥的形态只剩一种:一条扁平、封闭、一阶的 <strong>ops 流</strong> —— 这正是 display list。它不是实现细节,是整套架构的宪法(也是为什么 Vapor-on-Lynx 直接吐 ops)。</p>`,
-  // 90c E20c · 稠密 vs 稀疏命名
+  // 90d E20d · 稠密 vs 稀疏命名
   `<p><strong>指针过不去,名字就得接管 —— 而发名字有两种发法。</strong>Vapor <em>稠密</em>地发:一趟前序遍历给每个节点一个 uid(2–7)。两条线程跑的是同一趟遍历,于是无需传一个字节就能对齐每个名字 —— 可寻址集合是开放的(任何节点都可能被 effect、事件或 ref 摸到)。</p><p>Element Templates <em>稀疏</em>地发:VDOM 编译器早已证明了一个封闭的动态点集合(holes),diff 又保证静态节点永远不会被寻址 —— 于是只有 hole 拿到名字,灰色节点对协议完全隐形。稀疏不是省出来的,是<em>证出来的</em>。同一份模板,设计空间上的两个坐标。</p>`,
   // 91 E21 · 全景 · 左半
   `<p><strong>全景开始。</strong>线落下时逐一点名:Vue 的绿、React 的蓝、Svelte 和 Solid 隐约的黄、Octane 的红 —— 一种还在纺的新织物 —— CSS、Tailwind、Motion 和 Pretext、Rspack 的橘。整个 Web 生态,化作丝线。</p><p>它们全都收向同一个又细又有力的腰身。</p>`,

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -3199,3 +3199,60 @@ vl-media.snap.is-missing .vl-ph {
   color: rgba(15, 18, 22, 0.5);
 }
 vl-media.snap.is-missing .vl-ph__kind { color: rgba(15, 18, 22, 0.65); }
+
+/* =========================================================
+   "One more thing" · design-space slides (epilogue)
+   ① static/dynamic spectrum  ② the async cut (thread boundary)
+   ========================================================= */
+.dspace { --ds-static: #5dd5a8; --ds-dyn: #E8B44A; }
+.dsplit {
+  display: grid;
+  grid-template-columns: 0.92fr 1.08fr;
+  gap: clamp(28px, 5cqw, 64px);
+  align-items: center;
+  width: 100%;
+  max-width: 1080px;
+  margin: 8px auto 0;
+}
+.dsplit .codeframe { text-align: left; }
+/* binding-time coloring inside the card code */
+.code-static { color: var(--ds-static); }
+.code-dyn { color: var(--ds-dyn); background: color-mix(in srgb, var(--ds-dyn) 16%, transparent); border-radius: 3px; padding: 0 3px; }
+.ds-legend { display: flex; gap: 20px; justify-content: center; margin-top: 16px; font-family: var(--mono); font-size: 12px; color: var(--ink-mute); }
+.ds-legend .k { display: inline-flex; align-items: center; gap: 8px; }
+.ds-legend .sw { width: 11px; height: 11px; border-radius: 3px; flex: none; }
+
+/* spectrum: 3 stops on a runtime → compile-time track */
+.track { position: relative; padding: 30px 6px 0; }
+.track__line { position: absolute; left: 12%; right: 12%; top: 38px; height: 3px; border-radius: 2px;
+  background: linear-gradient(90deg, #4FB8F0, #42b883, #8a63d2); }
+.track__stops { display: flex; justify-content: space-between; position: relative; z-index: 1; }
+.stop { display: flex; flex-direction: column; align-items: center; gap: 9px; width: 33%; text-align: center; }
+.stop__dot { width: 16px; height: 16px; border-radius: 50%; border: 2px solid; background: var(--paper); }
+.stop__name { font-family: var(--mono); font-size: 14px; font-weight: 600; color: var(--ink); }
+.stop__sub { font-family: var(--mono); font-size: 11px; line-height: 1.45; color: var(--ink-mute); max-width: 15ch; }
+.track__ends { display: flex; justify-content: space-between; margin-top: 18px;
+  font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--ink-mute); }
+
+/* the async cut — BG | wall | MT */
+.dboundary { display: grid; grid-template-columns: 1fr 48px 1fr; align-items: stretch; gap: 0;
+  width: 100%; max-width: 1000px; margin: 12px auto 0; }
+.drealm { border: 1px solid var(--line); border-radius: 12px; background: var(--paper-elev); padding: 18px 20px; box-shadow: var(--shadow-sm); }
+.drealm__t { font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink-mute); margin-bottom: 15px; }
+.xfer { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 12px; }
+.xfer li { display: flex; gap: 10px; align-items: baseline; font-size: 14px; }
+.xfer .mono { font-family: var(--mono); }
+.xfer .ok { color: var(--vue-green); font-weight: 700; }
+.xfer .no { color: #e07570; font-weight: 700; }
+.xfer .lbl b { color: var(--ink); font-weight: 600; }
+.xfer .lbl { color: var(--ink-soft); }
+.dwall { position: relative; }
+.dwall::before { content: ""; position: absolute; left: 50%; top: 4px; bottom: 4px; border-left: 2px dashed var(--ink-faint); }
+.dwall span { position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%) rotate(90deg);
+  font-family: var(--mono); font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--ink-mute);
+  background: var(--paper); padding: 3px 9px; white-space: nowrap; }
+.opstream { display: flex; flex-wrap: wrap; gap: 8px; }
+.opstream .op { font-family: var(--mono); font-size: 12px; padding: 5px 10px; border-radius: 6px;
+  border: 1px solid var(--line); background: var(--paper-elev); color: var(--ink-soft); white-space: nowrap; }
+.opstream .op.dyn { color: #E8B44A; border-color: color-mix(in srgb, #E8B44A 55%, transparent); background: color-mix(in srgb, #E8B44A 12%, transparent); }
+.dboundary__cap { font-family: var(--mono); font-size: 11.5px; color: var(--ink-mute); margin-top: 12px; }

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -3277,6 +3277,11 @@ vl-media.snap.is-missing .vl-ph__kind { color: rgba(15, 18, 22, 0.65); }
 .brace.imm { color: var(--ds-name); }
 .brace.imm::before { border-color: color-mix(in srgb, var(--ds-name) 45%, transparent); }
 
+/* card tree inside the Vapor REGISTER/CLONE boxes (V·7a/b) */
+.node .dtree { width: 100%; max-width: 300px; height: auto; margin: 8px auto 2px; display: block; }
+.node__cap { display: block; text-align: center; font-family: var(--mono); font-size: 11px; color: var(--ink-mute); margin-top: 2px; }
+.node__cap b { color: var(--ds-name); font-weight: 600; }
+
 /* =========================================================
    IV · Instant First-Frame Rendering + Element Templates.
    Reuses the runtime chapter's .flow / .fb / .farr / .fcenter

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -3245,3 +3245,26 @@ vl-media.snap.is-missing .vl-ph__kind { color: rgba(15, 18, 22, 0.65); }
 .ds-legend .k { display: inline-flex; align-items: center; gap: 8px; }
 .ds-legend .sw { width: 11px; height: 11px; border-radius: 3px; flex: none; }
 .ds-legend .sw.name { border-radius: 50%; background: var(--ds-name); }
+
+/* retained→immediate spectrum (E20b) */
+.spectrum { width: 100%; max-width: 1080px; margin: 30px auto 0; }
+.spectrum__bar { position: relative; height: 6px; border-radius: 6px; margin: 40px 40px 0; background: linear-gradient(90deg, #4FB8F0, #42b883, #8bd6a0, #a78fff); }
+.spectrum__end { position: absolute; top: -30px; font-family: var(--mono); font-size: 12.5px; color: var(--ink); display: flex; flex-direction: column; line-height: 1.25; }
+.spectrum__end i { font-style: normal; font-size: 10.5px; color: var(--ink-mute); letter-spacing: 0.01em; }
+.spectrum__end.left { left: -28px; text-align: left; }
+.spectrum__end.right { right: -28px; text-align: right; }
+.spectrum__end.right i { align-self: flex-end; }
+.spectrum__dot { position: absolute; top: 50%; width: 15px; height: 15px; border-radius: 50%; transform: translate(-50%, -50%); background: var(--paper); border: 3px solid var(--c); box-shadow: 0 0 0 4px color-mix(in srgb, var(--c) 18%, transparent); }
+.spectrum__stops { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin-top: 26px; }
+.sstop { display: flex; flex-direction: column; align-items: center; text-align: center; gap: 6px; padding: 0 6px; }
+.sstop__name { font-family: var(--mono); font-size: 14px; font-weight: 600; color: var(--c); }
+.sstop__sub { font-family: var(--mono); font-size: 11px; line-height: 1.4; color: var(--ink-mute); max-width: 22ch; }
+.sstop__sub b { color: var(--ink); font-weight: 600; }
+.sstop.hot .sstop__sub b { color: var(--ds-name); }
+.spectrum__braces { display: grid; grid-template-columns: 3fr 1fr; gap: 12px; margin-top: 16px; }
+.brace { position: relative; padding-top: 13px; text-align: center; font-family: var(--mono); font-size: 11.5px; }
+.brace::before { content: ''; position: absolute; top: 0; left: 8%; right: 8%; height: 8px; border: 1.5px solid var(--line); border-bottom: none; border-radius: 7px 7px 0 0; }
+.brace.ret { color: var(--ds-dyn); }
+.brace.ret::before { border-color: color-mix(in srgb, var(--ds-dyn) 42%, transparent); }
+.brace.imm { color: var(--ds-name); }
+.brace.imm::before { border-color: color-mix(in srgb, var(--ds-name) 45%, transparent); }

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -3202,57 +3202,46 @@ vl-media.snap.is-missing .vl-ph__kind { color: rgba(15, 18, 22, 0.65); }
 
 /* =========================================================
    "One more thing" · design-space slides (epilogue)
-   ① static/dynamic spectrum  ② the async cut (thread boundary)
+   ① the async cut (thread boundary, schematic)
+   ② dense vs sparse naming trees (from the design note)
    ========================================================= */
-.dspace { --ds-static: #5dd5a8; --ds-dyn: #E8B44A; }
-.dsplit {
-  display: grid;
-  grid-template-columns: 0.92fr 1.08fr;
-  gap: clamp(28px, 5cqw, 64px);
-  align-items: center;
-  width: 100%;
-  max-width: 1080px;
-  margin: 8px auto 0;
-}
-.dsplit .codeframe { text-align: left; }
-/* binding-time coloring inside the card code */
-.code-static { color: var(--ds-static); }
-.code-dyn { color: var(--ds-dyn); background: color-mix(in srgb, var(--ds-dyn) 16%, transparent); border-radius: 3px; padding: 0 3px; }
-.ds-legend { display: flex; gap: 20px; justify-content: center; margin-top: 16px; font-family: var(--mono); font-size: 12px; color: var(--ink-mute); }
+.dspace { --ds-static: #5dd5a8; --ds-dyn: #E8B44A; --ds-name: #a78fff; }
+
+/* ① async cut — schematic SVG */
+.dschem { width: 100%; max-width: 1000px; margin: 14px auto 0; }
+.dschem svg { width: 100%; height: auto; display: block; }
+.dschem .lane { font-family: var(--mono); font-size: 12.5px; letter-spacing: 0.08em; text-transform: uppercase; fill: var(--ink-mute); }
+.dschem .chip-t { font-family: var(--mono); font-size: 13px; fill: var(--ink); }
+.dschem .chip-s { font-family: var(--mono); font-size: 10.5px; fill: var(--ink-mute); }
+.dschem .box { fill: var(--paper-elev); stroke: var(--line); }
+.dschem .flow-ok { stroke: var(--ds-static); stroke-width: 2; fill: none; marker-end: url(#dsArrow); }
+.dschem .flow-no { stroke: #e07570; stroke-width: 2; fill: none; stroke-dasharray: 5 4; }
+.dschem .wall { stroke: var(--ink-faint); stroke-width: 2; stroke-dasharray: 6 5; }
+.dschem .walltag { font-family: var(--mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; fill: var(--ink-mute); }
+.dschem .ok { fill: var(--ds-static); font-weight: 700; }
+.dschem .no { fill: #e07570; font-weight: 700; }
+.dschem .opnode { fill: color-mix(in srgb, var(--ds-static) 12%, transparent); stroke: color-mix(in srgb, var(--ds-static) 55%, transparent); }
+.dschem .opnode.dyn { fill: color-mix(in srgb, var(--ds-dyn) 14%, transparent); stroke: color-mix(in srgb, var(--ds-dyn) 55%, transparent); }
+.dschem .optext { font-family: var(--mono); font-size: 11px; fill: var(--ink-soft); }
+.dschem .streamlbl { font-family: var(--mono); font-size: 12px; fill: var(--ds-static); font-weight: 600; }
+
+/* ② dense / sparse naming trees */
+.dtrees { display: grid; grid-template-columns: 1fr 1fr; gap: clamp(24px, 4cqw, 60px); width: 100%; max-width: 1060px; margin: 6px auto 0; align-items: start; }
+.dtrees figure { margin: 0; display: flex; flex-direction: column; gap: 10px; }
+.dtrees figcaption { font-family: var(--mono); font-size: 12.5px; color: var(--ink-mute); text-align: center; }
+.dtrees figcaption b { color: var(--ink); font-weight: 600; }
+.dtrees figcaption .hot { color: var(--ds-name); }
+.dtree { width: 100%; height: auto; display: block; }
+.dtree .edge { stroke: var(--ink-faint); stroke-width: 1.4; }
+.dtree .edge.ghost, .dtree g.ghost { opacity: 0.26; }
+.dtree .nodebox { fill: var(--paper-elev); stroke: var(--line); }
+.dtree .nodebox.st { stroke: #5dd5a8; }
+.dtree .nodebox.dy { stroke: #E8B44A; }
+.dtree .tag { font-family: var(--mono); font-size: 12px; fill: var(--ink); }
+.dtree .uidbg { fill: rgba(167, 143, 255, 0.16); stroke: color-mix(in srgb, var(--ds-name) 45%, transparent); }
+.dtree .uid { font-family: var(--mono); font-size: 11px; font-weight: 700; fill: var(--ds-name); }
+.dtree .holelbl { font-family: var(--mono); font-size: 10px; fill: #E8B44A; }
+.ds-legend { display: flex; gap: 22px; justify-content: center; margin-top: 18px; font-family: var(--mono); font-size: 12px; color: var(--ink-mute); flex-wrap: wrap; }
 .ds-legend .k { display: inline-flex; align-items: center; gap: 8px; }
 .ds-legend .sw { width: 11px; height: 11px; border-radius: 3px; flex: none; }
-
-/* spectrum: 3 stops on a runtime → compile-time track */
-.track { position: relative; padding: 30px 6px 0; }
-.track__line { position: absolute; left: 12%; right: 12%; top: 38px; height: 3px; border-radius: 2px;
-  background: linear-gradient(90deg, #4FB8F0, #42b883, #8a63d2); }
-.track__stops { display: flex; justify-content: space-between; position: relative; z-index: 1; }
-.stop { display: flex; flex-direction: column; align-items: center; gap: 9px; width: 33%; text-align: center; }
-.stop__dot { width: 16px; height: 16px; border-radius: 50%; border: 2px solid; background: var(--paper); }
-.stop__name { font-family: var(--mono); font-size: 14px; font-weight: 600; color: var(--ink); }
-.stop__sub { font-family: var(--mono); font-size: 11px; line-height: 1.45; color: var(--ink-mute); max-width: 15ch; }
-.track__ends { display: flex; justify-content: space-between; margin-top: 18px;
-  font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--ink-mute); }
-
-/* the async cut — BG | wall | MT */
-.dboundary { display: grid; grid-template-columns: 1fr 48px 1fr; align-items: stretch; gap: 0;
-  width: 100%; max-width: 1000px; margin: 12px auto 0; }
-.drealm { border: 1px solid var(--line); border-radius: 12px; background: var(--paper-elev); padding: 18px 20px; box-shadow: var(--shadow-sm); }
-.drealm__t { font-family: var(--mono); font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase; color: var(--ink-mute); margin-bottom: 15px; }
-.xfer { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 12px; }
-.xfer li { display: flex; gap: 10px; align-items: baseline; font-size: 14px; }
-.xfer .mono { font-family: var(--mono); }
-.xfer .ok { color: var(--vue-green); font-weight: 700; }
-.xfer .no { color: #e07570; font-weight: 700; }
-.xfer .lbl b { color: var(--ink); font-weight: 600; }
-.xfer .lbl { color: var(--ink-soft); }
-.dwall { position: relative; }
-.dwall::before { content: ""; position: absolute; left: 50%; top: 4px; bottom: 4px; border-left: 2px dashed var(--ink-faint); }
-.dwall span { position: absolute; left: 50%; top: 50%; transform: translate(-50%, -50%) rotate(90deg);
-  font-family: var(--mono); font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--ink-mute);
-  background: var(--paper); padding: 3px 9px; white-space: nowrap; }
-.opstream { display: flex; flex-wrap: wrap; gap: 8px; }
-.opstream .op { font-family: var(--mono); font-size: 12px; padding: 5px 10px; border-radius: 6px;
-  border: 1px solid var(--line); background: var(--paper-elev); color: var(--ink-soft); white-space: nowrap; }
-.opstream .op.dyn { color: #E8B44A; border-color: color-mix(in srgb, #E8B44A 55%, transparent); background: color-mix(in srgb, #E8B44A 12%, transparent); }
-.dboundary__cap { font-family: var(--mono); font-size: 11.5px; color: var(--ink-mute); margin-top: 12px; }
+.ds-legend .sw.name { border-radius: 50%; background: var(--ds-name); }

--- a/slides/src/weave.js
+++ b/slides/src/weave.js
@@ -52,7 +52,7 @@ const hex = (h) => [1, 3, 5].map((k) => Number.parseInt(h.slice(k, k + 2), 16));
 const PAL = {
   vue: '#42b883', teal: '#3deae7',
   react: '#61dafb', svelte: '#ff9a4d', solid: '#ffd166', octane: '#ff5468',
-  css: '#8a63d2', tailwind: '#38bdf8', motion: '#f7e14d', rspack: '#ff7a1a',
+  css: '#8a63d2', tailwind: '#38bdf8', motion: '#f7e14d', pretext: '#ffc24d',
   ios: '#cdd6e4', android: '#3ddc84', web: '#56b8f0', harmony: '#ff6f61',
   macos: '#aab4c8', windows: '#2f7fe0', linux: '#f5c04a', more: '#8b93a3',
 };
@@ -67,7 +67,7 @@ const ECO = [
   { c: 'css', y: 0.55, n: 4, a: 0.9 },
   { c: 'tailwind', y: 0.63, n: 3, a: 0.85 },
   { c: 'motion', y: 0.71, n: 3, a: 0.7 },
-  { c: 'rspack', y: 0.80, n: 4, a: 0.9 },
+  { c: 'pretext', y: 0.80, n: 3, a: 0.7 },
 ];
 const PLAT = [
   { c: 'ios', y: 0.16 }, { c: 'android', y: 0.257 }, { c: 'web', y: 0.354 },
@@ -156,11 +156,15 @@ function compressScene() {
   return out;
 }
 
-function panoramaScene({ rightA = 1, dim = 1 }) {
+// `only` (a list of ECO keys) reveals just those strands — the rest keep
+// their pool index but tween to alpha 0, so the field builds up strand-by-
+// strand in place (React → React+Vue → all) without any thread reflow.
+function panoramaScene({ rightA = 1, dim = 1, only = null }) {
   const out = [];
   let i = 0;
   for (const g of ECO) {
     const src = hex(PAL[g.c]);
+    const shown = !only || only.includes(g.c);
     for (let k = 0; k < g.n; k++, i++) {
       const pl = PLAT[Math.floor(rnd(i, 11) * PLAT.length) % PLAT.length];
       out.push(mk({
@@ -174,7 +178,7 @@ function panoramaScene({ rightA = 1, dim = 1 }) {
           : pl.y + (rnd(i, 2) - 0.5) * 0.05,
         waist: 1, braid: 6,
         ampL: 6 + rnd(i, 3) * 9, ampR: 5 + rnd(i, 4) * 7,
-        alpha: g.a * dim * (0.75 + rnd(i, 5) * 0.25),
+        alpha: shown ? g.a * dim * (0.75 + rnd(i, 5) * 0.25) : 0,
         width: 1.35, aL: 0.5, aR: rightA * 0.7 + 0.04,
         shim: rnd(i, 7) < (dim < 0.5 ? 0.2 : 0.5) ? 1 : 0,
       }));
@@ -191,6 +195,8 @@ const SCENES = {
   loom: () => loomScene(1),
   'loom-dim': () => loomScene(0.22),
   compress: () => compressScene(),
+  'panorama-r': () => panoramaScene({ rightA: 0, dim: 1, only: ['react'] }),
+  'panorama-rv': () => panoramaScene({ rightA: 0, dim: 1, only: ['react', 'vue'] }),
   'panorama-left': () => panoramaScene({ rightA: 0, dim: 1 }),
   panorama: () => panoramaScene({ rightA: 1, dim: 1 }),
   finale: () => panoramaScene({ rightA: 1, dim: 0.3 }),


### PR DESCRIPTION
Two slides after **"A cradle for framework design"**, distilling the render design-space note into the deck's language (the point where the deck earns the "cradle for framework design" claim).

## What

- **108 · "A template is part static, part dynamic."** — the spectrum in one slide:
  - the `card.vue` template colored by **binding time** (green = static, amber `{{ title }}` = the one dynamic hole) + a legend
  - a **VDOM → Vapor → Element Templates** track on a *runtime → compile-time* axis
  - punchline: one question splits every renderer — **when** is "what changes" resolved?
- **109 · "Cut a thread — what can cross the wire?"** — the async point:
  - the **BG ↔ MT** serialization boundary: ✓ first-order data & names cross, ✗ pointers & closures don't
  - so what crosses is a flat **ops stream = a display list**

Both tie back to the Vapor slide (E19, "straight to ops") and the cradle thesis.

## Notes

- New `.dspace` CSS (binding-time code coloring, spectrum track, boundary viz).
- Bilingual: titles + leads translated to ZH; technical diagram labels kept EN, consistent with the neighboring epilogue slides (E19).
- Two `ZH_NOTES` added — **119 slides / 119 notes** aligned; `pnpm build` clean; verified EN + ZH via screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0156auPU7tSrwwYuEJ7ah6d4

---
_Generated by [Claude Code](https://claude.ai/code/session_0156auPU7tSrwwYuEJ7ah6d4)_