### PR TITLE
feat(slides): retell Chapter IV runtime narrative

### DIFF
--- a/slides/index.html
+++ b/slides/index.html
@@ -2660,7 +2660,7 @@ app.<span class="code-fn">use</span>(router)</pre>
            style="position:relative">
         <div class="phone__inner">
           <vl-media kind="iframe"
-                    src="https://platform.twitter.com/embed/Tweet.html?id=2036993665965416601"
+                    src="https://platform.twitter.com/embed/Tweet.html?id=2036993665965416601&theme=dark"
                     label="x.com/Huxpro · write-up"></vl-media>
         </div>
       </div>

--- a/slides/index.html
+++ b/slides/index.html
@@ -24,7 +24,7 @@
     </button>
   </div>
   <div class="chrome chrome--bottom">
-    <span data-counter>01 / 143</span>
+    <span data-counter>01 / 146</span>
   </div>
   <div class="chrome chrome--bottom-right">
     <a href="https://vue.lynxjs.org" target="_blank" rel="noreferrer">vue.lynxjs.org</a>
@@ -1674,58 +1674,57 @@ app.<span class="code-fn">use</span>(router)</pre>
     </aside>
   </section>
 
-  <!-- A1 — Vue lands on the background thread -->
+  <!-- W1 — Web is single-threaded -->
   <section class="slide stage">
     <span class="eyebrow">IV · Runtime</span>
-    <div class="flow">
-      <div class="flane" data-flip="lane-bg" style="--c:#5dd5a8;top:4%;height:42%">
-        <span class="flane__label"><i></i>Background thread</span>
-      </div>
-      <div class="flane" data-flip="lane-mt" style="--c:#56b8f0;top:54%;height:42%">
-        <span class="flane__label"><i></i>Main (UI) thread</span>
-      </div>
-      <div class="fb is-hero" data-flip="fb-vue" style="--c:#42b883;left:50%;top:25%">
-        Vue 3 runtime · VDOM
-        <small>@vue/runtime-core · untouched</small>
+    <div class="ifrtl" style="height:clamp(170px,30cqh,230px)">
+      <div class="ifrlane" data-flip="tl-main" style="--c:#56b8f0;top:22%;height:58%">
+        <span class="ifrlane__label"><i></i>Main</span>
+        <div class="tblk tblk--evt" data-flip="tl-evt" style="left:7%;width:12%;top:58%">Event</div>
+        <div class="tblk tblk--js" data-flip="tl-js" style="left:21%;width:38%;top:58%">JavaScript</div>
+        <div class="tblk is-paint" data-flip="tl-paint" style="left:61%;width:14%;top:58%">Paint</div>
+        <div class="tframe" data-flip="tl-frame" style="left:77%">
+          <span class="tframe__label">Frame</span>
+        </div>
       </div>
     </div>
     <p class="lead arch-cap" data-mm-fade>
-      Vue runs <em>whole</em> — on the background thread.
+      The Web is <em>one</em> thread.
     </p>
     <aside class="notes">
-      <p><strong>First decision: which thread does Vue live on?</strong> An early community experiment put Vue on the main thread — every event then had to be forwarded across. But Lynx delivers events to the background thread natively, so we run the entire runtime there: reactivity, diff, lifecycle, your handlers. Not a fork of Vue — the actual <code>@vue/runtime-core</code>, untouched.</p>
+      <p><strong>Start where the room already lives.</strong> A browser frame is one Main thread: event in, JavaScript runs, paint out. Everyone knows this picture — hold it for one beat before we break it.</p>
     </aside>
   </section>
 
-  <!-- A2 — ShadowElement -->
+  <!-- W2 — Native UI owns Main → need another thread -->
   <section class="slide stage">
     <span class="eyebrow">IV · Runtime</span>
-    <div class="flow">
-      <div class="flane" data-flip="lane-bg" style="--c:#5dd5a8;top:4%;height:42%">
-        <span class="flane__label"><i></i>Background thread</span>
+    <div class="ifrtl">
+      <div class="ifrlane" data-flip="tl-main" style="--c:#56b8f0;top:6%;height:38%">
+        <span class="ifrlane__label"><i></i>Main</span>
+        <div class="tblk tblk--evt" data-flip="tl-evt" style="left:5%;width:11%;top:58%">Event</div>
+        <div class="tblk tblk--ui" data-flip="tl-native" style="left:48%;width:16%;top:58%">Native UI</div>
+        <div class="tblk is-paint" data-flip="tl-paint" style="left:66%;width:13%;top:58%">Paint</div>
+        <div class="tframe" data-flip="tl-frame" style="left:40%">
+          <span class="tframe__label">Frame</span>
+        </div>
       </div>
-      <div class="flane" data-flip="lane-mt" style="--c:#56b8f0;top:54%;height:42%">
-        <span class="flane__label"><i></i>Main (UI) thread</span>
+      <div class="ifrlane" data-flip="tl-bg" data-mm-fade style="--c:#5dd5a8;top:56%;height:38%">
+        <span class="ifrlane__label"><i></i>Background</span>
+        <div class="tblk tblk--js" data-flip="tl-js" style="left:16%;width:30%;top:58%">JavaScript</div>
       </div>
-      <div class="fb" data-flip="fb-vue" style="--c:#42b883;left:23%;top:25%">
-        Vue 3 runtime · VDOM
-        <small>@vue/runtime-core · untouched</small>
-      </div>
-      <span class="farr" data-mm-fade style="left:41.5%;top:25%">nodeOps &rarr;</span>
-      <div class="fb is-hero" data-flip="fb-shadow" style="--c:#E8B44A;left:62%;top:25%">
-        ShadowElement tree
-        <small>linked list · sync reads</small>
-      </div>
+      <span class="tl-arr" data-mm-fade style="left:12%;top:48%">↓</span>
+      <span class="tl-arr" data-mm-fade style="left:38%;top:48%">↑</span>
     </div>
     <p class="lead arch-cap" data-mm-fade>
-      <code>createRenderer()</code> — a renderer, not a fork.
+      Native UI owns Main — so JS <em>must</em> leave.
     </p>
     <aside class="notes">
-      <p><strong>Vue's official custom renderer API is the whole trick.</strong> <code>createRenderer()</code> wants synchronous nodes — <code>parentNode()</code>, <code>nextSibling()</code> must answer immediately, but the real elements live on another thread. So nodeOps dual-writes: it maintains a lightweight <em>ShadowElement</em> linked-list on the background thread (satisfying every synchronous read Vue makes) while queueing the real work for later. Same pattern ReactLynx uses for its snapshot instances.</p>
+      <p><strong>The cross-platform dilemma.</strong> Native UI already lives on the main thread. Put the framework there too and the frame budget dies. So every serious native stack pulls JS onto a background thread — events go down, UI updates come back a frame later. Lynx makes the same cut.</p>
     </aside>
   </section>
 
-  <!-- A3 — ops buffer crosses -->
+  <!-- A1 — Vue + PAPI + Native UI on Main: won't work -->
   <section class="slide stage">
     <span class="eyebrow">IV · Runtime</span>
     <div class="flow">
@@ -1735,73 +1734,30 @@ app.<span class="code-fn">use</span>(router)</pre>
       <div class="flane" data-flip="lane-mt" style="--c:#56b8f0;top:54%;height:42%">
         <span class="flane__label"><i></i>Main (UI) thread</span>
       </div>
-      <div class="fb" data-flip="fb-vue" style="--c:#42b883;left:23%;top:25%">
-        Vue 3 runtime · VDOM
-        <small>@vue/runtime-core · untouched</small>
+      <div class="fb is-hero" data-flip="fb-vue" style="--c:#42b883;left:20%;top:75%;z-index:3">
+        Vue 3 · VDOM
+        <small>@vue/runtime-core</small>
       </div>
-      <span class="farr" style="left:41.5%;top:25%">nodeOps &rarr;</span>
-      <div class="fb" data-flip="fb-shadow" style="--c:#E8B44A;left:62%;top:25%">
-        ShadowElement tree
-        <small>linked list · sync reads</small>
-      </div>
-      <span class="farr" data-mm-fade style="--c:#4FB8F0;left:80%;top:31%">&#8600;</span>
-      <div class="fb is-hero" data-flip="fb-ops" style="--c:#4FB8F0;left:86%;top:50%">
-        ops
-        <small>flat array · per tick</small>
-      </div>
-    </div>
-    <p class="lead arch-cap" data-mm-fade>
-      Updates leave as a <b style="color:#4FB8F0">flat ops buffer</b> — once per tick.
-    </p>
-    <aside class="notes">
-      <p><strong>The only thing that crosses the thread boundary is data.</strong> <code>[CREATE, id, tag, INSERT, parent, child, SET_PROP, id, key, value…]</code> — numbers and strings, no objects to marshal, no functions. Batched on Vue's own flush cycle, so one reactive tick = one send. And Vue's compiler helps for free: static content produces zero ops — only dynamic bindings travel.</p>
-    </aside>
-  </section>
-
-  <!-- A4 — interpreter + PAPI -->
-  <section class="slide stage">
-    <span class="eyebrow">IV · Runtime</span>
-    <div class="flow">
-      <div class="flane" data-flip="lane-bg" style="--c:#5dd5a8;top:4%;height:42%">
-        <span class="flane__label"><i></i>Background thread</span>
-      </div>
-      <div class="flane" data-flip="lane-mt" style="--c:#56b8f0;top:54%;height:42%">
-        <span class="flane__label"><i></i>Main (UI) thread</span>
-      </div>
-      <div class="fb" data-flip="fb-vue" style="--c:#42b883;left:23%;top:25%">
-        Vue 3 runtime · VDOM
-        <small>@vue/runtime-core · untouched</small>
-      </div>
-      <span class="farr" style="left:41.5%;top:25%">nodeOps &rarr;</span>
-      <div class="fb" data-flip="fb-shadow" style="--c:#E8B44A;left:62%;top:25%">
-        ShadowElement tree
-        <small>linked list · sync reads</small>
-      </div>
-      <span class="farr" style="--c:#4FB8F0;left:80%;top:31%">&#8600;</span>
-      <div class="fb" data-flip="fb-ops" style="--c:#4FB8F0;left:86%;top:50%">
-        ops
-        <small>flat array · per tick</small>
-      </div>
-      <span class="farr" data-mm-fade style="--c:#4FB8F0;left:80%;top:66%">&#8601;</span>
-      <div class="fb" data-flip="fb-interp" style="--c:#56b8f0;left:62%;top:75%">
-        ops interpreter
-        <small>a switch loop</small>
-      </div>
-      <span class="farr" data-mm-fade style="left:43%;top:75%">&larr; replay</span>
-      <div class="fb is-hero" data-flip="fb-papi" style="--c:#F27A9E;left:24%;top:75%">
+      <span class="farr" data-mm-fade style="--c:#F27A9E;left:38%;top:75%">Element PAPI →</span>
+      <div class="fb is-hero" data-flip="fb-papi" style="--c:#F27A9E;left:56%;top:75%;z-index:2">
         Element PAPI
-        <small>__CreateView · __SetAttribute · …</small>
+        <small>__CreateView · …</small>
       </div>
+      <span class="farr" data-mm-fade style="left:72%;top:75%">→</span>
+      <div class="fb fb--lite is-hero" data-flip="fb-native" style="--c:#d7dbe3;left:86%;top:75%;z-index:1">
+        Native UI
+      </div>
+      <span class="fcenter fcenter--warn" data-mm-fade style="left:50%;top:25%">too much on Main</span>
     </div>
     <p class="lead arch-cap" data-mm-fade>
-      The main thread <b style="color:#F27A9E">replays</b> them — native elements appear.
+      Vue <em>through</em> Element PAPI on Main — no.
     </p>
     <aside class="notes">
-      <p><strong>Here's Lynx's framework-agnostic seam, up close.</strong> The main thread runs a tiny interpreter — literally a switch loop — that replays ops against the <em>Element PAPI</em>: <code>__CreateView</code>, <code>__AppendElement</code>, <code>__SetAttribute</code>… That C-flavored API is the contract Lynx offers every framework; ReactLynx feeds it, we feed it, the next framework will too. VDOM → ShadowElement → ops → PAPI: four stops, one straight line.</p>
+      <p><strong>The naive wiring.</strong> Vue talks Element PAPI, Element PAPI mutates Native UI. Put that whole chain on Main and you've rebuilt the Web's single-thread trap on a native shell. Same dilemma, new costume.</p>
     </aside>
   </section>
 
-  <!-- A5 — events ride back -->
+  <!-- A2 — Vue moves to BG → ? -->
   <section class="slide stage">
     <span class="eyebrow">IV · Runtime</span>
     <div class="flow">
@@ -1811,128 +1767,176 @@ app.<span class="code-fn">use</span>(router)</pre>
       <div class="flane" data-flip="lane-mt" style="--c:#56b8f0;top:54%;height:42%">
         <span class="flane__label"><i></i>Main (UI) thread</span>
       </div>
-      <div class="fb" data-flip="fb-vue" style="--c:#42b883;left:23%;top:25%">
-        Vue 3 runtime · VDOM
-        <small>@vue/runtime-core · untouched</small>
+      <div class="fb is-hero" data-flip="fb-vue" style="--c:#42b883;left:28%;top:25%;z-index:3">
+        Vue 3 · VDOM
+        <small>@vue/runtime-core</small>
       </div>
-      <span class="farr" style="left:41.5%;top:25%">nodeOps &rarr;</span>
-      <div class="fb" data-flip="fb-shadow" style="--c:#E8B44A;left:62%;top:25%">
-        ShadowElement tree
-        <small>linked list · sync reads</small>
+      <div class="fb" data-flip="fb-papi" style="--c:#F27A9E;left:56%;top:75%;z-index:2">
+        Element PAPI
+        <small>__CreateView · …</small>
       </div>
-      <span class="farr" style="--c:#4FB8F0;left:80%;top:31%">&#8600;</span>
-      <div class="fb" data-flip="fb-ops" style="--c:#4FB8F0;left:86%;top:50%">
+      <span class="farr" style="left:72%;top:75%">→</span>
+      <div class="fb fb--lite" data-flip="fb-native" style="--c:#d7dbe3;left:86%;top:75%;z-index:1">
+        Native UI
+      </div>
+      <span class="fcenter fcenter--q" data-flip="fb-q" data-mm-fade style="left:50%;top:50%">?</span>
+    </div>
+    <p class="lead arch-cap" data-mm-fade>
+      Vue leaves. What bridges the threads?
+    </p>
+    <aside class="notes">
+      <p><strong>Move Vue up.</strong> The runtime — reactivity, VDOM, your handlers — belongs on the background thread. Native UI and Element PAPI stay on Main. The open question is the seam: Vue's renderer wants synchronous DOM reads; the real nodes are a thread away.</p>
+    </aside>
+  </section>
+
+  <!-- A3 — ShadowElement + ops → Element PAPI → Native UI (sequential) -->
+  <section class="slide stage">
+    <span class="eyebrow">IV · Runtime</span>
+    <div class="flow">
+      <div class="flane" data-flip="lane-bg" style="--c:#5dd5a8;top:4%;height:42%">
+        <span class="flane__label"><i></i>Background thread</span>
+      </div>
+      <div class="flane" data-flip="lane-mt" style="--c:#56b8f0;top:54%;height:42%">
+        <span class="flane__label"><i></i>Main (UI) thread</span>
+      </div>
+      <div class="fb" data-flip="fb-vue" style="--c:#42b883;left:16%;top:25%;z-index:3">
+        Vue 3 · VDOM
+        <small>@vue/runtime-core</small>
+      </div>
+      <span class="farr" data-mm-fade style="left:32%;top:25%">nodeOps →</span>
+      <div class="fb is-hero" data-flip="fb-shadow" style="--c:#E8B44A;left:50%;top:25%;z-index:3">
+        ShadowElement
+        <small>DOM stand-in · sync reads</small>
+      </div>
+      <span class="farr" data-mm-fade style="--c:#4FB8F0;left:66%;top:32%">↘</span>
+      <div class="fb is-hero" data-flip="fb-ops" style="--c:#4FB8F0;left:74%;top:50%;z-index:4">
         ops
         <small>flat array · per tick</small>
       </div>
-      <span class="farr" style="--c:#4FB8F0;left:80%;top:66%">&#8601;</span>
-      <div class="fb" data-flip="fb-interp" style="--c:#56b8f0;left:62%;top:75%">
-        ops interpreter
-        <small>a switch loop</small>
-      </div>
-      <span class="farr" style="left:43%;top:75%">&larr; replay</span>
-      <div class="fb" data-flip="fb-papi" style="--c:#F27A9E;left:24%;top:75%">
+      <span class="farr" data-mm-fade style="--c:#4FB8F0;left:66%;top:66%">↙</span>
+      <div class="fb is-hero" data-flip="fb-papi" style="--c:#F27A9E;left:50%;top:75%;z-index:2">
         Element PAPI
-        <small>__CreateView · __SetAttribute · …</small>
+        <small>__CreateView · …</small>
       </div>
-      <div class="fb is-hero" data-flip="fb-evt" style="--c:#3deae7;left:8%;top:50%">
+      <span class="farr" data-mm-fade style="left:68%;top:75%">→</span>
+      <div class="fb fb--lite is-hero" data-flip="fb-native" style="--c:#d7dbe3;left:86%;top:75%;z-index:1">
+        Native UI
+      </div>
+      <span class="fcenter fcenter--q is-gone" data-flip="fb-q" style="left:50%;top:50%;opacity:0">?</span>
+    </div>
+    <p class="lead arch-cap" data-mm-fade>
+      ShadowElement → <b style="color:#4FB8F0">ops</b> → Element PAPI → Native UI.
+    </p>
+    <aside class="notes">
+      <p><strong>The seam, named.</strong> <code>createRenderer()</code> keeps a ShadowElement linked-list on the background thread so every sync DOM read answers instantly. Mutations leave as a flat ops buffer — numbers and strings only — and Main replays them through Element PAPI into Native UI. No fork of Vue; one straight line across the boundary.</p>
+    </aside>
+  </section>
+
+  <!-- A4 — magic-move to ring + events = nextTick -->
+  <section class="slide stage">
+    <span class="eyebrow">IV · Runtime</span>
+    <div class="flow flow--ring">
+      <div class="flane" data-flip="lane-bg" style="--c:#5dd5a8;top:4%;height:42%">
+        <span class="flane__label"><i></i>Background thread</span>
+      </div>
+      <div class="flane" data-flip="lane-mt" style="--c:#56b8f0;top:54%;height:42%">
+        <span class="flane__label"><i></i>Main (UI) thread</span>
+      </div>
+      <div class="fb" data-flip="fb-vue" style="--c:#42b883;left:28%;top:22%;z-index:3">
+        Vue 3 · VDOM
+        <small>@vue/runtime-core</small>
+      </div>
+      <div class="fb" data-flip="fb-shadow" style="--c:#E8B44A;left:72%;top:22%;z-index:3">
+        ShadowElement
+        <small>DOM stand-in · sync reads</small>
+      </div>
+      <div class="fb" data-flip="fb-ops" style="--c:#4FB8F0;left:88%;top:50%;z-index:4">
+        ops
+        <small>flat array · per tick</small>
+      </div>
+      <div class="fb" data-flip="fb-papi" style="--c:#F27A9E;left:72%;top:78%;z-index:2">
+        Element PAPI
+        <small>__CreateView · …</small>
+      </div>
+      <div class="fb fb--lite" data-flip="fb-native" style="--c:#d7dbe3;left:28%;top:78%;z-index:1">
+        Native UI
+      </div>
+      <div class="fb is-hero" data-flip="fb-evt" data-mm-fade style="--c:#3deae7;left:12%;top:50%;z-index:3">
         events
-        <small>&uarr; by sign, not by function</small>
+        <small>↑ by sign</small>
       </div>
+      <span class="farr" data-mm-fade style="left:50%;top:22%">→</span>
+      <span class="farr" data-mm-fade style="--c:#4FB8F0;left:82%;top:34%">↘</span>
+      <span class="farr" data-mm-fade style="--c:#4FB8F0;left:82%;top:66%">↙</span>
+      <span class="farr" data-mm-fade style="left:50%;top:78%">←</span>
+      <span class="farr" data-mm-fade style="--c:#3deae7;left:18%;top:66%">↖</span>
+      <span class="farr" data-mm-fade style="--c:#3deae7;left:18%;top:34%">↗</span>
+      <span class="fcenter" data-mm-fade style="left:50%;top:50%">nextTick()</span>
     </div>
     <p class="lead arch-cap" data-mm-fade>
-      Events ride back <b style="color:#3deae7">up</b> — handlers never leave Vue.
+      One lap — a dual-thread <b class="brand-text">nextTick</b>.
     </p>
     <aside class="notes">
-      <p><strong>The return path closes the loop.</strong> Functions can't cross threads, so they never do: each handler registers under a numeric <em>sign</em>; the main thread dispatches the sign, the background thread looks it up and calls your Vue function right where it lives — closures, reactivity and all. That's why every Vue semantics survives: nothing that matters ever crossed.</p>
+      <p><strong>Close the loop.</strong> Ops go down; events ride back up by numeric sign — handlers never leave Vue. One full lap is one tick. So <code>onMounted(() =&gt; nextTick(() =&gt; lynx.createSelectorQuery()…))</code> is the same mental model as web Vue, stretched across threads. Almost nothing else leaks into app code.</p>
     </aside>
   </section>
 
-  <!-- A6 — one lap = nextTick -->
+  <!-- T1 — Testing pipeline coverage -->
   <section class="slide stage">
-    <span class="eyebrow">IV · Runtime</span>
-    <div class="flow">
-      <div class="flane" data-flip="lane-bg" style="--c:#5dd5a8;top:4%;height:42%">
-        <span class="flane__label"><i></i>Background thread</span>
+    <span class="eyebrow">IV · Runtime · proof</span>
+    <h2 class="h-section" style="text-align:center;max-width:10ch">Testing?</h2>
+    <div class="tpipe">
+      <div class="tpipe__axis">
+        <div class="tpipe__half" style="--c:#5dd5a8">
+          <span class="tpipe__lab">BG</span>
+          <span class="tpipe__node">Vue</span>
+          <span class="tpipe__node">ShadowElement</span>
+          <span class="tpipe__node">Ops</span>
+        </div>
+        <div class="tpipe__cut" aria-hidden="true"></div>
+        <div class="tpipe__half" style="--c:#56b8f0">
+          <span class="tpipe__lab">Main</span>
+          <span class="tpipe__node">PAPI</span>
+          <span class="tpipe__node">Engine</span>
+          <span class="tpipe__node">UI</span>
+        </div>
       </div>
-      <div class="flane" data-flip="lane-mt" style="--c:#56b8f0;top:54%;height:42%">
-        <span class="flane__label"><i></i>Main (UI) thread</span>
+      <div class="tpipe__bars">
+        <div class="tpipe__bar" style="--c:#F27A9E;--from:0;--to:34">
+          <span class="tpipe__bar-lab">vue runtime-core</span>
+          <span class="tpipe__bar-cap">upstream — for free</span>
+        </div>
+        <div class="tpipe__bar" style="--c:#F27A9E;--from:0;--to:58">
+          <span class="tpipe__bar-lab">vue runtime-dom</span>
+          <span class="tpipe__bar-cap">882 / 1013 · 0 fail</span>
+        </div>
+        <div class="tpipe__bar" style="--c:#5dd5a8;--from:18;--to:78">
+          <span class="tpipe__bar-lab">E2E pipeline</span>
+          <span class="tpipe__bar-cap">ops → PAPI → jsdom</span>
+        </div>
+        <div class="tpipe__bar" style="--c:#5dd5a8;--from:58;--to:100">
+          <span class="tpipe__bar-lab">Agentic</span>
+          <span class="tpipe__bar-cap">DevTool MCP · UI probe</span>
+        </div>
       </div>
-      <div class="fb is-dim" data-flip="fb-vue" style="--c:#42b883;left:23%;top:25%">
-        Vue 3 runtime · VDOM
-        <small>@vue/runtime-core · untouched</small>
-      </div>
-      <div class="fb is-dim" data-flip="fb-shadow" style="--c:#E8B44A;left:62%;top:25%">
-        ShadowElement tree
-        <small>linked list · sync reads</small>
-      </div>
-      <div class="fb is-dim" data-flip="fb-ops" style="--c:#4FB8F0;left:86%;top:50%">
-        ops
-        <small>flat array · per tick</small>
-      </div>
-      <div class="fb is-dim" data-flip="fb-interp" style="--c:#56b8f0;left:62%;top:75%">
-        ops interpreter
-        <small>a switch loop</small>
-      </div>
-      <div class="fb is-dim" data-flip="fb-papi" style="--c:#F27A9E;left:24%;top:75%">
-        Element PAPI
-        <small>__CreateView · __SetAttribute · …</small>
-      </div>
-      <div class="fb is-dim" data-flip="fb-evt" style="--c:#3deae7;left:8%;top:50%">
-        events
-        <small>&uarr; by sign, not by function</small>
-      </div>
-      <span class="fcenter" data-mm-fade style="left:50%;top:50%">one lap = <b>nextTick()</b></span>
     </div>
-    <p class="lead arch-cap" data-mm-fade>
-      The threading leaks into your code in exactly <em>one</em> place.
-    </p>
     <aside class="notes">
-      <p><strong>How much of this do users feel? Almost none.</strong> The one visible seam: native elements materialize a beat after mount, so "wait for the DOM" means <code>onMounted(() =&gt; nextTick(() =&gt; lynx.createSelectorQuery()…))</code> — the same <code>nextTick</code> mental model as web Vue, stretched across a thread. One lap of this diagram <em>is</em> one tick. Everything else — reactivity, lifecycle, composables — behaves exactly as on the web. (Docs: Understanding the Dual-Thread Model.)</p>
+      <p><strong>Two threads, four test spans.</strong> Upstream runtime-core covers Vue→ShadowElement for free. runtime-dom rewires the suite through our renderer into PAPI — 882/1013, zero failures. Our E2E bridge exercises ops across the thread cut; the agentic layer inspects the rendered UI via DevTool MCP. Most of the coverage was inherited.</p>
     </aside>
   </section>
 
-  <!-- A7 — upstream tests -->
+  <!-- T2 — tests as the AI's eyes -->
   <section class="slide stage">
     <span class="eyebrow">IV · Runtime · proof</span>
     <div class="mega"><span class="brand-text">882</span><small style="font-size:0.4em;color:var(--ink-mute)"> / 1013</small></div>
-    <p class="lead">Vue core's own tests, replayed on our renderer. <b>0 fail.</b></p>
-    <div class="skipbar">
-      <div class="skipbar__track">
-        <span class="skipbar__seg" style="flex:77;background:#8b93a3"></span>
-        <span class="skipbar__seg" style="flex:22;background:#4FB8F0"></span>
-        <span class="skipbar__seg" style="flex:20;background:#9E86F0"></span>
-        <span class="skipbar__seg" style="flex:12;background:#F27A9E"></span>
-      </div>
-      <div class="skipbar__legend">
-        <span><i style="background:#8b93a3"></i><b>77</b> private-import artifacts</span>
-        <span><i style="background:#4FB8F0"></i><b>22</b> v-model · Lynx elements</span>
-        <span><i style="background:#9E86F0"></i><b>20</b> SVG / Web Components</span>
-        <span><i style="background:#F27A9E"></i><b>12</b> Teleport · DOM-only</span>
-      </div>
-    </div>
-    <p class="lead" data-mm-fade style="font-size:clamp(14px,1.25cqw,18px)">
-      131 documented skips — every one a test-infra artifact or browser-only
-      semantic, <b class="brand-text">not a Lynx gap.</b>
-    </p>
-    <aside class="notes">
-      <p><strong>"Semantics preserved" is a measured claim.</strong> We vendored <code>vuejs/core</code>'s test suites and run them against Vue Lynx at two layers: an adapter backing <code>@vue/runtime-test</code> with our real ShadowElement linked-list (validates the full renderer contract — keyed diff, LIS, fragments, lifecycle), and a runtime-dom layer that pushes <code>patchProp → ops → applyOps → PAPI</code> into jsdom. 882 of 1013 pass, 131 documented skips, zero failures.</p>
-    </aside>
-  </section>
-
-  <!-- A8 — testing library, the AI's eyes -->
-  <section class="slide stage">
-    <span class="eyebrow">IV · Runtime · proof</span>
-    <h2 class="h-section" style="text-align:center;max-width:22ch">
-      …and the tests are the <span class="brand-text">AI's eyes</span>.
-    </h2>
+    <p class="lead">Upstream Vue tests on our renderer. <b>0 fail.</b></p>
     <div class="demo__meta" style="justify-content:center">
-      <span class="chip chip--brand">upstream suites</span>
       <span class="chip chip--brand">vue-lynx-testing-library</span>
       <span class="chip">render / fireEvent / getByText</span>
+      <span class="chip">the AI's eyes</span>
     </div>
     <aside class="notes">
-      <p><strong>The AI-harness side of testing.</strong> We also built <code>vue-lynx-testing-library</code> — <code>render</code>, <code>fireEvent</code>, <code>getByText</code>, dual-thread abstracted away via <code>@lynx-js/testing-environment</code> — so component behavior is assertable in plain vitest. For a human that's good hygiene; for the AI harness it's <em>perception</em>: red/green is how the agent knows what it just did. The upstream suite was the reward signal that kept two weeks of generated code honest.</p>
+      <p><strong>Proof, then perception.</strong> The upstream suite is the reward signal that kept two weeks of generated code honest. <code>vue-lynx-testing-library</code> abstracts the dual-thread away — for humans that's hygiene; for the agent harness it's eyes: red/green is how it knows what it just did.</p>
     </aside>
   </section>
 
@@ -2632,30 +2636,33 @@ app.<span class="code-fn">use</span>(router)</pre>
   </section>
 
 
-  <!-- H1 — the harness -->
+  <!-- H — the harness write-up (merged) -->
   <section class="slide stage">
     <span class="eyebrow">IV · The harness</span>
-    <div class="mega" style="font-size:clamp(52px,7.5cqw,120px)"><span class="brand-text">2</span> weeks.</div>
-    <div class="demo__meta" style="justify-content:center">
-      <span class="chip">160 commits</span>
-      <span class="chip">21 active days</span>
-      <span class="chip chip--brand">1 human + Claude</span>
+    <div class="writeup">
+      <div class="writeup__side">
+        <h2 class="h-section" style="text-align:left;max-width:16ch;margin:0">
+          &ldquo;How I <span class="brand-text">vibed</span> this in two weeks&rdquo;
+        </h2>
+        <div class="demo__meta" style="justify-content:flex-start;margin-top:1.6cqh">
+          <span class="chip">160 commits</span>
+          <span class="chip">21 active days</span>
+          <span class="chip chip--brand">1 human + Claude</span>
+        </div>
+        <div class="qr-solo qr-solo--sm" data-qr="https://x.com/Huxpro/status/2036993665965416601" aria-label="QR: the write-up on X"></div>
+      </div>
+      <div class="phone phone--embed no-deck-scroll writeup__embed" data-embed="browser"
+           data-w="min(52cqw, 640px)" data-h="min(52cqh, 420px)"
+           style="position:relative">
+        <div class="phone__inner">
+          <vl-media kind="iframe"
+                    src="https://x.com/Huxpro/status/2036993665965416601"
+                    label="x.com/Huxpro · write-up"></vl-media>
+        </div>
+      </div>
     </div>
     <aside class="notes">
-      <p><strong>Now the number makes sense.</strong> Everything in this chapter — renderer, toolchain, MTS — was built nights-and-weekends in two weeks: plans written as specs, an agent harness executing them, upstream tests as the reward signal, AGENTS.md encoding the debugging playbook. And a quiet takeaway for the room: Lynx turned out to be remarkably <em>AI-legible</em> — web-standard APIs and real CSS mean the model's web instincts mostly just transfer.</p>
-    </aside>
-  </section>
-
-  <!-- H2 — the write-up -->
-  <section class="slide stage">
-    <span class="eyebrow">IV · The harness</span>
-    <h2 class="h-section" style="text-align:center;max-width:22ch">
-      &ldquo;How I <span class="brand-text">vibed</span> this in two weeks&rdquo;
-    </h2>
-    <div class="qr-solo" data-qr="https://x.com/Huxpro/status/2036993665965416601" aria-label="QR: the write-up on X"></div>
-    <p class="lead">The full write-up — harness, prompts, receipts. <b>@Huxpro</b> on X.</p>
-    <aside class="notes">
-      <p><strong>Point the phones here.</strong> The complete methodology is written up on X — how the harness was structured, what the plans looked like, where the AI failed and how the tests caught it. It's also linked from the vue.lynxjs.org homepage badge. Then bridge out: "so that's how it was built — and here's what it adds up to."</p>
+      <p><strong>Now the number makes sense — and the phones can open it.</strong> Everything in this chapter was built nights-and-weekends in two weeks: plans as specs, an agent harness executing them, upstream tests as the reward signal. The full write-up is embedded and QR'd — harness structure, prompts, where the AI failed and how the tests caught it. Then bridge: "so that's how it was built — and here's what it adds up to."</p>
     </aside>
   </section>
 

--- a/slides/index.html
+++ b/slides/index.html
@@ -1677,15 +1677,18 @@ app.<span class="code-fn">use</span>(router)</pre>
   <!-- W1 — Web is single-threaded -->
   <section class="slide stage">
     <span class="eyebrow">IV · Runtime</span>
-    <div class="ifrtl" style="height:clamp(170px,30cqh,230px)">
-      <div class="ifrlane" data-flip="tl-main" style="--c:#56b8f0;top:22%;height:58%">
+    <div class="ifrtl">
+      <div class="ifrlane" data-flip="tl-main" style="--c:#56b8f0;top:6%;height:38%">
         <span class="ifrlane__label"><i></i>Main</span>
-        <div class="tblk tblk--evt" data-flip="tl-evt" style="left:7%;width:12%;top:58%">Event</div>
-        <div class="tblk tblk--js" data-flip="tl-js" style="left:21%;width:38%;top:58%">JavaScript</div>
-        <div class="tblk is-paint" data-flip="tl-paint" style="left:61%;width:14%;top:58%">Paint</div>
-        <div class="tframe" data-flip="tl-frame" style="left:77%">
+        <div class="tblk tblk--evt" data-flip="tl-evt" style="left:5%;width:11%;top:58%">Event</div>
+        <div class="tblk tblk--js" data-flip="tl-js" style="left:18%;width:36%;top:58%">JavaScript</div>
+        <div class="tblk is-paint" data-flip="tl-paint" style="left:56%;width:13%;top:58%">Paint</div>
+        <div class="tframe" data-flip="tl-frame" style="left:72%">
           <span class="tframe__label">Frame</span>
         </div>
+      </div>
+      <div class="ifrlane is-idle-lane" data-flip="tl-bg" style="--c:#5dd5a8;top:56%;height:38%;opacity:0">
+        <span class="ifrlane__label"><i></i>Background</span>
       </div>
     </div>
     <p class="lead arch-cap" data-mm-fade>
@@ -1703,13 +1706,13 @@ app.<span class="code-fn">use</span>(router)</pre>
       <div class="ifrlane" data-flip="tl-main" style="--c:#56b8f0;top:6%;height:38%">
         <span class="ifrlane__label"><i></i>Main</span>
         <div class="tblk tblk--evt" data-flip="tl-evt" style="left:5%;width:11%;top:58%">Event</div>
-        <div class="tblk tblk--ui" data-flip="tl-native" style="left:48%;width:16%;top:58%">Native UI</div>
+        <div class="tblk tblk--ui" data-mm-fade style="left:48%;width:16%;top:58%">Native UI</div>
         <div class="tblk is-paint" data-flip="tl-paint" style="left:66%;width:13%;top:58%">Paint</div>
         <div class="tframe" data-flip="tl-frame" style="left:40%">
           <span class="tframe__label">Frame</span>
         </div>
       </div>
-      <div class="ifrlane" data-flip="tl-bg" data-mm-fade style="--c:#5dd5a8;top:56%;height:38%">
+      <div class="ifrlane" data-flip="tl-bg" style="--c:#5dd5a8;top:56%;height:38%">
         <span class="ifrlane__label"><i></i>Background</span>
         <div class="tblk tblk--js" data-flip="tl-js" style="left:16%;width:30%;top:58%">JavaScript</div>
       </div>
@@ -2652,11 +2655,12 @@ app.<span class="code-fn">use</span>(router)</pre>
         <div class="qr-solo qr-solo--sm" data-qr="https://x.com/Huxpro/status/2036993665965416601" aria-label="QR: the write-up on X"></div>
       </div>
       <div class="phone phone--embed no-deck-scroll writeup__embed" data-embed="browser"
+           data-external="https://x.com/Huxpro/status/2036993665965416601"
            data-w="min(52cqw, 640px)" data-h="min(52cqh, 420px)"
            style="position:relative">
         <div class="phone__inner">
           <vl-media kind="iframe"
-                    src="https://x.com/Huxpro/status/2036993665965416601"
+                    src="https://platform.twitter.com/embed/Tweet.html?id=2036993665965416601"
                     label="x.com/Huxpro · write-up"></vl-media>
         </div>
       </div>

--- a/slides/src/embeds.js
+++ b/slides/src/embeds.js
@@ -148,6 +148,7 @@ export function initEmbeds({ getScale, reducedMotion = false, embed = false } = 
       corners: ['nw', 'ne', 'sw', 'se'],
       anchor: 'center',
       externalUrl: () =>
+        frame.dataset.external ||
         (media && (media.getAttribute('kind') === 'iframe' ||
           inferKind(media.getAttribute('src') || '') === 'iframe')
           ? media.getAttribute('src') : null),

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -221,23 +221,34 @@ export const ZH = {
   'IV · The harness': 'IV · Harness',
   'Background thread': '<i></i>后台线程',
   'Main (UI) thread': '<i></i>主(UI)线程',
-  'Vue runs whole — on the background thread.':
-    'Vue <em>整个</em>跑在后台线程上。',
-  'createRenderer() — a renderer, not a fork.':
-    '<code>createRenderer()</code> —— 写一个渲染器,而不是 fork 一个 Vue。',
-  'Updates leave as a flat ops buffer — once per tick.':
-    '更新以<b style="color:#4FB8F0">扁平 ops 缓冲</b>的形式离开 —— 每个 tick 一次。',
-  'The main thread replays them — native elements appear.':
-    '主线程把它们<b style="color:#F27A9E">重放</b>出来 —— 原生元素出现。',
-  'Events ride back up — handlers never leave Vue.':
-    '事件坐车<b style="color:#3deae7">回来</b> —— 回调从未离开过 Vue。',
-  'The threading leaks into your code in exactly one place.':
-    '双线程漏进你代码里的,只有<em>一个</em>地方。',
-  'one lap = nextTick()': '绕一圈 = <b>nextTick()</b>',
-  "Vue core's own tests, replayed on our renderer. 0 fail.":
-    'Vue core 自己的测试,在我们的渲染器上重放。<b>0 失败。</b>',
-  "…and the tests are the AI's eyes.":
-    '……而这些测试,就是 <span class="brand-text">AI 的眼睛</span>。',
+  'Main': '<i></i>Main',
+  'Background': '<i></i>Background',
+  'The Web is one thread.':
+    'Web 是<em>一条</em>线程。',
+  'Native UI owns Main — so JS must leave.':
+    'Native UI 占着 Main —— 所以 JS <em>必须</em>离开。',
+  'Vue through Element PAPI on Main — no.':
+    'Vue <em>经</em> Element PAPI 全压在 Main 上 —— 不行。',
+  'too much on Main': 'Main 装不下',
+  'Vue leaves. What bridges the threads?':
+    'Vue 离开了。谁来桥接双线程?',
+  'ShadowElement → ops → Element PAPI → Native UI.':
+    'ShadowElement → <b style="color:#4FB8F0">ops</b> → Element PAPI → Native UI。',
+  'One lap — a dual-thread nextTick.':
+    '绕一圈 —— 跨双线程的 <b class="brand-text">nextTick</b>。',
+  'nextTick()': 'nextTick()',
+  'Testing?': '测试?',
+  'Upstream Vue tests on our renderer. 0 fail.':
+    '上游 Vue 测试,在我们的渲染器上跑。<b>0 失败。</b>',
+  "the AI's eyes": 'AI 的眼睛',
+  'vue runtime-core': 'vue runtime-core',
+  'vue runtime-dom': 'vue runtime-dom',
+  'E2E pipeline': 'E2E 管线',
+  'Agentic': 'Agentic',
+  'upstream — for free': '上游 —— 白送',
+  '882 / 1013 · 0 fail': '882 / 1013 · 0 失败',
+  'ops → PAPI → jsdom': 'ops → PAPI → jsdom',
+  'DevTool MCP · UI probe': 'DevTool MCP · UI 探针',
 
   // ---- IV · Instant First-Frame Rendering + Element Templates ----
   'IV · Instant first frame': 'IV · 首屏直出',
@@ -689,22 +700,22 @@ export const ZH_NOTES = [
   `<p><strong>移动端最难的布局,靠组合做出来。</strong>折叠头部 + 吸顶 tab + 横向翻页 + 每个 pane 各自纵向滚动 —— Twitter/X 的 profile。Web 上这是重型库(react-native-collapsible-tab-view、Android 的 CoordinatorLayout)在和主线程搏斗;这里是一次原生元件的组合,跑在平台自己的滚动线程上。</p><p><strong>Native UX ← Web DX。</strong>Lynx 把原生构件暴露成元件:<code>&lt;scroll-coordinator&gt;</code>(声明式的嵌套滚动交接:先折叠头部,再把滚动交给当前 pane 的列表,零 JS 滚动监听)、抽取出的 <code>&lt;viewpager&gt;</code>(原生吸附翻页 + 每个 pane 状态保留)、以及每个 pane 一个复用型 <code>&lt;list&gt;</code>。我们在一个 Vue SFC 里把它们组合起来。唯一的平台接缝就是标签名(Lynx for Web 的 <code>x-foldview-ng</code>/<code>x-viewpager-ng</code> ↔ 原生的 <code>scroll-coordinator</code>/<code>viewpager</code>)。</p><p><strong>一套代码,两个目标:</strong>同一个 SFC 既渲染真正的原生 profile,又渲染文档站里的 Lynx-for-Web 预览。tab 栏与翻页器通过原生 <code>selectTab</code>/<code>change</code> 方法双向同步,而非合成 DOM 事件。</p>`,
   // 35 Divider IV · How we did it
   `<p><strong>工程章。</strong>刚才看到的一切,是一个人两周做出来的 —— 这一章诚实回答"怎么做到的"。三次适配,每一次都揭开 Lynx 架构的一角:把 Vue 拆上双线程而不破坏语义;让一条工具链吐出两个世界;再让主线程本身可编程。AI harness 贯穿全程。</p>`,
-  // 36 A1 · Vue 落在后台线程
-  `<p><strong>第一个决定:Vue 住哪条线程?</strong>早期社区实验把 Vue 放在主线程 —— 于是每个事件都要跨线程转发。而 Lynx 原生就把事件送到后台线程,所以我们把整个运行时放在这里:响应式、diff、生命周期、你的回调。不是 fork —— 是原封不动的 <code>@vue/runtime-core</code>。</p>`,
-  // 37 A2 · ShadowElement
-  `<p><strong>Vue 官方的自定义渲染器 API 就是全部诀窍。</strong><code>createRenderer()</code> 要求同步的节点 —— <code>parentNode()</code>、<code>nextSibling()</code> 必须立刻有答案,但真实元素在另一条线程上。所以 nodeOps 双写:在后台线程维护一棵轻量 <em>ShadowElement</em> 链表(满足 Vue 的所有同步读取),同时把真正的工作排进队列。和 ReactLynx 的 snapshot instance 是同一个 pattern。</p>`,
-  // 38 A3 · ops 缓冲
-  `<p><strong>唯一跨过线程边界的,是数据。</strong><code>[CREATE, id, tag, INSERT, parent, child, SET_PROP, id, key, value…]</code> —— 只有数字和字符串,没有对象要序列化,没有函数。按 Vue 自己的 flush 周期批处理:一个响应式 tick = 一次发送。Vue 编译器还白送一层:静态内容零 ops,只有动态绑定在路上跑。</p>`,
-  // 39 A4 · 解释器 + PAPI
-  `<p><strong>这里就是 Lynx 框架无关的那条缝,凑近看。</strong>主线程跑一个小解释器 —— 字面意义上的 switch 循环 —— 把 ops 重放到 <em>Element PAPI</em> 上:<code>__CreateView</code>、<code>__AppendElement</code>、<code>__SetAttribute</code>……这套 C 风格 API 是 Lynx 给每个框架的合同;ReactLynx 在喂它,我们在喂它,下一个框架也会。VDOM → ShadowElement → ops → PAPI:四站,一条直线。</p>`,
-  // 40 A5 · 事件回程
-  `<p><strong>回程闭环。</strong>函数不能跨线程,所以它们从来不跨:每个回调注册一个数字 <em>sign</em>;主线程派发 sign,后台线程查表,就地调用你的 Vue 函数 —— 闭包、响应式,全都还在原地。这就是 Vue 语义得以保全的原因:真正要紧的东西从来没离开过。</p>`,
-  // 41 A6 · nextTick
-  `<p><strong>用户能感觉到多少?几乎为零。</strong>唯一可见的接缝:原生元素在 mount 之后一拍才落地,所以"等 DOM"写成 <code>onMounted(() =&gt; nextTick(() =&gt; lynx.createSelectorQuery()…))</code> —— 和 Web Vue 同一个 <code>nextTick</code> 心智模型,只是跨了一条线程。这张图绕一圈,<em>就是</em>一个 tick。其余一切 —— 响应式、生命周期、组合式函数 —— 行为和 Web 完全一致。(文档:Understanding the Dual-Thread Model。)</p>`,
-  // 42 A7 · 上游测试
-  `<p><strong>"语义保全"是可测量的命题。</strong>我们把 <code>vuejs/core</code> 的测试套件搬进仓库,在两层上对着 Vue Lynx 跑:一层用我们真实的 ShadowElement 链表垫在 <code>@vue/runtime-test</code> 下面(验证完整渲染器合同 —— keyed diff、LIS、fragment、生命周期);另一层 runtime-dom 把 <code>patchProp → ops → applyOps → PAPI</code> 推进 jsdom。1013 个通过 882,131 个 skip 全部有记录,零失败。</p>`,
-  // 43 A8 · 测试是 AI 的眼睛
-  `<p><strong>测试的 AI-harness 一面。</strong>我们还做了 <code>vue-lynx-testing-library</code> —— <code>render</code>、<code>fireEvent</code>、<code>getByText</code>,双线程被 <code>@lynx-js/testing-environment</code> 抽象掉 —— 组件行为在普通 vitest 里就能断言。对人来说这是卫生习惯;对 AI harness 来说这是<em>感知</em>:红绿就是 agent 知道自己刚才做了什么的方式。上游套件,就是让两周生成代码保持诚实的 reward signal。</p>`,
+  // W1 · Web 单线程
+  `<p><strong>从大家已经熟悉的图开始。</strong>浏览器的一帧就是一条 Main:事件进来、JavaScript 跑、Paint 出去。先把这张图立住,再把它拆开。</p>`,
+  // W2 · Native UI 占 Main
+  `<p><strong>跨端的困境。</strong>Native UI 已经住在主线程上了。框架也挤上去,帧预算就死。所以认真的原生栈都会把 JS 拉到后台 —— 事件下行,UI 更新往往下一帧才回来。Lynx 做的是同一刀。</p>`,
+  // A1 · 全压在 Main 不行
+  `<p><strong>天真接法。</strong>Vue 调 Element PAPI,Element PAPI 改 Native UI。整条链都放 Main,等于在原生壳子上重演 Web 的单线程陷阱。</p>`,
+  // A2 · Vue 上移 + ?
+  `<p><strong>把 Vue 挪上去。</strong>运行时 —— 响应式、VDOM、你的回调 —— 属于后台线程。Native UI 和 Element PAPI 留在 Main。真正的问题是那条缝:Vue 的渲染器要同步 DOM 读,真实节点却在另一条线程。</p>`,
+  // A3 · ShadowElement + ops
+  `<p><strong>给这条缝起名。</strong><code>createRenderer()</code> 在后台维护 ShadowElement 链表,同步 DOM 读立刻有答案;变更以扁平 ops 缓冲离开 —— 只有数字和字符串 —— Main 经 Element PAPI 重放到 Native UI。不是 fork Vue;跨边界一条直线。</p>`,
+  // A4 · nextTick 环
+  `<p><strong>闭环。</strong>ops 下行;事件按数字 sign 回程 —— 回调从不离开 Vue。绕一圈就是一个 tick。所以 <code>onMounted(() =&gt; nextTick(() =&gt; lynx.createSelectorQuery()…))</code> 和 Web Vue 是同一个心智模型,只是跨了线程。几乎没有别的东西漏进业务代码。</p>`,
+  // T1 · Testing 管线
+  `<p><strong>两条线程,四段覆盖。</strong>上游 runtime-core 白送 Vue→ShadowElement;runtime-dom 把套件经我们的渲染器接到 PAPI —— 882/1013,零失败。我们的 E2E 桥接跨过线程切面;Agentic 层用 DevTool MCP 看最终 UI。大部分覆盖是继承来的。</p>`,
+  // T2 · AI 的眼睛
+  `<p><strong>实证,然后是感知。</strong>上游套件是让两周生成代码保持诚实的 reward signal。<code>vue-lynx-testing-library</code> 把双线程抽象掉 —— 对人是卫生习惯,对 agent harness 是眼睛:红绿就是它知道自己刚才做了什么。</p>`,
   // IFR1 · 空白首帧
   `<p><strong>往返的代价。</strong>前六页讲的 VDOM → ShadowElement → ops → PAPI,在第一帧之前必须先整整跑一圈。设备上,这一圈再加后台线程启动与 bundle 求值,就是几十毫秒的白屏。</p>`,
   // IFR2 · IFR:先出画面
@@ -763,10 +774,8 @@ export const ZH_NOTES = [
   `<p>Lynx 从 ReactLynx 起步,但平台被刻意演进为框架无关 —— 前端层是真正的扩展点,不是 React 的附属功能。这不是宣传话术;马上给你看实证。</p>`,
   // 62 Web DX Native UX
   `<p><strong>一句话论点。</strong>Lynx 给你 Web 的开发体验、Native 的用户体验。而因为前端那条缝是开的 —— 这就是 Vue 的机会。于是……</p>`,
-  // 63 H1 · 2 weeks
-  `<p><strong>现在这个数字说得通了。</strong>这一章的一切 —— 渲染器、工具链、MTS —— 是两周的夜晚和周末做出来的:plan 写成 spec,agent harness 执行,上游测试当 reward signal,AGENTS.md 固化调试手册。给在座各位一个安静的结论:Lynx 出乎意料地 <em>AI 可读</em> —— Web 标准的 API 和真 CSS,意味着模型的 Web 直觉基本直接迁移。</p>`,
-  // 64 H2 · X 复盘
-  `<p><strong>让观众把手机对准这页。</strong>完整方法论写在 X 上 —— harness 怎么搭、plan 长什么样、AI 在哪儿失手、测试怎么接住的。vue.lynxjs.org 首页的 badge 也链着它。然后收束:"这就是它怎么被做出来的 —— 接下来看看它加起来意味着什么。"</p>`,
+  // H · harness write-up (merged)
+  `<p><strong>现在这个数字说得通了 —— 手机也能直接打开。</strong>这一章的一切是两周的夜晚和周末:plan 写成 spec,agent harness 执行,上游测试当 reward signal。完整复盘嵌在页里,也留了二维码 —— harness 结构、prompt、AI 失手处、测试怎么接住。然后收束:"这就是它怎么被做出来的 —— 接下来看看它加起来意味着什么。"</p>`,
   // 65 Combine
   `<p><strong>标题句。</strong>Vue × Lynx = Vue 跑在原生上。停顿,让等式落地。然后:"也很希望大家来一起把它做成。"</p>`,
   // 66 Divider V · close

--- a/slides/src/main.js
+++ b/slides/src/main.js
@@ -613,6 +613,7 @@ const I18N_SELECTOR = [
   '.flane__label', '.ifrlane__label', '.fcenter', '.lgtag',
   '.demo__caption', '.videopair figcaption',
   '.tile', '.wlab', '.wattr', '.wg b',
+  '.tpipe__bar-lab', '.tpipe__bar-cap', '.tpipe__lab',
 ].map((s) => `.slide ${s}`).join(', ') + ', .gate-legend span';
 
 let i18nEls = [];

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -2097,6 +2097,8 @@ body.is-blackout::after {
 }
 .fb.is-dim { opacity: 0.45; }
 .fb.is-hero { box-shadow: 0 0 22px -4px var(--c, #5dd5a8); }
+.fb.fb--lite { color: #111; }
+.fb.fb--lite small { color: rgba(17, 17, 17, 0.62); }
 
 /* Text arrow / inline flow label — mono, colorable, fades in. */
 .farr {
@@ -3369,6 +3371,177 @@ vl-media.snap.is-missing .vl-ph__kind { color: rgba(15, 18, 22, 0.65); }
   border: 1px dashed var(--line);
   background: transparent;
   color: var(--ink-faint);
+}
+.tblk--evt {
+  --c: #e8eaed;
+  color: #111;
+  font-weight: 600;
+}
+.tblk--js {
+  --c: #E8B44A;
+  color: color-mix(in srgb, #E8B44A 20%, #111);
+  font-weight: 600;
+}
+.tblk--ui {
+  --c: #e8eaed;
+  color: #111;
+  font-weight: 600;
+}
+.tframe {
+  position: absolute;
+  top: 18%;
+  bottom: 10%;
+  width: 2px;
+  background: #F27A9E;
+  transform: translateX(-50%);
+  z-index: 2;
+  pointer-events: none;
+}
+.tframe__label {
+  position: absolute;
+  top: -2px;
+  left: 8px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  color: #F27A9E;
+  white-space: nowrap;
+}
+.tl-arr {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  font-family: var(--mono);
+  font-size: 18px;
+  color: var(--ink-soft);
+  z-index: 3;
+}
+
+/* Runtime ring + warn/question center labels */
+.flow--ring { height: clamp(320px, 54cqh, 420px); }
+.fcenter--warn { color: #F27A9E; font-size: clamp(16px, 1.7cqw, 22px); }
+.fcenter--q {
+  font-family: var(--display);
+  font-size: clamp(52px, 7cqw, 84px);
+  font-weight: 700;
+  color: var(--ink-mute);
+  letter-spacing: -0.04em;
+}
+.fcenter--q.is-gone { pointer-events: none; }
+
+/* Testing pipeline coverage */
+.tpipe {
+  width: min(100%, 980px);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(14px, 2.2cqh, 22px);
+  margin-top: 1cqh;
+}
+.tpipe__axis {
+  display: grid;
+  grid-template-columns: 1fr 14px 1fr;
+  align-items: stretch;
+  gap: 0;
+}
+.tpipe__half {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid color-mix(in srgb, var(--c) 28%, transparent);
+  background: color-mix(in srgb, var(--c) 7%, transparent);
+}
+.tpipe__lab {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--c) 75%, var(--ink));
+  margin-right: 4px;
+  flex: none;
+}
+.tpipe__node {
+  flex: 1;
+  text-align: center;
+  padding: 8px 6px;
+  border-radius: 8px;
+  border: 1.3px solid color-mix(in srgb, var(--c) 45%, transparent);
+  background: color-mix(in srgb, var(--c) 12%, var(--paper));
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: clamp(12px, 1.2cqw, 15px);
+  color: var(--ink);
+  white-space: nowrap;
+}
+.tpipe__cut {
+  width: 2px;
+  margin: 6px auto;
+  border-radius: 2px;
+  background: repeating-linear-gradient(
+    to bottom,
+    var(--ink-mute) 0 5px,
+    transparent 5px 10px
+  );
+}
+.tpipe__bars {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  padding: 0 4px;
+}
+.tpipe__bar {
+  --from: 0;
+  --to: 100;
+  position: relative;
+  height: 28px;
+  margin-left: calc(var(--from) * 1%);
+  width: calc((var(--to) - var(--from)) * 1%);
+  border-radius: 7px;
+  background: color-mix(in srgb, var(--c) 55%, transparent);
+  border: 1px solid color-mix(in srgb, var(--c) 70%, transparent);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 12px;
+  gap: 10px;
+}
+.tpipe__bar-lab {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--ink);
+  white-space: nowrap;
+}
+.tpipe__bar-cap {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: color-mix(in srgb, var(--ink) 70%, transparent);
+  white-space: nowrap;
+}
+
+/* Harness write-up: copy + live iframe + small QR */
+.writeup {
+  width: min(100%, 1100px);
+  display: grid;
+  grid-template-columns: minmax(0, 0.92fr) minmax(0, 1.15fr);
+  gap: clamp(18px, 2.4cqw, 36px);
+  align-items: center;
+}
+.writeup__side {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1.2cqh;
+}
+.writeup__embed {
+  justify-self: end;
+}
+.qr-solo--sm {
+  width: clamp(72px, 8.5cqw, 96px);
+  height: clamp(72px, 8.5cqw, 96px);
+  padding: 8px;
+  border-radius: 12px;
+  margin-top: 1.2cqh;
 }
 
 /* ---- hydration reconcile (3-way) ---- */

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -3415,6 +3415,9 @@ vl-media.snap.is-missing .vl-ph__kind { color: rgba(15, 18, 22, 0.65); }
   color: var(--ink-soft);
   z-index: 3;
 }
+.ifrlane.is-idle-lane {
+  pointer-events: none;
+}
 
 /* Runtime ring + warn/question center labels */
 .flow--ring { height: clamp(320px, 54cqh, 420px); }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Reorder the “how we did it” runtime chapter around the new talk spine:

1. **Web is single-threaded** — Event → JavaScript → Paint timeline
2. **Native UI owns Main** — dual-thread dilemma (JS must leave)
3. **Vue → Element PAPI → Native UI on Main** — fails
4. **Vue moves to BG** — open `?` seam
5. **ShadowElement → ops → Element PAPI → Native UI** — sequential pipeline (no interpreter block)
6. **Magic-move ring + events = `nextTick()`**

Also collapses testing to two visual slides (pipeline coverage + 882 proof), and merges the harness write-up into one slide with a Twitter platform embed of the X write-up plus a smaller QR (↗ opens the real status URL).

**Verify:** `pnpm build` green. `pnpm test:morph` — new W1→W2 timeline flips are clean; remaining FAIL pair is pre-existing embed morph (`em-02a` / `em-02b`).

Base: `vueconf-2026`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c761d113-4777-4fc3-a746-840607549838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c761d113-4777-4fc3-a746-840607549838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

