### PR TITLE
feat(slides): enlarge phone preset ~125% and contain off-screen growth

### DIFF
--- a/slides/src/framework/device.js
+++ b/slides/src/framework/device.js
@@ -63,12 +63,17 @@ export function containDeviceFrame(el, getScale = () => 1) {
   let ox = 0;
   let oy = 0;
 
+  // Threshold for "clearly nearer one edge" vs "essentially centered". A few
+  // px of layout noise (slide padding, stage alignment) shouldn't flip a
+  // taller-than-stage phone into edge-pinning — that throws more of it off
+  // screen. Only pin when the home position is meaningfully off-center
+  // (e.g. a right-column demo), so overflow runs into the empty interior.
+  const BIAS = 24;
+
   if (overL > 0 && overR > 0) {
-    // Wider than the stage — pin to the nearer vertical edge so overflow runs
-    // into the interior (the empty / copy side), not off the outer edge.
-    // A truly centered frame (bias ≈ 0) keeps equal overflow on both sides.
     const bias = (rect.left + rect.right) / 2 - (bounds.left + bounds.right) / 2;
-    if (Math.abs(bias) >= 1) ox = (bias > 0 ? -overR : overL) / s;
+    if (Math.abs(bias) >= BIAS) ox = (bias > 0 ? -overR : overL) / s;
+    else ox = (overL - overR) / (2 * s); // equalize
   } else if (overL > 0) {
     ox = overL / s;
   } else if (overR > 0) {
@@ -77,7 +82,8 @@ export function containDeviceFrame(el, getScale = () => 1) {
 
   if (overT > 0 && overB > 0) {
     const bias = (rect.top + rect.bottom) / 2 - (bounds.top + bounds.bottom) / 2;
-    if (Math.abs(bias) >= 1) oy = (bias > 0 ? -overB : overT) / s;
+    if (Math.abs(bias) >= BIAS) oy = (bias > 0 ? -overB : overT) / s;
+    else oy = (overT - overB) / (2 * s); // equalize
   } else if (overT > 0) {
     oy = overT / s;
   } else if (overB > 0) {

--- a/slides/src/framework/device.js
+++ b/slides/src/framework/device.js
@@ -8,16 +8,85 @@
 import { ICONS } from './icons.js';
 
 // Canonical presets for the deck's scaled 1280×720 stage (authored in cqw/cqh).
-// Sizes are pushed close to the frame height so the phone reads at a realistic
-// handset scale (750rpx ≈ the frame width). The desktop preset is deliberately
-// wider than its column — the frame floats over the copy (see .demo__stage).
+// Phone is sized ~125% of the prior handset footprint so demos read larger on
+// stage; tablet keeps the previous height so the two shapes stay distinct.
+// The desktop preset is deliberately wider than its column — the frame floats
+// over the copy (see .demo__stage).
 export const DECK_PRESETS = {
-  phone:   { ar: '9 / 19.5',  w: 'auto',              h: 'min(92cqh, 650px)' },
+  phone:   { ar: '9 / 19.5',  w: 'auto',              h: 'min(115cqh, 812px)' },
   tablet:  { ar: '3 / 4',     w: 'auto',              h: 'min(92cqh, 650px)' },
   desktop: { ar: '16 / 10',   w: 'min(52cqw, 620px)', h: 'auto' },
 };
 
 const DEVICE_ICON = { phone: 'smartphone', tablet: 'tablet', desktop: 'monitor' };
+
+/**
+ * When a device frame would spill past the stage / play viewport, shift it so
+ * growth runs toward the empty side of the screen instead of scaling from the
+ * center (which pushes equal overflow off both edges).
+ *
+ * Uses the CSS `translate` property (`--phone-ox` / `--phone-oy`) so it
+ * composes with any existing `transform` (centering, magic-move, inline
+ * embed positioning) without fighting them.
+ */
+export function containDeviceFrame(el, getScale = () => 1) {
+  if (!el || el.classList.contains('is-fullscreen')) {
+    el?.style.setProperty('--phone-ox', '0px');
+    el?.style.setProperty('--phone-oy', '0px');
+    return;
+  }
+  // Embed frames carry inline transforms for magic-move; leave them alone.
+  if (el.classList.contains('phone--embed')) {
+    el.style.setProperty('--phone-ox', '0px');
+    el.style.setProperty('--phone-oy', '0px');
+    return;
+  }
+
+  // Measure the natural (uncompensated) position first.
+  el.style.setProperty('--phone-ox', '0px');
+  el.style.setProperty('--phone-oy', '0px');
+
+  const boundsEl =
+    el.closest('.frame') ||
+    el.closest('.play') ||
+    document.documentElement;
+  const bounds = boundsEl.getBoundingClientRect();
+  const rect = el.getBoundingClientRect();
+  const s = getScale() || 1;
+
+  // Positive ⇒ that edge is past the clip bounds.
+  const overL = bounds.left - rect.left;
+  const overR = rect.right - bounds.right;
+  const overT = bounds.top - rect.top;
+  const overB = rect.bottom - bounds.bottom;
+
+  let ox = 0;
+  let oy = 0;
+
+  if (overL > 0 && overR > 0) {
+    // Wider than the stage — pin to the nearer vertical edge so overflow runs
+    // into the interior (the empty / copy side), not off the outer edge.
+    // A truly centered frame (bias ≈ 0) keeps equal overflow on both sides.
+    const bias = (rect.left + rect.right) / 2 - (bounds.left + bounds.right) / 2;
+    if (Math.abs(bias) >= 1) ox = (bias > 0 ? -overR : overL) / s;
+  } else if (overL > 0) {
+    ox = overL / s;
+  } else if (overR > 0) {
+    ox = -overR / s;
+  }
+
+  if (overT > 0 && overB > 0) {
+    const bias = (rect.top + rect.bottom) / 2 - (bounds.top + bounds.bottom) / 2;
+    if (Math.abs(bias) >= 1) oy = (bias > 0 ? -overB : overT) / s;
+  } else if (overT > 0) {
+    oy = overT / s;
+  } else if (overB > 0) {
+    oy = -overB / s;
+  }
+
+  el.style.setProperty('--phone-ox', `${ox}px`);
+  el.style.setProperty('--phone-oy', `${oy}px`);
+}
 
 /** Snap an element to a named preset. `fullscreen` presets fill the viewport. */
 export function applyDevicePreset(el, name, presets = DECK_PRESETS) {
@@ -76,6 +145,13 @@ export function attachDeviceControls(el, {
 } = {}) {
   if (el.querySelector('.phone__resize')) return; // already wired
 
+  const contain = () => containDeviceFrame(el, getScale);
+  const apply = (name) => {
+    applyDevicePreset(el, name, presets);
+    // Layout must flush before we can measure overflow.
+    contain();
+  };
+
   // Preset switcher.
   const bar = document.createElement('div');
   bar.className = 'phone__presets';
@@ -104,7 +180,7 @@ export function attachDeviceControls(el, {
       return;
     }
     const btn = e.target.closest('.phone__preset');
-    if (btn) applyDevicePreset(el, btn.dataset.device, presets);
+    if (btn) apply(btn.dataset.device);
   });
 
   const clampVal = (v) => Math.max(clamp[0], Math.min(clamp[1], v));
@@ -146,21 +222,36 @@ export function attachDeviceControls(el, {
       // aspect-ratio no longer constrains the frame.
       el.style.width = `${clampVal(startW + gain * sign.sx * dx)}px`;
       el.style.height = `${clampVal(startH + gain * sign.sy * dy)}px`;
+      // Re-contain on every move so growth runs into empty space once an edge
+      // hits the stage — not continue scaling off-screen from the center.
+      contain();
     });
     const end = (e) => {
       if (!dragging) return;
       dragging = false;
       try { handle.releasePointerCapture(e.pointerId); } catch { /* already released */ }
+      contain();
     };
     handle.addEventListener('pointerup', end);
     handle.addEventListener('pointercancel', end);
     handle.addEventListener('touchstart', (e) => e.stopPropagation(), { passive: true });
     handle.addEventListener('dblclick', (e) => {
       e.stopPropagation();
-      applyDevicePreset(el, el.dataset.device || 'phone', presets);
+      apply(el.dataset.device || 'phone');
     });
   });
 
-  applyDevicePreset(el, initial || el.dataset.device || 'phone', presets);
+  apply(initial || el.dataset.device || 'phone');
   if (el.dataset.ar) el.style.setProperty('--phone-ar', el.dataset.ar);
+  // data-ar can change the laid-out size — re-contain after it applies.
+  contain();
+
+  // Keep containment honest across viewport / stage resizes.
+  window.addEventListener('resize', contain);
+  if (typeof ResizeObserver !== 'undefined') {
+    const ro = new ResizeObserver(() => contain());
+    ro.observe(el);
+    const boundsEl = el.closest('.frame') || el.closest('.play');
+    if (boundsEl) ro.observe(boundsEl);
+  }
 }

--- a/slides/src/framework/device.js
+++ b/slides/src/framework/device.js
@@ -25,9 +25,8 @@ const DEVICE_ICON = { phone: 'smartphone', tablet: 'tablet', desktop: 'monitor' 
  * growth runs toward the empty side of the screen instead of scaling from the
  * center (which pushes equal overflow off both edges).
  *
- * Uses the CSS `translate` property (`--phone-ox` / `--phone-oy`) so it
- * composes with any existing `transform` (centering, magic-move, inline
- * embed positioning) without fighting them.
+ * Offsets are written to `--phone-ox` / `--phone-oy` and consumed by the
+ * centering `transform` on `.demo__stage .phone` / `.phone--play`.
  */
 export function containDeviceFrame(el, getScale = () => 1) {
   if (!el || el.classList.contains('is-fullscreen')) {
@@ -37,6 +36,13 @@ export function containDeviceFrame(el, getScale = () => 1) {
   }
   // Embed frames carry inline transforms for magic-move; leave them alone.
   if (el.classList.contains('phone--embed')) {
+    el.style.setProperty('--phone-ox', '0px');
+    el.style.setProperty('--phone-oy', '0px');
+    return;
+  }
+  // Inactive slides aren't visible — skip (keeps offsets neutral until arrival).
+  const slide = el.closest('.slide');
+  if (slide && !slide.classList.contains('is-active')) {
     el.style.setProperty('--phone-ox', '0px');
     el.style.setProperty('--phone-oy', '0px');
     return;
@@ -54,11 +60,30 @@ export function containDeviceFrame(el, getScale = () => 1) {
   const rect = el.getBoundingClientRect();
   const s = getScale() || 1;
 
+  // Slides animate translateY(±20px) on enter/exit. getBoundingClientRect
+  // includes that interpolated offset, which would bias vertical containment
+  // for the whole transition. Strip the slide's own translate so we measure
+  // against the stage as if the slide were at rest.
+  let slideTX = 0;
+  let slideTY = 0;
+  if (slide) {
+    const tf = getComputedStyle(slide).transform;
+    if (tf && tf !== 'none') {
+      const m = new DOMMatrix(tf);
+      slideTX = m.m41;
+      slideTY = m.m42;
+    }
+  }
+  const left = rect.left - slideTX;
+  const right = rect.right - slideTX;
+  const top = rect.top - slideTY;
+  const bottom = rect.bottom - slideTY;
+
   // Positive ⇒ that edge is past the clip bounds.
-  const overL = bounds.left - rect.left;
-  const overR = rect.right - bounds.right;
-  const overT = bounds.top - rect.top;
-  const overB = rect.bottom - bounds.bottom;
+  const overL = bounds.left - left;
+  const overR = right - bounds.right;
+  const overT = bounds.top - top;
+  const overB = bottom - bounds.bottom;
 
   let ox = 0;
   let oy = 0;
@@ -71,7 +96,7 @@ export function containDeviceFrame(el, getScale = () => 1) {
   const BIAS = 24;
 
   if (overL > 0 && overR > 0) {
-    const bias = (rect.left + rect.right) / 2 - (bounds.left + bounds.right) / 2;
+    const bias = (left + right) / 2 - (bounds.left + bounds.right) / 2;
     if (Math.abs(bias) >= BIAS) ox = (bias > 0 ? -overR : overL) / s;
     else ox = (overL - overR) / (2 * s); // equalize
   } else if (overL > 0) {
@@ -81,7 +106,7 @@ export function containDeviceFrame(el, getScale = () => 1) {
   }
 
   if (overT > 0 && overB > 0) {
-    const bias = (rect.top + rect.bottom) / 2 - (bounds.top + bounds.bottom) / 2;
+    const bias = (top + bottom) / 2 - (bounds.top + bounds.bottom) / 2;
     if (Math.abs(bias) >= BIAS) oy = (bias > 0 ? -overB : overT) / s;
     else oy = (overT - overB) / (2 * s); // equalize
   } else if (overT > 0) {
@@ -151,11 +176,24 @@ export function attachDeviceControls(el, {
 } = {}) {
   if (el.querySelector('.phone__resize')) return; // already wired
 
-  const contain = () => containDeviceFrame(el, getScale);
+  // Coalesce containment to one measure per frame — ResizeObserver + preset
+  // apply + drag can otherwise thrash style ↔ layout in a tight loop.
+  let containRaf = 0;
+  const contain = () => {
+    if (containRaf) cancelAnimationFrame(containRaf);
+    containRaf = requestAnimationFrame(() => {
+      containRaf = 0;
+      containDeviceFrame(el, getScale);
+    });
+  };
+  const containNow = () => {
+    if (containRaf) { cancelAnimationFrame(containRaf); containRaf = 0; }
+    containDeviceFrame(el, getScale);
+  };
   const apply = (name) => {
     applyDevicePreset(el, name, presets);
     // Layout must flush before we can measure overflow.
-    contain();
+    containNow();
   };
 
   // Preset switcher.
@@ -230,13 +268,13 @@ export function attachDeviceControls(el, {
       el.style.height = `${clampVal(startH + gain * sign.sy * dy)}px`;
       // Re-contain on every move so growth runs into empty space once an edge
       // hits the stage — not continue scaling off-screen from the center.
-      contain();
+      containNow();
     });
     const end = (e) => {
       if (!dragging) return;
       dragging = false;
       try { handle.releasePointerCapture(e.pointerId); } catch { /* already released */ }
-      contain();
+      containNow();
     };
     handle.addEventListener('pointerup', end);
     handle.addEventListener('pointercancel', end);
@@ -250,14 +288,17 @@ export function attachDeviceControls(el, {
   apply(initial || el.dataset.device || 'phone');
   if (el.dataset.ar) el.style.setProperty('--phone-ar', el.dataset.ar);
   // data-ar can change the laid-out size — re-contain after it applies.
-  contain();
+  containNow();
 
-  // Keep containment honest across viewport / stage resizes.
+  // Keep containment honest across viewport resizes, phone size changes, and
+  // slide navigations (inactive slides are skipped — see containDeviceFrame).
   window.addEventListener('resize', contain);
+  document.addEventListener('deck:change', contain);
   if (typeof ResizeObserver !== 'undefined') {
+    // Observe only the phone itself. Observing the shared `.frame` made every
+    // device on every slide re-contain on one resize, including inactive
+    // slides whose enter/exit translateY poisoned the vertical offset.
     const ro = new ResizeObserver(() => contain());
     ro.observe(el);
-    const boundsEl = el.closest('.frame') || el.closest('.play');
-    if (boundsEl) ro.observe(boundsEl);
   }
 }

--- a/slides/src/play.js
+++ b/slides/src/play.js
@@ -10,10 +10,11 @@ import { attachDeviceControls } from './framework/device.js';
 
 registerVlDemo();
 
-// Play-page presets sized against the viewport (no scaled stage here). Desktop
+// Play-page presets sized against the viewport (no scaled stage here). Phone
+// matches the deck's ~125% handset scale; tablet height is unchanged. Desktop
 // fills the whole window.
 const PLAY_PRESETS = {
-  phone:   { ar: '9 / 19.5', w: 'auto', h: 'min(90vh, 860px)' },
+  phone:   { ar: '9 / 19.5', w: 'auto', h: 'min(112.5vh, 1075px)' },
   tablet:  { ar: '3 / 4',    w: 'auto', h: 'min(92vh, 1000px)' },
   desktop: { fullscreen: true },
 };

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -709,23 +709,26 @@ h1, h2, h3, p { margin: 0; }
 }
 .demo--api-duo .codeframe pre { padding: 12px 14px; }
 
-/* The device mockup keeps its phone-sized footprint in the two-column demo
-   layout no matter which preset is active: the stage reserves that space and the
-   frame is absolutely centred inside it, so growing to tablet / desktop makes the
-   frame FLOAT OVER the neighbouring copy instead of reflowing the grid and
-   colliding with the text (which is what the wide presets used to do). */
+/* The device mockup keeps a stable footprint in the two-column demo layout no
+   matter which preset is active: the stage reserves the tablet/prior-phone
+   height and the frame is absolutely centred inside it, so growing to the
+   larger phone / tablet / desktop presets makes the frame FLOAT OVER the
+   neighbouring copy instead of reflowing the grid. Off-screen overflow is
+   pulled back via --phone-ox/--phone-oy (see containDeviceFrame). */
 .demo__stage {
   display: flex;
   justify-content: center;
   align-items: center;
   position: relative;
-  height: min(92cqh, 650px);   /* reserved footprint = phone-preset height */
+  height: min(92cqh, 650px);   /* reserved footprint — stable across presets */
 }
 .demo__stage .phone {
   position: absolute;
   top: 50%;
   left: 50%;
-  transform: translate(-50%, -50%);
+  /* --phone-ox/--phone-oy shift the frame when it would overflow the stage so
+     growth runs toward the empty side instead of scaling off both edges. */
+  transform: translate(calc(-50% + var(--phone-ox, 0px)), calc(-50% + var(--phone-oy, 0px)));
   /* Let the frame grow past its grid column — that's what makes the wider
      presets (and free drags) genuinely float over the copy rather than being
      clamped to the column width by the base `.phone { max-width: 100% }`. */
@@ -826,6 +829,11 @@ a.qr:hover { color: var(--vue-green); }
 /* On the play page the device controls are the primary UI: always visible, and
    the preset switcher is a fixed toolbar at the bottom so it's reachable at any
    device size (including fullscreen). */
+.phone--play {
+  /* Same overflow compensation as .demo__stage .phone — play page is flex-
+     centered, so the shift is a plain translate rather than a -50% center. */
+  transform: translate(var(--phone-ox, 0px), var(--phone-oy, 0px));
+}
 .phone--play .phone__presets {
   position: fixed;
   left: 50%;
@@ -858,9 +866,11 @@ a.qr:hover { color: var(--vue-green); }
    (phone / tablet / desktop, set in main.js). A free drag sets explicit inline
    width+height (no aspect lock); presets clear those and restore the vars. */
 .phone {
-  --phone-ar: 270 / 590;
-  --phone-h: min(78cqh, 620px);
+  --phone-ar: 9 / 19.5;
+  --phone-h: min(115cqh, 812px);
   --phone-w: auto;
+  --phone-ox: 0px;
+  --phone-oy: 0px;
   aspect-ratio: var(--phone-ar);
   height: var(--phone-h);
   width: var(--phone-w);
@@ -1022,11 +1032,12 @@ vl-demo lynx-view {
   /* rpx is Lynx's density unit (750rpx = one screen width). Tracking the frame
      width 1:1 magnified the mobile UI whenever the frame grew past a phone (the
      tablet / desktop presets are much wider), which read as "zoomed in". Cap the
-     reference at the widest phone preset (~340px) so 750rpx maps to the phone
-     width there — a real handset density — and the wider presets hold at that
-     same 100% density, revealing more of the app instead of scaling it up.
+     reference at the widest phone preset (~375px at the 125% handset size) so
+     750rpx maps to the phone width there — a real handset density — and the
+     wider presets hold at that same 100% density, revealing more of the app
+     instead of scaling it up.
      Keep this in sync with the phone preset width in device.js (DECK_PRESETS). */
-  --rpx-unit: calc(min(100cqw, 340px) / 750);
+  --rpx-unit: calc(min(100cqw, 375px) / 750);
   --vh-unit: 1cqh;
   --vw-unit: 1cqw;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Scale the **phone** device preset to ~125% (`min(115cqh, 812px)` on the deck / `min(112.5vh, 1075px)` on play) so demo frames read larger on stage
- Keep the **tablet** preset height unchanged (`min(92cqh, 650px)`)
- When a frame would overflow the stage — via tablet, desktop, or free drag — shift it with `--phone-ox` / `--phone-oy` so growth runs toward the empty side of the screen instead of scaling off both edges from the center
- Sync the lynx-view `--rpx-unit` cap with the wider phone preset (~375px)

## Containment details

- Right-column demos pin to the right stage edge when too wide (overflow into the copy)
- Left-column / `demo--reverse` pins to the left edge (overflow into the copy on the right)
- Frames taller than the stage equalize top/bottom overflow
- Skips inactive slides and strips the slide enter/exit `translateY` when measuring, so the ±20px transition offset can't poison vertical correction

## Test plan

- [x] Phone preset is ~375×812 (~125% of prior 300×650)
- [x] Tablet height stays 650px
- [x] Wide drag on a right-column demo pins the right edge (`ox < 0`)
- [x] Wide drag on `demo--reverse` pins the left edge (`ox > 0`)
- [x] Phone taller than the stage equalizes vertical overflow (46px / 46px)
- [ ] Spot-check play.html phone/tablet presets similarly

[Wide drag pins right edge](https://cursor.com/agents/bc-cf2b0d9e-fa44-4fce-bd0e-de8d5c09c55c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fwide-drag.png)
[Reverse layout pins left edge](https://cursor.com/agents/bc-cf2b0d9e-fa44-4fce-bd0e-de8d5c09c55c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Freverse-wide.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf2b0d9e-fa44-4fce-bd0e-de8d5c09c55c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf2b0d9e-fa44-4fce-bd0e-de8d5c09c55c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

