### PR TITLE
fix(website): restore quick-start by adding missing go-web i18n keys

### DIFF
--- a/website/i18n.json
+++ b/website/i18n.json
@@ -54,5 +54,25 @@
   "go.deeplink.or": {
     "en": "or",
     "zh": "或"
+  },
+  "go.openin": {
+    "en": "Open",
+    "zh": "打开"
+  },
+  "go.openin.show-qrcode": {
+    "en": "Show QR Code",
+    "zh": "显示二维码"
+  },
+  "go.ultra": {
+    "en": "Open frameless",
+    "zh": "无边框打开"
+  },
+  "go.ultra.exit": {
+    "en": "Exit frameless",
+    "zh": "退出无边框"
+  },
+  "go.refresh": {
+    "en": "Refresh",
+    "zh": "刷新"
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`/guide/quick-start` was blank-screening with:

```
Uncaught Error: i18n key 'go.refresh' not found for language 'en'
```

Root cause: `@lynx-js/go-web` was bumped to `^0.7.0` (refresh control + frameless ultra mode) without updating `website/i18n.json`. Rspress `useI18n` throws on missing keys, so the `<Go>` embed crashes the whole page.

## Fix

Add the missing keys introduced by go-web 0.7.0:

- `go.refresh`
- `go.ultra` / `go.ultra.exit`
- `go.openin` / `go.openin.show-qrcode`

## Test plan

- [ ] Open `/guide/quick-start` — page renders (not white screen)
- [ ] Confirm `<Go>` hello-world preview loads
- [ ] Confirm `/zh/guide/quick-start` also renders
- [ ] Console has no `i18n key ... not found` errors

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2dd18ed8-8a77-4a23-89b7-b05991bf4977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2dd18ed8-8a77-4a23-89b7-b05991bf4977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

