### PR TITLE
feat(slides): select-storm scaling chart (unified bench #266)

### DIFF
--- a/slides/index.html
+++ b/slides/index.html
@@ -24,7 +24,7 @@
     </button>
   </div>
   <div class="chrome chrome--bottom">
-    <span data-counter>01 / 143</span>
+    <span data-counter>01 / 144</span>
   </div>
   <div class="chrome chrome--bottom-right">
     <a href="https://vue.lynxjs.org" target="_blank" rel="noreferrer">vue.lynxjs.org</a>
@@ -2936,6 +2936,50 @@ app.<span class="code-fn">use</span>(router)</pre>
     <aside class="notes">
       <p><strong>The core result — then the honest scorecard.</strong> Vue&rsquo;s official benchmark, ported to Lynx, same app in both modes. Background-thread cost = reactivity + render + ops serialization — Vapor&rsquo;s structural win shows up unfiltered here (5.8–9.8×). End-to-end multipliers are smaller (2.1–6.3×) because both modes emit near-identical ops.</p>
       <p>Don&rsquo;t oversell: creation is parity; the cost is a +26% bundle (Vapor runtime + DOM-compat shim). First screen is within noise. Green = win, pink = cost. Numbers: headless Chromium, Lynx for Web, medians with 95% CIs.</p>
+    </aside>
+  </section>
+
+  <!-- V·8c — Select-storm scaling: Vapor stays flat vs the field (unified bench #266) -->
+  <section class="slide stage" data-bg="clean">
+    <span class="eyebrow">One more thing · select storm × scale</span>
+    <div style="width:min(100%,1000px);margin:0 auto">
+      <svg viewBox="0 0 1000 460" style="width:100%;height:auto" aria-label="Select-storm latency vs rows">
+        <!-- axes -->
+        <line x1="90" y1="400" x2="945" y2="400" stroke="rgba(244,245,247,0.18)" stroke-width="1.5"/>
+        <line x1="90" y1="40" x2="90" y2="400" stroke="rgba(244,245,247,0.18)" stroke-width="1.5"/>
+        <!-- y gridlines + labels (ms) -->
+        <line x1="90" y1="305" x2="945" y2="305" stroke="rgba(244,245,247,0.07)"/>
+        <line x1="90" y1="210" x2="945" y2="210" stroke="rgba(244,245,247,0.07)"/>
+        <line x1="90" y1="116" x2="945" y2="116" stroke="rgba(244,245,247,0.07)"/>
+        <text x="80" y="404" text-anchor="end" fill="rgba(244,245,247,0.5)" font-family="Geist Mono, monospace" font-size="15">0</text>
+        <text x="80" y="309" text-anchor="end" fill="rgba(244,245,247,0.5)" font-family="Geist Mono, monospace" font-size="15">1s</text>
+        <text x="80" y="214" text-anchor="end" fill="rgba(244,245,247,0.5)" font-family="Geist Mono, monospace" font-size="15">2s</text>
+        <text x="80" y="120" text-anchor="end" fill="rgba(244,245,247,0.5)" font-family="Geist Mono, monospace" font-size="15">3s</text>
+        <!-- x labels (rows) -->
+        <text x="118" y="428" text-anchor="middle" fill="rgba(244,245,247,0.5)" font-family="Geist Mono, monospace" font-size="15">1k</text>
+        <text x="373" y="428" text-anchor="middle" fill="rgba(244,245,247,0.5)" font-family="Geist Mono, monospace" font-size="15">10k</text>
+        <text x="940" y="428" text-anchor="middle" fill="rgba(244,245,247,0.5)" font-family="Geist Mono, monospace" font-size="15">30k</text>
+        <!-- ReactLynx: 92 / 1018 / 3744 -->
+        <polyline points="118,391 373,304 940,45" fill="none" stroke="#E8B44A" stroke-width="3" stroke-linejoin="round"/>
+        <circle cx="118" cy="391" r="5" fill="#E8B44A"/><circle cx="373" cy="304" r="5" fill="#E8B44A"/><circle cx="940" cy="45" r="6" fill="#E8B44A"/>
+        <text x="928" y="40" text-anchor="end" fill="#E8B44A" font-family="Geist, sans-serif" font-size="18" font-weight="600">ReactLynx · 3.74s</text>
+        <!-- VDOM: 43 / 367 / 1459 -->
+        <polyline points="118,396 373,365 940,262" fill="none" stroke="#4FB8F0" stroke-width="3" stroke-linejoin="round"/>
+        <circle cx="118" cy="396" r="5" fill="#4FB8F0"/><circle cx="373" cy="365" r="5" fill="#4FB8F0"/><circle cx="940" cy="262" r="6" fill="#4FB8F0"/>
+        <text x="928" y="253" text-anchor="end" fill="#4FB8F0" font-family="Geist, sans-serif" font-size="18" font-weight="600">Vue VDOM · 1.46s</text>
+        <!-- Vapor: 26 / 45 / 128 (flat) -->
+        <polyline points="118,398 373,396 940,388" fill="none" stroke="#5dd5a8" stroke-width="3.5" stroke-linejoin="round"/>
+        <circle cx="118" cy="398" r="5" fill="#5dd5a8"/><circle cx="373" cy="396" r="5" fill="#5dd5a8"/><circle cx="940" cy="388" r="6" fill="#5dd5a8"/>
+        <text x="928" y="378" text-anchor="end" fill="#5dd5a8" font-family="Geist, sans-serif" font-size="18" font-weight="700">Vue Vapor · 128 ms</text>
+      </svg>
+    </div>
+    <p class="lead" data-mm-fade>
+      Same select storm, black-box wall-clock as rows grow: VDOM and ReactLynx
+      climb linearly; Vapor stays near the floor — <b class="brand-text">128 ms
+      at 30k</b> vs VDOM's 1.46 s. The gap widens with scale.
+    </p>
+    <aside class="notes">
+      <p><strong>The scaling picture (unified bench, PR #266).</strong> The 5.8–9.8× you just saw is the background-thread micro number; this is the user-visible wall-clock as the list grows. selectStorm across 1k → 10k → 30k, every tick re-selects one row. VDOM re-runs render + diffs the whole list each pass, so its curve rises with N; ReactLynx pays that plus its own overhead. Vapor's reactive effects touch only the changed node, so the curve is almost flat — the gap vs VDOM widens 1.7× @1k → 8.2× @10k → 11.4× @30k. Absolute ms are host-bound; the ratios are the portable claim.</p>
     </aside>
   </section>
 

--- a/slides/index.html
+++ b/slides/index.html
@@ -2947,39 +2947,43 @@ app.<span class="code-fn">use</span>(router)</pre>
         <!-- axes -->
         <line x1="90" y1="400" x2="945" y2="400" stroke="rgba(244,245,247,0.18)" stroke-width="1.5"/>
         <line x1="90" y1="40" x2="90" y2="400" stroke="rgba(244,245,247,0.18)" stroke-width="1.5"/>
-        <!-- y gridlines + labels (ms) -->
-        <line x1="90" y1="305" x2="945" y2="305" stroke="rgba(244,245,247,0.07)"/>
-        <line x1="90" y1="210" x2="945" y2="210" stroke="rgba(244,245,247,0.07)"/>
-        <line x1="90" y1="116" x2="945" y2="116" stroke="rgba(244,245,247,0.07)"/>
+        <!-- y gridlines + labels (ms); y-axis 0–10.5s, source: unified bench @346eccf (2026-07-28) -->
+        <line x1="90" y1="331" x2="945" y2="331" stroke="rgba(244,245,247,0.07)"/>
+        <line x1="90" y1="263" x2="945" y2="263" stroke="rgba(244,245,247,0.07)"/>
+        <line x1="90" y1="194" x2="945" y2="194" stroke="rgba(244,245,247,0.07)"/>
+        <line x1="90" y1="126" x2="945" y2="126" stroke="rgba(244,245,247,0.07)"/>
+        <line x1="90" y1="57" x2="945" y2="57" stroke="rgba(244,245,247,0.07)"/>
         <text x="80" y="404" text-anchor="end" fill="rgba(244,245,247,0.5)" font-family="Geist Mono, monospace" font-size="15">0</text>
-        <text x="80" y="309" text-anchor="end" fill="rgba(244,245,247,0.5)" font-family="Geist Mono, monospace" font-size="15">1s</text>
-        <text x="80" y="214" text-anchor="end" fill="rgba(244,245,247,0.5)" font-family="Geist Mono, monospace" font-size="15">2s</text>
-        <text x="80" y="120" text-anchor="end" fill="rgba(244,245,247,0.5)" font-family="Geist Mono, monospace" font-size="15">3s</text>
+        <text x="80" y="335" text-anchor="end" fill="rgba(244,245,247,0.5)" font-family="Geist Mono, monospace" font-size="15">2s</text>
+        <text x="80" y="267" text-anchor="end" fill="rgba(244,245,247,0.5)" font-family="Geist Mono, monospace" font-size="15">4s</text>
+        <text x="80" y="198" text-anchor="end" fill="rgba(244,245,247,0.5)" font-family="Geist Mono, monospace" font-size="15">6s</text>
+        <text x="80" y="130" text-anchor="end" fill="rgba(244,245,247,0.5)" font-family="Geist Mono, monospace" font-size="15">8s</text>
+        <text x="80" y="61" text-anchor="end" fill="rgba(244,245,247,0.5)" font-family="Geist Mono, monospace" font-size="15">10s</text>
         <!-- x labels (rows) -->
         <text x="118" y="428" text-anchor="middle" fill="rgba(244,245,247,0.5)" font-family="Geist Mono, monospace" font-size="15">1k</text>
         <text x="373" y="428" text-anchor="middle" fill="rgba(244,245,247,0.5)" font-family="Geist Mono, monospace" font-size="15">10k</text>
         <text x="940" y="428" text-anchor="middle" fill="rgba(244,245,247,0.5)" font-family="Geist Mono, monospace" font-size="15">30k</text>
-        <!-- ReactLynx: 92 / 1018 / 3744 -->
-        <polyline points="118,391 373,304 940,45" fill="none" stroke="#E8B44A" stroke-width="3" stroke-linejoin="round"/>
-        <circle cx="118" cy="391" r="5" fill="#E8B44A"/><circle cx="373" cy="304" r="5" fill="#E8B44A"/><circle cx="940" cy="45" r="6" fill="#E8B44A"/>
-        <text x="928" y="40" text-anchor="end" fill="#E8B44A" font-family="Geist, sans-serif" font-size="18" font-weight="600">ReactLynx · 3.74s</text>
-        <!-- VDOM: 43 / 367 / 1459 -->
-        <polyline points="118,396 373,365 940,262" fill="none" stroke="#4FB8F0" stroke-width="3" stroke-linejoin="round"/>
-        <circle cx="118" cy="396" r="5" fill="#4FB8F0"/><circle cx="373" cy="365" r="5" fill="#4FB8F0"/><circle cx="940" cy="262" r="6" fill="#4FB8F0"/>
-        <text x="928" y="253" text-anchor="end" fill="#4FB8F0" font-family="Geist, sans-serif" font-size="18" font-weight="600">Vue VDOM · 1.46s</text>
-        <!-- Vapor: 26 / 45 / 128 (flat) -->
-        <polyline points="118,398 373,396 940,388" fill="none" stroke="#5dd5a8" stroke-width="3.5" stroke-linejoin="round"/>
-        <circle cx="118" cy="398" r="5" fill="#5dd5a8"/><circle cx="373" cy="396" r="5" fill="#5dd5a8"/><circle cx="940" cy="388" r="6" fill="#5dd5a8"/>
-        <text x="928" y="378" text-anchor="end" fill="#5dd5a8" font-family="Geist, sans-serif" font-size="18" font-weight="700">Vue Vapor · 128 ms</text>
+        <!-- ReactLynx: 225.5 / 2632.4 / 10259.5 ms -->
+        <polyline points="118,392 373,310 940,48" fill="none" stroke="#E8B44A" stroke-width="3" stroke-linejoin="round"/>
+        <circle cx="118" cy="392" r="5" fill="#E8B44A"/><circle cx="373" cy="310" r="5" fill="#E8B44A"/><circle cx="940" cy="48" r="6" fill="#E8B44A"/>
+        <text x="928" y="43" text-anchor="end" fill="#E8B44A" font-family="Geist, sans-serif" font-size="18" font-weight="600">ReactLynx · 10.26s</text>
+        <!-- VDOM: 70.9 / 984.1 / 3569.8 ms -->
+        <polyline points="118,398 373,366 940,278" fill="none" stroke="#4FB8F0" stroke-width="3" stroke-linejoin="round"/>
+        <circle cx="118" cy="398" r="5" fill="#4FB8F0"/><circle cx="373" cy="366" r="5" fill="#4FB8F0"/><circle cx="940" cy="278" r="6" fill="#4FB8F0"/>
+        <text x="928" y="269" text-anchor="end" fill="#4FB8F0" font-family="Geist, sans-serif" font-size="18" font-weight="600">Vue VDOM · 3.57s</text>
+        <!-- Vapor: 20.5 / 118.6 / 275.2 ms (flat) -->
+        <polyline points="118,399 373,396 940,391" fill="none" stroke="#5dd5a8" stroke-width="3.5" stroke-linejoin="round"/>
+        <circle cx="118" cy="399" r="5" fill="#5dd5a8"/><circle cx="373" cy="396" r="5" fill="#5dd5a8"/><circle cx="940" cy="391" r="6" fill="#5dd5a8"/>
+        <text x="928" y="381" text-anchor="end" fill="#5dd5a8" font-family="Geist, sans-serif" font-size="18" font-weight="700">Vue Vapor · 275 ms</text>
       </svg>
     </div>
     <p class="lead" data-mm-fade>
       Same select storm, black-box wall-clock as rows grow: VDOM and ReactLynx
-      climb linearly; Vapor stays near the floor — <b class="brand-text">128 ms
-      at 30k</b> vs VDOM's 1.46 s. The gap widens with scale.
+      climb linearly; Vapor stays near the floor — <b class="brand-text">275 ms
+      at 30k</b> vs VDOM's 3.57 s. The gap widens with scale.
     </p>
     <aside class="notes">
-      <p><strong>The scaling picture (unified bench, PR #266).</strong> The 5.8–9.8× you just saw is the background-thread micro number; this is the user-visible wall-clock as the list grows. selectStorm across 1k → 10k → 30k, every tick re-selects one row. VDOM re-runs render + diffs the whole list each pass, so its curve rises with N; ReactLynx pays that plus its own overhead. Vapor's reactive effects touch only the changed node, so the curve is almost flat — the gap vs VDOM widens 1.7× @1k → 8.2× @10k → 11.4× @30k. Absolute ms are host-bound; the ratios are the portable claim.</p>
+      <p><strong>The scaling picture (unified bench, PR #266 · re-run @346eccf, 2026-07-28).</strong> The 5.8–9.8× you just saw is the background-thread micro number; this is the user-visible wall-clock as the list grows. selectStorm across 1k → 10k → 30k, every tick re-selects one row. VDOM re-runs render + diffs the whole list each pass, so its curve rises with N; ReactLynx pays that plus its own overhead. Vapor's reactive effects touch only the changed node, so the curve is almost flat — the gap vs VDOM widens 3.5× @1k → 8.3× @10k → 13× @30k. Absolute ms are host-bound (this host is slower than the first run); the ratios are the portable claim.</p>
     </aside>
   </section>
 

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -545,6 +545,9 @@ export const ZH = {
 
   'Where Vapor pulls away: 5.8–9.8×.':
     'Vapor 拉开差距的地方:<span class="brand-text">5.8–9.8×</span>。',
+  'One more thing · select storm × scale': '还有一件事 · select 风暴 × 规模',
+  "Same select storm, black-box wall-clock as rows grow: VDOM and ReactLynx climb linearly; Vapor stays near the floor — 128 ms at 30k vs VDOM's 1.46 s. The gap widens with scale.":
+    '同一个 select 风暴,随行数增长的黑盒墙钟时间:VDOM 和 ReactLynx 线性攀升;Vapor 几乎贴着地板 —— <b class="brand-text">30k 时 128 ms</b>,而 VDOM 是 1.46 s。差距随规模拉大。',
   'The entire delta is Vue work on the thread you share with your app logic — lower background cost means more headroom before dropped frames.':
     '整个差距都是 Vue 在那条你与应用逻辑共享的线程上的开销 —— 后台开销越低,离掉帧就越远。',
 
@@ -853,6 +856,8 @@ export const ZH_NOTES = [
   `<p><strong>Vapor 是什么 —— 没有虚拟 DOM。</strong>Vue 3.6 基于编译的渲染器:没有 vnode 树,没有逐组件 diff。预发布状态 —— 锁定在 <code>vue@3.6.0-beta.17</code>。</p><p><strong>同一份源码 —— 拨一下开关。</strong>按应用、构建期的开关:插件选项、入口 import、<code>vapor</code> 属性。两个纯入口 —— <code>vue-lynx</code> 与 <code>vue-lynx/vapor</code> —— 于是 vdom 专属 API 在 Vapor 应用里会在构建期报错,而不是在运行时出乱子。</p><p>我们要用数据支撑的主张:同样的 Vue,更新路径的开销小得多。</p>`,
   // 43+44 Benchmark · 更新柱状图 + 账本（合并）
   `<p><strong>核心结果 —— 再看诚实的成绩单。</strong>Vue 官方基准移植到 Lynx,同一个应用跑两种模式。后台线程开销 = 响应式 + 渲染 + ops 序列化 —— Vapor 的结构性优势在这里毫无遮掩地显现(5.8–9.8×)。端到端的倍数要小些(2.1–6.3×),因为两种模式发出的 ops 几乎一样。</p><p>别夸大:创建是打平的;代价是产物 +26%(Vapor 运行时 + DOM 兼容垫片)。首屏差异在噪声范围内。绿 = 赢,粉 = 代价。数据:headless Chromium、Lynx for Web、中位数带 95% 置信区间。</p>`,
+  // 44b select 风暴 × 规模（统一基准 #266）
+  `<p><strong>规模画面(统一基准,PR #266)。</strong>刚才那 5.8–9.8× 是后台线程的微观数字;这是随列表增长、用户可见的墙钟时间。selectStorm 跨 1k → 10k → 30k,每个 tick 只重选一行。VDOM 每轮重跑 render 并 diff 整张列表,曲线随 N 上扬;ReactLynx 在此之上再加自己的开销。Vapor 的响应式 effect 只碰变化的那个节点,曲线几乎压平 —— 对 VDOM 的差距 1k 1.7× → 10k 8.2× → 30k 11.4×。绝对 ms 与机器绑定;比值才是可移植的结论。</p>`,
   // 45b Vapor 上游测试 + 亲近性 + 7× mic-drop
   `<p><strong>Vapor 也有了自己的上游测试(PR #232)。</strong>30 个 <code>runtime-vapor</code> spec 文件跑在真实的 <code>vue-lynx/vapor</code> 表面和 ShadowElement 树上:<strong>545 通过、120 skip、0 失败</strong>。skiplist 是一个<em>封闭清单</em> —— 每个被排除的测试都有理由,任何未归类项都会让配置加载直接失败。</p><p><strong>这些 skip 不是一堆坏掉的东西。</strong>SSR/hydration 加 vdom↔vapor 互操作占了不跑项的 57% —— 两者都不是 Lynx 兼容性信号(没有 SSR 表面;互操作是刻意不支持的)。浏览器专属平台再占 24%。测试设施只占不到 1%(对比 vdom 那边高达 59%),因为“原始 bundle 再导出”这招几乎消灭了私有 import 问题。这个移植还顺手抓到一个真 bug(ShadowElement 会被响应式代理;<code>__v_skip</code> 修掉了)。</p><p><strong>亲近性这一点。</strong>在真正触及元素表面的测试上,Vapor 以 81% 对 vdom 的 57% 通过 —— 而且<em>零行为级垫片</em>:生产版 <code>@vue/runtime-vapor</code> 原封不动跑在 ShadowElement 上,而 vdom 模式需要 1,074 行在执行路径里的模拟。Vapor 的宿主契约 —— 克隆模板 + 对节点的命令式 setter —— 天生就与 Lynx 更契合。(是契合度,不是速度。)</p><p><strong>压轴数字 —— 7× VDOM。</strong>跨框架套件(ReactLynx vs Vue VDOM vs Vue Vapor),真实点击到 composed-DOM 终态。Vue 对 Vue 的头条:10k select 风暴上 Vapor 7.0× VDOM,update 风暴 1.9× —— 同一个应用、同一个产物,只差一个属性。</p>`,
   // 45 工作流 · 一份源码两个渲染器

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -546,8 +546,8 @@ export const ZH = {
   'Where Vapor pulls away: 5.8–9.8×.':
     'Vapor 拉开差距的地方:<span class="brand-text">5.8–9.8×</span>。',
   'One more thing · select storm × scale': '还有一件事 · select 风暴 × 规模',
-  "Same select storm, black-box wall-clock as rows grow: VDOM and ReactLynx climb linearly; Vapor stays near the floor — 128 ms at 30k vs VDOM's 1.46 s. The gap widens with scale.":
-    '同一个 select 风暴,随行数增长的黑盒墙钟时间:VDOM 和 ReactLynx 线性攀升;Vapor 几乎贴着地板 —— <b class="brand-text">30k 时 128 ms</b>,而 VDOM 是 1.46 s。差距随规模拉大。',
+  "Same select storm, black-box wall-clock as rows grow: VDOM and ReactLynx climb linearly; Vapor stays near the floor — 275 ms at 30k vs VDOM's 3.57 s. The gap widens with scale.":
+    '同一个 select 风暴,随行数增长的黑盒墙钟时间:VDOM 和 ReactLynx 线性攀升;Vapor 几乎贴着地板 —— <b class="brand-text">30k 时 275 ms</b>,而 VDOM 是 3.57 s。差距随规模拉大。',
   'The entire delta is Vue work on the thread you share with your app logic — lower background cost means more headroom before dropped frames.':
     '整个差距都是 Vue 在那条你与应用逻辑共享的线程上的开销 —— 后台开销越低,离掉帧就越远。',
 
@@ -857,7 +857,7 @@ export const ZH_NOTES = [
   // 43+44 Benchmark · 更新柱状图 + 账本（合并）
   `<p><strong>核心结果 —— 再看诚实的成绩单。</strong>Vue 官方基准移植到 Lynx,同一个应用跑两种模式。后台线程开销 = 响应式 + 渲染 + ops 序列化 —— Vapor 的结构性优势在这里毫无遮掩地显现(5.8–9.8×)。端到端的倍数要小些(2.1–6.3×),因为两种模式发出的 ops 几乎一样。</p><p>别夸大:创建是打平的;代价是产物 +26%(Vapor 运行时 + DOM 兼容垫片)。首屏差异在噪声范围内。绿 = 赢,粉 = 代价。数据:headless Chromium、Lynx for Web、中位数带 95% 置信区间。</p>`,
   // 44b select 风暴 × 规模（统一基准 #266）
-  `<p><strong>规模画面(统一基准,PR #266)。</strong>刚才那 5.8–9.8× 是后台线程的微观数字;这是随列表增长、用户可见的墙钟时间。selectStorm 跨 1k → 10k → 30k,每个 tick 只重选一行。VDOM 每轮重跑 render 并 diff 整张列表,曲线随 N 上扬;ReactLynx 在此之上再加自己的开销。Vapor 的响应式 effect 只碰变化的那个节点,曲线几乎压平 —— 对 VDOM 的差距 1k 1.7× → 10k 8.2× → 30k 11.4×。绝对 ms 与机器绑定;比值才是可移植的结论。</p>`,
+  `<p><strong>规模画面(统一基准,PR #266 · 于 346eccf 重跑,2026-07-28)。</strong>刚才那 5.8–9.8× 是后台线程的微观数字;这是随列表增长、用户可见的墙钟时间。selectStorm 跨 1k → 10k → 30k,每个 tick 只重选一行。VDOM 每轮重跑 render 并 diff 整张列表,曲线随 N 上扬;ReactLynx 在此之上再加自己的开销。Vapor 的响应式 effect 只碰变化的那个节点,曲线几乎压平 —— 对 VDOM 的差距 1k 3.5× → 10k 8.3× → 30k 13×。绝对 ms 与机器绑定(这台机比首轮更慢);比值才是可移植的结论。</p>`,
   // 45b Vapor 上游测试 + 亲近性 + 7× mic-drop
   `<p><strong>Vapor 也有了自己的上游测试(PR #232)。</strong>30 个 <code>runtime-vapor</code> spec 文件跑在真实的 <code>vue-lynx/vapor</code> 表面和 ShadowElement 树上:<strong>545 通过、120 skip、0 失败</strong>。skiplist 是一个<em>封闭清单</em> —— 每个被排除的测试都有理由,任何未归类项都会让配置加载直接失败。</p><p><strong>这些 skip 不是一堆坏掉的东西。</strong>SSR/hydration 加 vdom↔vapor 互操作占了不跑项的 57% —— 两者都不是 Lynx 兼容性信号(没有 SSR 表面;互操作是刻意不支持的)。浏览器专属平台再占 24%。测试设施只占不到 1%(对比 vdom 那边高达 59%),因为“原始 bundle 再导出”这招几乎消灭了私有 import 问题。这个移植还顺手抓到一个真 bug(ShadowElement 会被响应式代理;<code>__v_skip</code> 修掉了)。</p><p><strong>亲近性这一点。</strong>在真正触及元素表面的测试上,Vapor 以 81% 对 vdom 的 57% 通过 —— 而且<em>零行为级垫片</em>:生产版 <code>@vue/runtime-vapor</code> 原封不动跑在 ShadowElement 上,而 vdom 模式需要 1,074 行在执行路径里的模拟。Vapor 的宿主契约 —— 克隆模板 + 对节点的命令式 setter —— 天生就与 Lynx 更契合。(是契合度,不是速度。)</p><p><strong>压轴数字 —— 7× VDOM。</strong>跨框架套件(ReactLynx vs Vue VDOM vs Vue Vapor),真实点击到 composed-DOM 终态。Vue 对 Vue 的头条:10k select 风暴上 Vapor 7.0× VDOM,update 风暴 1.9× —— 同一个应用、同一个产物,只差一个属性。</p>`,
   // 45 工作流 · 一份源码两个渲染器


### PR DESCRIPTION
## Summary

Adds **one slide** to the Vapor chapter: a select-storm scaling chart (inline SVG) showing how the update-path advantage holds as the list grows. It complements the existing background-thread 5.8–9.8× number on the merged benchmark slide with the user-visible black-box wall-clock from the unified bench (`/guide/benchmark-unified`, PR #266).

Scope: **2 files** (`slides/index.html`, `slides/src/i18n.js`), on the current `vueconf-2026`.

> Note: this PR was rescoped. It no longer includes the cross-framework matrix / mic-drop / IFR-qualification edits that an earlier revision described — the base's own benchmark rework (per-axis charts, λ arc, the `/guide/benchmark-unified` link) already covers that ground. Only the scaling chart, which the base lacks, remains.

## The chart

`selectStorm` wall-clock across 1k → 10k → 30k for Vue Vapor / Vue VDOM / ReactLynx. Vapor stays near the floor (275 ms @30k) while VDOM (3.57 s) and ReactLynx (10.26 s) climb linearly; the gap vs VDOM widens **3.5× @1k → 8.3× @10k → 13× @30k**.

## Source

Numbers taken verbatim from the current unified bench on the `vapor` branch — `packages/benchmark/results/unified/ANALYSIS.md` + `latest.json`, regenerated **2026-07-28 @ 346eccf** (a slower host than the first run; the chart cites this and reiterates that absolute ms are host-bound while the ratios are the portable claim).

| selectStorm · ms median | 1k | 10k | 30k |
|---|---|---|---|
| Vue Vapor | 20.5 | 118.6 | 275.2 |
| Vue VDOM | 70.9 | 984.1 | 3569.8 |
| ReactLynx | 225.5 | 2632.4 | 10259.5 |

## Verification (fresh, current `vueconf-2026`)

- `pnpm install` + `pnpm build` → clean
- 144 slides ↔ 144 `ZH_NOTES` (1:1; new note inserted between the benchmark and upstream-test notes, verified by index)
- Every chart figure cross-checked against `ANALYSIS.md`/`latest.json` @346eccf
- Rendered in 中文 and English via headless Chromium (endpoint labels, axes, caption)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMLRRYvS3yYJdXfx2jrJ49