### PR TITLE
refactor(slides): remove eyebrows + tighten Chapter II–III case flow

### DIFF
--- a/slides/index.html
+++ b/slides/index.html
@@ -24,7 +24,7 @@
     </button>
   </div>
   <div class="chrome chrome--bottom">
-    <span data-counter>01 / 140</span>
+    <span data-counter>01 / 139</span>
   </div>
   <div class="chrome chrome--bottom-right">
     <a href="https://vue.lynxjs.org" target="_blank" rel="noreferrer">vue.lynxjs.org</a>
@@ -1498,14 +1498,10 @@ app.<span class="code-fn">use</span>(router)</pre>
   <!-- ====================================================
        Chapter IV · How we did it
        ==================================================== -->
-  <section class="slide divider">
-    <h2 class="divider__title">
-      And how was <br/>this built?
+  <section class="slide stage">
+    <h2 class="h-section" style="text-align:center;max-width:16ch">
+      And how was <span class="brand-text">this built</span>?
     </h2>
-    <p class="divider__tag">
-      Three adaptations — the runtime, the toolchain, the main thread — and an
-      AI harness running through all of them.
-    </p>
     <aside class="notes">
       <p><strong>The engineering chapter.</strong> Everything you just saw was built in two weeks by one person — and this chapter is the honest answer to "how". Three adaptations, each revealing one piece of Lynx's architecture: split Vue across two threads without breaking its semantics; make one toolchain emit both worlds; then make the main thread itself programmable. An AI harness threads through the whole story.</p>
     </aside>
@@ -2172,21 +2168,6 @@ app.<span class="code-fn">use</span>(router)</pre>
     </aside>
   </section>
 
-  <!-- B3 — a plugin, not a compiler -->
-  <section class="slide stage">
-    <h2 class="h-section" style="text-align:center;max-width:22ch">
-      We wrote a <span class="brand-text">plugin</span> — not a compiler.
-    </h2>
-    <div class="demo__meta" style="justify-content:center">
-      <span class="chip chip--brand">Rspeedy</span>
-      <span class="chip chip--brand">Rspack / Rsbuild</span>
-      <span class="chip">rspack-vue-loader</span>
-      <span class="chip">PostCSS</span>
-    </div>
-    <aside class="notes">
-      <p><strong>The reuse story, toolchain edition.</strong> Lynx's toolchain (Rspeedy) is Rspack/Rsbuild — and the Vue ecosystem already runs on Rspack, so the entire SFC pipeline came off the shelf: <code>rspack-vue-loader</code>, PostCSS, HMR. <code>pluginVueLynx()</code> is a thin adapter: split each entry into the two layers, wire the worklet loaders, configure CSS — that's the whole surface. Framework-agnostic isn't a slogan; it's measured in how little we had to write.</p>
-    </aside>
-  </section>
 
   <!-- B4 — CSS is CSS -->
   <section class="slide stage">
@@ -2210,50 +2191,70 @@ app.<span class="code-fn">use</span>(router)</pre>
   </section>
 
   <!-- C1 — why gestures lag -->
-  <section class="slide stage">
-    <div class="flow">
-      <div class="flane" data-flip="lane-bg" style="--c:#5dd5a8;top:4%;height:42%">
-        <span class="flane__label"><i></i>Background thread</span>
+  <section class="slide demo demo--tech demo--split">
+    <div class="demo__body">
+      <div class="flow" style="width:100%;height:clamp(200px,36cqh,280px)">
+        <div class="flane" data-flip="lane-bg" style="--c:#5dd5a8;top:4%;height:42%">
+          <span class="flane__label"><i></i>Background thread</span>
+        </div>
+        <div class="flane" data-flip="lane-mt" style="--c:#56b8f0;top:54%;height:42%">
+          <span class="flane__label"><i></i>Main (UI) thread</span>
+        </div>
+        <div class="fb is-hero" data-flip="fb-fn" style="--c:#42b883;left:50%;top:25%">
+          onScroll()
+          <small>a Vue handler</small>
+        </div>
+        <span class="farr" style="--c:#3deae7;left:26%;top:50%">&uarr; event</span>
+        <span class="farr" style="--c:#4FB8F0;left:74%;top:50%">&darr; ops</span>
+        <span class="fcenter" data-mm-fade style="left:50%;top:66%;font-size:clamp(14px,1.4cqw,18px)"><b style="color:#F27A9E">2</b> crossings behind your finger</span>
       </div>
-      <div class="flane" data-flip="lane-mt" style="--c:#56b8f0;top:54%;height:42%">
-        <span class="flane__label"><i></i>Main (UI) thread</span>
-      </div>
-      <div class="fb is-hero" data-flip="fb-fn" style="--c:#42b883;left:50%;top:25%">
-        onScroll()
-        <small>a Vue handler</small>
-      </div>
-      <span class="farr" style="--c:#3deae7;left:26%;top:50%">&uarr; event</span>
-      <span class="farr" style="--c:#4FB8F0;left:74%;top:50%">&darr; ops</span>
-      <span class="fcenter" data-mm-fade style="left:50%;top:66%"><b style="color:#F27A9E">2</b> crossings behind your finger</span>
+      <p class="lead arch-cap" style="margin-top:8px">
+        The dual-thread <em>cost</em>: gestures wait for the round trip.
+      </p>
     </div>
-    <p class="lead arch-cap" data-mm-fade>
-      The dual-thread <em>cost</em>: gestures wait for the round trip.
-    </p>
+    <div class="demo__stage">
+      <div class="phone" data-ar="480 / 400">
+        <div class="phone__inner">
+          <vl-demo bundle="main-thread/dist/background-draggable.web.bundle"></vl-demo>
+        </div>
+      </div>
+    </div>
     <aside class="notes">
-      <p><strong>Honest about the cost before selling the reward.</strong> A scroll-follow animation the normal way: the event fires on the main thread, hops to the background for your handler, and the resulting ops hop back — two crossings on every frame of a gesture. On a busy page that's visible lag. This is the one place the dual-thread architecture charges you.</p>
+      <p><strong>Honest about the cost before selling the reward.</strong> Same demo as the docs <code>&lt;Go&gt;</code> on vue.lynxjs.org/guide/main-thread-script: scroll the yellow list — the blue square follows on the background thread, with a visible lag from two thread crossings per frame.</p>
+      <p><strong>Do live:</strong> scroll the list; the square lags, especially if you scroll fast.</p>
     </aside>
   </section>
 
   <!-- C2 — the function changes threads -->
-  <section class="slide stage">
-    <div class="flow">
-      <div class="flane" data-flip="lane-bg" style="--c:#5dd5a8;top:4%;height:42%">
-        <span class="flane__label"><i></i>Background thread</span>
+  <section class="slide demo demo--tech demo--split">
+    <div class="demo__body">
+      <div class="flow" style="width:100%;height:clamp(200px,36cqh,280px)">
+        <div class="flane" data-flip="lane-bg" style="--c:#5dd5a8;top:4%;height:42%">
+          <span class="flane__label"><i></i>Background thread</span>
+        </div>
+        <div class="flane" data-flip="lane-mt" style="--c:#56b8f0;top:54%;height:42%">
+          <span class="flane__label"><i></i>Main (UI) thread</span>
+        </div>
+        <div class="fb is-hero" data-flip="fb-fn" style="--c:#42b883;left:50%;top:75%">
+          onScroll()
+          <small>'main thread'</small>
+        </div>
+        <span class="fcenter" data-mm-fade style="left:50%;top:25%;font-size:clamp(14px,1.4cqw,18px)"><b>0</b> crossings — it runs where events fire</span>
       </div>
-      <div class="flane" data-flip="lane-mt" style="--c:#56b8f0;top:54%;height:42%">
-        <span class="flane__label"><i></i>Main (UI) thread</span>
-      </div>
-      <div class="fb is-hero" data-flip="fb-fn" style="--c:#42b883;left:50%;top:75%">
-        onScroll()
-        <small>'main thread'</small>
-      </div>
-      <span class="fcenter" data-mm-fade style="left:50%;top:25%"><b>0</b> crossings — it runs where events fire</span>
+      <p class="lead arch-cap" style="margin-top:8px">
+        One directive. The function <em>changes threads</em>.
+      </p>
     </div>
-    <p class="lead arch-cap" data-mm-fade>
-      One directive. The function <em>changes threads</em>.
-    </p>
+    <div class="demo__stage">
+      <div class="phone" data-ar="480 / 400">
+        <div class="phone__inner">
+          <vl-demo bundle="main-thread/dist/main-thread-draggable.web.bundle"></vl-demo>
+        </div>
+      </div>
+    </div>
     <aside class="notes">
-      <p><strong>Watch the block move.</strong> Add <code>'main thread'</code> as the first line and the compiler relocates that function into the main-thread bundle — it now runs synchronously where events fire, with direct element access. The rest of your component stays ordinary Vue. That's the progressive-enhancement shape again: the dual-thread reward stays, the cost becomes opt-out per function.</p>
+      <p><strong>Watch the block move.</strong> The docs <code>&lt;Go&gt;</code> comparison: left square runs on the main thread (<code>'main thread'</code>), right square still goes through the background — scroll and feel the difference. Same Vue file; one directive relocates the handler.</p>
+      <p><strong>Do live:</strong> scroll — the left (MT) square sticks to the finger; the right lags.</p>
     </aside>
   </section>
 
@@ -2487,14 +2488,10 @@ app.<span class="code-fn">use</span>(router)</pre>
   <!-- ====================================================
        Chapter IV · Close
        ==================================================== -->
-  <section class="slide divider">
-    <h2 class="divider__title">
-      And we'd love <br/>your help.
+  <section class="slide stage">
+    <h2 class="h-section" style="text-align:center;max-width:16ch">
+      And we'd love <span class="brand-text">your help</span>.
     </h2>
-    <p class="divider__tag">
-      Vue Lynx is pre-alpha. The architecture is solid; Vue's API surface is
-      large. What ships next depends on who shows up.
-    </p>
     <aside class="notes">
       <p><strong>Tone shift to the ask.</strong> The project is real but needs the community. Architecture is solid; Vue's surface area is huge.</p>
     </aside>

--- a/slides/index.html
+++ b/slides/index.html
@@ -24,7 +24,7 @@
     </button>
   </div>
   <div class="chrome chrome--bottom">
-    <span data-counter>01 / 132</span>
+    <span data-counter>01 / 127</span>
   </div>
   <div class="chrome chrome--bottom-right">
     <a href="https://vue.lynxjs.org" target="_blank" rel="noreferrer">vue.lynxjs.org</a>
@@ -2448,87 +2448,13 @@ app.<span class="code-fn">use</span>(router)</pre>
     </aside>
   </section>
 
-  <section class="slide combine">
-    <div class="combine__tile">
-      <svg viewBox="0 0 261.76 226.69" aria-label="Vue logo">
-        <path d="M161.096.001l-30.225 52.351L100.647.001H0l130.877 226.688L261.749.001z" fill="#42b883" />
-        <path d="M161.096.001l-30.225 52.351L100.647.001H52.346l78.526 136.01L209.398.001z" fill="#35495e" />
-      </svg>
-      <span class="combine__name">Vue 3</span>
-    </div>
-    <span class="combine__op">&times;</span>
-    <div class="combine__tile">
-      <svg viewBox="0 0 27 28" aria-label="Lynx logo" fill="#00ddff">
-        <path fill-rule="evenodd" clip-rule="evenodd" d="M7.56542 6.19594L3.90642 8.7164C3.50877 8.99031 3.23346 9.40191 3.13675 9.86708L2.77902 11.5878C2.76005 11.679 2.71799 11.7642 2.65665 11.8355L0.996306 14.0121C0.772761 14.2722 0.778152 14.9632 1.39044 15.4057C1.62523 15.6103 1.93915 16.0691 2.29622 16.591C3.05224 17.6959 4.00169 19.0836 4.80312 18.9394C5.9372 18.541 7.32544 18.4135 8.39128 18.9394C10.4632 20.7282 9.95449 22.3775 9.22514 24.7421C8.93165 25.6936 8.60243 26.7609 8.39128 27.9997C9.38643 24.3777 11.6242 20.1711 15.6592 18.7437C14.9322 18.1498 13.4486 17.5981 12.1357 17.4653C12.1357 17.4653 16.1691 14.0121 21.1439 12.4254C17.671 4.16205 11.9386 0.213095 11.9386 0.213095C11.6465 -0.148197 11.0566 -0.0296711 10.9349 0.414774C10.8371 1.72112 10.675 2.60942 10.4074 3.44676L8.39128 1.12029C8.18068 0.866399 7.75965 1.013 7.76176 1.33949C8.10312 3.23719 8.05521 4.30239 7.56542 6.19594ZM8.9846 6.02248L8.99663 6.02171C9.02298 6.02002 9.0489 6.01659 9.07424 6.01153L8.9846 6.02248ZM11.7123 1.7617C13.094 4.1491 13.7199 5.5054 13.9322 8.03659C12.4625 7.2017 11.8221 6.98923 10.7413 6.99451C11.3718 5.0773 11.5644 3.92284 11.7123 1.7617Z" />
-        <path d="M20.5916 19.4929C14.9639 20.7806 11.7672 22.7198 9.32227 28.0001C13.7111 20.6367 26.9966 21.9536 26.9966 21.9536C26.7484 20.7508 24.1069 18.4571 22.3696 17.0503C22.3696 17.0503 23.7712 15.3272 26.8697 14.455C26.8697 14.455 20.9125 14.8002 17.4445 16.6727C18.568 17.2656 20.0071 18.2663 20.5916 19.4929Z" />
-      </svg>
-      <span class="combine__name">Lynx</span>
-    </div>
-    <span class="combine__op">=</span>
-    <div class="combine__result">
-      <span class="result-label">A new path</span>
-      <h2 class="result-text">
-        Vue, <br/><span class="brand-text">on native.</span>
-      </h2>
-    </div>
-    <aside class="notes">
-      <p><strong>The headline.</strong> Vue × Lynx = Vue on native. Hold the moment — let the equation land. Then: "And we'd love your help making this a thing."</p>
-    </aside>
-  </section>
-
   <!-- ====================================================
-       Chapter IV · Close
+       Close · one npm command (fake thank-you)
        ==================================================== -->
   <section class="slide stage">
-    <h2 class="h-section" style="text-align:center;max-width:16ch">
-      And we'd love <span class="brand-text">your help</span>.
-    </h2>
-    <aside class="notes">
-      <p><strong>Tone shift to the ask.</strong> The project is real but needs the community. Architecture is solid; Vue's surface area is huge.</p>
-    </aside>
-  </section>
-
-  <section class="slide stage">
-    <h2 class="cta__title" style="text-align:center;max-width:20ch">
-      Native shouldn't be a different <span class="brand-text">team</span>.
-    </h2>
-    <p class="cta__sub" style="margin-inline:auto;text-align:center">
-      Vue developers should ship native apps as naturally as they ship for the
-      web today.
-    </p>
-    <aside class="notes">
-      <p>Land on <em>"native shouldn't be a different team"</em> — that's the line you want them to remember.</p>
-    </aside>
-  </section>
-
-  <section class="slide stage">
-    <div style="display:flex;gap:clamp(32px,6vw,80px);flex-wrap:wrap;justify-content:center;text-align:left">
-      <div class="stack-y gap-sm">
-        <span class="eyebrow" style="margin-bottom:8px">What's there</span>
-        <ul class="web__list">
-          <li><b>Composition API &amp; SFCs</b></li>
-          <li><b>Transition, Suspense, KeepAlive, Teleport</b></li>
-          <li><b>Pinia, Router, Query, Tailwind</b></li>
-          <li><b>Main-Thread Script</b></li>
-        </ul>
-      </div>
-      <div class="stack-y gap-sm">
-        <span class="eyebrow" style="margin-bottom:8px">What's open</span>
-        <ul class="web__list">
-          <li><b>View pager &amp; more gestures</b></li>
-          <li><b>Vue DevTools integration</b></li>
-          <li><b>The ecosystem you'd port</b></li>
-        </ul>
-      </div>
-    </div>
-    <aside class="notes">
-      <p>Left = what works today, ready for production exploration. Right = where contributors can move the needle — the Elk view pager from Chapter III is literally on this list.</p>
-    </aside>
-  </section>
-
-  <section class="slide stage">
-    <h2 class="cta__title" style="text-align:center;max-width:16ch">
-      One <span class="brand-text">npm create</span>, and you're shipping native.
+    <p class="lead" style="margin-bottom:4px">Stars, questions, PRs</p>
+    <h2 class="cta__title" style="text-align:center;max-width:14ch">
+      One <span class="brand-text">npm</span> command.
     </h2>
 
     <div class="cta__commandbox" data-copy="npm create vue-lynx@latest" style="cursor:pointer">
@@ -2540,41 +2466,11 @@ app.<span class="code-fn">use</span>(router)</pre>
       <div class="agent">for Agent</div>
     </div>
 
-    <div class="cta__links" style="justify-content:center">
-      <a class="cta__link cta__link--brand"
-         href="https://vue.lynxjs.org/guide/quick-start"
-         target="_blank" rel="noreferrer">
-        Quick Start &rarr;
-      </a>
-      <a class="cta__link"
-         href="https://github.com/Huxpro/vue-lynx"
-         target="_blank" rel="noreferrer">
-        github.com/Huxpro/vue-lynx
-      </a>
-      <a class="cta__link"
-         href="https://vue.lynxjs.org/guide/introduction"
-         target="_blank" rel="noreferrer">
-        Read the intro
-      </a>
-    </div>
+    <p class="lead" style="margin-top:14px;font-size:clamp(16px,1.6cqw,22px);color:var(--ink-mute)">Thank you.</p>
     <aside class="notes">
+      <p><strong>The headline, then the ask.</strong> Vue × Lynx = Vue on native. We'd love your help — architecture is solid; Vue's surface area is huge. The line to remember: <em>native shouldn't be a different team</em>. What's there today: Composition API &amp; SFCs, Transition/Suspense/KeepAlive/Teleport, Pinia/Router/Query/Tailwind, Main-Thread Script. What's open: view pager &amp; gestures, Vue DevTools, the ecosystem you'd port.</p>
       <p><strong>Call to action.</strong> One command — <code>npm create vue-lynx@latest</code>. The "for Agent" button copies a bootstrap prompt. Promise: "Tonight, on the bus home, you can have a Vue app running on an iPhone."</p>
-    </aside>
-  </section>
-
-  <section class="slide thankyou">
-    <h1><span class="brand-text">Thank</span> you.</h1>
-    <p class="sig">
-      Questions, PRs, opinions — all welcome.
-    </p>
-    <div class="handles">
-      <a href="https://x.com/Huxpro" target="_blank" rel="noreferrer">@Huxpro</a>
-      <a href="https://github.com/Huxpro/vue-lynx" target="_blank" rel="noreferrer">huxpro/vue-lynx</a>
-      <a href="https://vue.lynxjs.org" target="_blank" rel="noreferrer">vue.lynxjs.org</a>
-    </div>
-    <aside class="notes">
-      <p><strong>The fake close.</strong> Play it completely straight: thank them, half a bow, reach for the water — hold until the room starts to applaud.</p>
-      <p>Then, deadpan: "啊——没有哈。这才过去十分钟。" Advance into the real second half.</p>
+      <p><strong>The fake close.</strong> Play it completely straight: thank them, half a bow, reach for the water — hold until the room starts to applaud. Then, deadpan: "啊——没有哈。这才过去十分钟。" Advance into the real second half.</p>
     </aside>
   </section>
 

--- a/slides/index.html
+++ b/slides/index.html
@@ -24,7 +24,7 @@
     </button>
   </div>
   <div class="chrome chrome--bottom">
-    <span data-counter>01 / 135</span>
+    <span data-counter>01 / 134</span>
   </div>
   <div class="chrome chrome--bottom-right">
     <a href="https://vue.lynxjs.org" target="_blank" rel="noreferrer">vue.lynxjs.org</a>
@@ -3269,20 +3269,7 @@ app.<span class="code-fn">use</span>(router)</pre>
     </aside>
   </section>
 
-  <!-- V·11 — The one number (mic-drop) -->
-  <section class="slide stage" data-bg="beam">
-    <div class="mega"><span class="brand-text">7&times;</span> VDOM</div>
-    <p class="lead">
-      Vapor vs Vue VDOM on the 10,000-row select storm — same app, same bundle,
-      one attribute apart.
-    </p>
-    <aside class="notes">
-      <p><strong>The mic-drop.</strong> Cross-framework suite (ReactLynx vs Vue VDOM vs Vue Vapor), real clicks to composed-DOM end state. The Vue-vs-Vue headline: Vapor 7.0× VDOM on the 10k select storm, 1.9× on update storm.</p>
-      <p>Let it hang. Then the last slide.</p>
-    </aside>
-  </section>
-
-  <!-- V·12 — Close: flip a switch -->
+  <!-- V·11 — Close: flip a switch -->
   <section class="slide stage" data-bg="beam" data-chrome="minimal">
     <h2 class="cta__title" style="text-align:center;max-width:15ch">
       Same source. <span class="brand-text">Flip a switch.</span>
@@ -3301,6 +3288,7 @@ app.<span class="code-fn">use</span>(router)</pre>
       Experimental today — but the fast path is already here.
     </p>
     <aside class="notes">
+      <p><strong>The mic-drop number — 7× VDOM.</strong> Cross-framework suite (ReactLynx vs Vue VDOM vs Vue Vapor), real clicks to composed-DOM end state. The Vue-vs-Vue headline: Vapor 7.0× VDOM on the 10k select storm, 1.9× on update storm — same app, same bundle, one attribute apart.</p>
       <p><strong>Close the encore.</strong> Vapor is a per-app, build-time flag: the plugin option, the entry import, the <code>vapor</code> attribute. Two pure entries — <code>vue-lynx</code> and <code>vue-lynx/vapor</code> — so vdom-only APIs fail at build time in a Vapor app instead of misbehaving at runtime.</p>
       <p>Land it: "same Vue you already write — now with a compile-time fast path. That's the one more thing."</p>
     </aside>

--- a/slides/index.html
+++ b/slides/index.html
@@ -3546,7 +3546,7 @@ app.<span class="code-fn">use</span>(router)</pre>
   <!-- E27 — finale · long live the frontend -->
   <section class="slide thankyou" data-bg="clean" data-chrome="minimal" data-weave="finale">
     <p class="fin-dead">The frontend is dead.</p>
-    <h1>Long live <span class="brand-text">the frontend</span>.</h1>
+    <h1>Long live <span class="brand-text">the frontend</span></h1>
     <p class="sig">
       Thank you &mdash; for real this time.
     </p>

--- a/slides/index.html
+++ b/slides/index.html
@@ -24,7 +24,7 @@
     </button>
   </div>
   <div class="chrome chrome--bottom">
-    <span data-counter>01 / 143</span>
+    <span data-counter>01 / 140</span>
   </div>
   <div class="chrome chrome--bottom-right">
     <a href="https://vue.lynxjs.org" target="_blank" rel="noreferrer">vue.lynxjs.org</a>
@@ -220,7 +220,6 @@
     </aside>
   </section>
 
-
   <!-- ====================================================
        5 — The field · every cross-platform answer, in a row
        ==================================================== -->
@@ -367,78 +366,17 @@
     </div>
     <aside class="notes">
       <p><strong>The reveal.</strong> This is Vue Lynx's first formal appearance — the title lands only after the argument earned it: the gap is real, the door is open, and this is the project walking through it.</p>
-      <p>Say the name, let the beam breathe, then straight into the proof.</p>
+      <p>Say the name, let the beam breathe, then straight into the demos.</p>
     </aside>
   </section>
 
-  <!-- ====================================================
-       Chapter II · The proof — how far does it go?
-       ==================================================== -->
-  <section class="slide divider">
-    <div class="divider__row">
-      <span class="divider__num numeral--brand">II</span>
-      <h2 class="divider__title">
-        So, how far <br/>does it go?
-      </h2>
-    </div>
-    <p class="divider__tag">
-      A feast of live demos — every phone in this deck is a real Vue Lynx app,
-      running right now.
-    </p>
-    <aside class="notes">
-      <p><strong>The show-off chapter.</strong> "为了让大家感受到诚意" — to show we're serious, I brought a feast of demos. Three courses: Vue API coverage, the ecosystem as-is, then whole applications.</p>
-      <p>Every phone you'll see is live — scan the QR codes to run them on your own device as we go.</p>
-    </aside>
-  </section>
-
-  <section class="slide stage">
-    <div class="mega"><span class="brand-text">882</span><small style="font-size:0.4em;color:var(--ink-mute)"> / 1013</small></div>
-    <p class="lead">upstream Vue core tests, passing on our renderer.</p>
-    <aside class="notes">
-      <p><strong>The hard number first.</strong> We run Vue core's own test suites against the Vue Lynx renderer: 882 of 1013 pass, 131 documented skips, <strong>zero failures</strong>. "Compatible with Vue" here is a measured claim, not a vibe.</p>
-    </aside>
-  </section>
+  
 
   <!-- ====================================================
        II · Vue API coverage — one feature per slide
        ordered by vue-lynx release version
        ==================================================== -->
-  <section class="slide demo demo--api">
-    <div class="demo__body">
-      <div class="demo__title-row">
-        <h2 class="demo__title"><code class="brand-text">ref()</code></h2>
-        <span class="ver-badge">0.2.0</span>
-      </div>
-      <div class="codeframe">
-        <div class="codeframe__head">
-          <span class="dots"><span></span><span></span><span></span></span>
-          <span>App.vue</span>
-        </div>
-<pre><span class="code-tag">&lt;script setup&gt;</span>
-<span class="code-key">import</span> { ref } <span class="code-key">from</span> <span class="code-str">'vue-lynx'</span>
-<span class="code-key">const</span> { y, jump } <span class="code-key">=</span> <span class="code-fn">useFlappy</span>()  <span class="code-com">// ref(0) inside</span>
-<span class="code-tag">&lt;/script&gt;</span>
-
-<span class="code-tag">&lt;template&gt;</span>
-  <span class="code-tag">&lt;view</span> <span class="code-attr">@tap</span>=<span class="code-str">"jump"</span><span class="code-tag">&gt;</span>
-    <span class="code-tag">&lt;image</span> <span class="code-attr">:style</span>=<span class="code-str">"{ transform:
-      `translateY(${y}px)` }"</span> <span class="code-tag">/&gt;</span>
-  <span class="code-tag">&lt;/view&gt;</span>
-<span class="code-tag">&lt;/template&gt;</span></pre>
-      </div>
-    </div>
-    <div class="demo__stage">
-      <div class="phone">
-        <div class="phone__inner">
-          <vl-demo bundle="hello-world/dist/main.web.bundle"></vl-demo>
-        </div>
-      </div>
-    </div>
-    <aside class="notes">
-      <p><strong>Start at the beginning:</strong> <code>ref()</code>, an event handler, a style binding. The only differences from web Vue on this whole slide: the import says <code>vue-lynx</code>, and the tags are <code>&lt;view&gt;</code>/<code>&lt;text&gt;</code>/<code>&lt;image&gt;</code>.</p>
-      <p><strong>Do live:</strong> tap — the logo springs on a ref-driven transform.</p>
-    </aside>
-  </section>
+  
 
   <section class="slide demo demo--api">
     <div class="demo__body">
@@ -1072,58 +1010,21 @@ app.<span class="code-fn">use</span>(router)</pre>
     </aside>
   </section>
 
-  <section class="slide stage">
-    <h2 class="h-section" style="text-align:center;max-width:20ch">
-      And the same bundles run on the <span class="brand-text">Web</span>.
-    </h2>
-    <p class="lead">
-      Every phone in this deck is Lynx for Web — the same bundle that runs
-      natively, rendering in your browser right now.
-    </p>
-    <aside class="notes">
-      <p><strong>The kicker for web compatibility:</strong> nothing you saw was a simulator. Each mockup is <em>Lynx for Web</em> running the exact bundle that ships to iOS/Android. Scan the Web QR on any slide — it opens in your phone's browser; scan the App QR — same bundle, native.</p>
-      <p>Web DX in, and the Web as a first-class render target out. That's the baseline. Now for the superset.</p>
-    </aside>
-  </section>
+  
 
   <!-- ====================================================
        Chapter III · The upgrade — web apps gaining native
        ==================================================== -->
-  <section class="slide divider">
-    <div class="divider__row">
-      <span class="divider__num numeral--brand">III</span>
-      <h2 class="divider__title">
-        Apps, <em style="font-family:var(--serif);font-weight:400">upgrading</em> <br/>
-        from Web to native.
-      </h2>
-    </div>
-    <p class="divider__tag">
-      Progressive enhancement: keep the codebase you have — gain the platform
-      you don't.
-    </p>
+  <section class="slide stage">
+    <h2 class="h-section" style="text-align:center;max-width:16ch">
+      Upgrading to <span class="brand-text">native</span>.
+    </h2>
     <aside class="notes">
-      <p><strong>The superset chapter.</strong> Coverage and ports prove the baseline. The real pitch is upward: take a living web app, fork it, and <em>upgrade</em> it — same Vue code where it matters, native capabilities where it counts. Two real forks follow.</p>
+      <p><strong>The upgrade chapter.</strong> Ports prove the baseline. The real pitch is upward: take a living web app and gain native capabilities — same Vue where it matters, native where it counts.</p>
     </aside>
   </section>
 
   <!-- Case 1 · AI Chat -->
-  <section class="slide stage">
-    <h2 class="h-section" style="text-align:center;max-width:24ch">
-      The Nuxt AI Chatbot, <span class="brand-text">forked</span>.
-    </h2>
-    <div class="demo__meta" style="justify-content:center">
-      <span class="chip chip--brand">AI SDK streaming</span>
-      <span class="chip">reasoning</span>
-      <span class="chip">markdown + code</span>
-      <span class="chip">tool cards</span>
-      <span class="chip">theming</span>
-    </div>
-    <p class="lead">Everything above came across <em>unchanged</em>.</p>
-    <aside class="notes">
-      <p><strong>What stayed.</strong> This is the official Nuxt AI Chatbot template, ported feature-by-feature: streaming with thinking/reasoning, markdown with highlighted code, weather/chart tool-call cards, history, votes, editing, theme picker. The Vue in it — components, composables, stores — is the point: it moved without drama.</p>
-    </aside>
-  </section>
-
   <section class="slide demo demo--reverse">
     <div class="demo__stage">
       <div class="phone">
@@ -1134,24 +1035,27 @@ app.<span class="code-fn">use</span>(router)</pre>
     </div>
     <div class="demo__body">
       <h2 class="demo__title">
-        Then it went <span class="brand-text">native</span>.
+        Native <span class="brand-text">experience</span>?
       </h2>
       <p class="demo__copy">
-        The keyboard slides in — the thread glides up with it. Hit send —
-        the bubble flies from the prompt box into the conversation.
+        The Nuxt AI Chatbot, forked — streaming, reasoning, markdown, tool cards.
+        Then the native interactions: the keyboard lifts the thread; send flies
+        the bubble into the conversation.
       </p>
       <div class="demo__meta">
         <span class="chip chip--brand">keyboard avoidance</span>
         <span class="chip chip--brand">send motion</span>
-        <span class="chip">MTS pressables</span>
+        <span class="chip">AI SDK streaming</span>
+        <span class="chip">tool cards</span>
       </div>
     </div>
     <aside class="notes">
-      <p><strong>What changed — the upgrades.</strong> ① <em>Keyboard avoidance</em>: the native <code>keyboardstatuschanged</code> event drives <code>setNativeProps</code> transforms, so the prompt box and thread follow the keyboard with a native curve — no web viewport hacks. ② <em>Send motion</em>: your message physically detaches from the input and flies into the thread as a bubble. ③ Press feedback runs as Main-Thread Script.</p>
-      <p>Credit where due: this native-chat bar was set by Vercel's <em>"How we built the v0 iOS app"</em> write-up — the next two slides show how the same feel costs far less on Lynx.</p>
-      <p><strong>Do live:</strong> focus the input (keyboard slides, layout follows), then send a message — watch the bubble.</p>
+      <p><strong>What the app feels like.</strong> Official Nuxt AI Chatbot template, ported feature-by-feature — then upgraded: ① keyboard avoidance via native <code>keyboardstatuschanged</code> + <code>setNativeProps</code>; ② send motion — the bubble detaches from the prompt and flies into the thread; ③ MTS press feedback.</p>
+      <p><strong>Do live:</strong> focus the input (keyboard slides, layout follows), then send — watch the bubble.</p>
     </aside>
   </section>
+
+  
 
   <!-- Case 1 · AI Chat · the send is a handoff (restored) -->
   <section class="slide demo demo--reverse techslide">
@@ -1319,70 +1223,38 @@ app.<span class="code-fn">use</span>(router)</pre>
   </section>
 
   <!-- Case 2 · Elk -->
-  <section class="slide stage">
-    <h2 class="h-section" style="text-align:center;max-width:24ch">
-      Elk — a <span class="brand-text">production-scale</span> fork.
-    </h2>
-    <div class="demo__meta" style="justify-content:center">
-      <span class="chip chip--brand">masto.js client</span>
-      <span class="chip">content pipeline</span>
-      <span class="chip">theme system</span>
-      <span class="chip">domain logic</span>
-    </div>
-    <p class="lead">Elk's framework-agnostic layers, reused. Only the UI was rebuilt.</p>
-    <aside class="notes">
-      <p><strong>Scale is the argument here.</strong> Elk is a real Mastodon client, not a demo: timelines, threads, profiles, polls, content warnings, custom emoji, search, compose. We forked it and kept its brains — the masto.js API client, the Mastodon-HTML content pipeline, themes, domain logic — and rebuilt only the view layer on native elements. That's the porting economics: the bigger the app, the more carries over.</p>
-    </aside>
-  </section>
+  
 
   <!-- Case 2 · Elk · a real Nuxt app, rebuilt on native (restored) -->
-  <section class="slide stage techslide">
-    <span class="app-badge" data-flip="elk-badge"><span class="dot dot--teal"></span>III · Case 2 · Elk</span>
-    <h2 class="h-section" style="text-align:center;max-width:20ch">
-      A real Nuxt app, <span class="brand-text">rebuilt on native.</span>
-    </h2>
-    <div class="statset" data-mm-fade style="display:flex;gap:clamp(28px,5cqw,72px);justify-content:center;margin:8px 0 4px">
-      <div style="text-align:center">
-        <div class="mega" style="font-size:clamp(40px,5cqw,72px)"><span class="brand-text">196</span></div>
-        <div class="app-badge" style="justify-content:center">components</div>
-      </div>
-      <div style="text-align:center">
-        <div class="mega" style="font-size:clamp(40px,5cqw,72px)"><span class="brand-text">55</span></div>
-        <div class="app-badge" style="justify-content:center">pages</div>
-      </div>
-      <div style="text-align:center">
-        <div class="mega" style="font-size:clamp(40px,5cqw,72px)"><span class="brand-text">50</span></div>
-        <div class="app-badge" style="justify-content:center">composables</div>
-      </div>
-    </div>
-    <p class="lead" data-mm-fade style="max-width:52ch">
-      No Nuxt, no DOM — so instead of forking, the port <strong>reuses Elk's
-      framework-agnostic layers</strong> and rebuilds the UI on Lynx elements.
-    </p>
-    <div class="demo__meta" data-mm-fade style="justify-content:center">
-      <span class="chip chip--brand">masto.js reused</span>
-      <span class="chip">content-render retargeted</span>
-      <span class="chip">native &lt;list&gt;</span>
-    </div>
-    <aside class="notes">
-      <p><strong>Elk.</strong> The beloved Mastodon web client by Anthony Fu and team, ported into a native Mastodon client — timelines, threads, profiles, search, trends. A Nuxt 3 app: ~196 components, 55 pages, 50 composables.</p>
-      <p><strong>The porting move:</strong> keep the framework-agnostic layers (masto.js client reused unpatched, the HTML content parser ~95% verbatim), retarget the vnode renderer to <code>&lt;text&gt;</code>/<code>&lt;image&gt;</code>, and swap Elk's DOM virtualizer for the native recycling <code>&lt;list&gt;</code> — <em>less</em> code.</p>
-    </aside>
-  </section>
+  
 
   <section class="slide demo">
     <div class="demo__body">
       <h2 class="demo__title">
-        Native <span class="brand-text">gestures</span>, for free-ish.
+        Native <span class="brand-text">gestures</span>?
       </h2>
+      <div class="statset" style="display:flex;gap:clamp(20px,3.5cqw,48px);margin:4px 0 8px">
+        <div style="text-align:center">
+          <div class="mega" style="font-size:clamp(32px,4cqw,56px)"><span class="brand-text">196</span></div>
+          <div class="app-badge" style="justify-content:center">components</div>
+        </div>
+        <div style="text-align:center">
+          <div class="mega" style="font-size:clamp(32px,4cqw,56px)"><span class="brand-text">55</span></div>
+          <div class="app-badge" style="justify-content:center">pages</div>
+        </div>
+        <div style="text-align:center">
+          <div class="mega" style="font-size:clamp(32px,4cqw,56px)"><span class="brand-text">50</span></div>
+          <div class="app-badge" style="justify-content:center">composables</div>
+        </div>
+      </div>
       <p class="demo__copy">
-        Infinite timelines on the native <code>&lt;list&gt;</code>. A bottom
-        sheet with rubber-banding and fling — every frame on the UI thread.
+        Elk — a production Mastodon client. Framework-agnostic layers reused;
+        only the UI rebuilt on Lynx elements.
       </p>
       <div class="demo__meta">
-        <span class="chip chip--brand">MTS bottom sheet</span>
-        <span class="chip chip--brand">native &lt;list&gt;</span>
-        <span class="chip chip--brand">native view pager</span>
+        <span class="chip chip--brand">masto.js reused</span>
+        <span class="chip">content pipeline</span>
+        <span class="chip">native &lt;list&gt;</span>
       </div>
     </div>
     <div class="demo__stage">
@@ -1393,17 +1265,15 @@ app.<span class="code-fn">use</span>(router)</pre>
       </div>
     </div>
     <aside class="notes">
-      <p><strong>The gesture upgrades.</strong> The compose/bottom sheet is Main-Thread Script end-to-end: an 8px gesture lock decides who owns the drag, rubber-band resistance past the limit, fling with real velocity + deceleration to open or dismiss — zero background-thread round-trips, so it never drops a frame even mid-stream.</p>
-      <p><strong>And now shipped</strong> (merged as PR #223): a native view pager for swiping between timeline tabs — the sheet showed the pattern; the pager repeats it (later in this chapter).</p>
-      <p><strong>Do live:</strong> scroll the timeline, drag the sheet slowly (rubber band), then fling it.</p>
+      <p><strong>Scale is the argument.</strong> Elk is a real Mastodon client — timelines, threads, profiles, polls, search, compose. ~196 components, 55 pages, 50 composables. Keep the brains (masto.js, content pipeline, themes); rebuild only the view layer on native elements.</p>
+      <p><strong>Do live:</strong> scroll the timeline, open compose — feel the weight of a production app on native.</p>
     </aside>
   </section>
 
   <!-- Case 2 · Elk · the draggable sheet · three owners (real UI + code) -->
   <section class="slide stage techslide">
-    <span class="app-badge"><span class="dot dot--teal"></span>III · Case 2 · Elk · draggable sheet</span>
-    <h2 class="h-section" style="text-align:center;max-width:18ch">
-      One sheet, <span class="brand-text">three owners.</span>
+    <h2 class="h-section" style="text-align:center;max-width:24ch;font-size:clamp(26px,3cqw,40px)">
+      Sheet with <span class="brand-text">Rubberband</span> effect
     </h2>
     <div class="sheet-split" style="max-width:1060px;margin:10px auto 0">
       <div class="mockcol" data-mm-fade>
@@ -1502,8 +1372,8 @@ app.<span class="code-fn">use</span>(router)</pre>
       </p>
     </div>
     <div class="demo__body" style="max-width:none">
-      <h2 class="demo__title" style="font-size:clamp(30px,3.4cqw,48px)">
-        Tabs on a <span class="brand-text">native view pager</span>.
+      <h2 class="demo__title">
+        <span class="brand-text">Native</span> Viewpager
       </h2>
       <div class="codeframe" style="width:100%;text-align:left">
         <div class="codeframe__head">
@@ -2463,7 +2333,6 @@ app.<span class="code-fn">use</span>(router)</pre>
     </aside>
   </section>
 
-
   <!-- ====================================================
        IV · The landscape — the architecture-level comparison
        ==================================================== -->
@@ -2564,7 +2433,6 @@ app.<span class="code-fn">use</span>(router)</pre>
       <p><strong>The thesis, one line.</strong> Lynx gives you the Web's developer experience with native's user experience. And because the frontend seam is open — this is Vue's opening. Which brings us to…</p>
     </aside>
   </section>
-
 
   <!-- H1 — the harness -->
   <section class="slide stage">

--- a/slides/index.html
+++ b/slides/index.html
@@ -1499,12 +1499,9 @@ app.<span class="code-fn">use</span>(router)</pre>
        Chapter IV · How we did it
        ==================================================== -->
   <section class="slide divider">
-    <div class="divider__row">
-      <span class="divider__num numeral--brand">IV</span>
-      <h2 class="divider__title">
-        And how was <br/>this built?
-      </h2>
-    </div>
+    <h2 class="divider__title">
+      And how was <br/>this built?
+    </h2>
     <p class="divider__tag">
       Three adaptations — the runtime, the toolchain, the main thread — and an
       AI harness running through all of them.
@@ -2491,12 +2488,9 @@ app.<span class="code-fn">use</span>(router)</pre>
        Chapter IV · Close
        ==================================================== -->
   <section class="slide divider">
-    <div class="divider__row">
-      <span class="divider__num numeral--brand">V</span>
-      <h2 class="divider__title">
-        And we'd love <br/>your help.
-      </h2>
-    </div>
+    <h2 class="divider__title">
+      And we'd love <br/>your help.
+    </h2>
     <p class="divider__tag">
       Vue Lynx is pre-alpha. The architecture is solid; Vue's API surface is
       large. What ships next depends on who shows up.
@@ -2601,12 +2595,9 @@ app.<span class="code-fn">use</span>(router)</pre>
        and the case for weaving. The (real) second half.
        ==================================================== -->
   <section class="slide divider">
-    <div class="divider__row">
-      <span class="divider__num numeral--brand">&infin;</span>
-      <h2 class="divider__title">
-        The elephant<br/>in the room.
-      </h2>
-    </div>
+    <h2 class="divider__title">
+      The elephant<br/>in the room.
+    </h2>
     <p class="divider__tag">
       &ldquo;Vibe coding&rdquo; is barely eighteen months old &mdash; and it
       already writes native apps. So why frameworks? Why Lynx? Why any of this?

--- a/slides/index.html
+++ b/slides/index.html
@@ -24,7 +24,7 @@
     </button>
   </div>
   <div class="chrome chrome--bottom">
-    <span data-counter>01 / 133</span>
+    <span data-counter>01 / 132</span>
   </div>
   <div class="chrome chrome--bottom-right">
     <a href="https://vue.lynxjs.org" target="_blank" rel="noreferrer">vue.lynxjs.org</a>
@@ -3532,34 +3532,18 @@ app.<span class="code-fn">use</span>(router)</pre>
     </aside>
   </section>
 
-  <!-- E26 — ten years, renewed -->
-  <section class="slide stage">
-    <h2 class="h-section" style="text-align:center;max-width:24ch">
-      I rebuilt everything <span class="brand-text">ten-years-ago me</span> dreamed of.
-    </h2>
-    <div class="demo__meta" style="justify-content:center">
-      <span class="chip">hux.pro &mdash; untouched for 10 years</span>
-      <span class="chip">my first Vue app &mdash; v0.12</span>
-      <span class="chip chip--brand">this deck &mdash; zero libraries, vibed</span>
-    </div>
-    <aside class="notes">
-      <p><strong>Personal receipts.</strong> This past year I went back and renewed every project ten-years-ago me dreamed of: my personal site that sat untouched for a decade; my very first Vue project, on Vue 0.12; and this deck — hand-vibed HTML, no slide library underneath, the direct descendant of the slide editor I built back then.</p>
-    </aside>
-  </section>
-
-  <!-- E27 — still frontend -->
+  <!-- E26 — natural language (merged ten-years + still-frontend) -->
   <section class="slide stage" data-bg="clean">
-    <h2 class="h-section" style="text-align:center;max-width:24ch">
-      I just changed languages &mdash; to <span class="brand-text">natural language</span>.
+    <h2 class="h-section" style="text-align:center;max-width:12ch">
+      <span class="brand-text">Natural language</span>.
     </h2>
-    <p class="lead">I'm still doing frontend.</p>
     <aside class="notes">
-      <p><strong>The turn.</strong> So what am I actually doing all day, prompting instead of typing? I just switched languages one more time — assembly to C to JS to… natural language. The source changed. The work didn't: I'm still translating human intent into something people can see and touch.</p>
-      <p>That has always been the job. That <em>is</em> frontend.</p>
+      <p><strong>Personal receipts.</strong> This past year I went back and renewed every project ten-years-ago me dreamed of: my personal site that sat untouched for a decade (hux.pro); my very first Vue project, on Vue 0.12; and this deck — hand-vibed HTML, no slide library underneath, the direct descendant of the slide editor I built back then.</p>
+      <p><strong>The turn — I'm still doing frontend.</strong> So what am I actually doing all day, prompting instead of typing? I just switched languages one more time — assembly to C to JS to… natural language. The source changed. The work didn't: I'm still translating human intent into something people can see and touch. That has always been the job. That <em>is</em> frontend.</p>
     </aside>
   </section>
 
-  <!-- E28 — finale · long live the frontend -->
+  <!-- E27 — finale · long live the frontend -->
   <section class="slide thankyou" data-bg="clean" data-chrome="minimal" data-weave="finale">
     <p class="fin-dead">The frontend is dead.</p>
     <h1>Long live <span class="brand-text">the frontend</span>.</h1>

--- a/slides/index.html
+++ b/slides/index.html
@@ -24,7 +24,7 @@
     </button>
   </div>
   <div class="chrome chrome--bottom">
-    <span data-counter>01 / 134</span>
+    <span data-counter>01 / 133</span>
   </div>
   <div class="chrome chrome--bottom-right">
     <a href="https://vue.lynxjs.org" target="_blank" rel="noreferrer">vue.lynxjs.org</a>
@@ -2845,18 +2845,29 @@ app.<span class="code-fn">use</span>(router)</pre>
         "One more thing…" reveal, leads into "the cradle")
        ==================================================== -->
 
-  <!-- V·2 — Vapor headline -->
+  <!-- V·2 — Vapor headline + the switch -->
   <section class="slide stage" data-bg="beam">
     <div class="xtag">Experimental</div>
     <h2 class="h-section" style="text-align:center;max-width:19ch">
       Vue <span class="brand-text">Vapor</span>.
     </h2>
+    <div class="codeframe" style="text-align:left;max-width:560px">
+      <div class="codeframe__head">
+        <span class="dots"><span></span><span></span><span></span></span>
+        <span>lynx.config.ts · src/index.ts</span>
+      </div>
+<pre><span class="code-fn">pluginVueLynx</span>({ <span class="code-attr">vapor</span>: <span class="code-key">true</span> })
+
+<span class="code-key">import</span> { <span class="code-fn">createApp</span> } <span class="code-key">from</span> <span class="code-str">'vue-lynx/vapor'</span>
+<span class="code-fn">createApp</span>(App).<span class="code-fn">mount</span>()</pre>
+    </div>
     <p class="lead">
       Templates compile straight to code that touches elements directly.
       We taught it to run on Lynx's two threads.
     </p>
     <aside class="notes">
       <p><strong>What Vapor is — no Virtual DOM.</strong> Vue 3.6's compilation-based renderer: no vnode tree, no per-component diffing. Prerelease — pinned to <code>vue@3.6.0-beta.17</code>.</p>
+      <p><strong>Same source — flip a switch.</strong> Per-app, build-time flag: the plugin option, the entry import, the <code>vapor</code> attribute. Two pure entries — <code>vue-lynx</code> and <code>vue-lynx/vapor</code> — so vdom-only APIs fail at build time in a Vapor app instead of misbehaving at runtime.</p>
       <p>The claim we'll back with numbers: same Vue, far less update-path work.</p>
     </aside>
   </section>
@@ -3266,31 +3277,7 @@ app.<span class="code-fn">use</span>(router)</pre>
       <p><strong>Vapor gets its own upstream suite (PR #232).</strong> 30 <code>runtime-vapor</code> spec files run against the real <code>vue-lynx/vapor</code> surface and ShadowElement tree: <strong>545 pass, 120 skip, 0 fail</strong>. The skiplist is a <em>closed inventory</em> — every excluded test carries a reason, config load fails on anything unclassified.</p>
       <p><strong>The skips aren't a broken list.</strong> SSR/hydration + vdom↔vapor interop are 57% of everything that doesn't run — neither is a Lynx-compatibility signal (no SSR surface exists; interop is deliberately unsupported). Browser-only platform is another 24%. Test-infra is under 1% — vs vdom's dominant 59% — because the raw-bundle re-export trick killed the private-import problem. The port even found a real bug (ShadowElement was reactivity-proxyable; <code>__v_skip</code> fixed it).</p>
       <p><strong>The affinity point.</strong> On the tests that touch the actual element surface, Vapor passes 81% vs vdom's 57% — and needs <em>zero behavioral shims</em>: production <code>@vue/runtime-vapor</code> runs unmodified over ShadowElement, where vdom mode needed 1,074 LOC of simulation in the execution path. Vapor's host contract — clone a template + imperative setters — is just a closer fit to Lynx. (Contract fit, not speed.)</p>
-    </aside>
-  </section>
-
-  <!-- V·11 — Close: flip a switch -->
-  <section class="slide stage" data-bg="beam" data-chrome="minimal">
-    <h2 class="cta__title" style="text-align:center;max-width:15ch">
-      Same source. <span class="brand-text">Flip a switch.</span>
-    </h2>
-    <div class="codeframe" style="text-align:left;max-width:560px">
-      <div class="codeframe__head">
-        <span class="dots"><span></span><span></span><span></span></span>
-        <span>lynx.config.ts · src/index.ts</span>
-      </div>
-<pre><span class="code-fn">pluginVueLynx</span>({ <span class="code-attr">vapor</span>: <span class="code-key">true</span> })
-
-<span class="code-key">import</span> { <span class="code-fn">createApp</span> } <span class="code-key">from</span> <span class="code-str">'vue-lynx/vapor'</span>
-<span class="code-fn">createApp</span>(App).<span class="code-fn">mount</span>()</pre>
-    </div>
-    <p class="cta__sub" style="margin-inline:auto;text-align:center">
-      Experimental today — but the fast path is already here.
-    </p>
-    <aside class="notes">
       <p><strong>The mic-drop number — 7× VDOM.</strong> Cross-framework suite (ReactLynx vs Vue VDOM vs Vue Vapor), real clicks to composed-DOM end state. The Vue-vs-Vue headline: Vapor 7.0× VDOM on the 10k select storm, 1.9× on update storm — same app, same bundle, one attribute apart.</p>
-      <p><strong>Close the encore.</strong> Vapor is a per-app, build-time flag: the plugin option, the entry import, the <code>vapor</code> attribute. Two pure entries — <code>vue-lynx</code> and <code>vue-lynx/vapor</code> — so vdom-only APIs fail at build time in a Vapor app instead of misbehaving at runtime.</p>
-      <p>Land it: "same Vue you already write — now with a compile-time fast path. That's the one more thing."</p>
     </aside>
   </section>
 

--- a/slides/index.html
+++ b/slides/index.html
@@ -2849,14 +2849,14 @@ app.<span class="code-fn">use</span>(router)</pre>
   <section class="slide stage" data-bg="beam">
     <div class="xtag">Experimental</div>
     <h2 class="h-section" style="text-align:center;max-width:19ch">
-      <span class="brand-text">Vapor</span> mode — no Virtual DOM.
+      Vue <span class="brand-text">Vapor</span>.
     </h2>
     <p class="lead">
       Templates compile straight to code that touches elements directly.
       We taught it to run on Lynx's two threads.
     </p>
     <aside class="notes">
-      <p><strong>What Vapor is.</strong> Vue 3.6's compilation-based renderer: no vnode tree, no per-component diffing. Prerelease — pinned to <code>vue@3.6.0-beta.17</code>.</p>
+      <p><strong>What Vapor is — no Virtual DOM.</strong> Vue 3.6's compilation-based renderer: no vnode tree, no per-component diffing. Prerelease — pinned to <code>vue@3.6.0-beta.17</code>.</p>
       <p>The claim we'll back with numbers: same Vue, far less update-path work.</p>
     </aside>
   </section>

--- a/slides/index.html
+++ b/slides/index.html
@@ -24,7 +24,7 @@
     </button>
   </div>
   <div class="chrome chrome--bottom">
-    <span data-counter>01 / 139</span>
+    <span data-counter>01 / 138</span>
   </div>
   <div class="chrome chrome--bottom-right">
     <a href="https://vue.lynxjs.org" target="_blank" rel="noreferrer">vue.lynxjs.org</a>
@@ -2258,7 +2258,7 @@ app.<span class="code-fn">use</span>(router)</pre>
     </aside>
   </section>
 
-  <!-- C3 — the code -->
+  <!-- C3 — the code (+ worklet reuse commentary in notes) -->
   <section class="slide stage">
     <div class="codeframe" style="width:100%;max-width:680px;text-align:left">
       <div class="codeframe__head">
@@ -2286,6 +2286,7 @@ app.<span class="code-fn">use</span>(router)</pre>
     </p>
     <aside class="notes">
       <p>The whole MTS surface in one file: <code>'main thread'</code> marks the function, <code>main-thread-bind*</code> attaches it to the event, <code>useMainThreadRef()</code> gives synchronous element access — <code>setStyleProperty</code> lands the same frame the finger moves.</p>
+      <p><strong>Reuse, then evolve.</strong> Under the hood we run ReactLynx's worklet runtime and its API shapes (<code>main-thread-bind*</code>, <code>useMainThreadRef</code>) — battle-tested, and instantly familiar across the Lynx ecosystem. But Vue deserves Vue-shaped ergonomics: think <code>&lt;script main-thread setup&gt;</code>, main-thread computed/watch. That design space is open — and it's a great place for the community to leave a mark.</p>
     </aside>
   </section>
 
@@ -2319,17 +2320,7 @@ app.<span class="code-fn">use</span>(router)</pre>
   </section>
 
   <!-- C5 — reuse + the open API space -->
-  <section class="slide stage">
-    <h2 class="h-section" style="text-align:center;max-width:24ch">
-      Same worklet engine as ReactLynx — <em style="font-family:var(--serif);font-weight:400">today</em>.
-    </h2>
-    <p class="lead">
-      A Vue-flavored MTS API is the open design space.
-    </p>
-    <aside class="notes">
-      <p><strong>Reuse, then evolve.</strong> Under the hood we run ReactLynx's worklet runtime and its API shapes (<code>main-thread-bind*</code>, <code>useMainThreadRef</code>) — battle-tested, and instantly familiar across the Lynx ecosystem. But Vue deserves Vue-shaped ergonomics: think <code>&lt;script main-thread setup&gt;</code>, main-thread computed/watch. That design space is open — and it's a great place for the community to leave a mark.</p>
-    </aside>
-  </section>
+  
 
   <!-- ====================================================
        IV · The landscape — the architecture-level comparison

--- a/slides/index.html
+++ b/slides/index.html
@@ -24,7 +24,7 @@
     </button>
   </div>
   <div class="chrome chrome--bottom">
-    <span data-counter>01 / 138</span>
+    <span data-counter>01 / 136</span>
   </div>
   <div class="chrome chrome--bottom-right">
     <a href="https://vue.lynxjs.org" target="_blank" rel="noreferrer">vue.lynxjs.org</a>
@@ -2640,30 +2640,7 @@ app.<span class="code-fn">use</span>(router)</pre>
     </aside>
   </section>
 
-  <!-- E3 — the claim / roadmap -->
-  <section class="slide stage">
-    <h2 class="h-section" style="text-align:center;max-width:22ch">
-      What <span class="brand-text">survives</span> AI?
-    </h2>
-    <div class="tiles">
-      <span class="tile" style="--c:#8b93a3">infrastructure</span>
-      <span class="tilearr">&rarr;</span>
-      <span class="tile" style="--c:#E8B44A">enablers</span>
-      <span class="tilearr">&rarr;</span>
-      <span class="tile" style="--c:#56b8f0">platforms</span>
-      <span class="tilearr">&rarr;</span>
-      <span class="tile" style="--c:#9E86F0">ecosystems</span>
-      <span class="tilearr">&rarr;</span>
-      <span class="tile is-hero" style="--c:#42b883">people</span>
-    </div>
-    <p class="lead" data-mm-fade>Two lemmas, then an answer.</p>
-    <aside class="notes">
-      <p><strong>The thesis, stated up front so the chapter has a spine.</strong> What's "saved" from AI is everything that <em>enables</em> instead of merely produces: infrastructure, enablers, platforms, ecosystems — and, at the end of the chain, people. Note the progression: each one is saved <em>because</em> it feeds the next.</p>
-      <p>I'll argue it with two lemmas: (1) technology's role flips from interface to harness; (2) technology's real job is connecting ecosystems — and people.</p>
-    </aside>
-  </section>
-
-  <!-- E4 — Lemma 1 · the stack, rewritten -->
+  <!-- E3 — Lemma 1 · from interface to Harness -->
   <section class="slide stage">
     <div class="flow" style="height:56cqh;width:min(100%,880px)">
       <div class="fb" data-flip="stk-human" style="--c:#8b93a3;left:44%;top:4%">human</div>
@@ -2676,31 +2653,15 @@ app.<span class="code-fn">use</span>(router)</pre>
       <span class="farr" data-mm-fade style="--c:#56b8f0;left:71.5%;top:40.8%">&larr; the new interface</span>
       <span class="farr" data-mm-fade style="left:73%;top:77.6%">&larr; they stay &mdash; and evolve</span>
     </div>
-    <p class="lead" data-mm-fade>The stack, rewritten.</p>
+    <p class="lead" data-mm-fade>Technology: from interface to <span class="brand-text">Harness</span>.</p>
     <aside class="notes">
-      <p><strong>Lemma 1 opens with the new stack.</strong> Natural language is the new source code; the agent is the new interface sitting where IDEs and GUIs used to. But look below the agent: code, frameworks, the system — they didn't vanish. They became what the agent <em>drives</em>.</p>
-      <p>Technology's job flipped: from serving humans directly to <em>harnessing</em> the thing that serves humans.</p>
+      <p><strong>What survives AI?</strong> Everything that <em>enables</em> instead of merely produces: infrastructure → enablers → platforms → ecosystems → people. Each one is saved <em>because</em> it feeds the next. Two lemmas: (1) technology flips from interface to harness; (2) technology's real job is connecting ecosystems — and people.</p>
+      <p><strong>Lemma 1 — the stack, rewritten.</strong> Natural language is the new source code; the agent is the new interface where IDEs and GUIs used to sit. Below the agent: code, frameworks, the system — they didn't vanish; they became what the agent <em>drives</em>. Technology's job flipped: from serving humans directly to <em>harnessing</em> the thing that serves humans.</p>
+      <p><strong>AI can do anything — harnessed.</strong> A harness turns raw capability into reliable work: context (docs · priors · AGENTS.md), tools (functions · capabilities), environment (runtime · sandbox), feedback (render · tests · logs). Chapter IV was secretly that beat: AGENTS.md was context, the toolchain tools, LynxExplorer the environment, upstream tests the feedback.</p>
     </aside>
   </section>
 
-  <!-- E5 — what makes a harness -->
-  <section class="slide stage">
-    <h2 class="h-section" style="text-align:center;max-width:24ch">
-      AI can do anything &mdash; <span class="brand-text">harnessed</span>.
-    </h2>
-    <div class="tiles">
-      <span class="tile" style="--c:#E8B44A">context <small>docs &middot; priors &middot; AGENTS.md</small></span>
-      <span class="tile" style="--c:#56b8f0">tools <small>functions &middot; capabilities</small></span>
-      <span class="tile" style="--c:#9E86F0">environment <small>runtime &middot; sandbox</small></span>
-      <span class="tile" style="--c:#42b883">feedback <small>render &middot; tests &middot; logs</small></span>
-    </div>
-    <aside class="notes">
-      <p><strong>Define the word, because the whole chapter leans on it.</strong> A harness is what turns raw capability into reliable work: context (what it knows going in), tools (what it can act with), an environment (where actions are safe and cheap), feedback (how it sees what it just did).</p>
-      <p>Chapter IV was secretly this slide: AGENTS.md was context, the toolchain was tools, LynxExplorer the environment, the upstream tests the feedback.</p>
-    </aside>
-  </section>
-
-  <!-- E6 — the browser is a great harness -->
+  <!-- E4 — the browser is a great harness -->
   <section class="slide stage">
     <div class="logo" style="position:static;width:8cqw;height:8cqw">
       <svg viewBox="0 0 48 48" aria-label="Chrome logo"><circle cx="24" cy="24" r="12" fill="#fff"/><path fill="#EA4335" d="M24 12h20.78a23.99 23.99 0 0 0-41.56.003L13.61 30l.009-.002A11.99 11.99 0 0 1 24 12Z"/><path fill="#FBBC04" d="M34.39 30.003 24 48a23.99 23.99 0 0 0 20.78-35.997H24l-.003.009a11.99 11.99 0 0 1 10.393 17.991Z"/><path fill="#34A853" d="M13.61 30.003 3.22 12.006A23.99 23.99 0 0 0 24 48l10.39-17.997-.007-.007a11.99 11.99 0 0 1-20.773.007Z"/><circle cx="24" cy="24" r="9.5" fill="#1A73E8"/></svg>

--- a/slides/index.html
+++ b/slides/index.html
@@ -24,7 +24,7 @@
     </button>
   </div>
   <div class="chrome chrome--bottom">
-    <span data-counter>01 / 136</span>
+    <span data-counter>01 / 135</span>
   </div>
   <div class="chrome chrome--bottom-right">
     <a href="https://vue.lynxjs.org" target="_blank" rel="noreferrer">vue.lynxjs.org</a>
@@ -2827,21 +2827,11 @@ app.<span class="code-fn">use</span>(router)</pre>
     <aside class="notes">
       <p><strong>Connect to Lynx and you connect to everything Lynx connects.</strong> The web fabrics you already use — Motion, Pretext — carry over. Electron via Node-API; the JSI world, Expo Modules included; every rendering strategy; the agent-UI protocols taking shape. And Lynx's own ecosystem — Sparkling, Lynxtron.</p>
       <p>The ecosystem and the community are what get carried over. That's the compounding.</p>
+      <p><strong>AI doesn't need mature libraries — it needs a place to vibe.</strong> With an agent at the keyboard, what you need isn't even a mature library — it's a platform where trying things is cheap, observable, and safe. That's what made the Web the Web. Lynx's bet is carrying that property to native.</p>
     </aside>
   </section>
 
-  <!-- E17 — a place to vibe -->
-  <section class="slide stage">
-    <h2 class="h-section" style="text-align:center;max-width:26ch">
-      AI doesn't need mature libraries. It needs a place to <span class="brand-text">vibe</span>.
-    </h2>
-    <p class="lead">The Web was that place. Lynx carries it to native.</p>
-    <aside class="notes">
-      <p><strong>Sharpen the ecosystem point for the AI era.</strong> With an agent at the keyboard, what you need isn't even a mature library — it's a platform where trying things is cheap, observable, and safe. That's what made the Web the Web. Lynx's bet is carrying that property to native.</p>
-    </aside>
-  </section>
-
-  <!-- E18 — one more thing -->
+  <!-- E17 — one more thing -->
   <section class="slide stage" data-bg="clean" data-chrome="none">
     <p class="kicker" style="font-size:clamp(44px,5.6cqw,80px);text-align:center;max-width:none">One more thing&hellip;</p>
     <aside class="notes">

--- a/slides/index.html
+++ b/slides/index.html
@@ -3283,9 +3283,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- E20a — design space · Vapor tree vs ET (naming) -->
   <section class="slide stage dspace">
-    <h2 class="h-section" style="text-align:center;max-width:24ch">
-      Pointers die — <span class="brand-text">names</span> take over.
-    </h2>
     <div class="dtrees">
       <figure>
         <figcaption><b>Vapor · dense</b> — every node gets a name</figcaption>

--- a/slides/index.html
+++ b/slides/index.html
@@ -375,7 +375,6 @@
        Chapter II · The proof — how far does it go?
        ==================================================== -->
   <section class="slide divider">
-    <span class="eyebrow">Chapter II</span>
     <div class="divider__row">
       <span class="divider__num numeral--brand">II</span>
       <h2 class="divider__title">
@@ -393,7 +392,6 @@
   </section>
 
   <section class="slide stage">
-    <span class="eyebrow">II · The proof</span>
     <div class="mega"><span class="brand-text">882</span><small style="font-size:0.4em;color:var(--ink-mute)"> / 1013</small></div>
     <p class="lead">upstream Vue core tests, passing on our renderer.</p>
     <aside class="notes">
@@ -407,7 +405,6 @@
        ==================================================== -->
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 1/12</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><code class="brand-text">ref()</code></h2>
         <span class="ver-badge">0.2.0</span>
@@ -445,7 +442,6 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 2/12</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><code class="brand-text">reactive()</code> + composables</h2>
         <span class="ver-badge">0.2.0</span>
@@ -479,7 +475,6 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 3/12</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><code class="brand-text">v-model</code></h2>
         <span class="ver-badge">0.2.0</span>
@@ -518,7 +513,6 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 4/12</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><code class="brand-text">&lt;slot&gt;</code></h2>
         <span class="ver-badge">0.2.0</span>
@@ -554,7 +548,6 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 5/12</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><code class="brand-text">provide / inject</code></h2>
         <span class="ver-badge">0.2.0</span>
@@ -586,7 +579,6 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 6/12</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><code class="brand-text">&lt;Suspense&gt;</code></h2>
         <span class="ver-badge">0.2.0</span>
@@ -621,7 +613,6 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 7/12</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><code class="brand-text">&lt;Transition&gt;</code></h2>
         <span class="ver-badge">0.2.0</span>
@@ -654,7 +645,6 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 8/12</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><span class="brand-text">CSS</span> features</h2>
         <span class="ver-badge">0.3.0</span>
@@ -697,7 +687,6 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 9/12</span>
       <div class="demo__title-row">
         <h2 class="demo__title">Event <span class="brand-text">modifiers</span></h2>
         <span class="ver-badge">0.4.0</span>
@@ -735,7 +724,6 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 10/12</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><code class="brand-text">&lt;KeepAlive&gt;</code></h2>
         <span class="ver-badge">0.4.0</span>
@@ -771,7 +759,6 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 11/12</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><code class="brand-text">&lt;Teleport&gt;</code></h2>
         <span class="ver-badge">0.4.0</span>
@@ -808,7 +795,6 @@
 
   <section class="slide demo demo--api demo--api-duo">
     <div class="demo__body">
-      <span class="eyebrow">II · Vue coverage · 12/12</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><code class="brand-text">v-once</code> / <code class="brand-text">v-memo</code></h2>
         <span class="ver-badge">0.4.0</span>
@@ -857,7 +843,6 @@
        II · Ecosystem — libraries work as-is
        ==================================================== -->
   <section class="slide stage">
-    <span class="eyebrow">II · The proof</span>
     <h2 class="h-section" style="text-align:center;max-width:22ch">
       The ecosystem, <span class="brand-text">as-is</span>.
     </h2>
@@ -877,7 +862,6 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Ecosystem · 1/4</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><span class="brand-text">Pinia</span></h2>
       </div>
@@ -912,7 +896,6 @@
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Ecosystem · 2/4</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><span class="brand-text">Vue Router</span></h2>
       </div>
@@ -950,7 +933,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Ecosystem · 3/4</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><span class="brand-text">Vue Query</span></h2>
       </div>
@@ -990,7 +972,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <section class="slide demo demo--api">
     <div class="demo__body">
-      <span class="eyebrow">II · Ecosystem · 4/4</span>
       <div class="demo__title-row">
         <h2 class="demo__title"><span class="brand-text">Tailwind</span></h2>
       </div>
@@ -1029,7 +1010,6 @@ app.<span class="code-fn">use</span>(router)</pre>
        II · Whole apps — the Web-DX baseline
        ==================================================== -->
   <section class="slide stage">
-    <span class="eyebrow">II · The proof</span>
     <h2 class="h-section" style="text-align:center;max-width:20ch">
       Whole <span class="brand-text">apps</span> port, too.
     </h2>
@@ -1040,7 +1020,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <section class="slide demo">
     <div class="demo__body">
-      <span class="eyebrow">II · Whole apps</span>
       <h2 class="demo__title">
         <span class="brand-text">TodoMVC</span>
       </h2>
@@ -1075,7 +1054,6 @@ app.<span class="code-fn">use</span>(router)</pre>
       </div>
     </div>
     <div class="demo__body">
-      <span class="eyebrow">II · Whole apps</span>
       <h2 class="demo__title">
         <span class="brand-text">HackerNews</span>
       </h2>
@@ -1095,7 +1073,6 @@ app.<span class="code-fn">use</span>(router)</pre>
   </section>
 
   <section class="slide stage">
-    <span class="eyebrow">II · The proof</span>
     <h2 class="h-section" style="text-align:center;max-width:20ch">
       And the same bundles run on the <span class="brand-text">Web</span>.
     </h2>
@@ -1113,7 +1090,6 @@ app.<span class="code-fn">use</span>(router)</pre>
        Chapter III · The upgrade — web apps gaining native
        ==================================================== -->
   <section class="slide divider">
-    <span class="eyebrow">Chapter III</span>
     <div class="divider__row">
       <span class="divider__num numeral--brand">III</span>
       <h2 class="divider__title">
@@ -1132,7 +1108,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- Case 1 · AI Chat -->
   <section class="slide stage">
-    <span class="eyebrow">III · Case 1 · AI Chat</span>
     <h2 class="h-section" style="text-align:center;max-width:24ch">
       The Nuxt AI Chatbot, <span class="brand-text">forked</span>.
     </h2>
@@ -1158,7 +1133,6 @@ app.<span class="code-fn">use</span>(router)</pre>
       </div>
     </div>
     <div class="demo__body">
-      <span class="eyebrow">III · Case 1 · AI Chat</span>
       <h2 class="demo__title">
         Then it went <span class="brand-text">native</span>.
       </h2>
@@ -1346,7 +1320,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- Case 2 · Elk -->
   <section class="slide stage">
-    <span class="eyebrow">III · Case 2 · Elk</span>
     <h2 class="h-section" style="text-align:center;max-width:24ch">
       Elk — a <span class="brand-text">production-scale</span> fork.
     </h2>
@@ -1399,7 +1372,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <section class="slide demo">
     <div class="demo__body">
-      <span class="eyebrow">III · Case 2 · Elk</span>
       <h2 class="demo__title">
         Native <span class="brand-text">gestures</span>, for free-ish.
       </h2>
@@ -1530,7 +1502,6 @@ app.<span class="code-fn">use</span>(router)</pre>
       </p>
     </div>
     <div class="demo__body" style="max-width:none">
-      <span class="eyebrow">III · Case 2 · Elk</span>
       <h2 class="demo__title" style="font-size:clamp(30px,3.4cqw,48px)">
         Tabs on a <span class="brand-text">native view pager</span>.
       </h2>
@@ -1658,7 +1629,6 @@ app.<span class="code-fn">use</span>(router)</pre>
        Chapter IV · How we did it
        ==================================================== -->
   <section class="slide divider">
-    <span class="eyebrow">Chapter IV</span>
     <div class="divider__row">
       <span class="divider__num numeral--brand">IV</span>
       <h2 class="divider__title">
@@ -1676,7 +1646,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- A1 — Vue lands on the background thread -->
   <section class="slide stage">
-    <span class="eyebrow">IV · Runtime</span>
     <div class="flow">
       <div class="flane" data-flip="lane-bg" style="--c:#5dd5a8;top:4%;height:42%">
         <span class="flane__label"><i></i>Background thread</span>
@@ -1699,7 +1668,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- A2 — ShadowElement -->
   <section class="slide stage">
-    <span class="eyebrow">IV · Runtime</span>
     <div class="flow">
       <div class="flane" data-flip="lane-bg" style="--c:#5dd5a8;top:4%;height:42%">
         <span class="flane__label"><i></i>Background thread</span>
@@ -1727,7 +1695,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- A3 — ops buffer crosses -->
   <section class="slide stage">
-    <span class="eyebrow">IV · Runtime</span>
     <div class="flow">
       <div class="flane" data-flip="lane-bg" style="--c:#5dd5a8;top:4%;height:42%">
         <span class="flane__label"><i></i>Background thread</span>
@@ -1760,7 +1727,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- A4 — interpreter + PAPI -->
   <section class="slide stage">
-    <span class="eyebrow">IV · Runtime</span>
     <div class="flow">
       <div class="flane" data-flip="lane-bg" style="--c:#5dd5a8;top:4%;height:42%">
         <span class="flane__label"><i></i>Background thread</span>
@@ -1803,7 +1769,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- A5 — events ride back -->
   <section class="slide stage">
-    <span class="eyebrow">IV · Runtime</span>
     <div class="flow">
       <div class="flane" data-flip="lane-bg" style="--c:#5dd5a8;top:4%;height:42%">
         <span class="flane__label"><i></i>Background thread</span>
@@ -1850,7 +1815,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- A6 — one lap = nextTick -->
   <section class="slide stage">
-    <span class="eyebrow">IV · Runtime</span>
     <div class="flow">
       <div class="flane" data-flip="lane-bg" style="--c:#5dd5a8;top:4%;height:42%">
         <span class="flane__label"><i></i>Background thread</span>
@@ -1894,7 +1858,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- A7 — upstream tests -->
   <section class="slide stage">
-    <span class="eyebrow">IV · Runtime · proof</span>
     <div class="mega"><span class="brand-text">882</span><small style="font-size:0.4em;color:var(--ink-mute)"> / 1013</small></div>
     <p class="lead">Vue core's own tests, replayed on our renderer. <b>0 fail.</b></p>
     <div class="skipbar">
@@ -1922,7 +1885,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- A8 — testing library, the AI's eyes -->
   <section class="slide stage">
-    <span class="eyebrow">IV · Runtime · proof</span>
     <h2 class="h-section" style="text-align:center;max-width:22ch">
       …and the tests are the <span class="brand-text">AI's eyes</span>.
     </h2>
@@ -1938,7 +1900,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- IFR1 — the first frame waits a full lap -->
   <section class="slide stage">
-    <span class="eyebrow">IV · Instant first frame</span>
     <div class="ifrtl">
       <div class="ifrlane" style="--c:#56b8f0;top:6%;height:38%">
         <span class="ifrlane__label"><i></i>Main (UI) thread</span>
@@ -1967,7 +1928,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- IFR2 — IFR: paint first, hydrate later (magic-move the paint flag) -->
   <section class="slide stage">
-    <span class="eyebrow">IV · Instant first frame</span>
     <div class="ifrtl">
       <div class="ifrlane" style="--c:#56b8f0;top:6%;height:38%">
         <span class="ifrlane__label"><i></i>Main (UI) thread</span>
@@ -2000,7 +1960,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- IFR3 — the trick: record + reconcile -->
   <section class="slide stage">
-    <span class="eyebrow">IV · Instant first frame</span>
     <h2 class="h-section" style="text-align:center;max-width:20ch">
       Both threads render. The ops stream <span class="brand-text">is</span> the recording.
     </h2>
@@ -2048,7 +2007,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- IFR4 — Element Templates: the pivot -->
   <section class="slide stage">
-    <span class="eyebrow">IV · Instant first frame</span>
     <h2 class="h-section" style="text-align:center;max-width:24ch">
       IFR changes <em class="ifr-em">when</em> the frame renders.<br/>
       <span class="brand-text">Element Templates</span> change how much work it does.
@@ -2063,7 +2021,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- IFR5 — the pipeline, per node (reuses the runtime flow boxes) -->
   <section class="slide stage">
-    <span class="eyebrow">IV · Instant first frame</span>
     <div class="flow ifr-pipe">
       <div class="fb" data-flip="etp-vdom" style="--c:#42b883;left:9%;top:50%">VDOM<small>one vnode / node</small></div>
       <span class="farr" data-mm-fade style="left:21%;top:50%">&rarr;</span>
@@ -2088,7 +2045,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- IFR6 — Element Templates collapse the pipeline (magic-move) -->
   <section class="slide stage">
-    <span class="eyebrow">IV · Instant first frame</span>
     <div class="flow ifr-pipe">
       <div class="fb" data-flip="etp-vdom" style="--c:#42b883;left:16%;top:50%">one vnode<small>__vlx-tpl:…</small></div>
       <span class="farr" data-mm-fade style="left:33%;top:50%">&rarr;</span>
@@ -2110,7 +2066,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- IFR7 — baked skeleton + holes + generated create() -->
   <section class="slide stage">
-    <span class="eyebrow">IV · Instant first frame</span>
     <div class="etcode">
       <div class="codeframe etcode__src">
         <div class="codeframe__head">
@@ -2156,7 +2111,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- IFR8 — benchmark table (proof) -->
   <section class="slide stage">
-    <span class="eyebrow">IV · Instant first frame · proof</span>
     <table class="bench-table">
       <thead>
         <tr><th>configuration</th><th>FCP</th><th>render cost</th><th>TTI proxy</th><th>bundle gzip</th></tr>
@@ -2199,7 +2153,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- IFR9 — benchmark data-viz (proof) -->
   <section class="slide stage">
-    <span class="eyebrow">IV · Instant first frame · proof</span>
     <div class="bench-viz">
       <div class="bench-chart">
         <h3 class="bench-chart__title">render cost <span>~1,000 el · jitless · ms</span></h3>
@@ -2251,7 +2204,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- IFR10 — honest trade-offs -->
   <section class="slide stage">
-    <span class="eyebrow">IV · Instant first frame</span>
     <div class="ifr-trade">
       <div class="stack-y gap-sm">
         <span class="eyebrow ifr-trade__head ifr-trade__head--cost">what it costs</span>
@@ -2284,7 +2236,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- B1 — one bundle, two worlds -->
   <section class="slide stage">
-    <span class="eyebrow">IV · Toolchain</span>
     <div class="flow">
       <div class="fbox" style="--c:#5dd5a8;left:50%;top:52%;width:56%;height:76%">
         <span class="fbox__label">app.lynx.bundle</span>
@@ -2308,7 +2259,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- B2 — same code enters twice (layers) -->
   <section class="slide stage">
-    <span class="eyebrow">IV · Toolchain</span>
     <div class="flow">
       <div class="fb is-hero" style="--c:#42b883;left:50%;top:8%">
         App.vue
@@ -2357,7 +2307,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- B3 — a plugin, not a compiler -->
   <section class="slide stage">
-    <span class="eyebrow">IV · Toolchain</span>
     <h2 class="h-section" style="text-align:center;max-width:22ch">
       We wrote a <span class="brand-text">plugin</span> — not a compiler.
     </h2>
@@ -2374,7 +2323,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- B4 — CSS is CSS -->
   <section class="slide stage">
-    <span class="eyebrow">IV · Toolchain</span>
     <div class="flow" style="height:clamp(200px,30cqh,240px)">
       <div class="fb" style="--c:#9E86F0;left:30%;top:50%">
         &lt;style scoped&gt;
@@ -2396,7 +2344,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- C1 — why gestures lag -->
   <section class="slide stage">
-    <span class="eyebrow">IV · Main-Thread Script</span>
     <div class="flow">
       <div class="flane" data-flip="lane-bg" style="--c:#5dd5a8;top:4%;height:42%">
         <span class="flane__label"><i></i>Background thread</span>
@@ -2422,7 +2369,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- C2 — the function changes threads -->
   <section class="slide stage">
-    <span class="eyebrow">IV · Main-Thread Script</span>
     <div class="flow">
       <div class="flane" data-flip="lane-bg" style="--c:#5dd5a8;top:4%;height:42%">
         <span class="flane__label"><i></i>Background thread</span>
@@ -2485,7 +2431,6 @@ app.<span class="code-fn">use</span>(router)</pre>
       </div>
     </div>
     <div class="demo__body">
-      <span class="eyebrow">IV · Main-Thread Script</span>
       <h2 class="demo__title">
         ReactLynx's tutorials, <span class="brand-text">remade in Vue</span>.
       </h2>
@@ -2507,7 +2452,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- C5 — reuse + the open API space -->
   <section class="slide stage">
-    <span class="eyebrow">IV · Main-Thread Script</span>
     <h2 class="h-section" style="text-align:center;max-width:24ch">
       Same worklet engine as ReactLynx — <em style="font-family:var(--serif);font-weight:400">today</em>.
     </h2>
@@ -2524,7 +2468,6 @@ app.<span class="code-fn">use</span>(router)</pre>
        IV · The landscape — the architecture-level comparison
        ==================================================== -->
   <section class="slide stage">
-    <span class="eyebrow">IV · The landscape</span>
     <h2 class="h-section" style="text-align:center;max-width:22ch">
       Zoom out: every stack is <span class="brand-text">layers</span> — and seams.
     </h2>
@@ -2535,7 +2478,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- Scaffold: five layers, four seams -->
   <section class="slide stage">
-    <span class="eyebrow">IV · The landscape · the map</span>
     <div class="arch-mount" data-arch-shown="0"></div>
     <div class="gate-legend arch-cap" data-mm-fade>
       <span><i></i>open — an extension point</span>
@@ -2549,7 +2491,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- One framework column drops in per slide -->
   <section class="slide stage">
-    <span class="eyebrow">IV · The landscape</span>
     <div class="arch-mount" data-arch-shown="1"></div>
     <p class="lead arch-cap" data-mm-fade>
       <b style="color:#4FB8F0">Web</b> — the DX everyone wants. But the sandbox
@@ -2559,7 +2500,6 @@ app.<span class="code-fn">use</span>(router)</pre>
   </section>
 
   <section class="slide stage">
-    <span class="eyebrow">IV · The landscape</span>
     <div class="arch-mount" data-arch-shown="2"></div>
     <p class="lead arch-cap" data-mm-fade>
       <b style="color:#6FA8FF">Ionic</b> — the Web in a shell.
@@ -2569,7 +2509,6 @@ app.<span class="code-fn">use</span>(router)</pre>
   </section>
 
   <section class="slide stage">
-    <span class="eyebrow">IV · The landscape</span>
     <div class="arch-mount" data-arch-shown="3"></div>
     <p class="lead arch-cap" data-mm-fade>
       <b style="color:#E8B44A">NativeScript</b> — direct native access.
@@ -2579,7 +2518,6 @@ app.<span class="code-fn">use</span>(router)</pre>
   </section>
 
   <section class="slide stage">
-    <span class="eyebrow">IV · The landscape</span>
     <div class="arch-mount" data-arch-shown="4"></div>
     <p class="lead arch-cap" data-mm-fade>
       <b style="color:#F27A9E">Flutter</b> — Dart plus self-rendering.
@@ -2589,7 +2527,6 @@ app.<span class="code-fn">use</span>(router)</pre>
   </section>
 
   <section class="slide stage">
-    <span class="eyebrow">IV · The landscape</span>
     <div class="arch-mount" data-arch-shown="5"></div>
     <p class="lead arch-cap" data-mm-fade>
       <b style="color:#9E86F0">React Native</b> — closest to the dream.
@@ -2599,7 +2536,6 @@ app.<span class="code-fn">use</span>(router)</pre>
   </section>
 
   <section class="slide stage">
-    <span class="eyebrow">IV · The landscape · the answer</span>
     <div class="arch-mount" data-arch-shown="6"></div>
     <p class="lead arch-cap" data-mm-fade>
       <b class="brand-text">Lynx</b> — all four seams open.
@@ -2611,7 +2547,6 @@ app.<span class="code-fn">use</span>(router)</pre>
   </section>
 
   <section class="slide stage">
-    <span class="eyebrow">IV · The landscape</span>
     <h2 class="h-section" style="text-align:center;max-width:22ch">
       Lynx evolved <span class="brand-text">framework-agnostic</span>.
     </h2>
@@ -2621,7 +2556,6 @@ app.<span class="code-fn">use</span>(router)</pre>
   </section>
 
   <section class="slide stage">
-    <span class="eyebrow">IV · The landscape</span>
     <div class="mega" style="font-size:clamp(44px,6.6cqw,108px);line-height:1.14">
       <span style="color:#4FB8F0">Web</span> DX.
       <span class="brand-text">Native</span> UX.
@@ -2634,7 +2568,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- H1 — the harness -->
   <section class="slide stage">
-    <span class="eyebrow">IV · The harness</span>
     <div class="mega" style="font-size:clamp(52px,7.5cqw,120px)"><span class="brand-text">2</span> weeks.</div>
     <div class="demo__meta" style="justify-content:center">
       <span class="chip">160 commits</span>
@@ -2648,7 +2581,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- H2 — the write-up -->
   <section class="slide stage">
-    <span class="eyebrow">IV · The harness</span>
     <h2 class="h-section" style="text-align:center;max-width:22ch">
       &ldquo;How I <span class="brand-text">vibed</span> this in two weeks&rdquo;
     </h2>
@@ -2691,7 +2623,6 @@ app.<span class="code-fn">use</span>(router)</pre>
        Chapter IV · Close
        ==================================================== -->
   <section class="slide divider">
-    <span class="eyebrow">Chapter V</span>
     <div class="divider__row">
       <span class="divider__num numeral--brand">V</span>
       <h2 class="divider__title">
@@ -2708,7 +2639,6 @@ app.<span class="code-fn">use</span>(router)</pre>
   </section>
 
   <section class="slide stage">
-    <span class="eyebrow">The ask</span>
     <h2 class="cta__title" style="text-align:center;max-width:20ch">
       Native shouldn't be a different <span class="brand-text">team</span>.
     </h2>
@@ -2722,7 +2652,6 @@ app.<span class="code-fn">use</span>(router)</pre>
   </section>
 
   <section class="slide stage">
-    <span class="eyebrow">Where it stands</span>
     <div style="display:flex;gap:clamp(32px,6vw,80px);flex-wrap:wrap;justify-content:center;text-align:left">
       <div class="stack-y gap-sm">
         <span class="eyebrow" style="margin-bottom:8px">What's there</span>
@@ -2748,7 +2677,6 @@ app.<span class="code-fn">use</span>(router)</pre>
   </section>
 
   <section class="slide stage">
-    <span class="eyebrow">Try it tonight</span>
     <h2 class="cta__title" style="text-align:center;max-width:16ch">
       One <span class="brand-text">npm create</span>, and you're shipping native.
     </h2>
@@ -2785,7 +2713,6 @@ app.<span class="code-fn">use</span>(router)</pre>
   </section>
 
   <section class="slide thankyou">
-    <span class="eyebrow">Fin.</span>
     <h1><span class="brand-text">Thank</span> you.</h1>
     <p class="sig">
       Questions, PRs, opinions — all welcome.
@@ -2806,7 +2733,6 @@ app.<span class="code-fn">use</span>(router)</pre>
        and the case for weaving. The (real) second half.
        ==================================================== -->
   <section class="slide divider">
-    <span class="eyebrow">Epilogue</span>
     <div class="divider__row">
       <span class="divider__num numeral--brand">&infin;</span>
       <h2 class="divider__title">
@@ -2852,7 +2778,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- E2 — the question, honestly -->
   <section class="slide stage">
-    <span class="eyebrow">Epilogue · the question</span>
     <h2 class="h-section" style="text-align:center;max-width:20ch">
       Does AI obsolete <span class="brand-text">all of us</span>?
     </h2>
@@ -2870,7 +2795,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- E3 — the claim / roadmap -->
   <section class="slide stage">
-    <span class="eyebrow">Epilogue · a claim</span>
     <h2 class="h-section" style="text-align:center;max-width:22ch">
       What <span class="brand-text">survives</span> AI?
     </h2>
@@ -2894,7 +2818,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- E4 — Lemma 1 · the stack, rewritten -->
   <section class="slide stage">
-    <span class="eyebrow">Epilogue · Lemma 1</span>
     <div class="flow" style="height:56cqh;width:min(100%,880px)">
       <div class="fb" data-flip="stk-human" style="--c:#8b93a3;left:44%;top:4%">human</div>
       <div class="fb is-hero" data-flip="stk-nl" style="--c:#42b883;left:44%;top:22.4%">natural languages</div>
@@ -2915,7 +2838,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- E5 — what makes a harness -->
   <section class="slide stage">
-    <span class="eyebrow">Epilogue · Lemma 1 · harness</span>
     <h2 class="h-section" style="text-align:center;max-width:24ch">
       AI can do anything &mdash; <span class="brand-text">harnessed</span>.
     </h2>
@@ -2933,7 +2855,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- E6 — the browser is a great harness -->
   <section class="slide stage">
-    <span class="eyebrow">Epilogue · Lemma 1 · platforms</span>
     <div class="logo" style="position:static;width:8cqw;height:8cqw">
       <svg viewBox="0 0 48 48" aria-label="Chrome logo"><circle cx="24" cy="24" r="12" fill="#fff"/><path fill="#EA4335" d="M24 12h20.78a23.99 23.99 0 0 0-41.56.003L13.61 30l.009-.002A11.99 11.99 0 0 1 24 12Z"/><path fill="#FBBC04" d="M34.39 30.003 24 48a23.99 23.99 0 0 0 20.78-35.997H24l-.003.009a11.99 11.99 0 0 1 10.393 17.991Z"/><path fill="#34A853" d="M13.61 30.003 3.22 12.006A23.99 23.99 0 0 0 24 48l10.39-17.997-.007-.007a11.99 11.99 0 0 1-20.773.007Z"/><circle cx="24" cy="24" r="9.5" fill="#1A73E8"/></svg>
     </div>
@@ -2954,7 +2875,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- E7 — frameworks were always harnesses -->
   <section class="slide stage">
-    <span class="eyebrow">Epilogue · Lemma 1 · frameworks</span>
     <h2 class="h-section" style="text-align:center;max-width:24ch">
       Frameworks were always <span class="brand-text">harnesses</span>.
     </h2>
@@ -2996,7 +2916,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- E10 — intermission meme -->
   <section class="slide stage" data-bg="clean">
-    <span class="eyebrow">Epilogue &middot; intermission</span>
     <vl-media class="meme" src="/media/embeds/88-meme.png" label="88-meme.png · the roast"
               style="--ph-ar:4/3"></vl-media>
     <p class="kicker" style="text-align:center">&ldquo;Getting metaphysical again &mdash; &#38634;&#30887; is going to roast me.&rdquo;</p>
@@ -3023,7 +2942,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- E12 — own the patchwork -->
   <section class="slide stage" data-bg="clean" data-weave="loom-dim">
-    <span class="eyebrow">Epilogue &middot; Lemma 2</span>
     <h2 class="h-section" style="text-align:center;max-width:24ch">
       &ldquo;A patchwork monster&rdquo;? <span class="brand-text">Exactly.</span>
     </h2>
@@ -3052,7 +2970,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- E14 — people -->
   <section class="slide stage">
-    <span class="eyebrow">Epilogue &middot; Lemma 2 &middot; people</span>
     <h2 class="h-section" style="text-align:center;max-width:24ch">
       Technology is nothing without its <span class="brand-text">people</span>.
     </h2>
@@ -3070,7 +2987,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- E15 — not a framework, a connection -->
   <section class="slide stage">
-    <span class="eyebrow">Epilogue &middot; Lemma 2</span>
     <h2 class="h-section" style="text-align:center;max-width:26ch">
       Vue Lynx isn't a framework. It's a <span class="brand-text">connection</span>.
     </h2>
@@ -3089,7 +3005,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- E16 — connections compound -->
   <section class="slide stage">
-    <span class="eyebrow">Epilogue &middot; Lemma 2 &middot; compounding</span>
     <h2 class="h-section" style="text-align:center;max-width:22ch">
       One connection <span class="brand-text">compounds</span>.
     </h2>
@@ -3109,7 +3024,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- E17 — a place to vibe -->
   <section class="slide stage">
-    <span class="eyebrow">Epilogue &middot; Lemma 2</span>
     <h2 class="h-section" style="text-align:center;max-width:26ch">
       AI doesn't need mature libraries. It needs a place to <span class="brand-text">vibe</span>.
     </h2>
@@ -3135,7 +3049,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- V·2 — Vapor headline -->
   <section class="slide stage" data-bg="beam">
-    <span class="eyebrow">One more thing · Vue Vapor</span>
     <div class="xtag">Experimental</div>
     <h2 class="h-section" style="text-align:center;max-width:19ch">
       <span class="brand-text">Vapor</span> mode — no Virtual DOM.
@@ -3152,7 +3065,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- V·3 — Virtual DOM update path (concept, magic-move A) -->
   <section class="slide stage" data-bg="clean">
-    <span class="eyebrow">Virtual DOM · the update path</span>
     <div class="vflow">
       <div class="vnode vnode--vue" data-flip="vp-state">
         <span class="vnode__k">state</span><span class="vnode__t">count++</span>
@@ -3180,7 +3092,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- V·4 — Vapor update path (concept, magic-move B) -->
   <section class="slide stage" data-bg="clean">
-    <span class="eyebrow">Vapor · the update path</span>
     <div class="vflow">
       <div class="vnode vnode--vue" data-flip="vp-state">
         <span class="vnode__k">state</span><span class="vnode__t">count++</span>
@@ -3206,7 +3117,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- V·5 — The Vapor output (compiled code) -->
   <section class="slide stage" data-bg="clean">
-    <span class="eyebrow">The Vapor output · @vue/compiler-vapor</span>
     <div style="display:flex;align-items:center;gap:clamp(14px,2.2cqw,36px);width:100%;justify-content:center">
       <div class="codeframe" style="text-align:left;flex:0 0 auto">
         <div class="codeframe__head">
@@ -3257,7 +3167,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- V·6 — Code reuse: unmodified runtime-vapor on a DOM-shaped surface -->
   <section class="slide stage" data-bg="clean">
-    <span class="eyebrow">Code reuse · from compile to runtime</span>
     <div class="pipe">
       <div class="pipe__layer">
         <span class="k">compiled</span><span class="t">vapor component — <b>import 'vue'</b></span>
@@ -3296,7 +3205,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- V·7a — Cross-thread template protocol: REGISTER once -->
   <section class="slide stage" data-bg="clean">
-    <span class="eyebrow">Across the thread boundary · register</span>
     <div class="archflow">
       <div class="node" data-flip="vx-bg">
         <span class="node__label"><span class="dot"></span>Background · Vapor</span>
@@ -3354,7 +3262,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- V·7b — Cross-thread template protocol: CLONE per row (magic-move) -->
   <section class="slide stage" data-bg="clean">
-    <span class="eyebrow">Across the thread boundary · clone</span>
     <div class="archflow">
       <div class="node" data-flip="vx-bg">
         <span class="node__label"><span class="dot"></span>Background · Vapor</span>
@@ -3418,7 +3325,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- V·8 — Benchmark: update-path speedup (bar chart) -->
   <section class="slide stage" data-bg="clean">
-    <span class="eyebrow">Benchmark · update path, background thread</span>
     <h2 class="h-section" style="text-align:center;font-size:clamp(28px,3.4cqw,50px);max-width:24ch">
       Where Vapor pulls away: <span class="brand-text">5.8–9.8&times;</span>.
     </h2>
@@ -3456,7 +3362,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- V·9 — Benchmark: the whole ledger (table) -->
   <section class="slide stage" data-bg="clean">
-    <span class="eyebrow">Benchmark · the whole ledger</span>
     <table class="btable">
       <thead>
         <tr><th>metric · create-1k unless noted</th><th>vdom</th><th>vapor</th><th>delta</th></tr>
@@ -3501,7 +3406,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- V·10 — Workflow: one source, two renderers, verified -->
   <section class="slide stage" data-bg="clean">
-    <span class="eyebrow">The workflow · one source, two renderers</span>
     <div class="vsplit">
       <div class="vsource">
         <span class="node__label" style="color:var(--ink)">App.vue</span>
@@ -3532,7 +3436,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- V·10b — Upstream Vapor tests + host-fit (styled like the VDOM proof slide A7) -->
   <section class="slide stage" data-bg="clean">
-    <span class="eyebrow">One more thing · Vapor · proof</span>
     <div class="mega" style="font-size:clamp(52px,9cqw,140px)">
       <span class="brand-text">545</span><small style="font-size:0.4em;color:var(--ink-mute)"> / 671 run · 0 fail</small>
     </div>
@@ -3570,7 +3473,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- V·11 — The one number (mic-drop) -->
   <section class="slide stage" data-bg="beam">
-    <span class="eyebrow">One more number</span>
     <div class="mega"><span class="brand-text">7&times;</span> VDOM</div>
     <p class="lead">
       Vapor vs Vue VDOM on the 10,000-row select storm — same app, same bundle,
@@ -3584,7 +3486,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- V·12 — Close: flip a switch -->
   <section class="slide stage" data-bg="beam" data-chrome="minimal">
-    <span class="eyebrow">Vapor · one flag away</span>
     <h2 class="cta__title" style="text-align:center;max-width:15ch">
       Same source. <span class="brand-text">Flip a switch.</span>
     </h2>
@@ -3609,7 +3510,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- E20a — design space · Vapor tree vs ET (naming) -->
   <section class="slide stage dspace">
-    <span class="eyebrow">One more thing &middot; the design space</span>
     <h2 class="h-section" style="text-align:center;max-width:24ch">
       Pointers die — <span class="brand-text">names</span> take over.
     </h2>
@@ -3667,7 +3567,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- E20b — design space · the retained→write-only spectrum -->
   <section class="slide stage dspace">
-    <span class="eyebrow">One more thing &middot; the design space</span>
     <h2 class="h-section" style="text-align:center;max-width:26ch">
       One template — a whole <span class="brand-text">spectrum</span> of renderers.
     </h2>
@@ -3714,7 +3613,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- E20c — the cradle · closes the design-space arc -->
   <section class="slide stage">
-    <span class="eyebrow">One more thing</span>
     <h2 class="h-section" style="text-align:center;max-width:22ch">
       A <span class="brand-text">cradle</span> for framework design.
     </h2>
@@ -3804,7 +3702,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- E23 — coda · Germany, part 1 -->
   <section class="slide stage">
-    <span class="eyebrow">Epilogue &middot; coda</span>
     <p class="wquote">&ldquo;AI took away the fun.&rdquo;</p>
     <span class="wattr">&mdash; a workshop attendee &middot; Germany, last week</span>
     <p class="lead" data-mm-fade>Find a new dopamine.</p>
@@ -3825,7 +3722,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- E25 — coda · Germany, part 2 -->
   <section class="slide stage">
-    <span class="eyebrow">Epilogue &middot; coda</span>
     <p class="wquote">&ldquo;But prompting <em>is</em> the dopamine.&rdquo;</p>
     <span class="wattr">&mdash; another attendee &middot; he vibed a Pok&eacute;mon game that night</span>
     <p class="lead" data-mm-fade>
@@ -3868,7 +3764,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- E26 — ten years, renewed -->
   <section class="slide stage">
-    <span class="eyebrow">Epilogue &middot; coda</span>
     <h2 class="h-section" style="text-align:center;max-width:24ch">
       I rebuilt everything <span class="brand-text">ten-years-ago me</span> dreamed of.
     </h2>
@@ -3896,7 +3791,6 @@ app.<span class="code-fn">use</span>(router)</pre>
 
   <!-- E28 — finale · long live the frontend -->
   <section class="slide thankyou" data-bg="clean" data-chrome="minimal" data-weave="finale">
-    <span class="eyebrow">Fin. &mdash; for real</span>
     <p class="fin-dead">The frontend is dead.</p>
     <h1>Long live <span class="brand-text">the frontend</span>.</h1>
     <p class="sig">

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -251,10 +251,6 @@ export const ZH = {
     'Lynx 的两个官方 MTS 教程 —— gallery 滚动条和这个 swiper —— 在 Vue Lynx 上逐行重建。',
   'tutorial: swiper': '教程:swiper',
   'tutorial: gallery': '教程:gallery',
-  'Same worklet engine as ReactLynx — today.':
-    '与 ReactLynx <em style="font-family:var(--serif);font-weight:400">同一套</em> worklet 引擎 —— 这是今天。',
-  'A Vue-flavored MTS API is the open design space.':
-    '而 Vue 味的 MTS API,是留给未来的设计空间。',
   '2 weeks.': '<span class="brand-text">2</span> 周。',
   '160 commits': '160 次提交',
   '21 active days': '21 个活跃日',
@@ -625,11 +621,9 @@ export const ZH_NOTES = [
   // 49 C2 · 函数换线程
   `<p><strong>看方块移动。</strong>文档 <code>&lt;Go&gt;</code> 的对比：左边方块跑在主线程（<code>'main thread'</code>），右边仍走后台 —— 一滚就能摸到差别。还是同一个 Vue 文件；一条指令把处理函数换了线程。</p><p><strong>现场：</strong>滚动 —— 左边（MT）跟手，右边掉帧。</p>`,
   // 50 C3 · 代码样例
-  `<p>MTS 的全部表面积,一个文件讲完:<code>'main thread'</code> 标记函数,<code>main-thread-bind*</code> 挂到事件上,<code>useMainThreadRef()</code> 给出同步元素访问 —— <code>setStyleProperty</code> 在手指移动的同一帧落地。</p>`,
+  `<p>MTS 的全部表面积,一个文件讲完:<code>'main thread'</code> 标记函数,<code>main-thread-bind*</code> 挂到事件上,<code>useMainThreadRef()</code> 给出同步元素访问 —— <code>setStyleProperty</code> 在手指移动的同一帧落地。</p><p><strong>先复用,再演化。</strong>引擎层我们直接跑 ReactLynx 的 worklet runtime 和它的 API 形状(<code>main-thread-bind*</code>、<code>useMainThreadRef</code>)—— 久经考验,而且在 Lynx 生态里通用。但 Vue 值得 Vue 形状的人体工学:想象 <code>&lt;script main-thread setup&gt;</code>、主线程的 computed/watch。这个设计空间是开放的 —— 也是社区留下印记的好地方。</p>`,
   // 51 C4 · 教程复刻
   `<p><strong>复刻即证明。</strong>lynxjs.org 用两个教程教 MTS,都是为 ReactLynx 写的。两个都在 Vue Lynx 上重做了,live 在我们的文档站上 —— 同样的拖拽物理、同样的吸附、同样的主线程滚动条。平台教程能干净地移植过来,能力就是真的在。</p><p><strong>现场:</strong>慢慢拖 —— 指示器逐像素同步;一甩,吸附。</p>`,
-  // 52 C5 · 复用与开放的 API 空间
-  `<p><strong>先复用,再演化。</strong>引擎层我们直接跑 ReactLynx 的 worklet runtime 和它的 API 形状(<code>main-thread-bind*</code>、<code>useMainThreadRef</code>)—— 久经考验,而且在 Lynx 生态里通用。但 Vue 值得 Vue 形状的人体工学:想象 <code>&lt;script main-thread setup&gt;</code>、主线程的 computed/watch。这个设计空间是开放的 —— 也是社区留下印记的好地方。</p>`,
   // 53 IV · 格局 · 引入
   `<p><strong>兑现承诺的 deep-dive。</strong>开场时我们是"凭感觉"相亲;现在运行时、工具链、MTS 都摆上桌了,可以来架构级的版本了。把任何跨端栈拆成五层,层间四条缝 —— 每条要么是扩展点,要么是焊死的墙。诚实地给所有人打分,包括 Lynx 自己。</p>`,
   // 54 Map scaffold

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -20,9 +20,6 @@ export const ZH = {
   'Develop Lynx with the familiar Vue 3.': '用熟悉的 Vue 3 开发 Lynx。',
 
   // ---- Chapter I · The gap ----
-  'IV · The landscape': 'IV · 格局',
-  'IV · The landscape · the map': 'IV · 格局 · 地图',
-  'IV · The landscape · the answer': 'IV · 格局 · 答案',
   'Zoom out: every stack is layers — and seams.':
     '拉远看:每个技术栈都是<span class="brand-text">层</span> —— 与缝。',
   'self-rendered': '自渲染',
@@ -55,27 +52,13 @@ export const ZH = {
     '<span style="color:#4FB8F0">Web</span> 的开发体验。<br/><span class="brand-text">Native</span> 的用户体验。',
 
   // ---- Chapter II · The proof ----
-  'Chapter II': '第二章',
   'So, how far does it go?': '那,它到底<br/>做到哪一步了?',
   'A feast of live demos — every phone in this deck is a real Vue Lynx app, running right now.':
     '一桌丰盛的现场 demo —— 这套 deck 里的每台手机,都是一个此刻正在运行的 Vue Lynx 应用。',
-  'II · The proof': 'II · 完成度',
   'upstream Vue core tests, passing on our renderer.':
     '来自 Vue core 上游的测试,在我们的渲染器上直接通过。',
 
   // ---- API coverage ----
-  'II · Vue coverage · 1/12': 'II · Vue 覆盖度 · 1/12',
-  'II · Vue coverage · 2/12': 'II · Vue 覆盖度 · 2/12',
-  'II · Vue coverage · 3/12': 'II · Vue 覆盖度 · 3/12',
-  'II · Vue coverage · 4/12': 'II · Vue 覆盖度 · 4/12',
-  'II · Vue coverage · 5/12': 'II · Vue 覆盖度 · 5/12',
-  'II · Vue coverage · 6/12': 'II · Vue 覆盖度 · 6/12',
-  'II · Vue coverage · 7/12': 'II · Vue 覆盖度 · 7/12',
-  'II · Vue coverage · 8/12': 'II · Vue 覆盖度 · 8/12',
-  'II · Vue coverage · 9/12': 'II · Vue 覆盖度 · 9/12',
-  'II · Vue coverage · 10/12': 'II · Vue 覆盖度 · 10/12',
-  'II · Vue coverage · 11/12': 'II · Vue 覆盖度 · 11/12',
-  'II · Vue coverage · 12/12': 'II · Vue 覆盖度 · 12/12',
   'v-once / v-memo':
     '<code class="brand-text">v-once</code> / <code class="brand-text">v-memo</code>',
   'reactive() + composables':
@@ -87,13 +70,7 @@ export const ZH = {
   'The ecosystem, as-is.': '生态,<span class="brand-text">原样</span>可用。',
   'Pinia, Vue Router, TanStack Query, Tailwind — the libraries you\'d already reach for on the web, running unchanged.':
     'Pinia、Vue Router、TanStack Query、Tailwind —— 你在 Web 上已经会用的库,原封不动就能跑。',
-  'II · Ecosystem · 1/4': 'II · 生态 · 1/4',
-  'II · Ecosystem · 2/4': 'II · 生态 · 2/4',
-  'II · Ecosystem · 3/4': 'II · 生态 · 3/4',
-  'II · Ecosystem · 4/4': 'II · 生态 · 4/4',
-
   // ---- Whole apps ----
-  'II · Whole apps': 'II · 完整应用',
   'Whole apps port, too.': '整个<span class="brand-text">应用</span>,也搬得动。',
   'The classic, verbatim — reactive state, v-model, computed totals. On a native input and native scroll.':
     '经典原样照搬 —— 响应式状态、<code>v-model</code>、computed 合计。跑在原生输入框、原生滚动上。',
@@ -107,7 +84,6 @@ export const ZH = {
   'native <list>': '原生 &lt;list&gt;',
 
   // ---- Chapter III · The upgrade ----
-  'Chapter III': '第三章',
   'Apps, upgrading from Web to native.':
     'App,从 Web <em style="font-family:var(--serif);font-weight:400">升级</em>到原生。',
   "Progressive enhancement: keep the codebase you have — gain the platform you don't.":
@@ -210,15 +186,9 @@ export const ZH = {
   'Main-Thread Script': '<b>主线程脚本</b>',
 
   // ---- Chapter IV · How we did it ----
-  'Chapter IV': '第四章',
   'And how was this built?': '那,它是<br/>怎么被做出来的?',
   'Three adaptations — the runtime, the toolchain, the main thread — and an AI harness running through all of them.':
     '三次适配 —— 运行时、工具链、主线程 —— 以及一路贯穿其中的 AI harness。',
-  'IV · Runtime': 'IV · 运行时',
-  'IV · Runtime · proof': 'IV · 运行时 · 实证',
-  'IV · Toolchain': 'IV · 工具链',
-  'IV · Main-Thread Script': 'IV · 主线程脚本',
-  'IV · The harness': 'IV · Harness',
   'Background thread': '<i></i>后台线程',
   'Main (UI) thread': '<i></i>主(UI)线程',
   'Vue runs whole — on the background thread.':
@@ -240,8 +210,6 @@ export const ZH = {
     '……而这些测试,就是 <span class="brand-text">AI 的眼睛</span>。',
 
   // ---- IV · Instant First-Frame Rendering + Element Templates ----
-  'IV · Instant first frame': 'IV · 首屏直出',
-  'IV · Instant first frame · proof': 'IV · 首屏直出 · 佐证',
   // headlines
   'Both threads render. The ops stream is the recording.':
     '两条线程都渲染。那条 ops 流<span class="brand-text">就是</span>录制。',
@@ -323,23 +291,18 @@ export const ZH = {
   '1 human + Claude': '1 个人 + Claude',
   'The full write-up — harness, prompts, receipts. @Huxpro on X.':
     '完整复盘 —— harness、prompt、全部凭证。X 上的 <b>@Huxpro</b>。',
-  'Chapter V': '第五章',
-
   // ---- Combine ----
   'A new path': '一条新路',
   'Vue, on native.': 'Vue,<span class="brand-text">跑在原生上。</span>',
 
   // ---- Close ----
-  'Chapter IV': '第四章',
   "And we'd love your help.": '也很希望你能<br/>搭把手。',
   "Vue Lynx is pre-alpha. The architecture is solid; Vue's API surface is large. What ships next depends on who shows up.":
     'Vue Lynx 还是 pre-alpha。架构很稳;Vue 的 API 面很大。接下来能做出什么,取决于谁愿意来。',
-  'The ask': '我们的请求',
   "Native shouldn't be a different team.":
     '原生,不该是另一个<span class="brand-text">团队</span>的事。',
   'Vue developers should ship native apps as naturally as they ship for the web today.':
     'Vue 开发者应该能像今天发 Web 一样,自然地发原生应用。',
-  'Where it stands': '现状',
   "What's there": '已经有的',
   "What's open": '还缺的',
   'Composition API & SFCs': '<b>Composition API 与 SFC</b>',
@@ -349,29 +312,24 @@ export const ZH = {
   'View pager & more gestures': '<b>View pager 与更多手势</b>',
   'Vue DevTools integration': '<b>Vue DevTools 集成</b>',
   "The ecosystem you'd port": '<b>等你来移植的生态</b>',
-  'Try it tonight': '今晚就试',
   "One npm create, and you're shipping native.":
     '一行 <span class="brand-text">npm create</span>,你就在发原生了。',
   'for Agent': '给 Agent',
   'Quick Start →': '快速开始 →',
   'Read the intro': '读简介',
-  'Fin.': '完。',
   'Thank you.': '<span class="brand-text">谢</span>谢。',
   'Questions, PRs, opinions — all welcome.': '提问、PR、想法 —— 都欢迎。',
 
   // ---- Epilogue · the elephant / fabrics ----
-  'Epilogue': '终章',
   'The elephant in the room.': '聊聊房间里的<br/>大象。',
   '“Vibe coding” is barely eighteen months old — and it already writes native apps. So why frameworks? Why Lynx? Why any of this?':
     '"vibe coding" 这个词诞生至今不过一年半 —— 它已经能直接写出原生应用了。那,还要框架干嘛?还要 Lynx 干嘛?这一切还有什么意义?',
-  'Epilogue · the question': '终章 · 问题',
   'Does AI obsolete all of us?':
     'AI 会让<span class="brand-text">我们所有人</span>都过时吗?',
   'no frameworks?': '不要框架?',
   'no libraries?': '不要类库?',
   'no docs?': '不要文档?',
   'no us?': '不要我们?',
-  'Epilogue · a claim': '终章 · 一个论断',
   'What survives AI?':
     '什么能在 AI 之后<span class="brand-text">留下来</span>?',
   'infrastructure': '基础设施',
@@ -380,23 +338,19 @@ export const ZH = {
   'ecosystems': '生态',
   'people': '人',
   'Two lemmas, then an answer.': '两个引理,一个答案。',
-  'Epilogue · Lemma 1': '终章 · 引理一',
   'The stack, rewritten.': '技术栈,被重写了。',
-  'Epilogue · Lemma 1 · harness': '终章 · 引理一 · Harness',
   'AI can do anything — harnessed.':
     'AI 什么都能做 —— 只要有好的 <span class="brand-text">harness</span>。',
   'context docs · priors · AGENTS.md': '上下文 <small>文档 · 先验 · AGENTS.md</small>',
   'tools functions · capabilities': '工具 <small>函数 · 能力</small>',
   'environment runtime · sandbox': '环境 <small>运行时 · 沙箱</small>',
   'feedback render · tests · logs': '反馈 <small>渲染 · 测试 · 日志</small>',
-  'Epilogue · Lemma 1 · platforms': '终章 · 引理一 · 平台',
   'Nobody says AI will replace the browser.':
     '没人会说,AI 要取代<span style="color:#4FB8F0">浏览器</span>。',
   'open by default': '天生开放',
   'sandboxed': '天然沙箱',
   'endlessly capable': '能力无穷',
   'fully observable': '完全可观测',
-  'Epilogue · Lemma 1 · frameworks': '终章 · 引理一 · 框架',
   'Frameworks were always harnesses.':
     '框架,从来都是 <span class="brand-text">harness</span>。',
   'then architecting how humans reason': '过去 <small>规训人类如何推理</small>',
@@ -406,11 +360,9 @@ export const ZH = {
   'templates': '模板',
   'reactivity': '响应式',
   'mutable state': '可变状态',
-  'Epilogue · intermission': '终章 · 幕间',
   '“Getting metaphysical again — 雪碧 is going to roast me.”':
     '"又开始形而上了 —— 雪碧又要批评我了。"',
   'Lynx — the loom.': 'Lynx —— 织机。',
-  'Epilogue · Lemma 2': '终章 · 引理二',
   '“A patchwork monster”? Exactly.':
     '"缝合怪"?—— <span class="brand-text">正是。</span>',
   'web-friendly surface': 'Web 亲和的表面',
@@ -419,7 +371,6 @@ export const ZH = {
   'Frameworks compress the search space.': '框架,压缩了搜索空间。',
   'everything the model could emit': '模型可能吐出的一切',
   'the idiom': '惯用法',
-  'Epilogue · Lemma 2 · people': '终章 · 引理二 · 人',
   'Technology is nothing without its people.':
     '技术若没有<span class="brand-text">人</span>,什么都不是。',
   '3D prints · 小音': '帮忙 3D 打印 · 小音',
@@ -428,7 +379,6 @@ export const ZH = {
   'Evan · Anthony · you': 'Evan · Anthony · 还有你',
   "Vue Lynx isn't a framework. It's a connection.":
     'Vue Lynx 不是一个框架,而是一次<span class="brand-text">连接</span>。',
-  'Epilogue · Lemma 2 · compounding': '终章 · 引理二 · 复利',
   'One connection compounds.':
     '一次连接,产生<span class="brand-text">复利</span>。',
   'Rendering': '渲染',
@@ -459,7 +409,6 @@ export const ZH = {
   'Weave the whole Web…': '把整个 Web 织进来……',
   '…into every platform.': '……再织向每一个平台。',
   'more…': '<i></i> 更多……',
-  'Epilogue · coda': '终章 · 尾声',
   '“AI took away the fun.”': '"AI 把乐趣拿走了。"',
   '— a workshop attendee · Germany, last week': '—— 一位 workshop 学员 · 上周,德国',
   'Find a new dopamine.': '去找新的多巴胺。',
@@ -477,35 +426,27 @@ export const ZH = {
   'I just changed languages — to natural language.':
     '我只是又换了一门语言 —— <span class="brand-text">自然语言</span>。',
   "I'm still doing frontend.": '可我做的,还是前端。',
-  'Fin. — for real': '终 · 这次是真的',
   'The frontend is dead.': '前端已死。',
   'Long live the frontend.': '前端<span class="brand-text">永生</span>。',
   'Thank you — for real this time.': '谢谢 —— 这次是真的。',
 
   // ---- One more thing · Vue Vapor (the deep dive) ----
-  'One more thing · Vue Vapor': '还有一件事 · Vue Vapor',
   'Vapor mode — no Virtual DOM.':
     '<span class="brand-text">Vapor</span> 模式 —— 没有虚拟 DOM。',
   "Templates compile straight to code that touches elements directly. We taught it to run on Lynx's two threads.":
     '模板直接编译成操作元素的代码。我们让它跑在了 Lynx 的两条线程上。',
 
-  'Virtual DOM · the update path': '虚拟 DOM · 更新路径',
-  'Vapor · the update path': 'Vapor · 更新路径',
   'Every change re-runs the component, rebuilds a VNode tree, and diffs it. Work scales with the whole tree.':
     '每次变更都要重跑组件、重建 VNode 树、再做 diff。开销随整棵树增长。',
   'No tree. No diff. A reactive effect writes straight to the one node that changed — work scales with what actually changed.':
     '没有树。没有 diff。一个响应式 effect 直接写入那个变化的节点 —— 开销只随真正变化的部分增长。',
 
-  'The Vapor output · @vue/compiler-vapor': 'Vapor 产物 · @vue/compiler-vapor',
   '① a template registered once · ② cloned per instance · ③ one effect that updates a single node.':
     '<span class="codenote">①</span> 模板注册一次 · <span class="codenote">②</span> 每个实例克隆一份 · <span class="codenote">③</span> 一个 effect 只更新一个节点。',
 
-  'Code reuse · from compile to runtime': '代码复用 · 从编译到运行时',
   "Vapor drives the browser DOM directly. We make the background thread's tree look like the DOM — so upstream Vapor runs untouched.":
     'Vapor 直接驱动浏览器 DOM。我们让后台线程的那棵树“长得像”DOM —— 于是上游 Vapor 原封不动地跑起来。',
 
-  'Across the thread boundary · register': '跨越线程边界 · 注册',
-  'Across the thread boundary · clone': '跨越线程边界 · 克隆',
   'Background · Vapor': '<span class="dot"></span>后台 · Vapor',
   'Main · interpreter': '<span class="dot"></span>主线程 · 解释器',
   'inert prototype': '惰性原型',
@@ -524,32 +465,26 @@ export const ZH = {
   'create-1k across the boundary: 17,000 ops · 327 KB → 7,000 ops · 160 KB':
     'create-1k 跨越边界:<span style="color:var(--ink-mute);text-decoration:line-through">17,000 ops · 327 KB</span> → <b class="brand-text">7,000 ops · 160 KB</b>',
 
-  'Benchmark · update path, background thread': 'Benchmark · 更新路径,后台线程',
   'Where Vapor pulls away: 5.8–9.8×.':
     'Vapor 拉开差距的地方:<span class="brand-text">5.8–9.8×</span>。',
   'The entire delta is Vue work on the thread you share with your app logic — lower background cost means more headroom before dropped frames.':
     '整个差距都是 Vue 在那条你与应用逻辑共享的线程上的开销 —— 后台开销越低,离掉帧就越远。',
 
-  'Benchmark · the whole ledger': 'Benchmark · 完整账本',
   'Big wins on updates and traffic; creation at parity; you pay in bundle size.':
     '更新与传输大幅领先;创建打平;代价是产物体积。',
 
-  'The workflow · one source, two renderers': '工作流 · 一份源码,两个渲染器',
   "Every example built & driven in both modes through Lynx for Web. The support matrix is generated from the run — it can't drift from what actually passed.":
     '每个示例都通过 Lynx for Web 在两种模式下构建并驱动。支持矩阵由运行结果生成 —— 不会与真正通过的结果发生漂移。',
 
   // ---- upstream-test slides (VDOM A7 skip breakdown + Vapor proof) ----
   '131 documented skips — every one a test-infra artifact or browser-only semantic, not a Lynx gap.':
     '131 个 skip 都有据可查 —— 每一个要么是测试设施产物,要么是浏览器专属语义,<b class="brand-text">没有一个是 Lynx 的缺口。</b>',
-  'One more thing · Vapor · proof': '还有一件事 · Vapor · 佐证',
   "Vapor's own suite — unmodified on ShadowElement. It passes the element-surface tests at 81% vs vdom's 57%: the closer fit to Lynx.":
     'Vapor 自己的上游测试 —— 在 ShadowElement 上<b>原封不动</b>地跑。触及元素表面的那些测试,它以 81% 对 vdom 的 57% 通过:与 Lynx 更亲近的契合。',
 
-  'One more number': '还有一个数字',
   'Vapor vs Vue VDOM on the 10,000-row select storm — same app, same bundle, one attribute apart.':
     'Vapor 对 Vue VDOM,在 10,000 行的 select 风暴中 —— 同一个应用、同一个产物,只差一个属性。',
 
-  'Vapor · one flag away': 'Vapor · 只差一个开关',
   'Same source. Flip a switch.':
     '同一份源码。<span class="brand-text">拨一下开关。</span>',
   'Experimental today — but the fast path is already here.':

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -51,13 +51,7 @@ export const ZH = {
   'Web DX. Native UX.':
     '<span style="color:#4FB8F0">Web</span> 的开发体验。<br/><span class="brand-text">Native</span> 的用户体验。',
 
-  // ---- Chapter II · The proof ----
-  'So, how far does it go?': '那,它到底<br/>做到哪一步了?',
-  'A feast of live demos — every phone in this deck is a real Vue Lynx app, running right now.':
-    '一桌丰盛的现场 demo —— 这套 deck 里的每台手机,都是一个此刻正在运行的 Vue Lynx 应用。',
-  'upstream Vue core tests, passing on our renderer.':
-    '来自 Vue core 上游的测试,在我们的渲染器上直接通过。',
-
+  // ---- Chapter II · demos ----
   // ---- API coverage ----
   'v-once / v-memo':
     '<code class="brand-text">v-once</code> / <code class="brand-text">v-memo</code>',
@@ -76,29 +70,25 @@ export const ZH = {
     '经典原样照搬 —— 响应式状态、<code>v-model</code>、computed 合计。跑在原生输入框、原生滚动上。',
   'Live API, infinite feed, comment trees — Vue Query for data, Tailwind for styling, native <list> for scroll.':
     '真实 API、无限流、评论树 —— 数据用 Vue Query,样式用 Tailwind,滚动用原生 <code>&lt;list&gt;</code>。',
-  'And the same bundles run on the Web.':
-    '而且,同一份产物还能跑回 <span class="brand-text">Web</span>。',
-  'Every phone in this deck is Lynx for Web — the same bundle that runs natively, rendering in your browser right now.':
-    'deck 里的每台手机都是 Lynx for Web —— 和原生端同一份产物,此刻就渲染在你的浏览器里。',
   'native <input>': '原生 &lt;input&gt;',
   'native <list>': '原生 &lt;list&gt;',
 
   // ---- Chapter III · The upgrade ----
-  'Apps, upgrading from Web to native.':
-    'App,从 Web <em style="font-family:var(--serif);font-weight:400">升级</em>到原生。',
-  "Progressive enhancement: keep the codebase you have — gain the platform you don't.":
-    '渐进增强:留住你已有的代码,得到你还没有的平台。',
+  'Upgrading to native.': '升级到<span class="brand-text">原生体验</span>。',
+  'Native experience?': '原生体验？',
+  'The Nuxt AI Chatbot, forked — streaming, reasoning, markdown, tool cards. Then the native interactions: the keyboard lifts the thread; send flies the bubble into the conversation.':
+    'Nuxt 官方 AI Chatbot,fork 过来 —— 流式、思维链、markdown、工具卡片。再看原生交互:键盘托起对话流;发送让气泡飞进会话。',
+  'Native gestures?': '原生手势？',
+  'Elk — a production Mastodon client. Framework-agnostic layers reused; only the UI rebuilt on Lynx elements.':
+    'Elk —— 生产级 Mastodon 客户端。与框架无关的层全部复用;只在 Lynx 元素上重建 UI。',
+  'Sheet with Rubberband effect': '带<span class="brand-text">橡皮筋</span>效果的 Sheet',
+  'Native Viewpager': '原生 <span class="brand-text">Viewpager</span>',
+
   'III · Case 1 · AI Chat': 'III · 案例一 · AI Chat',
-  'The Nuxt AI Chatbot, forked.':
-    'Nuxt 官方 AI Chatbot,<span class="brand-text">fork</span> 过来。',
   'AI SDK streaming': 'AI SDK 流式',
   'reasoning': '思维链',
   'tool cards': '工具卡片',
   'theming': '主题系统',
-  'Everything above came across unchanged.': '上面这些,原封不动地搬了过来。',
-  'Then it went native.': '然后,它<span class="brand-text">原生</span>了。',
-  'The keyboard slides in — the thread glides up with it. Hit send — the bubble flies from the prompt box into the conversation.':
-    '键盘升起 —— 对话跟着一起上滑。按下发送 —— 气泡从输入框飞进对话流。',
   'keyboard avoidance': '键盘回避',
   'send motion': '发送动效',
   'MTS pressables': 'MTS 按压反馈',
@@ -109,18 +99,10 @@ export const ZH = {
   'earlier turns stay masked until the motion starts':
     '动画启动之前,先前的对话保持遮蔽',
   'III · Case 2 · Elk': 'III · 案例二 · Elk',
-  'Elk — a production-scale fork.':
-    'Elk —— 一次<span class="brand-text">生产级规模</span>的 fork。',
   'masto.js client': 'masto.js 客户端',
   'content pipeline': '内容管线',
   'theme system': '主题系统',
   'domain logic': '领域逻辑',
-  "Elk's framework-agnostic layers, reused. Only the UI was rebuilt.":
-    'Elk 与框架无关的那些层,全部复用 —— 只重建了 UI。',
-  'Native gestures, for free-ish.':
-    '原生<span class="brand-text">手势</span>,几乎白拿。',
-  'Infinite timelines on the native <list>. A bottom sheet with rubber-banding and fling — every frame on the UI thread.':
-    '无限时间线跑在原生 <code>&lt;list&gt;</code> 上。底部抽屉带橡皮筋回弹与甩动惯性 —— 每一帧都在 UI 线程。',
   'MTS bottom sheet': 'MTS 底部抽屉',
   'next: view pager': '下一步:view pager',
   'native view pager': '原生 view pager',
@@ -136,8 +118,6 @@ export const ZH = {
     '<b>First send</b> —— 气泡离开输入框,落到锚点。',
   'Second send — the old turn holds steady while the new one travels to the top.':
     '<b>Second send</b> —— 旧轮次保持稳定,新一轮移动到顶部。',
-  'Tabs on a native view pager.':
-    '标签页跑在<span class="brand-text">原生 view pager</span> 上。',
   'Panes swipe with a native snap; content & scroll position are retained across swipes.':
     '分屏以原生吸附滑动;内容与滚动位置在滑动间保留。',
 
@@ -158,19 +138,13 @@ export const ZH = {
     '新一轮消息该在<span class="brand-text">顶部</span>。',
   'Second send — the old turn stays stable while the new bubble travels to the top anchor.':
     'Second send —— 旧轮次保持稳定,新气泡移动到顶部锚点。',
-  'A real Nuxt app, rebuilt on native.':
-    '一个真实的 Nuxt 应用,<span class="brand-text">在原生上重建。</span>',
   'components': '组件',
   'pages': '页面',
   'composables': 'composable',
-  'No Nuxt, no DOM — so instead of forking, the port reuses Elk\'s framework-agnostic layers and rebuilds the UI on Lynx elements.':
-    '没有 Nuxt,没有 DOM —— 于是不去 fork,而是<strong>复用 Elk 与框架无关的层</strong>,在 Lynx 元素上重建 UI。',
   'masto.js reused': 'masto.js 复用',
   'content-render retargeted': 'content-render 改目标',
 
   // ---- Chapter III · Elk draggable sheet ----
-  'III · Case 2 · Elk · draggable sheet': 'III · 案例二 · Elk · 可拖拽 sheet',
-  'One sheet, three owners.': '一个 sheet,<span class="brand-text">三个归属者。</span>',
   'Three owners, in code.': '三个归属者,<span class="brand-text">用代码讲。</span>',
   "The drag runs on the main thread — so even while Vue's background thread fetches, diffs, or rebuilds the list, the sheet still tracks the finger. On the web, gesture JS and render share one thread.":
     '拖拽跑在主线程上 —— 于是即便 Vue 的后台线程正在请求数据、diff 或重建列表,sheet 依然跟手。<span class="dim">在 Web 上,手势 JS 与渲染共享同一条主线程。</span>',
@@ -551,13 +525,7 @@ export const ZH_NOTES = [
   // 11 Lynx 主动连上
   `<p><strong>然后,Lynx 走出队列 —— 站到正中央,Vue 的正下方;其余候选人整体让到左侧。</strong>前端这条缝是天生打开的:Web 标准的编程模型、真 CSS、框架无关的合同。这根线,短、垂直、实心。</p><p>再看下面的覆盖:iOS、Android、Web、HarmonyOS 走<em>原生 UI primitive</em>;桌面与更多平台走<em>自定义渲染引擎</em>。Web 的开发体验进,Native 的用户体验出 —— 这个组合,配得上一个正式的标题……</p>`,
   // 12 Title reveal · Vue Lynx 正式亮相
-  `<p><strong>亮相。</strong>这是 Vue Lynx 第一次正式出场 —— 标题在论证之后才落下:空缺是真的,门是开的,而这个项目正走进那扇门。</p><p>念出名字,让背景光呼吸一拍,然后直接进入"完成度"。</p>`,
-  // 13 Divider II
-  `<p><strong>秀肌肉章节。</strong>"为了让大家感受到诚意" —— 我带了一桌丰盛的 demo。三道菜:Vue API 覆盖度、生态原样可用、然后是完整应用。</p><p>接下来看到的每台手机都是活的 —— 边看边扫码,在自己设备上跑。</p>`,
-  // 14 852/949
-  `<p><strong>先上硬指标。</strong>我们把 Vue core 自己的测试套件拿来直接跑在 Vue Lynx 渲染器上:949 个通过 852 个;每个 skip 都有记录、有交代。"兼容 Vue"在这里是可测量的命题,不是一句口号。</p>`,
-  // 15 ref
-  `<p><strong>从最简单的开始:</strong><code>ref()</code>、一个事件回调、一个样式绑定。整页和 Web Vue 的差别只有两处:import 写 <code>vue-lynx</code>,标签是 <code>&lt;view&gt;/&lt;text&gt;/&lt;image&gt;</code>。</p><p><strong>现场:</strong>点一下 —— logo 沿着 ref 驱动的 transform 弹起来。</p>`,
+  `<p><strong>亮相。</strong>这是 Vue Lynx 第一次正式出场 —— 标题在论证之后才落下:空缺是真的,门是开的,而这个项目正走进那扇门。</p><p>念出名字,让背景光呼吸一拍,然后直接进入 demo。</p>`,
   // 16 reactive
   `<p>整个响应式内核原样复用自 Vue —— <code>reactive</code>、<code>toRefs</code>、<code>computed</code>、watch 全部一致。这意味着<strong>组合式函数 —— 你组织 Vue 应用的方式 —— 原封不动可用</strong>。这个秒表就是一个普通的 composable。</p>`,
   // 17 v-model
@@ -596,26 +564,18 @@ export const ZH_NOTES = [
   `<p><strong>TodoMVC</strong> —— 每个框架的成人礼。和写 Web 一模一样的 Composition API;输入框是<em>原生</em>的,滚动是<em>原生</em>的,点击延迟不到一帧。</p><p><strong>现场:</strong>加一条、勾几条、清除已完成。</p>`,
   // 35 HackerNews
   `<p><strong>HackerNews</strong> —— 社区公认的"真应用"基准:网络、分页、嵌套评论。数据 TanStack Vue Query,样式 Tailwind,滚动跑在带复用的原生 <code>&lt;list&gt;</code> 上。<strong>跟着过来的不只是框架,是生态。</strong></p>`,
-  // 36 Runs on web
-  `<p><strong>Web 兼容的点睛:</strong>刚才没有任何模拟器。每个手机壳里都是 <em>Lynx for Web</em>,跑的就是发到 iOS/Android 的那份产物。任何一页扫 Web 码 —— 浏览器直接打开;扫 App 码 —— 同一份产物,原生运行。</p><p>Web DX 进,Web 渲染目标出。基线讲完 —— 上超集。</p>`,
   // 28 Divider III
-  `<p><strong>超集章节。</strong>覆盖度和移植证明的是下限;真正的卖点是向上:拿一个活着的 Web 应用,fork 它,然后<em>升级</em>它 —— 该是 Vue 的地方还是 Vue,该用原生的地方全上原生。两个真实 fork。</p>`,
+  `<p><strong>升级章节。</strong>移植证明的是下限;真正的卖点是向上:拿一个活着的 Web 应用,然后<em>升级</em>到原生体验 —— 该是 Vue 的地方还是 Vue,该用原生的地方全上原生。</p>`,
   // 29 AI Chat unchanged
-  `<p><strong>不变的部分。</strong>这是 Nuxt 官方 AI Chatbot 模板,逐特性移植:流式 + 思维链、markdown + 代码高亮、天气/图表工具卡片、历史、投票、编辑、主题。里面的 Vue —— 组件、composable、store —— 才是重点:<strong>它们毫无波澜地搬了过来。</strong></p>`,
-  // 30 AI Chat native
-  `<p><strong>变的部分 —— 升级项。</strong>① <em>键盘回避</em>:原生 <code>keyboardstatuschanged</code> 事件驱动 <code>setNativeProps</code> 变换,输入框和对话流跟着键盘一起、按原生曲线上滑 —— 不需要任何 Web 视口 hack。② <em>发送动效</em>:消息从输入框里"physically"飞出,变成气泡落进对话流。③ 按压反馈全部是主线程脚本。</p><p>致谢:这套原生聊天体验的标准,是 Vercel 的《How we built the v0 iOS app》立下的 —— 接下来两页看同样的手感在 Lynx 上要付出多少。</p><p><strong>现场:</strong>先聚焦输入框(键盘升、布局跟),再发一条消息 —— 看气泡。</p>`,
+  `<p><strong>这个 app 的交互。</strong>Nuxt 官方 AI Chatbot 模板逐特性移植后,再升级原生手感:① 键盘回避 —— 原生 <code>keyboardstatuschanged</code> + <code>setNativeProps</code>;② 发送动效 —— 气泡从输入框飞进对话流;③ MTS 按压反馈。</p><p><strong>现场:</strong>聚焦输入框(键盘升、布局跟),再发一条 —— 看气泡。</p>`,
   // 31 AI Chat · handoff（first send 视频）
   `<p><strong>AI Chat。</strong>从 Nuxt AI Chatbot 模板逐特性移植的生产级聊天：流式、推理、Markdown、工具卡片、历史 —— 迄今对 Vue Lynx 最苛刻的真实世界考验。</p><p><strong>写作视角</strong>（借鉴 Vercel 的 v0 iOS 复盘）：一次漂亮的发送不是一个动画,而是一次交接 —— 输入框、消息列表、键盘、流式响应之间的交接。接下来三页,把每个瞬间都追溯到背后的 API。</p><p><strong>现场演示:</strong>循环片段 —— first send 从输入框出发,落到锚点。</p>`,
   // 32 AI Chat · 键盘也是布局
   `<p><strong>键盘。</strong>Lynx 的 <code>&lt;input&gt;</code> 不会自动避让键盘。输入框绝对定位吸在底部,监听全局 <code>keyboardstatuschanged</code> 事件,用 <code>setNativeProps</code> 施加上报的键盘高度 —— 不绕后台线程。列表只在原本就跟随新内容时才继续跟随。</p><p>这个 mock 就是 v0 草图的思路:一块空白的 <em>contentInset</em> 被键盘吃掉,输入框正好抬升一个键盘高度。</p>`,
   // 33 AI Chat · 新一轮消息在顶部
   `<p><strong>第二次发送才是真正的考验。</strong>重复发送会暴露空状态藏起来的问题。原生把新的用户轮次锚定在顶部,但在移动的气泡到位前,让上一轮保持稳定。Vue Lynx 的 <code>nextTick()</code> 等待挂起的 ops 抵达主线程,再由 <code>scrollIntoView</code> 完成最终对齐 —— 然后助手才开始流式输出。</p><p><strong>Web 走另一套策略</strong> —— 没有原生定位保证,于是把列表钉在底部。手感一致,机制不同。</p>`,
-  // 33 Elk unchanged
-  `<p><strong>这一页讲规模。</strong>Elk 是真实的 Mastodon 客户端,不是 demo:时间线、会话、个人页、投票、内容警告、自定义表情、搜索、发帖。我们 fork 它,保住它的"大脑" —— masto.js API 客户端、Mastodon-HTML 内容管线、主题、领域逻辑 —— 只把视图层重建到原生元素上。这就是移植经济学:<strong>应用越大,能复用的越多。</strong></p>`,
-  // 34b Elk · 真实 Nuxt 应用,在原生上重建
-  `<p><strong>Elk。</strong>Anthony Fu 团队广受喜爱的 Mastodon Web 客户端,被移植成原生 Mastodon 客户端 —— 时间线、串、资料页、搜索、趋势。一个 Nuxt 3 应用:约 196 个组件、55 个页面、50 个 composable。</p><p><strong>移植手法:</strong>保留与框架无关的层(masto.js 客户端原样复用、HTML 内容解析约 95% 逐字保留),把 vnode 渲染器改写目标到 <code>&lt;text&gt;</code>/<code>&lt;image&gt;</code>,再用原生复用 <code>&lt;list&gt;</code> 替换 Elk 的 DOM 虚拟化 —— 代码更<em>少</em>。</p>`,
   // 34 Elk gestures
-  `<p><strong>手势升级。</strong>底部抽屉从头到尾是主线程脚本:8px 手势锁判定谁接管拖拽,超限后的橡皮筋阻尼,带真实速度 + 减速度的甩动开合 —— 零后台线程往返,流式加载中也不掉帧。</p><p><strong>现已合入</strong>(PR #223):原生 view pager,横滑切时间线 tab —— 抽屉展示了范式,pager 复用它(见本章后续)。</p><p><strong>现场:</strong>滚时间线,慢拖抽屉(橡皮筋),再甩一下。</p>`,
+  `<p><strong>这个 app 的形态。</strong>Elk 是生产级 Mastodon 客户端 —— 约 196 个组件、55 个页面、50 个 composable。保住大脑(masto.js、内容管线、主题),只把视图层重建到原生元素上。规模本身就是论证。</p><p><strong>现场:</strong>滚时间线、打开发帖 —— 感受一个复杂应用落在原生上的分量。</p>`,
   // 34c Elk · 可拖拽 sheet · 三个归属者（真实 UI + 代码）
   `<p><strong>可拖拽 sheet —— 难的不是"从底部滑上来",而是三套状态机协同。</strong>① Vue <code>&lt;Transition&gt;</code> 管"sheet 是否存在于视觉状态"(开/关);<code>v-show</code> 让节点保持挂载,关闭后滚动位置与状态得以保留,同时跑完整的 persisted transition 生命周期 —— 正是这项修复让该能力从 experimental 毕业。② 一个 <code>'main thread'</code> worklet 管"手指每一帧在哪":通过 <code>:main-thread-bindtouch*</code> 绑定,用 <code>setStyleProperty</code> 直接写 <code>transform</code>,绕开 Vue diff,并在拉过顶部时施加橡皮筋阻力。③ 原生 <code>&lt;scroll-view&gt;</code> 管"这串触摸属于谁":8px 手势锁先一次性判定方向与来源;若向下拖且列表已到顶,sheet 关掉原生滚动(<code>enable-scroll=false</code>)接管拖动,否则让给它。<code>runOnBackground</code> 只在状态边界(关闭时)跨线程,绝不每帧跨。</p><p><strong>结构即属性归属:</strong>外层 surface 归 Transition(CSS class),内层归拖动(inline <code>transform</code>)。两者写同一元素,inline 覆盖 class —— 经典的"第一次能动,之后动画消失"。</p><p><strong>双线程红利:</strong>拖拽跑在 UI 线程上,贴着原生输入与布局,即便 Vue 后台线程正在请求数据、diff 或重建列表也照样跟手;Web 上手势 JS 与渲染共享一条主线程,一有长任务就掉帧。</p>`,
   // 34b Elk · 原生 view pager

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -291,21 +291,8 @@ export const ZH = {
   'no libraries?': '不要类库?',
   'no docs?': '不要文档?',
   'no us?': '不要我们?',
-  'What survives AI?':
-    '什么能在 AI 之后<span class="brand-text">留下来</span>?',
-  'infrastructure': '基础设施',
-  'enablers': '使能者',
-  'platforms': '平台',
-  'ecosystems': '生态',
-  'people': '人',
-  'Two lemmas, then an answer.': '两个引理,一个答案。',
-  'The stack, rewritten.': '技术栈,被重写了。',
-  'AI can do anything — harnessed.':
-    'AI 什么都能做 —— 只要有好的 <span class="brand-text">harness</span>。',
-  'context docs · priors · AGENTS.md': '上下文 <small>文档 · 先验 · AGENTS.md</small>',
-  'tools functions · capabilities': '工具 <small>函数 · 能力</small>',
-  'environment runtime · sandbox': '环境 <small>运行时 · 沙箱</small>',
-  'feedback render · tests · logs': '反馈 <small>渲染 · 测试 · 日志</small>',
+  'Technology: from interface to Harness.':
+    '技术：从接口到 <span class="brand-text">Harness</span>。',
   'Nobody says AI will replace the browser.':
     '没人会说,AI 要取代<span style="color:#4FB8F0">浏览器</span>。',
   'open by default': '天生开放',
@@ -665,15 +652,11 @@ export const ZH_NOTES = [
   `<p><strong>下移 + 轻微放大</strong> —— 下半截:<em>"It's not too bad for throwaway weekend projects…"</em> 十八个月后,它已经在写原生应用了。让这句落地,翻页 —— 推文淡出,进入提问。</p>`,
   // 72 E2 · 诚实的问题
   `<p><strong>先诚实:我不知道。</strong>AI 对 Lynx、对 Vue 意味着什么,我为什么还要费这个劲?如果没有人类会读,文档还重要吗?如果模型能从裸金属重建,类库还重要吗?</p><p>可以丢的数据点:AI 时代 React 的使用量反而<em>暴涨</em> —— 模型默认写 React —— 但 React 本身却没有过去那么重要了;Anthropic 刚写过 Claude 用纯 HTML 搓一次性内部工具、什么框架都不用。地面真的在动。</p>`,
-  // 73 E3 · 论断
-  `<p><strong>先把论点立起来,这一章才有脊柱。</strong>从 AI 手里"幸存"下来的,是所有<em>使能</em>而非仅仅产出的东西:基础设施、使能者、平台、生态 —— 以及链条尽头的,人。注意这是递进:每一环都因为喂养下一环而幸存。</p><p>我用两个引理来论证:(1) 技术的角色从 interface 翻转为 harness;(2) 技术真正的工作,是连接生态 —— 和人。</p>`,
-  // 74 E4 · 新的栈
-  `<p><strong>引理一,从新的技术栈开始。</strong>自然语言是新的源代码;agent 是新的 interface,坐在 IDE 和 GUI 曾经的位置上。但看 agent 下面:code、frameworks、system —— 它们没有消失,它们变成了 agent <em>驾驭的对象</em>。</p><p>技术的工作翻转了:从直接服务人,变成 harness 那个服务人的东西。</p>`,
-  // 75 E5 · harness 是什么
-  `<p><strong>把这个词定义清楚,整章都压在它上面。</strong>Harness 是把原始能力变成可靠工作的东西:上下文(它带着什么进来)、工具(它能用什么行动)、环境(行动在哪里既安全又便宜)、反馈(它如何看见自己刚做了什么)。</p><p>第四章其实偷偷讲的就是这页:AGENTS.md 是上下文,工具链是工具,LynxExplorer 是环境,上游测试是反馈。</p>`,
-  // 76 E6 · 浏览器是个好 harness
+  // 73 E3 · 技术：从接口到 Harness（含原「留下来」「harness 定义」）
+  `<p><strong>什么能在 AI 之后留下来?</strong>从 AI 手里"幸存"下来的,是所有<em>使能</em>而非仅仅产出的东西:基础设施 → 使能者 → 平台 → 生态 → 人。每一环都因为喂养下一环而幸存。两个引理:(1) 技术从 interface 翻转为 harness;(2) 技术真正的工作,是连接生态 —— 和人。</p><p><strong>引理一 —— 技术栈被重写了。</strong>自然语言是新的源代码;agent 是新的 interface,坐在 IDE 和 GUI 曾经的位置上。agent 下面:code、frameworks、system —— 没有消失,变成了 agent <em>驾驭的对象</em>。技术的工作翻转了:从直接服务人,变成 harness 那个服务人的东西。</p><p><strong>AI 什么都能做 —— 只要有好的 harness。</strong>Harness 把原始能力变成可靠工作:上下文(文档 · 先验 · AGENTS.md)、工具(函数 · 能力)、环境(运行时 · 沙箱)、反馈(渲染 · 测试 · 日志)。第四章其实偷偷讲的就是这拍:AGENTS.md 是上下文,工具链是工具,LynxExplorer 是环境,上游测试是反馈。</p>`,
+  // 74 E4 · 浏览器是个好 harness
   `<p><strong>平台之所以幸存,是因为平台是极好的 harness。</strong>浏览器:开放的数据与文档(上下文)、巨大的能力表面(工具)、天然的沙箱(环境)、彻底的透明 —— DOM、DevTools(反馈)。</p><p>没有人argue Web 会被 AI 淘汰。我甚至更进一步:GUI 本身都不会 —— 人类总要<em>看</em>。</p>`,
-  // 77 E7 · 框架一直是 harness
+  // 75 E5 · 框架一直是 harness
   `<p><strong>让框架与 AI 相关的那次重构。</strong>在 Web 上你本来爱怎么改 DOM 都行 —— React 和 Vue 赢,是因为它们<em>约束</em>了我们:一种架构,把人类的推理 harness 成吐出下一个正确 token 的过程。</p><p>我们才是第一批被 harness 的 token 预测器。模型只是下一批。高层抽象仍然有用 —— 它帮过我们,也会帮它。</p>`,
   // 78 E8 · FABRIC I
   `<p><strong>本章的意象登场。</strong>先让线呼吸一会儿再开口。在我"前端已死"的演讲里,我试着从第一性原理论证:UI/App 抽象永远都需要 —— 意图与像素之间,总要有一层织物。现代软件是缝出来的,不是凿出来的。</p><p>于是,贯穿后半场的比喻:每一种技术都是一种织物 —— 有自己的纤维、自己的织法、自己的手感。</p>`,

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -424,11 +424,7 @@ export const ZH = {
   "Vapor's own suite — unmodified on ShadowElement. It passes the element-surface tests at 81% vs vdom's 57%: the closer fit to Lynx.":
     'Vapor 自己的上游测试 —— 在 ShadowElement 上<b>原封不动</b>地跑。触及元素表面的那些测试,它以 81% 对 vdom 的 57% 通过:与 Lynx 更亲近的契合。',
 
-  'Same source. Flip a switch.':
-    '同一份源码。<span class="brand-text">拨一下开关。</span>',
-  'Experimental today — but the fast path is already here.':
-    '今天还是实验性的 —— 但那条快路已经在这了。',
-};
+  };
 
 // Speaker-view chrome labels.
 export const SPEAKER_LABELS = {
@@ -670,8 +666,8 @@ export const ZH_NOTES = [
   // 87 E17 · One more thing
   `<p><strong>停住。</strong>数两拍,再翻页。</p>`,
   // ---- One more thing · Vue Vapor deep dive (12 slides) ----
-  // 36 Vapor 标题（Vue Vapor.；“没有虚拟 DOM”放 notes）
-  `<p><strong>Vapor 是什么 —— 没有虚拟 DOM。</strong>Vue 3.6 基于编译的渲染器:没有 vnode 树,没有逐组件 diff。预发布状态 —— 锁定在 <code>vue@3.6.0-beta.17</code>。</p><p>我们要用数据支撑的主张:同样的 Vue,更新路径的开销小得多。</p>`,
+  // 36 Vapor 标题 + 开关代码（原“拨一下开关”并入）
+  `<p><strong>Vapor 是什么 —— 没有虚拟 DOM。</strong>Vue 3.6 基于编译的渲染器:没有 vnode 树,没有逐组件 diff。预发布状态 —— 锁定在 <code>vue@3.6.0-beta.17</code>。</p><p><strong>同一份源码 —— 拨一下开关。</strong>按应用、构建期的开关:插件选项、入口 import、<code>vapor</code> 属性。两个纯入口 —— <code>vue-lynx</code> 与 <code>vue-lynx/vapor</code> —— 于是 vdom 专属 API 在 Vapor 应用里会在构建期报错,而不是在运行时出乱子。</p><p>我们要用数据支撑的主张:同样的 Vue,更新路径的开销小得多。</p>`,
   // 37 虚拟 DOM 更新路径
   `<p><strong>先立对比。</strong>从左到右过一遍五个方块。中间三个虚线的就是税:重跑、分配、diff —— 每次更新都要交,无论变了多少。</p><p>下一页用一次 magic move 把中间这段收掉。</p>`,
   // 38 Vapor 更新路径
@@ -690,10 +686,8 @@ export const ZH_NOTES = [
   `<p><strong>诚实的成绩单。</strong>别夸大 —— 创建是打平的(一开始慢 1.9×;是 ops 遥测把它推到持平)。代价是产物 +26%:Vapor 运行时加上 DOM 兼容垫片。首屏差异在噪声范围内。</p><p>绿 = 赢,粉 = 代价。数据:headless Chromium、Lynx for Web、中位数带 95% 置信区间。</p>`,
   // 45 工作流 · 一份源码两个渲染器
   `<p><strong>凭什么信它。</strong>Vapor 应用是<em>从 vdom 源码生成的</em> —— 唯一差别是 <code>vapor</code> 属性,所以负载逐字节相同。36/36 个受支持示例与其 vdom 孪生体做到 0.000% 像素差。</p><p>矩阵(<code>examples/vapor-support.json</code>,带每条目源码哈希)生成文档表格 —— 不会与验证输出发生漂移。</p>`,
-  // 45b Vapor 上游测试 + 亲近性（对应 VDOM 那页 A7）
-  `<p><strong>Vapor 也有了自己的上游测试(PR #232)。</strong>30 个 <code>runtime-vapor</code> spec 文件跑在真实的 <code>vue-lynx/vapor</code> 表面和 ShadowElement 树上:<strong>545 通过、120 skip、0 失败</strong>。skiplist 是一个<em>封闭清单</em> —— 每个被排除的测试都有理由,任何未归类项都会让配置加载直接失败。</p><p><strong>这些 skip 不是一堆坏掉的东西。</strong>SSR/hydration 加 vdom↔vapor 互操作占了不跑项的 57% —— 两者都不是 Lynx 兼容性信号(没有 SSR 表面;互操作是刻意不支持的)。浏览器专属平台再占 24%。测试设施只占不到 1%(对比 vdom 那边高达 59%),因为“原始 bundle 再导出”这招几乎消灭了私有 import 问题。这个移植还顺手抓到一个真 bug(ShadowElement 会被响应式代理;<code>__v_skip</code> 修掉了)。</p><p><strong>亲近性这一点。</strong>在真正触及元素表面的测试上,Vapor 以 81% 对 vdom 的 57% 通过 —— 而且<em>零行为级垫片</em>:生产版 <code>@vue/runtime-vapor</code> 原封不动跑在 ShadowElement 上,而 vdom 模式需要 1,074 行在执行路径里的模拟。Vapor 的宿主契约 —— 克隆模板 + 对节点的命令式 setter —— 天生就与 Lynx 更契合。(是契合度,不是速度。)</p>`,
-  // 46 收束 · 拨一下开关（含原 7× VDOM mic-drop）
-  `<p><strong>压轴数字 —— 7× VDOM。</strong>跨框架套件(ReactLynx vs Vue VDOM vs Vue Vapor),真实点击到 composed-DOM 终态。Vue 对 Vue 的头条:10k select 风暴上 Vapor 7.0× VDOM,update 风暴 1.9× —— 同一个应用、同一个产物,只差一个属性。</p><p><strong>收尾返场。</strong>Vapor 是按应用、构建期的开关:插件选项、入口 import、<code>vapor</code> 属性。两个纯入口 —— <code>vue-lynx</code> 与 <code>vue-lynx/vapor</code> —— 于是 vdom 专属 API 在 Vapor 应用里会在构建期报错,而不是在运行时出乱子。</p><p>落地:“还是你早就在写的那套 Vue —— 只是多了一条编译期的快路。这就是那‘还有一件事’。”</p>`,
+  // 45b Vapor 上游测试 + 亲近性 + 7× mic-drop
+  `<p><strong>Vapor 也有了自己的上游测试(PR #232)。</strong>30 个 <code>runtime-vapor</code> spec 文件跑在真实的 <code>vue-lynx/vapor</code> 表面和 ShadowElement 树上:<strong>545 通过、120 skip、0 失败</strong>。skiplist 是一个<em>封闭清单</em> —— 每个被排除的测试都有理由,任何未归类项都会让配置加载直接失败。</p><p><strong>这些 skip 不是一堆坏掉的东西。</strong>SSR/hydration 加 vdom↔vapor 互操作占了不跑项的 57% —— 两者都不是 Lynx 兼容性信号(没有 SSR 表面;互操作是刻意不支持的)。浏览器专属平台再占 24%。测试设施只占不到 1%(对比 vdom 那边高达 59%),因为“原始 bundle 再导出”这招几乎消灭了私有 import 问题。这个移植还顺手抓到一个真 bug(ShadowElement 会被响应式代理;<code>__v_skip</code> 修掉了)。</p><p><strong>亲近性这一点。</strong>在真正触及元素表面的测试上,Vapor 以 81% 对 vdom 的 57% 通过 —— 而且<em>零行为级垫片</em>:生产版 <code>@vue/runtime-vapor</code> 原封不动跑在 ShadowElement 上,而 vdom 模式需要 1,074 行在执行路径里的模拟。Vapor 的宿主契约 —— 克隆模板 + 对节点的命令式 setter —— 天生就与 Lynx 更契合。(是契合度,不是速度。)</p><p><strong>压轴数字 —— 7× VDOM。</strong>跨框架套件(ReactLynx vs Vue VDOM vs Vue Vapor),真实点击到 composed-DOM 终态。Vue 对 Vue 的头条:10k select 风暴上 Vapor 7.0× VDOM,update 风暴 1.9× —— 同一个应用、同一个产物,只差一个属性。</p>`,
   // 90a E20a · 稠密 vs 稀疏 (Vapor tree vs ET)
   `<p><strong>指针过不去,名字就得接管 —— 而发名字有两种发法。</strong>Vapor <em>稠密</em>地发:一趟前序遍历给每个节点一个 uid(2–7)。两条线程跑的是同一趟遍历,于是无需传一个字节就能对齐每个名字 —— 可寻址集合是开放的(任何节点都可能被 effect、事件或 ref 摸到)。</p><p>Element Templates <em>稀疏</em>地发:VDOM 编译器早已证明了一个封闭的动态点集合(holes),diff 又保证静态节点永远不会被寻址 —— 于是只有 hole 拿到名字,灰色节点对协议完全隐形。稀疏不是省出来的,是<em>证出来的</em>。同一份模板,设计空间上的两个坐标。</p>`,
   // 90b E20b · 动静光谱 · retained → write-only

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -161,8 +161,6 @@ export const ZH = {
 
   // ---- Chapter IV · How we did it ----
   'And how was this built?': '那,它是<br/>怎么被做出来的?',
-  'Three adaptations — the runtime, the toolchain, the main thread — and an AI harness running through all of them.':
-    '三次适配 —— 运行时、工具链、主线程 —— 以及一路贯穿其中的 AI harness。',
   'Background thread': '<i></i>后台线程',
   'Main (UI) thread': '<i></i>主(UI)线程',
   'Vue runs whole — on the background thread.':
@@ -235,8 +233,6 @@ export const ZH = {
   'One file ships both threads.': '一个文件,装下<em>两条</em>线程。',
   'The same code enters twice — webpack layers route it.':
     '同一份代码,进两次 —— webpack layers 负责分流。',
-  'We wrote a plugin — not a compiler.':
-    '我们写的是一个<span class="brand-text">插件</span> —— 不是编译器。',
   "Your CSS isn't translated. It's just CSS.":
     '你的 CSS 没有被翻译。它就是 <b style="color:#F27A9E">CSS</b>。',
   '2 crossings behind your finger':
@@ -271,8 +267,6 @@ export const ZH = {
 
   // ---- Close ----
   "And we'd love your help.": '也很希望你能<br/>搭把手。',
-  "Vue Lynx is pre-alpha. The architecture is solid; Vue's API surface is large. What ships next depends on who shows up.":
-    'Vue Lynx 还是 pre-alpha。架构很稳;Vue 的 API 面很大。接下来能做出什么,取决于谁愿意来。',
   "Native shouldn't be a different team.":
     '原生,不该是另一个<span class="brand-text">团队</span>的事。',
   'Vue developers should ship native apps as naturally as they ship for the web today.':
@@ -624,14 +618,12 @@ export const ZH_NOTES = [
   `<p><strong>Lynx 的交付物是一个装着两个程序的 bundle</strong> —— 后台代码跑在 JS VM,主线程代码跑在 Lepus(PrimJS)。两个 VM、两个入口、一个产物;同一个文件既能原生渲染,也能经 Lynx for Web 跑在浏览器里。于是工具链的问题变成:一次构建,怎么从一份 Vue 代码吐出两个世界?</p>`,
   // 45 B2 · 同一份代码进两次
   `<p><strong>两个入口都 import 你的真实应用。</strong>每个入口在一个 webpack <em>layer</em> 下编译 —— <code>vue:background</code> 和 <code>vue:main-thread</code> —— <code>issuerLayer</code> 规则给每层各自的 loader 链:BG 侧编译完整 SFC;MT 侧只抽取主线程需要的部分。逐 entry 的隔离,是 webpack 依赖图白送的。(这套 layer 方案我们是从 ReactLynx 学来的 —— 第一版扁平 bundle 架构隔离不了多入口应用。)</p>`,
-  // 46 B3 · 插件而非编译器
-  `<p><strong>复用故事的工具链篇。</strong>Lynx 的工具链(Rspeedy)就是 Rspack/Rsbuild —— 而 Vue 生态本来就跑在 Rspack 上,所以整条 SFC 流水线是现成的:<code>rspack-vue-loader</code>、PostCSS、HMR。<code>pluginVueLynx()</code> 是一层薄适配:把入口拆成两个 layer、接上 worklet loader、配好 CSS —— 表面积就这么大。框架无关不是口号,是用"我们只需要写多少"来度量的。</p>`,
   // 47 B4 · CSS 就是 CSS
   `<p><strong>整章样式能力背后安静的超能力:</strong>Lynx 在原生侧带了真正的 CSS 引擎 —— 选择器、级联、动画。所以 <code>&lt;style scoped&gt;</code> 映射到 Lynx 的 cssId 作用域,CSS Modules 和外链样式直接透传,CSS 里的 <code>v-bind()</code> 骑在 CSS 变量上,Tailwind 能跑是因为 PostCSS 就是 PostCSS。没有 StyleSheet 对象方言,没有会漏的翻译层。</p>`,
   // 48 C1 · 手势为什么会迟
-  `<p><strong>先诚实讲代价,再卖回报。</strong>普通写法的滚动跟随动画:事件在主线程触发,跳去后台跑你的回调,产生的 ops 再跳回来 —— 手势的每一帧背后是两次跨线程。页面一忙,肉眼可见地迟。这是双线程架构唯一收费的地方。</p>`,
+  `<p><strong>先认账再卖点。</strong>和文档里的 <code>&lt;Go&gt;</code>（<a href="https://vue.lynxjs.org/guide/main-thread-script">vue.lynxjs.org/guide/main-thread-script</a>）同一个 demo：滚黄色列表 —— 蓝方块走后台线程，每一帧两次跨线程，跟手会有可见延迟。</p><p><strong>现场：</strong>快滚列表，看方块掉队。</p>`,
   // 49 C2 · 函数换线程
-  `<p><strong>看方块移动。</strong>把 <code>'main thread'</code> 写成函数第一行,编译器就把这个函数搬进主线程 bundle —— 它从此同步运行在事件发生的地方,直接访问元素。组件的其余部分还是普通 Vue。又是渐进增强的形状:双线程的回报留着,代价变成按函数粒度的可选项。</p>`,
+  `<p><strong>看方块移动。</strong>文档 <code>&lt;Go&gt;</code> 的对比：左边方块跑在主线程（<code>'main thread'</code>），右边仍走后台 —— 一滚就能摸到差别。还是同一个 Vue 文件；一条指令把处理函数换了线程。</p><p><strong>现场：</strong>滚动 —— 左边（MT）跟手，右边掉帧。</p>`,
   // 50 C3 · 代码样例
   `<p>MTS 的全部表面积,一个文件讲完:<code>'main thread'</code> 标记函数,<code>main-thread-bind*</code> 挂到事件上,<code>useMainThreadRef()</code> 给出同步元素访问 —— <code>setStyleProperty</code> 在手指移动的同一帧落地。</p>`,
   // 51 C4 · 教程复刻

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -10,13 +10,10 @@ export function normalizeKey(s) {
   return (s || '').replace(/\s+/g, ' ').trim();
 }
 
-// Cover verbs cycle via main.js — swapped there, not here.
-export const ZH_VERBS = ['解锁', '随手写', '渲染', '发布'];
-
 // key = normalized English textContent · value = Chinese innerHTML
 export const ZH = {
   // ---- Cover ----
-  'Native for Vue': '原生,给 <span class="brand-text">Vue</span>',
+  // Big title stays English ("Unlock Native for Vue"); only the tagline flips.
   'Develop Lynx with the familiar Vue 3.': '用熟悉的 Vue 3 开发 Lynx。',
 
   // ---- Chapter I · The gap ----

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -424,9 +424,6 @@ export const ZH = {
   "Vapor's own suite — unmodified on ShadowElement. It passes the element-surface tests at 81% vs vdom's 57%: the closer fit to Lynx.":
     'Vapor 自己的上游测试 —— 在 ShadowElement 上<b>原封不动</b>地跑。触及元素表面的那些测试,它以 81% 对 vdom 的 57% 通过:与 Lynx 更亲近的契合。',
 
-  'Vapor vs Vue VDOM on the 10,000-row select storm — same app, same bundle, one attribute apart.':
-    'Vapor 对 Vue VDOM,在 10,000 行的 select 风暴中 —— 同一个应用、同一个产物,只差一个属性。',
-
   'Same source. Flip a switch.':
     '同一份源码。<span class="brand-text">拨一下开关。</span>',
   'Experimental today — but the fast path is already here.':
@@ -695,10 +692,8 @@ export const ZH_NOTES = [
   `<p><strong>凭什么信它。</strong>Vapor 应用是<em>从 vdom 源码生成的</em> —— 唯一差别是 <code>vapor</code> 属性,所以负载逐字节相同。36/36 个受支持示例与其 vdom 孪生体做到 0.000% 像素差。</p><p>矩阵(<code>examples/vapor-support.json</code>,带每条目源码哈希)生成文档表格 —— 不会与验证输出发生漂移。</p>`,
   // 45b Vapor 上游测试 + 亲近性（对应 VDOM 那页 A7）
   `<p><strong>Vapor 也有了自己的上游测试(PR #232)。</strong>30 个 <code>runtime-vapor</code> spec 文件跑在真实的 <code>vue-lynx/vapor</code> 表面和 ShadowElement 树上:<strong>545 通过、120 skip、0 失败</strong>。skiplist 是一个<em>封闭清单</em> —— 每个被排除的测试都有理由,任何未归类项都会让配置加载直接失败。</p><p><strong>这些 skip 不是一堆坏掉的东西。</strong>SSR/hydration 加 vdom↔vapor 互操作占了不跑项的 57% —— 两者都不是 Lynx 兼容性信号(没有 SSR 表面;互操作是刻意不支持的)。浏览器专属平台再占 24%。测试设施只占不到 1%(对比 vdom 那边高达 59%),因为“原始 bundle 再导出”这招几乎消灭了私有 import 问题。这个移植还顺手抓到一个真 bug(ShadowElement 会被响应式代理;<code>__v_skip</code> 修掉了)。</p><p><strong>亲近性这一点。</strong>在真正触及元素表面的测试上,Vapor 以 81% 对 vdom 的 57% 通过 —— 而且<em>零行为级垫片</em>:生产版 <code>@vue/runtime-vapor</code> 原封不动跑在 ShadowElement 上,而 vdom 模式需要 1,074 行在执行路径里的模拟。Vapor 的宿主契约 —— 克隆模板 + 对节点的命令式 setter —— 天生就与 Lynx 更契合。(是契合度,不是速度。)</p>`,
-  // 46 那一个数字（mic-drop）
-  `<p><strong>压轴数字。</strong>跨框架套件(ReactLynx vs Vue VDOM vs Vue Vapor),真实点击到 composed-DOM 终态。Vue 对 Vue 的头条:10k select 风暴上 Vapor 7.0× VDOM,update 风暴 1.9×。</p><p>让它悬一会儿。然后最后一页。</p>`,
-  // 47 收束 · 拨一下开关
-  `<p><strong>收尾返场。</strong>Vapor 是按应用、构建期的开关:插件选项、入口 import、<code>vapor</code> 属性。两个纯入口 —— <code>vue-lynx</code> 与 <code>vue-lynx/vapor</code> —— 于是 vdom 专属 API 在 Vapor 应用里会在构建期报错,而不是在运行时出乱子。</p><p>落地:“还是你早就在写的那套 Vue —— 只是多了一条编译期的快路。这就是那‘还有一件事’。”</p>`,
+  // 46 收束 · 拨一下开关（含原 7× VDOM mic-drop）
+  `<p><strong>压轴数字 —— 7× VDOM。</strong>跨框架套件(ReactLynx vs Vue VDOM vs Vue Vapor),真实点击到 composed-DOM 终态。Vue 对 Vue 的头条:10k select 风暴上 Vapor 7.0× VDOM,update 风暴 1.9× —— 同一个应用、同一个产物,只差一个属性。</p><p><strong>收尾返场。</strong>Vapor 是按应用、构建期的开关:插件选项、入口 import、<code>vapor</code> 属性。两个纯入口 —— <code>vue-lynx</code> 与 <code>vue-lynx/vapor</code> —— 于是 vdom 专属 API 在 Vapor 应用里会在构建期报错,而不是在运行时出乱子。</p><p>落地:“还是你早就在写的那套 Vue —— 只是多了一条编译期的快路。这就是那‘还有一件事’。”</p>`,
   // 90a E20a · 稠密 vs 稀疏 (Vapor tree vs ET)
   `<p><strong>指针过不去,名字就得接管 —— 而发名字有两种发法。</strong>Vapor <em>稠密</em>地发:一趟前序遍历给每个节点一个 uid(2–7)。两条线程跑的是同一趟遍历,于是无需传一个字节就能对齐每个名字 —— 可寻址集合是开放的(任何节点都可能被 effect、事件或 ref 摸到)。</p><p>Element Templates <em>稀疏</em>地发:VDOM 编译器早已证明了一个封闭的动态点集合(holes),diff 又保证静态节点永远不会被寻址 —— 于是只有 hole 拿到名字,灰色节点对协议完全隐形。稀疏不是省出来的,是<em>证出来的</em>。同一份模板,设计空间上的两个坐标。</p>`,
   // 90b E20b · 动静光谱 · retained → write-only

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -319,8 +319,7 @@ export const ZH = {
   'Frameworks compress the search space.': '框架,压缩了搜索空间。',
   'everything the model could emit': '模型可能吐出的一切',
   'the idiom': '惯用法',
-  'Technology is nothing without its people.':
-    '技术若没有<span class="brand-text">人</span>,什么都不是。',
+  // Stays English in both languages (like the cover title).
   '3D prints · 小音': '帮忙 3D 打印 · 小音',
   'a dinner in Fuzhou · 雪碧': '上一顿饭在福州 · 雪碧',
   'Poland, then here · Nector': '上一面在波兰 · Nector',

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -347,8 +347,6 @@ export const ZH = {
     '切一刀线程 —— 什么能过桥?',
   'Only closed, first-order terms survive the cut — a flat ops stream, i.e. a display list.':
     '只有封闭的一阶项能扛过这一刀 —— 一串扁平的 ops,也就是一份 display list。',
-  'Pointers die — names take over.':
-    '指针死去 —— <span class="brand-text">名字</span>接管。',
   'Weave the whole Web…': '把整个 Web 织进来……',
   '…into every platform.': '……再织向每一个平台。',
   'more…': '<i></i> 更多……',

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -333,10 +333,6 @@ export const ZH = {
   'native': '原生元件',
   'custom': '自渲染',
   'hybrid': '混合',
-  "AI doesn't need mature libraries. It needs a place to vibe.":
-    'AI 要的不是成熟的类库,而是一个能 <span class="brand-text">vibe</span> 的地方。',
-  'The Web was that place. Lynx carries it to native.':
-    'Web 曾经就是那个地方。Lynx 把它带到原生。',
   'Vapor on Lynx — no VDOM. Straight to ops.':
     'Vapor on Lynx —— 没有 VDOM,直达 <b style="color:#4FB8F0">ops</b>。',
   'A cradle for framework design.':
@@ -673,11 +669,9 @@ export const ZH_NOTES = [
   `<p><strong>引理落在人身上。</strong>如果 AI 最终 boil down 到人的品味,那人只会更重要 —— 连接一个社区,就是连接一群人。</p><p>点名现场:帮忙 3D 打印的小音,非常感谢;雪碧 —— 上一顿饭还在福州,没想到今天在这里遇见;Nector —— 上一面还在波兰!你可以说"这个平台才有我想追的偶像" —— 那,Evan 和 Anthony 就在这个平台上。</p>`,
   // 85 E15 · 不是框架,是连接
   `<p><strong>那我到底做了个什么?</strong>AI 时代你理论上并不<em>需要</em>框架 —— 十年前我做过一个在线 HTML slides 编辑器;今天这套 deck 完全是生成的,底下什么库都没有。Vue Lynx 真正是一个开端:说服 Vue 社区,来给原生做点东西。</p><p>更深一层的道理:只要连接<em>存在</em>,AI 就会放大发生的连接。编程语言之间移植容易,因为大家都图灵完备、都有 runtime —— 桥本来就在。Web ↔ Native 之间没有天然的桥。Lynx 这个开源项目的命题,就是那座桥的<em>设计</em>。(顺带:我选择投身的技术,商业价值是一,理想也总要有一点。)</p>`,
-  // 86 E16 · 连接复利
-  `<p><strong>连上 Lynx,就连上了 Lynx 连接的一切。</strong>你已经在用的 Web 织物 —— Motion、Pretext —— 直接带过来;经 Node-API 连 Electron;JSI 世界连 Expo Modules;每一种渲染策略;正在成形的 agent-UI 协议。还有 Lynx 自己的生态 —— Sparkling、Lynxtron。</p><p>被带过来的,是生态和社区本身。这就是复利。</p>`,
-  // 87 E17 · 能 vibe 的地方
-  `<p><strong>把生态论点按 AI 时代磨尖。</strong>键盘前坐着 agent 的时候,你需要的甚至不是成熟的类库 —— 而是一个试错便宜、可观测、够安全的平台。Web 之所以是 Web,靠的就是这个。Lynx 的赌注,是把这个性质带到原生。</p>`,
-  // 88 E18 · One more thing
+  // 86 E16 · 连接复利（含原「能 vibe 的地方」）
+  `<p><strong>连上 Lynx,就连上了 Lynx 连接的一切。</strong>你已经在用的 Web 织物 —— Motion、Pretext —— 直接带过来;经 Node-API 连 Electron;JSI 世界连 Expo Modules;每一种渲染策略;正在成形的 agent-UI 协议。还有 Lynx 自己的生态 —— Sparkling、Lynxtron。</p><p>被带过来的,是生态和社区本身。这就是复利。</p><p><strong>AI 要的不是成熟的类库,而是一个能 vibe 的地方。</strong>键盘前坐着 agent 的时候,你需要的甚至不是成熟的类库 —— 而是一个试错便宜、可观测、够安全的平台。Web 之所以是 Web,靠的就是这个。Lynx 的赌注,是把这个性质带到原生。</p>`,
+  // 87 E17 · One more thing
   `<p><strong>停住。</strong>数两拍,再翻页。</p>`,
   // ---- One more thing · Vue Vapor deep dive (12 slides) ----
   // 36 Vapor 标题

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -362,7 +362,7 @@ export const ZH = {
   'Natural language.':
     '<span class="brand-text">自然语言</span>。',
   'The frontend is dead.': '前端已死。',
-  'Long live the frontend.': '前端<span class="brand-text">永生</span>。',
+  'Long live the frontend': '前端<span class="brand-text">永生</span>',
   'Thank you — for real this time.': '谢谢 —— 这次是真的。',
 
   // ---- One more thing · Vue Vapor (the deep dive) ----

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -254,32 +254,12 @@ export const ZH = {
   '1 human + Claude': '1 个人 + Claude',
   'The full write-up — harness, prompts, receipts. @Huxpro on X.':
     '完整复盘 —— harness、prompt、全部凭证。X 上的 <b>@Huxpro</b>。',
-  // ---- Combine ----
-  'A new path': '一条新路',
-  'Vue, on native.': 'Vue,<span class="brand-text">跑在原生上。</span>',
-
-  // ---- Close ----
-  "And we'd love your help.": '也很希望你能<br/>搭把手。',
-  "Native shouldn't be a different team.":
-    '原生,不该是另一个<span class="brand-text">团队</span>的事。',
-  'Vue developers should ship native apps as naturally as they ship for the web today.':
-    'Vue 开发者应该能像今天发 Web 一样,自然地发原生应用。',
-  "What's there": '已经有的',
-  "What's open": '还缺的',
-  'Composition API & SFCs': '<b>Composition API 与 SFC</b>',
-  'Transition, Suspense, KeepAlive, Teleport': '<b>Transition、Suspense、KeepAlive、Teleport</b>',
-  'Pinia, Router, Query, Tailwind': '<b>Pinia、Router、Query、Tailwind</b>',
-  'Main-Thread Script': '<b>Main-Thread Script</b>',
-  'View pager & more gestures': '<b>View pager 与更多手势</b>',
-  'Vue DevTools integration': '<b>Vue DevTools 集成</b>',
-  "The ecosystem you'd port": '<b>等你来移植的生态</b>',
-  "One npm create, and you're shipping native.":
-    '一行 <span class="brand-text">npm create</span>,你就在发原生了。',
+  // ---- Close · one npm command (fake thank-you) ----
+  'Stars, questions, PRs': 'Star、提问、PR',
+  'One npm command.':
+    '一行 <span class="brand-text">npm</span> 命令。',
   'for Agent': '给 Agent',
-  'Quick Start →': '快速开始 →',
-  'Read the intro': '读简介',
-  'Thank you.': '<span class="brand-text">谢</span>谢。',
-  'Questions, PRs, opinions — all welcome.': '提问、PR、想法 —— 都欢迎。',
+  'Thank you.': '谢谢。',
 
   // ---- Epilogue · the elephant / fabrics ----
   'The elephant in the room.': '聊聊房间里的<br/>大象。',
@@ -611,18 +591,8 @@ export const ZH_NOTES = [
   `<p><strong>现在这个数字说得通了。</strong>这一章的一切 —— 渲染器、工具链、MTS —— 是两周的夜晚和周末做出来的:plan 写成 spec,agent harness 执行,上游测试当 reward signal,AGENTS.md 固化调试手册。给在座各位一个安静的结论:Lynx 出乎意料地 <em>AI 可读</em> —— Web 标准的 API 和真 CSS,意味着模型的 Web 直觉基本直接迁移。</p>`,
   // 64 H2 · X 复盘
   `<p><strong>让观众把手机对准这页。</strong>完整方法论写在 X 上 —— harness 怎么搭、plan 长什么样、AI 在哪儿失手、测试怎么接住的。vue.lynxjs.org 首页的 badge 也链着它。然后收束:"这就是它怎么被做出来的 —— 接下来看看它加起来意味着什么。"</p>`,
-  // 65 Combine
-  `<p><strong>标题句。</strong>Vue × Lynx = Vue 跑在原生上。停顿,让等式落地。然后:"也很希望大家来一起把它做成。"</p>`,
-  // 66 Divider V · close
-  `<p><strong>转向请求。</strong>项目是真的,但需要社区。架构很稳;Vue 的表面积很大。</p>`,
-  // 67 Ask
-  `<p>落在这句上 —— <em>"原生,不该是另一个团队的事。"</em>这是你想让他们记住的一句。</p>`,
-  // 68 What's there / open
-  `<p>左边 = 今天就能用、可以做生产探索的。右边 = 贡献者能发力的地方 —— 第三章里 Elk 的 view pager,就在这个清单上。</p>`,
-  // 69 Try
-  `<p><strong>行动号召。</strong>一行命令 —— <code>npm create vue-lynx@latest</code>。"给 Agent"按钮会复制一段引导 prompt。承诺:"今晚回家的公交上,你就能让一个 Vue 应用跑在 iPhone 上。"</p>`,
-  // 70 Thank you (the FAKE close)
-  `<p><strong>假收尾。</strong>演得越真越好:道谢、微微鞠躬、伸手去拿水 —— 停住,等掌声起来。</p><p>然后面无表情:"啊——没有哈。这才过去十分钟。"翻页,进入真正的后半场。</p>`,
+  // 65 Close · 一行 npm 命令（含原 combine / 搭把手 / 另一个团队 / what's there / 假收尾）
+  `<p><strong>标题句,然后请求。</strong>Vue × Lynx = Vue 跑在原生上。也很希望你能搭把手 —— 架构很稳;Vue 的表面积很大。记住这句:<em>原生,不该是另一个团队的事</em>。已经有的:Composition API 与 SFC、Transition/Suspense/KeepAlive/Teleport、Pinia/Router/Query/Tailwind、Main-Thread Script。还缺的:view pager 与更多手势、Vue DevTools、等你来移植的生态。</p><p><strong>行动号召。</strong>一行命令 —— <code>npm create vue-lynx@latest</code>。"给 Agent"按钮会复制一段引导 prompt。承诺:"今晚回家的公交上,你就能让一个 Vue 应用跑在 iPhone 上。"</p><p><strong>假收尾。</strong>演得越真越好:道谢、微微鞠躬、伸手去拿水 —— 停住,等掌声起来。然后面无表情:"啊——没有哈。这才过去十分钟。"翻页,进入真正的后半场。</p>`,
   // 71 Epilogue divider · 大象
   `<p><strong>重置全场。</strong>"那,用省下来的十分钟,聊聊房间里的大象。"如果 AI 什么都能做,为什么不直接 prompt 出 N 个原生应用,跳过框架、跳过跨端、跳过这一切?</p><p>语气转变:少一点产品推介,多一点自言自语。这半场讲的是 <em>why</em>,不是 <em>what</em>。</p>`,
   // 71a Overlay · 推文上半

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -374,8 +374,7 @@ export const ZH = {
   'Thank you — for real this time.': '谢谢 —— 这次是真的。',
 
   // ---- One more thing · Vue Vapor (the deep dive) ----
-  'Vapor mode — no Virtual DOM.':
-    '<span class="brand-text">Vapor</span> 模式 —— 没有虚拟 DOM。',
+  // "Vue Vapor." stays English in both languages.
   "Templates compile straight to code that touches elements directly. We taught it to run on Lynx's two threads.":
     '模板直接编译成操作元素的代码。我们让它跑在了 Lynx 的两条线程上。',
 
@@ -674,8 +673,8 @@ export const ZH_NOTES = [
   // 87 E17 · One more thing
   `<p><strong>停住。</strong>数两拍,再翻页。</p>`,
   // ---- One more thing · Vue Vapor deep dive (12 slides) ----
-  // 36 Vapor 标题
-  `<p><strong>Vapor 是什么。</strong>Vue 3.6 基于编译的渲染器:没有 vnode 树,没有逐组件 diff。预发布状态 —— 锁定在 <code>vue@3.6.0-beta.17</code>。</p><p>我们要用数据支撑的主张:同样的 Vue,更新路径的开销小得多。</p>`,
+  // 36 Vapor 标题（Vue Vapor.；“没有虚拟 DOM”放 notes）
+  `<p><strong>Vapor 是什么 —— 没有虚拟 DOM。</strong>Vue 3.6 基于编译的渲染器:没有 vnode 树,没有逐组件 diff。预发布状态 —— 锁定在 <code>vue@3.6.0-beta.17</code>。</p><p>我们要用数据支撑的主张:同样的 Vue,更新路径的开销小得多。</p>`,
   // 37 虚拟 DOM 更新路径
   `<p><strong>先立对比。</strong>从左到右过一遍五个方块。中间三个虚线的就是税:重跑、分配、diff —— 每次更新都要交,无论变了多少。</p><p>下一页用一次 magic move 把中间这段收掉。</p>`,
   // 38 Vapor 更新路径

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -359,14 +359,8 @@ export const ZH = {
     '—— 另一位学员 · 他当晚 vibe 出了一个宝可梦',
   "I know AI makes it easy. I'm glad it's easy — I haven't been this excited in years.":
     '我知道有 AI 这不难。我很高兴这不难 —— 我好久没这么兴奋过了。',
-  'I rebuilt everything ten-years-ago me dreamed of.':
-    '我把 <span class="brand-text">10 年前的自己</span>想做的东西,全部翻新了一遍。',
-  'hux.pro — untouched for 10 years': 'hux.pro —— 十年没动过',
-  'my first Vue app — v0.12': '我的第一个 Vue 应用 —— v0.12',
-  'this deck — zero libraries, vibed': '这套 deck —— 零依赖,纯 vibe',
-  'I just changed languages — to natural language.':
-    '我只是又换了一门语言 —— <span class="brand-text">自然语言</span>。',
-  "I'm still doing frontend.": '可我做的,还是前端。',
+  'Natural language.':
+    '<span class="brand-text">自然语言</span>。',
   'The frontend is dead.': '前端已死。',
   'Long live the frontend.': '前端<span class="brand-text">永生</span>。',
   'Thank you — for real this time.': '谢谢 —— 这次是真的。',
@@ -710,10 +704,8 @@ export const ZH_NOTES = [
   `<p><strong>证据甩上桌</strong> —— 两张照片夹着中间的竖屏视频,压在 quote 之上。中间的视频静音自动播放;照片带一点快照式的倾斜。</p><p>文件:<code>103-photo-1.png</code>、<code>103-video-portrait.mp4</code>、<code>103-photo-2.png</code>,放在 <code>slides/public/media/embeds/</code>。</p>`,
   // 95b Overlay · 宝可梦横屏
   `<p><strong>再点一下 —— 宝可梦,全宽登场。</strong>三连散去,横屏视频占满舞台。文件:<code>103-video-wide.mp4</code>。</p>`,
-  // 96 E26 · 十年翻新
-  `<p><strong>个人的证据。</strong>这一年我回头把 10 年前的自己想做的项目全都翻新了一遍:十年没动过的个人网站;我的第一个 Vue 项目,Vue 0.12;还有这套 deck —— 手 vibe 的 HTML,底下没有任何 slide 库,正是当年那个 slides 编辑器的直系后代。</p>`,
-  // 97 E27 · 还是前端
-  `<p><strong>转折。</strong>那我整天在做什么呢,从敲代码变成 prompt?我只是又换了一门语言 —— 汇编到 C 到 JS 到……自然语言。源变了,工作没变:我仍然在把人的意图,翻译成人能看见、能触摸的东西。</p><p>这从来就是这份工作。这<em>就是</em>前端。</p>`,
-  // 98 E28 · 前端永生
+  // 96 E26 · 自然语言（含原「十年翻新」「还是前端」）
+  `<p><strong>个人的证据。</strong>这一年我回头把 10 年前的自己想做的项目全都翻新了一遍:十年没动过的个人网站(hux.pro);我的第一个 Vue 项目,Vue 0.12;还有这套 deck —— 手 vibe 的 HTML,底下没有任何 slide 库,正是当年那个 slides 编辑器的直系后代。</p><p><strong>转折 —— 可我做的,还是前端。</strong>那我整天在做什么呢,从敲代码变成 prompt?我只是又换了一门语言 —— 汇编到 C 到 JS 到……自然语言。源变了,工作没变:我仍然在把人的意图,翻译成人能看见、能触摸的东西。这从来就是这份工作。这<em>就是</em>前端。</p>`,
+  // 97 E27 · 前端永生
   `<p><strong>真正的收尾。</strong>小字划掉:前端已死。大字:前端永生。谢谢 —— 这次是真的 —— 然后留在这页做 Q&amp;A。</p><p>Q&amp;A 弹药:"能上生产吗?" —— pre-alpha,架构稳,已覆盖的部分测试充分。"Android?" —— 同一份产物,两端都跑。"AI 会取代 Vue 吗?" —— 你刚看完整个答案。</p>`,
 ];

--- a/slides/src/main.js
+++ b/slides/src/main.js
@@ -555,7 +555,7 @@ let vtext = verbs[0];
 let vdeleting = false;
 let vpaused = false;
 
-function setVerbLang(lang) {
+function setVerbLang(_lang) {
   // Cover title stays English in both languages; only the tagline is bilingual.
   verbs = EN_VERBS;
   vi = 0;

--- a/slides/src/main.js
+++ b/slides/src/main.js
@@ -2,7 +2,7 @@ import './styles.css';
 import { mountMeteors } from './meteors.js';
 import { initArch } from './arch.js';
 import { initWeave } from './weave.js';
-import { ZH, ZH_VERBS, ZH_NOTES, normalizeKey } from './i18n.js';
+import { ZH, ZH_NOTES, normalizeKey } from './i18n.js';
 import { readFlags, expandChrome } from './framework/flags.js';
 import { initCommand } from './framework/command.js';
 import { initDevtool } from './framework/devtool.js';
@@ -556,7 +556,8 @@ let vdeleting = false;
 let vpaused = false;
 
 function setVerbLang(lang) {
-  verbs = lang === 'zh' ? ZH_VERBS : EN_VERBS;
+  // Cover title stays English in both languages; only the tagline is bilingual.
+  verbs = EN_VERBS;
   vi = 0;
   vtext = '';
   vdeleting = false;
@@ -607,7 +608,7 @@ document.querySelectorAll('[data-copy]').forEach((el) => {
 // =========================================================
 const I18N_SELECTOR = [
   '.eyebrow', 'h1', 'h2', 'h3', 'p', 'li',
-  '.chip', '.pstack__item', '.cover__tagline', '.cover__title-line',
+  '.chip', '.pstack__item', '.cover__tagline',
   '.combine__name', '.result-label', '.tl-item__week', '.node__label',
   '.arrow', '.cta__link', '.agent', '.mega', '.label',
   '.flane__label', '.ifrlane__label', '.fcenter', '.lgtag',

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -1154,39 +1154,13 @@ vl-demo[data-ready="true"] .vl-demo__loading {
   gap: 24px;
 }
 
-.divider__row {
-  display: flex;
-  align-items: flex-end;
-  gap: clamp(24px, 4cqw, 56px);
-  max-width: 100%;
-}
-
-.divider__num {
-  font-family: var(--serif);
-  font-style: italic;
-  font-size: clamp(160px, 22cqw, 320px);
-  line-height: 0.85;
-  letter-spacing: -0.05em;
-  color: var(--ink);
-  flex-shrink: 0;
-}
-
-.divider__num.numeral--brand {
-  background: var(--brand-gradient);
-  background-size: 200% 100%;
-  -webkit-background-clip: text;
-  background-clip: text;
-  color: transparent;
-  animation: gradientMove 9s linear infinite;
-}
-
 .divider__title {
   font-family: var(--display);
   font-weight: 600;
   font-size: clamp(48px, 6cqw, 96px);
   line-height: 0.95;
   letter-spacing: -0.035em;
-  max-width: 16ch;
+  max-width: 18ch;
   padding-bottom: clamp(20px, 2cqw, 32px);
 }
 

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -1700,7 +1700,7 @@ vl-demo[data-ready="true"] .vl-demo__loading {
 .thankyou .sig {
   font-family: var(--serif);
   font-style: italic;
-  font-size: clamp(20px, 2cqw, 32px);
+  font-size: clamp(24px, 2.4cqw, 38px);
   color: var(--ink-soft);
 }
 
@@ -1708,7 +1708,7 @@ vl-demo[data-ready="true"] .vl-demo__loading {
   display: flex;
   gap: 28px;
   font-family: var(--mono);
-  font-size: 14px;
+  font-size: 16px;
   color: var(--ink-mute);
 }
 .thankyou .handles a {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Tighten the VueConf deck: drop chapter eyebrows/numerals, compress case studies and the AI/Vapor epilogue, fold beats into speaker notes.

## Latest
- Collapse the mid-talk close: drop Vue×Lynx / “搭把手” / “另一个团队” / what’s-there; one slide = **Stars, questions, PRs** → **One npm command.** → command box → small **Thank you.**
- Dropped content lives in that slide’s speaker notes (incl. fake-close beat).
- Finale: no trailing period on 前端永生; thank-you body a bit larger.
- Coda: **Natural language.** / **自然语言。**

## Test plan
- [ ] Counter `01 / 127`; `#slides` = `#notes` = `ZH_NOTES`
- [ ] After “How I vibed…” → npm-command fake close → elephant
- [ ] 中文: Star、提问、PR / 一行 npm 命令。 / 谢谢。
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8aa08879-aedf-495d-a7af-73fd54ea03b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8aa08879-aedf-495d-a7af-73fd54ea03b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

