### PR TITLE
Sync vapor onto latest main

### DIFF
--- a/.changeset/ifr-seal-first-screen-snapshot.md
+++ b/.changeset/ifr-seal-first-screen-snapshot.md
@@ -1,5 +1,0 @@
----
-"vue-lynx": patch
----
-
-Seal the IFR first-screen ops snapshot when the sync mount returns, so Suspense / `defineAsyncComponent` resolves on the main thread cannot extend the hydration stream and wipe the tree on mismatch.

--- a/examples/7guis/CHANGELOG.md
+++ b/examples/7guis/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @vue-lynx-example/7guis
 
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies [[`85ce206`](https://github.com/Huxpro/vue-lynx/commit/85ce20642266e6c6b3ffe7faff99abd9788efa5d)]:
+  - vue-lynx@0.5.1
+
 ## 0.2.8
 
 ### Patch Changes

--- a/examples/7guis/package.json
+++ b/examples/7guis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-lynx-example/7guis",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": false,
   "description": "7 GUIs benchmark — Counter, Temperature Converter, Flight Booker, Timer, CRUD, Circle Drawer, Cells",
   "license": "Apache-2.0",

--- a/examples/basic/CHANGELOG.md
+++ b/examples/basic/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @vue-lynx-example/basic
 
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies [[`85ce206`](https://github.com/Huxpro/vue-lynx/commit/85ce20642266e6c6b3ffe7faff99abd9788efa5d)]:
+  - vue-lynx@0.5.1
+
 ## 0.2.8
 
 ### Patch Changes

--- a/examples/basic/package.json
+++ b/examples/basic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-lynx-example/basic",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": false,
   "description": "Vue-Lynx basic demo examples",
   "license": "Apache-2.0",

--- a/examples/css-features/CHANGELOG.md
+++ b/examples/css-features/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @vue-lynx-example/css-features
 
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies [[`85ce206`](https://github.com/Huxpro/vue-lynx/commit/85ce20642266e6c6b3ffe7faff99abd9788efa5d)]:
+  - vue-lynx@0.5.1
+
 ## 0.2.8
 
 ### Patch Changes

--- a/examples/css-features/package.json
+++ b/examples/css-features/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-lynx-example/css-features",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": false,
   "description": "Vue-Lynx CSS features demo — scoped, modules, v-bind()",
   "license": "Apache-2.0",

--- a/examples/gallery/CHANGELOG.md
+++ b/examples/gallery/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @vue-lynx-example/gallery
 
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies [[`85ce206`](https://github.com/Huxpro/vue-lynx/commit/85ce20642266e6c6b3ffe7faff99abd9788efa5d)]:
+  - vue-lynx@0.5.1
+
 ## 0.2.8
 
 ### Patch Changes

--- a/examples/gallery/package.json
+++ b/examples/gallery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-lynx-example/gallery",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": false,
   "description": "Vue-Lynx gallery tutorial examples",
   "license": "Apache-2.0",

--- a/examples/hackernews-css/CHANGELOG.md
+++ b/examples/hackernews-css/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @vue-lynx-example/hackernews-css
 
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies [[`85ce206`](https://github.com/Huxpro/vue-lynx/commit/85ce20642266e6c6b3ffe7faff99abd9788efa5d)]:
+  - vue-lynx@0.5.1
+
 ## 0.2.8
 
 ### Patch Changes

--- a/examples/hackernews-css/package.json
+++ b/examples/hackernews-css/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-lynx-example/hackernews-css",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": false,
   "description": "HackerNews clone built with Vue-Lynx + Vue Router + Pinia + TanStack Query + SCSS",
   "license": "Apache-2.0",

--- a/examples/hackernews-tailwind/CHANGELOG.md
+++ b/examples/hackernews-tailwind/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @vue-lynx-example/hackernews
 
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies [[`85ce206`](https://github.com/Huxpro/vue-lynx/commit/85ce20642266e6c6b3ffe7faff99abd9788efa5d)]:
+  - vue-lynx@0.5.1
+
 ## 0.2.8
 
 ### Patch Changes

--- a/examples/hackernews-tailwind/package.json
+++ b/examples/hackernews-tailwind/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-lynx-example/hackernews",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": false,
   "description": "HackerNews clone built with Vue-Lynx + Vue Router + Pinia + TanStack Query + Tailwind CSS",
   "license": "Apache-2.0",

--- a/examples/hello-world/CHANGELOG.md
+++ b/examples/hello-world/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @vue-lynx-example/hello-world
 
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies [[`85ce206`](https://github.com/Huxpro/vue-lynx/commit/85ce20642266e6c6b3ffe7faff99abd9788efa5d)]:
+  - vue-lynx@0.5.1
+
 ## 0.2.8
 
 ### Patch Changes

--- a/examples/hello-world/package.json
+++ b/examples/hello-world/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-lynx-example/hello-world",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": false,
   "type": "module",
   "files": [

--- a/examples/keep-alive/CHANGELOG.md
+++ b/examples/keep-alive/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @vue-lynx-example/keep-alive
 
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies [[`85ce206`](https://github.com/Huxpro/vue-lynx/commit/85ce20642266e6c6b3ffe7faff99abd9788efa5d)]:
+  - vue-lynx@0.5.1
+
 ## 0.2.8
 
 ### Patch Changes

--- a/examples/keep-alive/package.json
+++ b/examples/keep-alive/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-lynx-example/keep-alive",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": false,
   "description": "Vue-Lynx KeepAlive demo — component caching and state preservation",
   "license": "Apache-2.0",

--- a/examples/main-thread/CHANGELOG.md
+++ b/examples/main-thread/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @vue-lynx-example/main-thread
 
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies [[`85ce206`](https://github.com/Huxpro/vue-lynx/commit/85ce20642266e6c6b3ffe7faff99abd9788efa5d)]:
+  - vue-lynx@0.5.1
+
 ## 0.2.8
 
 ### Patch Changes

--- a/examples/main-thread/package.json
+++ b/examples/main-thread/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-lynx-example/main-thread",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": false,
   "description": "Vue-Lynx main thread demo — draggable examples comparing Main Thread vs Background Thread updates",
   "type": "module",

--- a/examples/option-api/CHANGELOG.md
+++ b/examples/option-api/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @vue-lynx-example/option-api
 
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies [[`85ce206`](https://github.com/Huxpro/vue-lynx/commit/85ce20642266e6c6b3ffe7faff99abd9788efa5d)]:
+  - vue-lynx@0.5.1
+
 ## 0.2.8
 
 ### Patch Changes

--- a/examples/option-api/package.json
+++ b/examples/option-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-lynx-example/option-api",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": false,
   "description": "Vue-Lynx Options API demo — validates that optionsApi: true works",
   "type": "module",

--- a/examples/pinia/CHANGELOG.md
+++ b/examples/pinia/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @vue-lynx-example/pinia
 
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies [[`85ce206`](https://github.com/Huxpro/vue-lynx/commit/85ce20642266e6c6b3ffe7faff99abd9788efa5d)]:
+  - vue-lynx@0.5.1
+
 ## 0.2.8
 
 ### Patch Changes

--- a/examples/pinia/package.json
+++ b/examples/pinia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-lynx-example/pinia",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": false,
   "description": "Vue-Lynx + Pinia state management demo",
   "license": "Apache-2.0",

--- a/examples/provide-inject/CHANGELOG.md
+++ b/examples/provide-inject/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @vue-lynx-example/provide-inject
 
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies [[`85ce206`](https://github.com/Huxpro/vue-lynx/commit/85ce20642266e6c6b3ffe7faff99abd9788efa5d)]:
+  - vue-lynx@0.5.1
+
 ## 0.2.8
 
 ### Patch Changes

--- a/examples/provide-inject/package.json
+++ b/examples/provide-inject/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-lynx-example/provide-inject",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": false,
   "description": "Vue-Lynx provide/inject dependency injection demo",
   "license": "Apache-2.0",

--- a/examples/reactivity/CHANGELOG.md
+++ b/examples/reactivity/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @vue-lynx-example/reactivity
 
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies [[`85ce206`](https://github.com/Huxpro/vue-lynx/commit/85ce20642266e6c6b3ffe7faff99abd9788efa5d)]:
+  - vue-lynx@0.5.1
+
 ## 0.2.8
 
 ### Patch Changes

--- a/examples/reactivity/package.json
+++ b/examples/reactivity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-lynx-example/reactivity",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": false,
   "type": "module",
   "files": [

--- a/examples/slots/CHANGELOG.md
+++ b/examples/slots/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @vue-lynx-example/slots
 
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies [[`85ce206`](https://github.com/Huxpro/vue-lynx/commit/85ce20642266e6c6b3ffe7faff99abd9788efa5d)]:
+  - vue-lynx@0.5.1
+
 ## 0.2.8
 
 ### Patch Changes

--- a/examples/slots/package.json
+++ b/examples/slots/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-lynx-example/slots",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": false,
   "description": "Vue-Lynx slots (default, named, scoped) demo",
   "license": "Apache-2.0",

--- a/examples/suspense/CHANGELOG.md
+++ b/examples/suspense/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @vue-lynx-example/suspense
 
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies [[`85ce206`](https://github.com/Huxpro/vue-lynx/commit/85ce20642266e6c6b3ffe7faff99abd9788efa5d)]:
+  - vue-lynx@0.5.1
+
 ## 0.2.8
 
 ### Patch Changes

--- a/examples/suspense/package.json
+++ b/examples/suspense/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-lynx-example/suspense",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": false,
   "description": "Vue-Lynx Suspense demo — async setup, defineAsyncComponent, error handling",
   "type": "module",

--- a/examples/swiper/CHANGELOG.md
+++ b/examples/swiper/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @vue-lynx-example/swiper
 
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies [[`85ce206`](https://github.com/Huxpro/vue-lynx/commit/85ce20642266e6c6b3ffe7faff99abd9788efa5d)]:
+  - vue-lynx@0.5.1
+
 ## 0.2.8
 
 ### Patch Changes

--- a/examples/swiper/package.json
+++ b/examples/swiper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-lynx-example/swiper",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": false,
   "description": "Vue-Lynx swiper tutorial examples",
   "license": "Apache-2.0",

--- a/examples/tailwindcss/CHANGELOG.md
+++ b/examples/tailwindcss/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @vue-lynx-example/tailwindcss
 
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies [[`85ce206`](https://github.com/Huxpro/vue-lynx/commit/85ce20642266e6c6b3ffe7faff99abd9788efa5d)]:
+  - vue-lynx@0.5.1
+
 ## 0.2.8
 
 ### Patch Changes

--- a/examples/tailwindcss/package.json
+++ b/examples/tailwindcss/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-lynx-example/tailwindcss",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": false,
   "type": "module",
   "files": [

--- a/examples/teleport/CHANGELOG.md
+++ b/examples/teleport/CHANGELOG.md
@@ -1,0 +1,8 @@
+# @vue-lynx-example/teleport
+
+## 0.0.1
+
+### Patch Changes
+
+- Updated dependencies [[`85ce206`](https://github.com/Huxpro/vue-lynx/commit/85ce20642266e6c6b3ffe7faff99abd9788efa5d)]:
+  - vue-lynx@0.5.1

--- a/examples/teleport/package.json
+++ b/examples/teleport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-lynx-example/teleport",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "private": false,
   "description": "Vue-Lynx Teleport demo — render content to a remote #id target",
   "license": "Apache-2.0",

--- a/examples/todomvc-codex/CHANGELOG.md
+++ b/examples/todomvc-codex/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @vue-lynx-example/todomvc-codex
 
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies [[`85ce206`](https://github.com/Huxpro/vue-lynx/commit/85ce20642266e6c6b3ffe7faff99abd9788efa5d)]:
+  - vue-lynx@0.5.1
+
 ## 0.2.8
 
 ### Patch Changes

--- a/examples/todomvc-codex/package.json
+++ b/examples/todomvc-codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-lynx-example/todomvc-codex",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": false,
   "description": "A closer TodoMVC reference clone built with Vue-Lynx and Vue Router",
   "license": "Apache-2.0",

--- a/examples/todomvc/CHANGELOG.md
+++ b/examples/todomvc/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @vue-lynx-example/todomvc
 
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies [[`85ce206`](https://github.com/Huxpro/vue-lynx/commit/85ce20642266e6c6b3ffe7faff99abd9788efa5d)]:
+  - vue-lynx@0.5.1
+
 ## 0.2.8
 
 ### Patch Changes

--- a/examples/todomvc/package.json
+++ b/examples/todomvc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-lynx-example/todomvc",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": false,
   "description": "TodoMVC built with Vue 3 × Lynx",
   "type": "module",

--- a/examples/transition/CHANGELOG.md
+++ b/examples/transition/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @vue-lynx-example/transition
 
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies [[`85ce206`](https://github.com/Huxpro/vue-lynx/commit/85ce20642266e6c6b3ffe7faff99abd9788efa5d)]:
+  - vue-lynx@0.5.1
+
 ## 0.2.8
 
 ### Patch Changes

--- a/examples/transition/package.json
+++ b/examples/transition/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-lynx-example/transition",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": false,
   "description": "Vue-Lynx Transition & TransitionGroup demo",
   "license": "Apache-2.0",

--- a/examples/v-model/CHANGELOG.md
+++ b/examples/v-model/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @vue-lynx-example/v-model
 
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies [[`85ce206`](https://github.com/Huxpro/vue-lynx/commit/85ce20642266e6c6b3ffe7faff99abd9788efa5d)]:
+  - vue-lynx@0.5.1
+
 ## 0.2.8
 
 ### Patch Changes

--- a/examples/v-model/package.json
+++ b/examples/v-model/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-lynx-example/v-model",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": false,
   "type": "module",
   "files": [

--- a/examples/v-once-memo/CHANGELOG.md
+++ b/examples/v-once-memo/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @vue-lynx-example/v-once-memo
 
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies [[`85ce206`](https://github.com/Huxpro/vue-lynx/commit/85ce20642266e6c6b3ffe7faff99abd9788efa5d)]:
+  - vue-lynx@0.5.1
+
 ## 0.2.8
 
 ### Patch Changes

--- a/examples/v-once-memo/package.json
+++ b/examples/v-once-memo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-lynx-example/v-once-memo",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": false,
   "description": "Vue-Lynx v-once and v-memo directive demo",
   "license": "Apache-2.0",

--- a/examples/vue-router/CHANGELOG.md
+++ b/examples/vue-router/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @vue-lynx-example/vue-router
 
+## 0.2.9
+
+### Patch Changes
+
+- Updated dependencies [[`85ce206`](https://github.com/Huxpro/vue-lynx/commit/85ce20642266e6c6b3ffe7faff99abd9788efa5d)]:
+  - vue-lynx@0.5.1
+
 ## 0.2.8
 
 ### Patch Changes

--- a/examples/vue-router/package.json
+++ b/examples/vue-router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue-lynx-example/vue-router",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "private": false,
   "description": "Vue-Lynx + Vue Router demo using createMemoryHistory",
   "license": "Apache-2.0",

--- a/packages/vue-lynx/CHANGELOG.md
+++ b/packages/vue-lynx/CHANGELOG.md
@@ -1,5 +1,11 @@
 # vue-lynx
 
+## 0.5.1
+
+### Patch Changes
+
+- Seal the IFR first-screen ops snapshot when the sync mount returns, so Suspense / `defineAsyncComponent` resolves on the main thread cannot extend the hydration stream and wipe the tree on mismatch. ([#257](https://github.com/Huxpro/vue-lynx/pull/257))
+
 ## 0.5.0
 
 ### Minor Changes

--- a/packages/vue-lynx/package.json
+++ b/packages/vue-lynx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-lynx",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": false,
   "description": "Vue 3 framework for building Lynx apps",
   "keywords": [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Brings `vapor` up to date with current `main` so [#222](https://github.com/Huxpro/vue-lynx/pull/222) can merge cleanly.

Vapor’s history already syncs via merge commits (not a linear replay of ~100 commits), so this update is a `Merge origin/main into vapor` with conflict resolution — same end state as “rebase onto main” for this branch shape.

### Conflict resolutions

- **IFR (`ifr.ts`)**: Kept the Vapor flat-stream / `renderSealed` protocol; absorbed main’s Suspense snapshot-seal rationale and warning copy
- **Docs (`ifr.mdx` en/zh)**: Kept vapor’s VDOM+Vapor cohesive rewrite; refreshed stale UNIFIED-RERUN links
- **`prepare-examples.mjs`**: Combined vapor support-matrix loading with main’s `PLUGIN_DIST` check + Vercel pre-gzip
- **ifr-bench**: Kept vapor’s unified rerun results/docs; added main’s `reeval/` pointers and Chromium path coverage
- **worklet-utils / tests**: Took main’s element-template extraction docs; kept vapor’s fuller test imports (JSDoc case already covered)
- **lockfile**: Regenerated with `pnpm install`

### Test plan

- [ ] `pnpm install` / lockfile coherent with `examples/vapor` + `examples/v-once-memo`
- [ ] Targeted IFR / worklet unit tests
- [ ] Confirm PR #222 merge state is no longer conflicting after this lands on `vapor`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3db0ba7f-ee85-4b4f-b289-414434dad1f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3db0ba7f-ee85-4b4f-b289-414434dad1f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

