### PR TITLE
feat(slides): add Vue ecosystem lib demos (Pinia, Router, Query, Tailwind)

### DIFF
--- a/slides/index.html
+++ b/slides/index.html
@@ -24,7 +24,11 @@
     </button>
   </div>
   <div class="chrome chrome--bottom">
+<<<<<<< HEAD
     <span data-counter>01 / 139</span>
+=======
+    <span data-counter>01 / 122</span>
+>>>>>>> cf31457e (feat(slides): add Vue ecosystem lib demos (Pinia, Router, Query, Tailwind))
   </div>
   <div class="chrome chrome--bottom-right">
     <a href="https://vue.lynxjs.org" target="_blank" rel="noreferrer">vue.lynxjs.org</a>
@@ -387,7 +391,7 @@
       running right now.
     </p>
     <aside class="notes">
-      <p><strong>The show-off chapter.</strong> "为了让大家感受到诚意" — to show we're serious, I brought a feast of demos. Three courses: Vue API coverage, whole applications, then native superpowers.</p>
+      <p><strong>The show-off chapter.</strong> "为了让大家感受到诚意" — to show we're serious, I brought a feast of demos. Three courses: Vue API coverage, the ecosystem as-is, then whole applications.</p>
       <p>Every phone you'll see is live — scan the QR codes to run them on your own device as we go.</p>
     </aside>
   </section>
@@ -876,7 +880,179 @@
       </div>
     </div>
     <aside class="notes">
-      <p><code>v-memo</code> skips a subtree when its deps are unchanged — same cross-thread win as <code>v-once</code>, but keyed on a dependency list. Common in <code>v-for</code> rows. <code>isMemoSame</code> export + tests from @KealanAU (#156 / #181) in <code>0.4.0</code>. Thirteen features, thirteen live apps. That's the API story. Now — whole applications.</p>
+      <p><code>v-memo</code> skips a subtree when its deps are unchanged — same cross-thread win as <code>v-once</code>, but keyed on a dependency list. Common in <code>v-for</code> rows. <code>isMemoSame</code> export + tests from @KealanAU (#156 / #181) in <code>0.4.0</code>. Thirteen features, thirteen live apps. That's the API story. Now — the ecosystem that rides on it.</p>
+    </aside>
+  </section>
+
+  <!-- ====================================================
+       II · Ecosystem — libraries work as-is
+       ==================================================== -->
+  <section class="slide stage">
+    <span class="eyebrow">II · The proof</span>
+    <h2 class="h-section" style="text-align:center;max-width:22ch">
+      The ecosystem, <span class="brand-text">as-is</span>.
+    </h2>
+    <p class="lead" style="text-align:center;max-width:36ch;margin-inline:auto">
+      Pinia, Vue Router, TanStack Query, Tailwind — the libraries you'd already reach for on the web, running unchanged.
+    </p>
+    <div class="demo__meta" style="justify-content:center;margin-top:18px">
+      <span class="chip chip--brand">Pinia</span>
+      <span class="chip">Vue Router</span>
+      <span class="chip">Vue Query</span>
+      <span class="chip">Tailwind</span>
+    </div>
+    <aside class="notes">
+      <p><strong>The compatibility claim, sharpened.</strong> Vue isn't just an API — it's an ecosystem. If Pinia, Router, Query, and Tailwind need forks to run, we failed. They don't. Four live phones next; same packages, same APIs.</p>
+    </aside>
+  </section>
+
+  <section class="slide demo demo--api">
+    <div class="demo__body">
+      <span class="eyebrow">II · Ecosystem · 1/4</span>
+      <div class="demo__title-row">
+        <h2 class="demo__title"><span class="brand-text">Pinia</span></h2>
+      </div>
+      <div class="codeframe">
+        <div class="codeframe__head">
+          <span class="dots"><span></span><span></span><span></span></span>
+          <span>stores/counter.ts</span>
+        </div>
+<pre><span class="code-key">import</span> { defineStore } <span class="code-key">from</span> <span class="code-str">'pinia'</span>
+
+<span class="code-key">export const</span> useCounterStore <span class="code-key">=</span> <span class="code-fn">defineStore</span>(
+  <span class="code-str">'counter'</span>, () <span class="code-key">=&gt;</span> {
+  <span class="code-key">const</span> count <span class="code-key">=</span> <span class="code-fn">ref</span>(<span class="code-str">0</span>)
+  <span class="code-key">const</span> double <span class="code-key">=</span> <span class="code-fn">computed</span>(() <span class="code-key">=&gt;</span> count.value * <span class="code-str">2</span>)
+  <span class="code-key">function</span> <span class="code-fn">increment</span>() { count.value++ }
+  <span class="code-key">return</span> { count, double, increment }
+})</pre>
+      </div>
+    </div>
+    <div class="demo__stage">
+      <div class="phone">
+        <div class="phone__inner">
+          <vl-demo bundle="pinia/dist/main.web.bundle"></vl-demo>
+        </div>
+      </div>
+    </div>
+    <aside class="notes">
+      <p><strong>Pinia, untouched.</strong> Same <code>createPinia</code>, same setup-store <code>defineStore</code>. It rides on provide/inject — which is why the earlier slide mattered. Two stores in this phone: a counter and a todo list.</p>
+      <p><strong>Do live:</strong> tap +, watch the double getter update; flip to the todos section.</p>
+    </aside>
+  </section>
+
+  <section class="slide demo demo--api">
+    <div class="demo__body">
+      <span class="eyebrow">II · Ecosystem · 2/4</span>
+      <div class="demo__title-row">
+        <h2 class="demo__title"><span class="brand-text">Vue Router</span></h2>
+      </div>
+      <div class="codeframe">
+        <div class="codeframe__head">
+          <span class="dots"><span></span><span></span><span></span></span>
+          <span>router.ts</span>
+        </div>
+<pre><span class="code-key">import</span> { createRouter, createMemoryHistory }
+  <span class="code-key">from</span> <span class="code-str">'vue-router'</span>
+
+<span class="code-key">const</span> router <span class="code-key">=</span> <span class="code-fn">createRouter</span>({
+  history: <span class="code-fn">createMemoryHistory</span>(),
+  routes: [
+    { path: <span class="code-str">'/'</span>, component: Home },
+    { path: <span class="code-str">'/users/:id'</span>, component: UserDetail },
+  ],
+})
+
+app.<span class="code-fn">use</span>(router)</pre>
+      </div>
+    </div>
+    <div class="demo__stage">
+      <div class="phone">
+        <div class="phone__inner">
+          <vl-demo bundle="vue-router/dist/main.web.bundle"></vl-demo>
+        </div>
+      </div>
+    </div>
+    <aside class="notes">
+      <p><strong>Vue Router, as published.</strong> The only Lynx-shaped choice is the history mode: no <code>window.location</code>, so <code>createMemoryHistory()</code> — the same API React Router's MemoryRouter uses. Nested routes, params, <code>router.push</code> / <code>back</code> all work. Nav uses <code>RouterLink</code>'s custom slot over native <code>&lt;text&gt;</code>.</p>
+      <p><strong>Do live:</strong> tap Home → About → Users → open a user.</p>
+    </aside>
+  </section>
+
+  <section class="slide demo demo--api">
+    <div class="demo__body">
+      <span class="eyebrow">II · Ecosystem · 3/4</span>
+      <div class="demo__title-row">
+        <h2 class="demo__title"><span class="brand-text">Vue Query</span></h2>
+      </div>
+      <div class="codeframe">
+        <div class="codeframe__head">
+          <span class="dots"><span></span><span></span><span></span></span>
+          <span>App.vue</span>
+        </div>
+<pre><span class="code-key">import</span> { useQuery } <span class="code-key">from</span> <span class="code-str">'@tanstack/vue-query'</span>
+
+<span class="code-key">const</span> { data, isLoading } <span class="code-key">=</span> <span class="code-fn">useQuery</span>({
+  queryKey: [<span class="code-str">'users'</span>],
+  queryFn: () <span class="code-key">=&gt;</span>
+    fetch(<span class="code-str">'…/users'</span>).then(r <span class="code-key">=&gt;</span> r.json()),
+})
+
+<span class="code-com">// dependent query refetches when id changes</span>
+<span class="code-key">const</span> { data: posts } <span class="code-key">=</span> <span class="code-fn">useQuery</span>({
+  queryKey: <span class="code-fn">computed</span>(() <span class="code-key">=&gt;</span>
+    [<span class="code-str">'users'</span>, selectedId.value, <span class="code-str">'posts'</span>]),
+  queryFn: () <span class="code-key">=&gt;</span> fetchPosts(selectedId.value),
+})</pre>
+      </div>
+    </div>
+    <div class="demo__stage">
+      <div class="phone">
+        <div class="phone__inner">
+          <vl-demo bundle="networking/dist/main.web.bundle"></vl-demo>
+        </div>
+      </div>
+    </div>
+    <aside class="notes">
+      <p><strong>TanStack Vue Query, as-is.</strong> <code>useQuery</code>, dependent keys, mutations, the plugin install — none of it is Lynx-aware. This phone hits a real JSON API: list users, tap one, posts load via a dependent query.</p>
+      <p><strong>Do live:</strong> wait for the list, tap a user, watch posts arrive.</p>
+    </aside>
+  </section>
+
+  <section class="slide demo demo--api">
+    <div class="demo__body">
+      <span class="eyebrow">II · Ecosystem · 4/4</span>
+      <div class="demo__title-row">
+        <h2 class="demo__title"><span class="brand-text">Tailwind</span></h2>
+      </div>
+      <div class="codeframe">
+        <div class="codeframe__head">
+          <span class="dots"><span></span><span></span><span></span></span>
+          <span>App.vue</span>
+        </div>
+<pre><span class="code-tag">&lt;scroll-view</span> <span class="code-attr">class</span>=<span class="code-str">"w-full h-full bg-background"</span><span class="code-tag">&gt;</span>
+  <span class="code-tag">&lt;view</span> <span class="code-attr">class</span>=<span class="code-str">"p-6 flex flex-col gap-6"</span><span class="code-tag">&gt;</span>
+    <span class="code-tag">&lt;text</span> <span class="code-attr">class</span>=<span class="code-str">"text-2xl font-bold"</span><span class="code-tag">&gt;</span>
+      Settings
+    <span class="code-tag">&lt;/text&gt;</span>
+    <span class="code-tag">&lt;view</span> <span class="code-attr">class</span>=<span class="code-str">"bg-card rounded-lg
+      border border-border p-4"</span><span class="code-tag">&gt;</span>
+      …
+    <span class="code-tag">&lt;/view&gt;</span>
+  <span class="code-tag">&lt;/view&gt;</span>
+<span class="code-tag">&lt;/scroll-view&gt;</span></pre>
+      </div>
+    </div>
+    <div class="demo__stage">
+      <div class="phone">
+        <div class="phone__inner">
+          <vl-demo bundle="tailwindcss/dist/main.web.bundle"></vl-demo>
+        </div>
+      </div>
+    </div>
+    <aside class="notes">
+      <p><strong>Tailwind works because CSS works.</strong> No StyleSheet dialect — PostCSS emits real CSS, Lynx's native engine applies it. Theme tokens via CSS variables; tap Dark / Light / Ocean and watch the whole tree re-token.</p>
+      <p><strong>Do live:</strong> flip themes, toggle a setting.</p>
     </aside>
   </section>
 
@@ -889,7 +1065,7 @@
       Whole <span class="brand-text">apps</span> port, too.
     </h2>
     <aside class="notes">
-      <p>Passing API checks is table stakes. The real test of "Web DX as the baseline" is taking an entire Vue codebase — state, routing, styling, data fetching — and landing it on native. Two classics, then.</p>
+      <p>Libraries in isolation are the warm-up. The real test is composing them — state, routing, styling, data fetching — into an entire Vue codebase on native. Two classics, then.</p>
     </aside>
   </section>
 

--- a/slides/index.html
+++ b/slides/index.html
@@ -24,11 +24,7 @@
     </button>
   </div>
   <div class="chrome chrome--bottom">
-<<<<<<< HEAD
-    <span data-counter>01 / 139</span>
-=======
-    <span data-counter>01 / 122</span>
->>>>>>> cf31457e (feat(slides): add Vue ecosystem lib demos (Pinia, Router, Query, Tailwind))
+    <span data-counter>01 / 143</span>
   </div>
   <div class="chrome chrome--bottom-right">
     <a href="https://vue.lynxjs.org" target="_blank" rel="noreferrer">vue.lynxjs.org</a>
@@ -411,7 +407,7 @@
        ==================================================== -->
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 1/13</span>
+      <span class="eyebrow">II · Vue coverage · 1/12</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><code class="brand-text">ref()</code></h2>
         <span class="ver-badge">0.2.0</span>
@@ -449,7 +445,7 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 2/13</span>
+      <span class="eyebrow">II · Vue coverage · 2/12</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><code class="brand-text">reactive()</code> + composables</h2>
         <span class="ver-badge">0.2.0</span>
@@ -483,7 +479,7 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 3/13</span>
+      <span class="eyebrow">II · Vue coverage · 3/12</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><code class="brand-text">v-model</code></h2>
         <span class="ver-badge">0.2.0</span>
@@ -522,7 +518,7 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 4/13</span>
+      <span class="eyebrow">II · Vue coverage · 4/12</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><code class="brand-text">&lt;slot&gt;</code></h2>
         <span class="ver-badge">0.2.0</span>
@@ -558,7 +554,7 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 5/13</span>
+      <span class="eyebrow">II · Vue coverage · 5/12</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><code class="brand-text">provide / inject</code></h2>
         <span class="ver-badge">0.2.0</span>
@@ -590,7 +586,7 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 6/13</span>
+      <span class="eyebrow">II · Vue coverage · 6/12</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><code class="brand-text">&lt;Suspense&gt;</code></h2>
         <span class="ver-badge">0.2.0</span>
@@ -625,7 +621,7 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 7/13</span>
+      <span class="eyebrow">II · Vue coverage · 7/12</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><code class="brand-text">&lt;Transition&gt;</code></h2>
         <span class="ver-badge">0.2.0</span>
@@ -658,7 +654,7 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 8/13</span>
+      <span class="eyebrow">II · Vue coverage · 8/12</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><span class="brand-text">CSS</span> features</h2>
         <span class="ver-badge">0.3.0</span>
@@ -701,7 +697,7 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 9/13</span>
+      <span class="eyebrow">II · Vue coverage · 9/12</span>
       <div class="demo__title-row">
         <h2 class="demo__title">Event <span class="brand-text">modifiers</span></h2>
         <span class="ver-badge">0.4.0</span>
@@ -739,7 +735,7 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 10/13</span>
+      <span class="eyebrow">II · Vue coverage · 10/12</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><code class="brand-text">&lt;KeepAlive&gt;</code></h2>
         <span class="ver-badge">0.4.0</span>
@@ -775,7 +771,7 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 11/13</span>
+      <span class="eyebrow">II · Vue coverage · 11/12</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><code class="brand-text">&lt;Teleport&gt;</code></h2>
         <span class="ver-badge">0.4.0</span>
@@ -810,11 +806,11 @@
     </aside>
   </section>
 
-  <section class="slide demo demo--api">
+  <section class="slide demo demo--api demo--api-duo">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 12/13</span>
+      <span class="eyebrow">II · Vue coverage · 12/12</span>
       <div class="demo__title-row">
-        <h2 class="demo__title"><code class="brand-text">v-once</code></h2>
+        <h2 class="demo__title"><code class="brand-text">v-once</code> / <code class="brand-text">v-memo</code></h2>
         <span class="ver-badge">0.4.0</span>
       </div>
       <a class="gh-badge" href="https://github.com/KealanAU" target="_blank" rel="noopener noreferrer">
@@ -824,42 +820,16 @@
       <div class="codeframe">
         <div class="codeframe__head">
           <span class="dots"><span></span><span></span><span></span></span>
-          <span>App.vue</span>
+          <span>v-once</span>
         </div>
 <pre><span class="code-tag">&lt;text&gt;</span>Live: {{ count }}<span class="code-tag">&lt;/text&gt;</span>
 <span class="code-tag">&lt;text</span> <span class="code-attr">v-once</span><span class="code-tag">&gt;</span>Frozen: {{ count }}<span class="code-tag">&lt;/text&gt;</span>
-
-<span class="code-com">// cache hit → zero cross-thread ops</span>
-<span class="code-com">// for that subtree on later renders</span></pre>
+<span class="code-com">// cache hit → zero cross-thread ops</span></pre>
       </div>
-    </div>
-    <div class="demo__stage">
-      <div class="phone">
-        <div class="phone__inner">
-          <vl-demo bundle="v-once-memo/dist/main.web.bundle"></vl-demo>
-        </div>
-      </div>
-    </div>
-    <aside class="notes">
-      <p><code>v-once</code> freezes after the first render. On Lynx a cache hit skips the <strong>entire cross-thread op batch</strong> for that subtree — more valuable than in the browser. Verified and documented by @KealanAU (#176) in <code>0.4.0</code>. Tap Increment: live updates, frozen stays.</p>
-    </aside>
-  </section>
-
-  <section class="slide demo demo--api">
-    <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 13/13</span>
-      <div class="demo__title-row">
-        <h2 class="demo__title"><code class="brand-text">v-memo</code></h2>
-        <span class="ver-badge">0.4.0</span>
-      </div>
-      <a class="gh-badge" href="https://github.com/KealanAU" target="_blank" rel="noopener noreferrer">
-        <img class="gh-badge__avatar" src="https://github.com/KealanAU.png?size=48" alt="" width="18" height="18" loading="lazy" decoding="async" />
-        <span>@KealanAU</span>
-      </a>
       <div class="codeframe">
         <div class="codeframe__head">
           <span class="dots"><span></span><span></span><span></span></span>
-          <span>App.vue</span>
+          <span>v-memo</span>
         </div>
 <pre><span class="code-tag">&lt;view</span>
   <span class="code-attr">v-for</span>=<span class="code-str">"item in items"</span>
@@ -867,9 +837,7 @@
   <span class="code-attr">v-memo</span>=<span class="code-str">"[item.selected, item.label]"</span>
 <span class="code-tag">&gt;</span>
   <span class="code-tag">&lt;text&gt;</span>{{ item.label }} · saw {{ count }}<span class="code-tag">&lt;/text&gt;</span>
-<span class="code-tag">&lt;/view&gt;</span>
-
-<span class="code-com">// bump count → rows skip; toggle → refresh</span></pre>
+<span class="code-tag">&lt;/view&gt;</span></pre>
       </div>
     </div>
     <div class="demo__stage">
@@ -880,7 +848,8 @@
       </div>
     </div>
     <aside class="notes">
-      <p><code>v-memo</code> skips a subtree when its deps are unchanged — same cross-thread win as <code>v-once</code>, but keyed on a dependency list. Common in <code>v-for</code> rows. <code>isMemoSame</code> export + tests from @KealanAU (#156 / #181) in <code>0.4.0</code>. Thirteen features, thirteen live apps. That's the API story. Now — the ecosystem that rides on it.</p>
+      <p><strong>Two skip directives, one cross-thread win.</strong> <code>v-once</code> freezes after the first render; <code>v-memo</code> skips when its deps are unchanged — same idea, keyed. On Lynx a cache hit skips the <strong>entire cross-thread op batch</strong> for that subtree. @KealanAU: <code>v-once</code> (#176), <code>isMemoSame</code> + <code>v-memo</code> (#156 / #181), <code>0.4.0</code>.</p>
+      <p><strong>Do live:</strong> Increment — live updates, frozen stays; rows skip until you toggle/rename. Twelve features. That's the API story. Now — the ecosystem that rides on it.</p>
     </aside>
   </section>
 

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -64,19 +64,20 @@ export const ZH = {
     '来自 Vue core 上游的测试,在我们的渲染器上直接通过。',
 
   // ---- API coverage ----
-  'II · Vue coverage · 1/13': 'II · Vue 覆盖度 · 1/13',
-  'II · Vue coverage · 2/13': 'II · Vue 覆盖度 · 2/13',
-  'II · Vue coverage · 3/13': 'II · Vue 覆盖度 · 3/13',
-  'II · Vue coverage · 4/13': 'II · Vue 覆盖度 · 4/13',
-  'II · Vue coverage · 5/13': 'II · Vue 覆盖度 · 5/13',
-  'II · Vue coverage · 6/13': 'II · Vue 覆盖度 · 6/13',
-  'II · Vue coverage · 7/13': 'II · Vue 覆盖度 · 7/13',
-  'II · Vue coverage · 8/13': 'II · Vue 覆盖度 · 8/13',
-  'II · Vue coverage · 9/13': 'II · Vue 覆盖度 · 9/13',
-  'II · Vue coverage · 10/13': 'II · Vue 覆盖度 · 10/13',
-  'II · Vue coverage · 11/13': 'II · Vue 覆盖度 · 11/13',
-  'II · Vue coverage · 12/13': 'II · Vue 覆盖度 · 12/13',
-  'II · Vue coverage · 13/13': 'II · Vue 覆盖度 · 13/13',
+  'II · Vue coverage · 1/12': 'II · Vue 覆盖度 · 1/12',
+  'II · Vue coverage · 2/12': 'II · Vue 覆盖度 · 2/12',
+  'II · Vue coverage · 3/12': 'II · Vue 覆盖度 · 3/12',
+  'II · Vue coverage · 4/12': 'II · Vue 覆盖度 · 4/12',
+  'II · Vue coverage · 5/12': 'II · Vue 覆盖度 · 5/12',
+  'II · Vue coverage · 6/12': 'II · Vue 覆盖度 · 6/12',
+  'II · Vue coverage · 7/12': 'II · Vue 覆盖度 · 7/12',
+  'II · Vue coverage · 8/12': 'II · Vue 覆盖度 · 8/12',
+  'II · Vue coverage · 9/12': 'II · Vue 覆盖度 · 9/12',
+  'II · Vue coverage · 10/12': 'II · Vue 覆盖度 · 10/12',
+  'II · Vue coverage · 11/12': 'II · Vue 覆盖度 · 11/12',
+  'II · Vue coverage · 12/12': 'II · Vue 覆盖度 · 12/12',
+  'v-once / v-memo':
+    '<code class="brand-text">v-once</code> / <code class="brand-text">v-memo</code>',
   'reactive() + composables':
     '<code class="brand-text">reactive()</code> + 组合式函数',
   'Event modifiers': '事件<span class="brand-text">修饰符</span>',
@@ -632,10 +633,8 @@ export const ZH_NOTES = [
   `<p>原生树上的组件实例缓存 —— 切 tab 再回来,状态还在。<code>include</code> / <code>exclude</code> / <code>max</code>,加上 <code>onActivated</code> / <code>onDeactivated</code>。@jynxbt 贡献(#153),落在 <code>0.4.0</code>。</p>`,
   // 25 Teleport
   `<p>按 id 渲染到目标节点 —— modal / overlay,不用和滚动层叠硬刚。BG 侧 <code>idRegistry</code> 解析 <code>to="#id"</code>;内容保持响应式,<code>:disabled</code> 则就地渲染。@sentomk 贡献(#161),落在 <code>0.4.0</code>。</p>`,
-  // 26 v-once
-  `<p><code>v-once</code> 首次渲染后冻结。在 Lynx 上缓存命中会跳过该子树的<strong>整批跨线程 ops</strong> —— 比浏览器更值钱。@KealanAU 验证并文档化(#176), <code>0.4.0</code>。点 Increment:live 会变,frozen 不动。</p>`,
-  // 27 v-memo
-  `<p><code>v-memo</code> 在依赖未变时跳过子树 —— 和 <code>v-once</code> 一样有跨线程收益,但按依赖列表判定。常见于 <code>v-for</code> 行。<code>isMemoSame</code> 导出与测试来自 @KealanAU(#156 / #181), <code>0.4.0</code>。十三个特性、十三个现场应用。API 讲完了 —— 接下来,骑在它上面的生态。</p>`,
+  // 26 v-once / v-memo
+  `<p><strong>两个跳过指令,同一套跨线程收益。</strong><code>v-once</code> 首次渲染后冻结;<code>v-memo</code> 在依赖未变时跳过 —— 同一思路,按依赖列表判定。在 Lynx 上缓存命中会跳过该子树的<strong>整批跨线程 ops</strong>。@KealanAU:<code>v-once</code>(#176), <code>isMemoSame</code> + <code>v-memo</code>(#156 / #181), <code>0.4.0</code>。</p><p><strong>现场:</strong>点 Increment —— live 会变,frozen 不动;行在依赖未变前会跳过,直到你 toggle/rename。十二个特性。API 讲完了 —— 接下来,骑在它上面的生态。</p>`,
   // 28 Ecosystem intro
   `<p><strong>把兼容性主张说死。</strong>Vue 不只是一套 API —— 它是一个生态。如果 Pinia、Router、Query、Tailwind 都要 fork 才能跑,我们就失败了。它们不用。接下来四台现场手机;同一批包、同一套 API。</p>`,
   // 29 Pinia

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -82,6 +82,19 @@ export const ZH = {
   'Event modifiers': '事件<span class="brand-text">修饰符</span>',
   'CSS features': '<span class="brand-text">CSS</span> 特性',
 
+  // ---- Ecosystem ----
+  'The ecosystem, as-is.': '生态,<span class="brand-text">原样</span>可用。',
+  'Pinia, Vue Router, TanStack Query, Tailwind — the libraries you\'d already reach for on the web, running unchanged.':
+    'Pinia、Vue Router、TanStack Query、Tailwind —— 你在 Web 上已经会用的库,原封不动就能跑。',
+  'II · Ecosystem · 1/4': 'II · 生态 · 1/4',
+  'II · Ecosystem · 2/4': 'II · 生态 · 2/4',
+  'II · Ecosystem · 3/4': 'II · 生态 · 3/4',
+  'II · Ecosystem · 4/4': 'II · 生态 · 4/4',
+  'Pinia': '<span class="brand-text">Pinia</span>',
+  'Vue Router': '<span class="brand-text">Vue Router</span>',
+  'Vue Query': '<span class="brand-text">Vue Query</span>',
+  'Tailwind': '<span class="brand-text">Tailwind</span>',
+
   // ---- Whole apps ----
   'II · Whole apps': 'II · 完整应用',
   'Whole apps port, too.': '整个<span class="brand-text">应用</span>,也搬得动。',
@@ -598,7 +611,7 @@ export const ZH_NOTES = [
   // 12 Title reveal · Vue Lynx 正式亮相
   `<p><strong>亮相。</strong>这是 Vue Lynx 第一次正式出场 —— 标题在论证之后才落下:空缺是真的,门是开的,而这个项目正走进那扇门。</p><p>念出名字,让背景光呼吸一拍,然后直接进入"完成度"。</p>`,
   // 13 Divider II
-  `<p><strong>秀肌肉章节。</strong>"为了让大家感受到诚意" —— 我带了一桌丰盛的 demo。三道菜:Vue API 覆盖度、完整应用、然后是原生超能力。</p><p>接下来看到的每台手机都是活的 —— 边看边扫码,在自己设备上跑。</p>`,
+  `<p><strong>秀肌肉章节。</strong>"为了让大家感受到诚意" —— 我带了一桌丰盛的 demo。三道菜:Vue API 覆盖度、生态原样可用、然后是完整应用。</p><p>接下来看到的每台手机都是活的 —— 边看边扫码,在自己设备上跑。</p>`,
   // 14 852/949
   `<p><strong>先上硬指标。</strong>我们把 Vue core 自己的测试套件拿来直接跑在 Vue Lynx 渲染器上:949 个通过 852 个;每个 skip 都有记录、有交代。"兼容 Vue"在这里是可测量的命题,不是一句口号。</p>`,
   // 15 ref
@@ -626,14 +639,24 @@ export const ZH_NOTES = [
   // 26 v-once
   `<p><code>v-once</code> 首次渲染后冻结。在 Lynx 上缓存命中会跳过该子树的<strong>整批跨线程 ops</strong> —— 比浏览器更值钱。@KealanAU 验证并文档化(#176), <code>0.4.0</code>。点 Increment:live 会变,frozen 不动。</p>`,
   // 27 v-memo
-  `<p><code>v-memo</code> 在依赖未变时跳过子树 —— 和 <code>v-once</code> 一样有跨线程收益,但按依赖列表判定。常见于 <code>v-for</code> 行。<code>isMemoSame</code> 导出与测试来自 @KealanAU(#156 / #181), <code>0.4.0</code>。十三个特性、十三个现场应用。API 讲完了 —— 接下来,整个应用。</p>`,
-  // 28 Whole apps
-  `<p>API 逐个通过只是入场券。"Web DX 是基线"真正的考验,是把一整个 Vue 代码库 —— 状态、路由、样式、数据请求 —— 整体落到原生上。来两个经典。</p>`,
-  // 29 TodoMVC
+  `<p><code>v-memo</code> 在依赖未变时跳过子树 —— 和 <code>v-once</code> 一样有跨线程收益,但按依赖列表判定。常见于 <code>v-for</code> 行。<code>isMemoSame</code> 导出与测试来自 @KealanAU(#156 / #181), <code>0.4.0</code>。十三个特性、十三个现场应用。API 讲完了 —— 接下来,骑在它上面的生态。</p>`,
+  // 28 Ecosystem intro
+  `<p><strong>把兼容性主张说死。</strong>Vue 不只是一套 API —— 它是一个生态。如果 Pinia、Router、Query、Tailwind 都要 fork 才能跑,我们就失败了。它们不用。接下来四台现场手机;同一批包、同一套 API。</p>`,
+  // 29 Pinia
+  `<p><strong>Pinia,原封不动。</strong>同样的 <code>createPinia</code>,同样的 setup-store <code>defineStore</code>。它骑在 provide/inject 上 —— 所以前面那页才重要。这台手机里有两个 store:一个计数器,一个待办列表。</p><p><strong>现场:</strong>点 +,看 double getter 更新;再切到 todos 区。</p>`,
+  // 30 Vue Router
+  `<p><strong>Vue Router,按发布原样。</strong>唯一带 Lynx 形状的选择是 history 模式:没有 <code>window.location</code>,所以用 <code>createMemoryHistory()</code> —— 和 React Router 的 MemoryRouter 同一套 API。嵌套路由、params、<code>router.push</code> / <code>back</code> 全都有。导航用 <code>RouterLink</code> 的 custom slot 渲染原生 <code>&lt;text&gt;</code>。</p><p><strong>现场:</strong>点 Home → About → Users → 打开一个用户。</p>`,
+  // 31 Vue Query
+  `<p><strong>TanStack Vue Query,原样可用。</strong><code>useQuery</code>、依赖 key、mutation、插件安装 —— 没有任何一处是 Lynx 特供。这台手机打真实 JSON API:列用户、点一个、帖子通过依赖查询加载。</p><p><strong>现场:</strong>等列表出来,点一个用户,看 posts 到达。</p>`,
+  // 32 Tailwind
+  `<p><strong>Tailwind 能跑,是因为 CSS 能跑。</strong>没有 StyleSheet 方言 —— PostCSS 吐真实 CSS,Lynx 的原生引擎直接吃。主题 token 走 CSS 变量;点 Dark / Light / Ocean,整棵树跟着换 token。</p><p><strong>现场:</strong>切主题,拨一个开关。</p>`,
+  // 33 Whole apps
+  `<p>库单独跑通只是热身。真正的考验是把它们组合起来 —— 状态、路由、样式、数据请求 —— 整份 Vue 代码库落到原生上。来两个经典。</p>`,
+  // 34 TodoMVC
   `<p><strong>TodoMVC</strong> —— 每个框架的成人礼。和写 Web 一模一样的 Composition API;输入框是<em>原生</em>的,滚动是<em>原生</em>的,点击延迟不到一帧。</p><p><strong>现场:</strong>加一条、勾几条、清除已完成。</p>`,
-  // 26 HackerNews
+  // 35 HackerNews
   `<p><strong>HackerNews</strong> —— 社区公认的"真应用"基准:网络、分页、嵌套评论。数据 TanStack Vue Query,样式 Tailwind,滚动跑在带复用的原生 <code>&lt;list&gt;</code> 上。<strong>跟着过来的不只是框架,是生态。</strong></p>`,
-  // 27 Runs on web
+  // 36 Runs on web
   `<p><strong>Web 兼容的点睛:</strong>刚才没有任何模拟器。每个手机壳里都是 <em>Lynx for Web</em>,跑的就是发到 iOS/Android 的那份产物。任何一页扫 Web 码 —— 浏览器直接打开;扫 App 码 —— 同一份产物,原生运行。</p><p>Web DX 进,Web 渲染目标出。基线讲完 —— 上超集。</p>`,
   // 28 Divider III
   `<p><strong>超集章节。</strong>覆盖度和移植证明的是下限;真正的卖点是向上:拿一个活着的 Web 应用,fork 它,然后<em>升级</em>它 —— 该是 Vue 的地方还是 Vue,该用原生的地方全上原生。两个真实 fork。</p>`,

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -90,10 +90,6 @@ export const ZH = {
   'II · Ecosystem · 2/4': 'II · 生态 · 2/4',
   'II · Ecosystem · 3/4': 'II · 生态 · 3/4',
   'II · Ecosystem · 4/4': 'II · 生态 · 4/4',
-  'Pinia': '<span class="brand-text">Pinia</span>',
-  'Vue Router': '<span class="brand-text">Vue Router</span>',
-  'Vue Query': '<span class="brand-text">Vue Query</span>',
-  'Tailwind': '<span class="brand-text">Tailwind</span>',
 
   // ---- Whole apps ----
   'II · Whole apps': 'II · 完整应用',

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -701,6 +701,14 @@ h1, h2, h3, p { margin: 0; }
 }
 .demo--api .codeframe pre { padding: 16px 18px; }
 
+/* Two compact codeframes on one API slide (v-once / v-memo). */
+.demo--api-duo .demo__body { gap: 10px; }
+.demo--api-duo .codeframe {
+  font-size: 11.5px;
+  line-height: 1.5;
+}
+.demo--api-duo .codeframe pre { padding: 12px 14px; }
+
 /* The device mockup keeps its phone-sized footprint in the two-column demo
    layout no matter which preset is active: the stage reserves that space and the
    frame is absolutely centred inside it, so growing to tablet / desktop makes the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Chapter II **Ecosystem** section between Vue API coverage and whole apps, demonstrating that the Vue ecosystem works on Lynx as-is:

1. **Intro stage** — “The ecosystem, as-is.” with Pinia / Vue Router / Vue Query / Tailwind chips
2. **Pinia** — `defineStore` setup store + live `pinia` example
3. **Vue Router** — `createMemoryHistory` + live `vue-router` example
4. **Vue Query** — TanStack `useQuery` / dependent queries + live `networking` example
5. **Tailwind** — utility classes on Lynx elements + live `tailwindcss` example

Also updates bilingual `ZH` strings and `ZH_NOTES` (122 slides / notes aligned), and the Chapter II divider notes to name the ecosystem course.

## Test plan

- [ ] `cd slides && pnpm build` stays green
- [ ] Slide/note/`ZH_NOTES` counts stay equal (`122`)
- [ ] Build example bundles (`pinia`, `vue-router`, `networking`, `tailwindcss`) and `prepare-examples` so demos load
- [ ] Keyboard-walk the new ecosystem slides; no `pageerror`s
- [ ] Toggle 中文 on the new slides; titles/eyebrows/lead copy translate
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f7226-4a03-7e1f-b11a-c5de981c3514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f7226-4a03-7e1f-b11a-c5de981c3514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

