### PR TITLE
feat(slides): global localhost serve-sim overlay via command palette

### DIFF
--- a/slides/AGENTS.md
+++ b/slides/AGENTS.md
@@ -82,7 +82,10 @@ deterministic (seeded `rnd(i, salt)`, never `Math.random`).
   (`⌘K` / `/`). Never add global keydown shortcuts.
 - Demos only get the keyboard after a **deliberate click inside** them;
   autofocus grabs are blurred (`demoEngaged` in `main.js`). Scroll/swipe
-  inside `.phone` / `.no-deck-scroll` never advances the deck.
+  inside `.phone` / `.no-deck-scroll` / `.sim-float` never advances the deck.
+- **Local simulator** (`src/sim-overlay.js`): optional localhost-only floating
+  serve-sim frame, toggled from the palette (`m`). Do not wire it into
+  individual slides — keep cloud-hosted decks free of simulator coupling.
 
 ## Verify
 

--- a/slides/README.md
+++ b/slides/README.md
@@ -15,23 +15,21 @@ pnpm dev
 Vite serves example bundles via a symlink to `../website/docs/public/examples`.
 Run `cd ../website && pnpm prepare:docs` once if those bundles are missing.
 
-### Local iOS Simulator (`serve-sim`)
+### Local iOS Simulator (`serve-sim`) — optional, localhost only
 
-The Vite dev server mounts [serve-sim](https://github.com/EvanBacon/serve-sim)
-middleware at **`/.sim`**, so the deck can stream a booted Apple Simulator into
-the browser (used by the duplicated `ref()` slide — Web `<lynx-view>` beside
-the native sim).
+For live presenting on your Mac, the Vite **dev** server mounts
+[serve-sim](https://github.com/EvanBacon/serve-sim) at **`/.sim`**. A floating,
+draggable simulator frame can sit above any slide — toggle it from the command
+palette (`⌘K` / `/` → **`m`**). The palette entry and overlay only appear on
+**localhost** / `127.0.0.1`, so cloud-hosted decks (examples, Vercel previews)
+are unaffected. Production builds never include the middleware.
 
 ```bash
 # macOS + Xcode, with a simulator already booted (e.g. Lynx Explorer):
-npx serve-sim --detach
-cd slides && pnpm dev
-# preview UI: http://localhost:4321/.sim
+cd slides
+pnpm sim          # or: npx serve-sim --detach
+pnpm dev          # http://localhost:4321  ·  /.sim ·  palette → m
 ```
-
-`proxyHelpers` stays off so Vite's HMR WebSocket is untouched; the helper's
-own loopback ports serve the stream (CORS is open). Production / Vercel builds
-do not include the middleware — the slide's iframe is for local presenting.
 
 ## Navigation
 
@@ -58,6 +56,7 @@ Inside the palette (`⌘K` search or `/` then the key):
 | `]` | Last slide          | `d` | DevTool panel            |
 | `s` | Open speaker view   | `f` | Toggle fullscreen        |
 | `o` | Overview grid       | `b` | Blackout audience screen |
+| `m` | Simulator overlay   |     | *(localhost only)*       |
 
 Jump to any slide by title from the palette's **Slides** section (type to
 filter, `↑`/`↓` or `←`/`→` to move, `Enter` to go).

--- a/slides/index.html
+++ b/slides/index.html
@@ -24,7 +24,7 @@
     </button>
   </div>
   <div class="chrome chrome--bottom">
-    <span data-counter>01 / 124</span>
+    <span data-counter>01 / 123</span>
   </div>
   <div class="chrome chrome--bottom-right">
     <a href="https://vue.lynxjs.org" target="_blank" rel="noreferrer">vue.lynxjs.org</a>
@@ -376,51 +376,6 @@
        II · Vue API coverage — one feature per slide
        ordered by vue-lynx release version
        ==================================================== -->
-  
-
-  <!-- First <lynx-view> demo (ref / hello-world) + local iOS Simulator via
-       serve-sim (Vite mounts /.sim in `pnpm dev`). -->
-  <section class="slide demo demo--api demo--sim">
-    <div class="demo__body">
-      <div class="demo__title-row">
-        <h2 class="demo__title"><code class="brand-text">ref()</code> <span class="demo__title-sub">· live sim</span></h2>
-        <span class="ver-badge">serve-sim</span>
-      </div>
-      <div class="codeframe">
-        <div class="codeframe__head">
-          <span class="dots"><span></span><span></span><span></span></span>
-          <span>App.vue</span>
-        </div>
-<pre><span class="code-tag">&lt;script setup&gt;</span>
-<span class="code-key">import</span> { ref } <span class="code-key">from</span> <span class="code-str">'vue-lynx'</span>
-<span class="code-key">const</span> { y, jump } <span class="code-key">=</span> <span class="code-fn">useFlappy</span>()  <span class="code-com">// ref(0) inside</span>
-<span class="code-tag">&lt;/script&gt;</span>
-
-<span class="code-tag">&lt;template&gt;</span>
-  <span class="code-tag">&lt;view</span> <span class="code-attr">@tap</span>=<span class="code-str">"jump"</span><span class="code-tag">&gt;</span>
-    <span class="code-tag">&lt;image</span> <span class="code-attr">:style</span>=<span class="code-str">"{ transform:
-      `translateY(${y}px)` }"</span> <span class="code-tag">/&gt;</span>
-  <span class="code-tag">&lt;/view&gt;</span>
-<span class="code-tag">&lt;/template&gt;</span></pre>
-      </div>
-    </div>
-    <div class="demo__stage demo__stage--pair">
-      <div class="phone" data-caption="Web · lynx-view">
-        <div class="phone__inner">
-          <vl-demo bundle="hello-world/dist/main.web.bundle"></vl-demo>
-        </div>
-      </div>
-      <div class="phone no-deck-scroll" data-caption="Native · serve-sim">
-        <div class="phone__inner">
-          <vl-media kind="iframe" src="/.sim" label="/.sim · local iOS Simulator (serve-sim)"></vl-media>
-        </div>
-      </div>
-    </div>
-    <aside class="notes">
-      <p><strong>Start at the beginning — with the real simulator beside it.</strong> <code>ref()</code>, an event handler, a style binding. Left is Lynx for Web (<code>&lt;lynx-view&gt;</code>); right is the local iOS Simulator streamed through <a href="https://github.com/EvanBacon/serve-sim">serve-sim</a> at <code>/.sim</code>.</p>
-      <p><strong>Before the talk:</strong> boot a sim + Lynx Explorer with the hello-world bundle, then <code>npx serve-sim --detach</code>. The Vite deck mounts the preview middleware automatically.</p>
-    </aside>
-  </section>
 
   <section class="slide demo demo--api">
     <div class="demo__body">

--- a/slides/src/framework/command.js
+++ b/slides/src/framework/command.js
@@ -11,6 +11,7 @@ export function initCommand(api, { devtool } = {}) {
   if (api.embed()) return null;
 
   // Action = { section, key, label, icon, run }. `label` may be a function.
+  // Localhost-only presenter tools (serve-sim overlay) are appended when available.
   const ACTIONS = [
     { section: 'Navigate', key: 'n', label: 'Next slide', icon: 'arrowRight', run: api.next },
     { section: 'Navigate', key: 'p', label: 'Previous slide', icon: 'arrowLeft', run: api.prev },
@@ -30,6 +31,17 @@ export function initCommand(api, { devtool } = {}) {
 
   const resolveLabel = (a) => (typeof a.label === 'function' ? a.label() : a.label);
 
+  function localActions() {
+    if (!api.simAvailable?.()) return [];
+    return [{
+      section: 'Presenter',
+      key: 'm',
+      label: () => `Simulator: ${api.simOpen?.() ? 'on' : 'off'}`,
+      icon: 'smartphone',
+      run: () => api.toggleSim?.(),
+    }];
+  }
+
   function slideActions() {
     return api.meta().map((m, i) => ({
       section: 'Slides',
@@ -45,8 +57,19 @@ export function initCommand(api, { devtool } = {}) {
   let items = [];
   let selected = 0;
 
+  function allActions() {
+    // Insert localhost simulator next to other Presenter actions.
+    const base = [...ACTIONS];
+    const locals = localActions();
+    if (locals.length) {
+      const i = base.findIndex((a) => a.section === 'Settings');
+      base.splice(i === -1 ? base.length : i, 0, ...locals);
+    }
+    return [...base, ...slideActions()];
+  }
+
   function visibleActions() {
-    const all = [...ACTIONS, ...slideActions()];
+    const all = allActions();
     if (!query) return all;
     const q = query.toLowerCase();
     return all.filter((a) => resolveLabel(a).toLowerCase().includes(q));
@@ -177,7 +200,7 @@ export function initCommand(api, { devtool } = {}) {
     if (slash) {
       if (e.key === 'Backspace') { e.preventDefault(); setSlash(false); return; }
       if (e.key.length === 1) {
-        const a = ACTIONS.find((x) => x.key === e.key.toLowerCase());
+        const a = allActions().find((x) => x.key === e.key.toLowerCase());
         if (a) { e.preventDefault(); run(a); }
       }
       return;

--- a/slides/src/framework/framework.css
+++ b/slides/src/framework/framework.css
@@ -240,6 +240,134 @@
 .sys-ic { display: inline-flex; width: 16px; height: 16px; }
 .sys-ic svg { width: 100%; height: 100%; display: block; }
 
+/* =========================================================
+   Local Simulator float (serve-sim) — viewport-fixed, above
+   the scaled stage, below the command palette. localhost only.
+   ========================================================= */
+.sim-float {
+  position: fixed;
+  z-index: 1500;
+  display: flex;
+  flex-direction: column;
+  min-width: 200px;
+  min-height: 320px;
+  border-radius: 18px;
+  overflow: hidden;
+  background: #0a0c10;
+  border: 1px solid var(--line);
+  box-shadow:
+    0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 24px 70px -18px rgba(0, 0, 0, 0.7);
+  color: var(--ink);
+  touch-action: none;
+  animation: simFloatIn 0.18s cubic-bezier(0.2, 0.7, 0.2, 1);
+}
+@keyframes simFloatIn {
+  from { opacity: 0; transform: translateY(8px) scale(0.98); }
+  to   { opacity: 1; transform: none; }
+}
+.sim-float__chrome {
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 8px 10px;
+  background: color-mix(in srgb, var(--paper) 88%, transparent);
+  backdrop-filter: blur(16px) saturate(1.2);
+  border-bottom: 1px solid var(--line-soft);
+  cursor: grab;
+  user-select: none;
+}
+.sim-float__chrome:active { cursor: grabbing; }
+.sim-float__title {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+.sim-float__title .sys-ic { color: var(--vue-green); }
+.sim-float__actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+.sim-float__btn {
+  appearance: none;
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--ink-mute);
+  cursor: pointer;
+  text-decoration: none;
+  transition: color 0.15s ease, background 0.15s ease;
+}
+.sim-float__btn:hover {
+  color: var(--vue-green);
+  background: rgba(66, 184, 131, 0.12);
+}
+.sim-float__body {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  background: #000;
+}
+.sim-float__frame {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  background: #000;
+}
+.sim-float__hint {
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  bottom: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  background: color-mix(in srgb, var(--paper) 82%, transparent);
+  border: 1px solid var(--line-soft);
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--ink-mute);
+  pointer-events: none;
+  opacity: 0.85;
+}
+.sim-float__hint code {
+  color: var(--vue-green);
+  font-size: 10px;
+}
+.sim-float__hint.is-hidden { display: none; }
+.sim-float__resize {
+  position: absolute;
+  right: 2px;
+  bottom: 2px;
+  width: 18px;
+  height: 18px;
+  cursor: nwse-resize;
+  background:
+    linear-gradient(135deg, transparent 55%, rgba(93, 213, 168, 0.55) 55%,
+      rgba(93, 213, 168, 0.55) 62%, transparent 62%),
+    linear-gradient(135deg, transparent 72%, rgba(93, 213, 168, 0.55) 72%,
+      rgba(93, 213, 168, 0.55) 79%, transparent 79%);
+  opacity: 0.55;
+  z-index: 2;
+}
+.sim-float__resize:hover { opacity: 1; }
+
 @media (prefers-reduced-motion: reduce) {
-  .cmdk__box, .cmdk__scrim { animation: none; }
+  .cmdk__box, .cmdk__scrim, .sim-float { animation: none; }
 }

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -50,7 +50,6 @@ export const ZH = {
 
   // ---- Chapter II · demos ----
   // ---- API coverage ----
-  'ref() · live sim': '<code class="brand-text">ref()</code> <span class="demo__title-sub">· 真机模拟</span>',
   'v-once / v-memo':
     '<code class="brand-text">v-once</code> / <code class="brand-text">v-memo</code>',
   'reactive() + composables':
@@ -472,8 +471,6 @@ export const ZH_NOTES = [
   `<p><strong>然后,Lynx 走出队列 —— 站到正中央,Vue 的正下方;其余候选人整体让到左侧。</strong>前端这条缝是天生打开的:Web 标准的编程模型、真 CSS、框架无关的合同。这根线,短、垂直、实心。</p><p>再看下面的覆盖:iOS、Android、Web、HarmonyOS 走<em>原生 UI primitive</em>;桌面与更多平台走<em>自定义渲染引擎</em>。Web 的开发体验进,Native 的用户体验出 —— 这个组合,配得上一个正式的标题……</p>`,
   // 12 Title reveal · Vue Lynx 正式亮相
   `<p><strong>亮相。</strong>这是 Vue Lynx 第一次正式出场 —— 标题在论证之后才落下:空缺是真的,门是开的,而这个项目正走进那扇门。</p><p>念出名字,让背景光呼吸一拍,然后直接进入 demo。</p>`,
-  // 13 ref + serve-sim (first lynx-view demo + local simulator)
-  `<p><strong>从最简单的开始 —— 并排真机模拟器。</strong><code>ref()</code>、一个事件回调、一个样式绑定。左边是 Lynx for Web(<code>&lt;lynx-view&gt;</code>);右边是通过 <a href="https://github.com/EvanBacon/serve-sim">serve-sim</a> 在 <code>/.sim</code> 推过来的本地 iOS Simulator。</p><p><strong>上场前:</strong>先 boot 模拟器 + Lynx Explorer 加载 hello-world bundle,再跑 <code>npx serve-sim --detach</code>。Vite deck 会自动挂上 preview middleware。</p>`,
   // 16 reactive
   `<p>整个响应式内核原样复用自 Vue —— <code>reactive</code>、<code>toRefs</code>、<code>computed</code>、watch 全部一致。这意味着<strong>组合式函数 —— 你组织 Vue 应用的方式 —— 原封不动可用</strong>。这个秒表就是一个普通的 composable。</p>`,
   // 17 v-model

--- a/slides/src/main.js
+++ b/slides/src/main.js
@@ -12,6 +12,7 @@ import { attachDeviceControls, DECK_PRESETS } from './framework/device.js';
 import { registerVlDemo } from './demo.js';
 import { initEmbeds } from './embeds.js';
 import { initQRCodes } from './qrcodes.js';
+import { initSimOverlay } from './sim-overlay.js';
 
 // =========================================================
 // URL flags — ?embed=1 locks the deck to a single slide and
@@ -367,7 +368,7 @@ if (!embedMode) {
 // keyboard back.
 // =========================================================
 let demoEngaged = false;
-const inDemo = (el) => !!el?.closest?.('.phone, .no-deck-scroll');
+const inDemo = (el) => !!el?.closest?.('.phone, .no-deck-scroll, .sim-float');
 
 if (!embedMode) {
   document.addEventListener('pointerdown', (e) => {
@@ -738,6 +739,15 @@ const deckApi = {
   reducedMotion: () => REDUCED_MOTION,
   embed: () => embedMode,
 };
+
+// Optional localhost-only floating iOS Simulator (serve-sim at /.sim).
+// Cloud / non-loopback hosts get null — no palette entry, no overlay.
+const sim = initSimOverlay({ embed: embedMode });
+Object.assign(deckApi, {
+  simAvailable: () => !!sim?.available?.(),
+  simOpen: () => !!sim?.isOpen?.(),
+  toggleSim: () => sim?.toggle?.(),
+});
 
 const devtool = initDevtool(deckApi);
 const command = initCommand(deckApi, { devtool });

--- a/slides/src/sim-overlay.js
+++ b/slides/src/sim-overlay.js
@@ -1,0 +1,189 @@
+// =============================================================================
+// Local iOS Simulator overlay — optional localhost presenter tool.
+//
+// Streams Evan Bacon's serve-sim preview (Vite mounts /.sim in `pnpm dev`) as a
+// floating, draggable frame above any slide. Cloud / non-localhost hosts never
+// see the command or the overlay — examples and the deck stay cloud-safe.
+// Toggle from the command palette (⌘K / `/` → `m`).
+// =============================================================================
+
+import { icon } from './framework/icons.js';
+
+const STORAGE_KEY = 'deck-sim-float';
+const DEFAULT = { x: null, y: null, w: 320, h: 640 };
+
+/** True only on loopback — cloud previews and LAN shares stay clean. */
+export function isLocalHost(hostname = location.hostname) {
+  return (
+    hostname === 'localhost' ||
+    hostname === '127.0.0.1' ||
+    hostname === '[::1]' ||
+    hostname === '::1'
+  );
+}
+
+function loadGeom() {
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return { ...DEFAULT };
+    return { ...DEFAULT, ...JSON.parse(raw) };
+  } catch {
+    return { ...DEFAULT };
+  }
+}
+
+function saveGeom(g) {
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(g));
+  } catch { /* ignore */ }
+}
+
+/**
+ * @returns {{ available: () => boolean, isOpen: () => boolean, toggle: () => void, open: () => void, close: () => void } | null}
+ */
+export function initSimOverlay({ embed = false } = {}) {
+  if (embed || !isLocalHost()) return null;
+
+  let root = null;
+  let geom = loadGeom();
+
+  function applyGeom() {
+    if (!root) return;
+    const maxW = Math.min(window.innerWidth - 24, 560);
+    const maxH = Math.min(window.innerHeight - 24, 900);
+    const w = Math.max(200, Math.min(geom.w, maxW));
+    const h = Math.max(320, Math.min(geom.h, maxH));
+    let x = geom.x;
+    let y = geom.y;
+    if (x == null || y == null) {
+      x = Math.max(12, window.innerWidth - w - 28);
+      y = Math.max(12, Math.round((window.innerHeight - h) / 2));
+    }
+    x = Math.max(0, Math.min(x, window.innerWidth - 48));
+    y = Math.max(0, Math.min(y, window.innerHeight - 48));
+    geom = { x, y, w, h };
+    root.style.width = `${w}px`;
+    root.style.height = `${h}px`;
+    root.style.left = `${x}px`;
+    root.style.top = `${y}px`;
+  }
+
+  function mount() {
+    if (root) return;
+    root = document.createElement('div');
+    root.className = 'sim-float no-deck-scroll';
+    root.setAttribute('role', 'dialog');
+    root.setAttribute('aria-label', 'Local iOS Simulator');
+    root.innerHTML =
+      `<div class="sim-float__chrome" data-drag>` +
+        `<span class="sim-float__title">${icon('smartphone')}<span>Simulator</span></span>` +
+        `<div class="sim-float__actions">` +
+          `<a class="sim-float__btn" data-ext href="/.sim" target="_blank" rel="noreferrer" ` +
+            `title="Open /.sim in a new tab">${icon('external')}</a>` +
+          `<button type="button" class="sim-float__btn" data-close title="Close">${icon('x')}</button>` +
+        `</div>` +
+      `</div>` +
+      `<div class="sim-float__body">` +
+        `<iframe class="sim-float__frame" src="/.sim" title="serve-sim preview" ` +
+          `allow="autoplay; fullscreen"></iframe>` +
+        `<div class="sim-float__hint">` +
+          `<span>Need a booted sim?</span>` +
+          `<code>npx serve-sim --detach</code>` +
+        `</div>` +
+      `</div>` +
+      `<div class="sim-float__resize" data-resize title="Drag to resize"></div>`;
+
+    document.body.appendChild(root);
+    applyGeom();
+    wireChrome(root);
+
+    // Soft hint for "run serve-sim --detach" — hide once the preview loads so
+    // it doesn't sit on top of a live stream.
+    const frame = root.querySelector('.sim-float__frame');
+    const hint = root.querySelector('.sim-float__hint');
+    frame?.addEventListener('load', () => hint?.classList.add('is-hidden'));
+    frame?.addEventListener('error', () => hint?.classList.remove('is-hidden'));
+  }
+
+  function wireChrome(el) {
+    el.querySelector('[data-close]')?.addEventListener('click', close);
+
+    // Drag by the chrome bar (viewport pixels — overlay lives outside .frame).
+    const bar = el.querySelector('[data-drag]');
+    bar?.addEventListener('pointerdown', (e) => {
+      if (e.button !== 0) return;
+      if (e.target.closest('a, button')) return;
+      e.preventDefault();
+      const startX = e.clientX;
+      const startY = e.clientY;
+      const origX = geom.x ?? el.offsetLeft;
+      const origY = geom.y ?? el.offsetTop;
+      bar.setPointerCapture?.(e.pointerId);
+      const onMove = (ev) => {
+        geom.x = origX + (ev.clientX - startX);
+        geom.y = origY + (ev.clientY - startY);
+        applyGeom();
+      };
+      const onUp = () => {
+        bar.releasePointerCapture?.(e.pointerId);
+        bar.removeEventListener('pointermove', onMove);
+        bar.removeEventListener('pointerup', onUp);
+        saveGeom(geom);
+      };
+      bar.addEventListener('pointermove', onMove);
+      bar.addEventListener('pointerup', onUp);
+    });
+
+    // SE resize grip.
+    const grip = el.querySelector('[data-resize]');
+    grip?.addEventListener('pointerdown', (e) => {
+      if (e.button !== 0) return;
+      e.preventDefault();
+      e.stopPropagation();
+      const startX = e.clientX;
+      const startY = e.clientY;
+      const origW = geom.w;
+      const origH = geom.h;
+      grip.setPointerCapture?.(e.pointerId);
+      const onMove = (ev) => {
+        geom.w = origW + (ev.clientX - startX);
+        geom.h = origH + (ev.clientY - startY);
+        applyGeom();
+      };
+      const onUp = () => {
+        grip.releasePointerCapture?.(e.pointerId);
+        grip.removeEventListener('pointermove', onMove);
+        grip.removeEventListener('pointerup', onUp);
+        saveGeom(geom);
+      };
+      grip.addEventListener('pointermove', onMove);
+      grip.addEventListener('pointerup', onUp);
+    });
+
+    window.addEventListener('resize', applyGeom);
+  }
+
+  function open() {
+    mount();
+  }
+
+  function close() {
+    if (!root) return;
+    saveGeom(geom);
+    root.remove();
+    root = null;
+  }
+
+  function toggle() {
+    if (root) close();
+    else open();
+  }
+
+  return {
+    available: () => true,
+    isOpen: () => !!root,
+    toggle,
+    open,
+    close,
+  };
+}

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -735,43 +735,6 @@ h1, h2, h3, p { margin: 0; }
   max-width: none;
 }
 
-/* Side-by-side Web <lynx-view> + native serve-sim on the duplicated ref() slide. */
-.demo__stage--pair {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 2.2cqw;
-  height: min(92cqh, 650px);
-}
-.demo__stage--pair .phone {
-  position: relative;
-  top: auto;
-  left: auto;
-  transform: none;
-  --phone-h: min(72cqh, 520px);
-  flex: 0 0 auto;
-}
-.demo__stage--pair .phone[data-caption]::after {
-  content: attr(data-caption);
-  position: absolute;
-  left: 50%;
-  bottom: -28px;
-  transform: translateX(-50%);
-  white-space: nowrap;
-  font-family: var(--mono);
-  font-size: 11px;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--ink-mute);
-}
-.demo__title-sub {
-  font-family: var(--serif);
-  font-weight: 400;
-  font-style: italic;
-  color: var(--ink-mute);
-  font-size: 0.55em;
-  margin-left: 0.15em;
-}
 /* Lift the frame above the copy (and deepen its shadow) once it grows past the
    phone preset, so an overlapping expansion reads as floating, not broken. */
 .demo__stage .phone:not([data-device="phone"]) {

--- a/slides/vite.config.js
+++ b/slides/vite.config.js
@@ -27,9 +27,10 @@ function ensureExamplesSymlink() {
 }
 ensureExamplesSymlink();
 
-// Mount Evan Bacon's serve-sim preview at /.sim so the deck can stream a local
-// iOS Simulator during the talk. Helper ports stay on loopback (no upgrade
-// hijack — Vite HMR keeps its WebSocket). Start the helper separately:
+// Optional localhost presenter aid: mount Evan Bacon's serve-sim preview at
+// /.sim during `pnpm dev` only (`configureServer` never runs in production /
+// Vercel builds, so cloud-hosted decks stay unaffected). The floating overlay
+// is toggled from the command palette on loopback hosts. Start the helper:
 //   npx serve-sim --detach
 function serveSimPlugin() {
   return {
@@ -39,7 +40,7 @@ function serveSimPlugin() {
         const { simMiddleware } = await import('serve-sim/middleware');
         const middleware = simMiddleware({ basePath: '/.sim' });
         server.middlewares.use(middleware);
-        console.log('[slides] serve-sim preview at /.sim  (run: npx serve-sim --detach)');
+        console.log('[slides] serve-sim at /.sim  (palette → m · run: npx serve-sim --detach)');
       } catch (err) {
         console.warn('[slides] serve-sim middleware unavailable:', err?.message ?? err);
       }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the per-slide serve-sim demo (#275) with an **optional, localhost-only floating simulator** that can sit above any slide — so cloud-hosted decks (examples, Vercel) stay decoupled from the Mac-only helper.

- **Remove** the side-by-side `ref()` / serve-sim slide
- **Keep** Vite `/.sim` middleware in `pnpm dev` only (`configureServer` — never in production builds)
- **Add** a draggable/resizable overlay (`src/sim-overlay.js`), toggled from the command palette (`⌘K` / `/` → **`m`**)
- Palette entry + overlay only appear on `localhost` / `127.0.0.1`
- Supersedes #280

## Presenter setup

```bash
cd slides
pnpm sim    # or: npx serve-sim --detach
pnpm dev    # open http://localhost:4321 → palette → m
```

Drag the chrome bar to move; SE grip to resize. Position/size persist for the session.

## Test plan

- [x] `pnpm build`
- [x] Slide / notes / `ZH_NOTES` = 123
- [x] `GET /.sim` → 200 on `pnpm dev`
- [x] Playwright: `/` → `m` opens `.sim-float`; drag moves it
- [ ] On a Vercel / non-localhost host: no Simulator palette entry
- [ ] On macOS with a booted sim: overlay streams the device above any slide
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92b11556-2a16-4244-810e-64eb40e93ded"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92b11556-2a16-4244-810e-64eb40e93ded"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

