### PR TITLE
feat(slides): serve local iOS Simulator via serve-sim

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -726,6 +726,9 @@ importers:
       qrcode-generator:
         specifier: ^2.0.4
         version: 2.0.4
+      serve-sim:
+        specifier: 0.1.44
+        version: 0.1.44(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
     devDependencies:
       playwright-core:
         specifier: ^1.49.0
@@ -3925,6 +3928,12 @@ packages:
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
+  inspect-webkit@0.0.5:
+    resolution: {integrity: sha512-584wP/2nJO1LX74nqHP2j0tQzlK9ZTi+D0Z9qeLQjtUR/LCMXQHGX8M0vrsqBwTeGakF7q5GMFpg81nxUYlCvw==}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5
+
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
@@ -5508,6 +5517,11 @@ packages:
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
 
+  serve-sim@0.1.44:
+    resolution: {integrity: sha512-wu7+qewcYcaZd5ljv8udIyKXVzbU3DXXaXRoIvodmC1qZfhsDfBLdiCFOmHoZQFnL2P11eFkvb1yXi7IBgQ4nw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
@@ -5582,6 +5596,12 @@ packages:
   socket.io@4.8.1:
     resolution: {integrity: sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==}
     engines: {node: '>=10.2.0'}
+
+  sonner@2.0.7:
+    resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -6223,6 +6243,18 @@ packages:
 
   ws@8.19.0:
     resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.21.1:
+    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -9790,6 +9822,10 @@ snapshots:
 
   inline-style-parser@0.2.7: {}
 
+  inspect-webkit@0.0.5(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
+
   internal-slot@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -11681,6 +11717,18 @@ snapshots:
     dependencies:
       randombytes: 2.1.0
 
+  serve-sim@0.1.44(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
+    dependencies:
+      inspect-webkit: 0.0.5(typescript@5.9.3)
+      sonner: 2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      ws: 8.21.1
+    transitivePeerDependencies:
+      - bufferutil
+      - react
+      - react-dom
+      - typescript
+      - utf-8-validate
+
   set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
@@ -11804,6 +11852,11 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  sonner@2.0.7(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   source-map-js@1.2.1: {}
 
@@ -12537,6 +12590,8 @@ snapshots:
   ws@8.18.3: {}
 
   ws@8.19.0: {}
+
+  ws@8.21.1: {}
 
   xml-name-validator@5.0.0: {}
 

--- a/slides/README.md
+++ b/slides/README.md
@@ -15,6 +15,24 @@ pnpm dev
 Vite serves example bundles via a symlink to `../website/docs/public/examples`.
 Run `cd ../website && pnpm prepare:docs` once if those bundles are missing.
 
+### Local iOS Simulator (`serve-sim`)
+
+The Vite dev server mounts [serve-sim](https://github.com/EvanBacon/serve-sim)
+middleware at **`/.sim`**, so the deck can stream a booted Apple Simulator into
+the browser (used by the duplicated `ref()` slide — Web `<lynx-view>` beside
+the native sim).
+
+```bash
+# macOS + Xcode, with a simulator already booted (e.g. Lynx Explorer):
+npx serve-sim --detach
+cd slides && pnpm dev
+# preview UI: http://localhost:4321/.sim
+```
+
+`proxyHelpers` stays off so Vite's HMR WebSocket is untouched; the helper's
+own loopback ports serve the stream (CORS is open). Production / Vercel builds
+do not include the middleware — the slide's iframe is for local presenting.
+
 ## Navigation
 
 Only **slide movement** is bound to bare keys. Every discrete command lives

--- a/slides/index.html
+++ b/slides/index.html
@@ -24,7 +24,7 @@
     </button>
   </div>
   <div class="chrome chrome--bottom">
-    <span data-counter>01 / 127</span>
+    <span data-counter>01 / 128</span>
   </div>
   <div class="chrome chrome--bottom-right">
     <a href="https://vue.lynxjs.org" target="_blank" rel="noreferrer">vue.lynxjs.org</a>
@@ -377,6 +377,50 @@
        ordered by vue-lynx release version
        ==================================================== -->
   
+
+  <!-- First <lynx-view> demo (ref / hello-world) + local iOS Simulator via
+       serve-sim (Vite mounts /.sim in `pnpm dev`). -->
+  <section class="slide demo demo--api demo--sim">
+    <div class="demo__body">
+      <div class="demo__title-row">
+        <h2 class="demo__title"><code class="brand-text">ref()</code> <span class="demo__title-sub">· live sim</span></h2>
+        <span class="ver-badge">serve-sim</span>
+      </div>
+      <div class="codeframe">
+        <div class="codeframe__head">
+          <span class="dots"><span></span><span></span><span></span></span>
+          <span>App.vue</span>
+        </div>
+<pre><span class="code-tag">&lt;script setup&gt;</span>
+<span class="code-key">import</span> { ref } <span class="code-key">from</span> <span class="code-str">'vue-lynx'</span>
+<span class="code-key">const</span> { y, jump } <span class="code-key">=</span> <span class="code-fn">useFlappy</span>()  <span class="code-com">// ref(0) inside</span>
+<span class="code-tag">&lt;/script&gt;</span>
+
+<span class="code-tag">&lt;template&gt;</span>
+  <span class="code-tag">&lt;view</span> <span class="code-attr">@tap</span>=<span class="code-str">"jump"</span><span class="code-tag">&gt;</span>
+    <span class="code-tag">&lt;image</span> <span class="code-attr">:style</span>=<span class="code-str">"{ transform:
+      `translateY(${y}px)` }"</span> <span class="code-tag">/&gt;</span>
+  <span class="code-tag">&lt;/view&gt;</span>
+<span class="code-tag">&lt;/template&gt;</span></pre>
+      </div>
+    </div>
+    <div class="demo__stage demo__stage--pair">
+      <div class="phone" data-caption="Web · lynx-view">
+        <div class="phone__inner">
+          <vl-demo bundle="hello-world/dist/main.web.bundle"></vl-demo>
+        </div>
+      </div>
+      <div class="phone no-deck-scroll" data-caption="Native · serve-sim">
+        <div class="phone__inner">
+          <vl-media kind="iframe" src="/.sim" label="/.sim · local iOS Simulator (serve-sim)"></vl-media>
+        </div>
+      </div>
+    </div>
+    <aside class="notes">
+      <p><strong>Start at the beginning — with the real simulator beside it.</strong> <code>ref()</code>, an event handler, a style binding. Left is Lynx for Web (<code>&lt;lynx-view&gt;</code>); right is the local iOS Simulator streamed through <a href="https://github.com/EvanBacon/serve-sim">serve-sim</a> at <code>/.sim</code>.</p>
+      <p><strong>Before the talk:</strong> boot a sim + Lynx Explorer with the hello-world bundle, then <code>npx serve-sim --detach</code>. The Vite deck mounts the preview middleware automatically.</p>
+    </aside>
+  </section>
 
   <section class="slide demo demo--api">
     <div class="demo__body">

--- a/slides/package.json
+++ b/slides/package.json
@@ -8,12 +8,14 @@
     "dev": "vite --host 0.0.0.0 --port 4321",
     "build": "vite build",
     "preview": "vite preview --host 0.0.0.0 --port 4321",
+    "sim": "serve-sim --detach",
     "test:morph": "node tests/morph-invariant.mjs"
   },
   "dependencies": {
     "@lynx-js/web-core": "^0.20.0",
     "@lynx-js/web-elements": "^0.12.0",
-    "qrcode-generator": "^2.0.4"
+    "qrcode-generator": "^2.0.4",
+    "serve-sim": "0.1.44"
   },
   "devDependencies": {
     "playwright-core": "^1.49.0",

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -50,6 +50,7 @@ export const ZH = {
 
   // ---- Chapter II · demos ----
   // ---- API coverage ----
+  'ref() · live sim': '<code class="brand-text">ref()</code> <span class="demo__title-sub">· 真机模拟</span>',
   'v-once / v-memo':
     '<code class="brand-text">v-once</code> / <code class="brand-text">v-memo</code>',
   'reactive() + composables':
@@ -459,6 +460,8 @@ export const ZH_NOTES = [
   `<p><strong>然后,Lynx 走出队列 —— 站到正中央,Vue 的正下方;其余候选人整体让到左侧。</strong>前端这条缝是天生打开的:Web 标准的编程模型、真 CSS、框架无关的合同。这根线,短、垂直、实心。</p><p>再看下面的覆盖:iOS、Android、Web、HarmonyOS 走<em>原生 UI primitive</em>;桌面与更多平台走<em>自定义渲染引擎</em>。Web 的开发体验进,Native 的用户体验出 —— 这个组合,配得上一个正式的标题……</p>`,
   // 12 Title reveal · Vue Lynx 正式亮相
   `<p><strong>亮相。</strong>这是 Vue Lynx 第一次正式出场 —— 标题在论证之后才落下:空缺是真的,门是开的,而这个项目正走进那扇门。</p><p>念出名字,让背景光呼吸一拍,然后直接进入 demo。</p>`,
+  // 13 ref + serve-sim (first lynx-view demo + local simulator)
+  `<p><strong>从最简单的开始 —— 并排真机模拟器。</strong><code>ref()</code>、一个事件回调、一个样式绑定。左边是 Lynx for Web(<code>&lt;lynx-view&gt;</code>);右边是通过 <a href="https://github.com/EvanBacon/serve-sim">serve-sim</a> 在 <code>/.sim</code> 推过来的本地 iOS Simulator。</p><p><strong>上场前:</strong>先 boot 模拟器 + Lynx Explorer 加载 hello-world bundle,再跑 <code>npx serve-sim --detach</code>。Vite deck 会自动挂上 preview middleware。</p>`,
   // 16 reactive
   `<p>整个响应式内核原样复用自 Vue —— <code>reactive</code>、<code>toRefs</code>、<code>computed</code>、watch 全部一致。这意味着<strong>组合式函数 —— 你组织 Vue 应用的方式 —— 原封不动可用</strong>。这个秒表就是一个普通的 composable。</p>`,
   // 17 v-model

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -734,6 +734,44 @@ h1, h2, h3, p { margin: 0; }
      clamped to the column width by the base `.phone { max-width: 100% }`. */
   max-width: none;
 }
+
+/* Side-by-side Web <lynx-view> + native serve-sim on the duplicated ref() slide. */
+.demo__stage--pair {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2.2cqw;
+  height: min(92cqh, 650px);
+}
+.demo__stage--pair .phone {
+  position: relative;
+  top: auto;
+  left: auto;
+  transform: none;
+  --phone-h: min(72cqh, 520px);
+  flex: 0 0 auto;
+}
+.demo__stage--pair .phone[data-caption]::after {
+  content: attr(data-caption);
+  position: absolute;
+  left: 50%;
+  bottom: -28px;
+  transform: translateX(-50%);
+  white-space: nowrap;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.demo__title-sub {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-style: italic;
+  color: var(--ink-mute);
+  font-size: 0.55em;
+  margin-left: 0.15em;
+}
 /* Lift the frame above the copy (and deepen its shadow) once it grows past the
    phone preset, so an overlapping expansion reads as floating, not broken. */
 .demo__stage .phone:not([data-device="phone"]) {

--- a/slides/vite.config.js
+++ b/slides/vite.config.js
@@ -27,12 +27,33 @@ function ensureExamplesSymlink() {
 }
 ensureExamplesSymlink();
 
+// Mount Evan Bacon's serve-sim preview at /.sim so the deck can stream a local
+// iOS Simulator during the talk. Helper ports stay on loopback (no upgrade
+// hijack — Vite HMR keeps its WebSocket). Start the helper separately:
+//   npx serve-sim --detach
+function serveSimPlugin() {
+  return {
+    name: 'serve-sim',
+    async configureServer(server) {
+      try {
+        const { simMiddleware } = await import('serve-sim/middleware');
+        const middleware = simMiddleware({ basePath: '/.sim' });
+        server.middlewares.use(middleware);
+        console.log('[slides] serve-sim preview at /.sim  (run: npx serve-sim --detach)');
+      } catch (err) {
+        console.warn('[slides] serve-sim middleware unavailable:', err?.message ?? err);
+      }
+    },
+  };
+}
+
 export default defineConfig({
   // When built for the docs site it is served under /deck/ (see
   // website/scripts/prepare-deck.mjs); standalone dev/build stays at root.
   base: process.env.DECK_BASE || '/',
   // web-core ships top-level await — needs ES2022+
   esbuild: { target: 'es2022' },
+  plugins: [serveSimPlugin()],
   build: {
     target: 'es2022',
     outDir: 'dist',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Integrates [Evan Bacon's serve-sim](https://github.com/EvanBacon/serve-sim) into the VueConf deck so a booted Apple Simulator can be streamed into the talk.

- Vite mounts `serve-sim/middleware` at `/.sim` during `pnpm dev` (helper stays on loopback; Vite HMR untouched)
- Duplicates the first `<lynx-view>` demo (`ref()` / hello-world) with **Web · lynx-view** and **Native · serve-sim** phones side by side
- Adds `pnpm sim` (`serve-sim --detach`), ZH notes, and README presenter instructions

## Presenter setup

```bash
# macOS: boot sim + Lynx Explorer with the hello-world bundle, then:
cd slides
pnpm sim          # or: npx serve-sim --detach
pnpm dev          # http://localhost:4321  ·  preview at /.sim
```

## Test plan

- [x] `pnpm build` in `slides/`
- [x] Dev server logs `[slides] serve-sim preview at /.sim`
- [x] `GET /.sim` returns the Simulator Preview HTML (200)
- [ ] On macOS with a booted sim: right phone streams the simulator; left phone still runs Lynx for Web
- [ ] Deck navigation / speaker notes / 中文 toggle still line up (144 slides)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92b11556-2a16-4244-810e-64eb40e93ded"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92b11556-2a16-4244-810e-64eb40e93ded"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

