### PR TITLE
feat(slides): show disabled Simulator palette entry off localhost

### DIFF
--- a/slides/AGENTS.md
+++ b/slides/AGENTS.md
@@ -83,8 +83,9 @@ deterministic (seeded `rnd(i, salt)`, never `Math.random`).
 - Demos only get the keyboard after a **deliberate click inside** them;
   autofocus grabs are blurred (`demoEngaged` in `main.js`). Scroll/swipe
   inside `.phone` / `.no-deck-scroll` / `.sim-float` never advances the deck.
-- **Local simulator** (`src/sim-overlay.js`): optional localhost-only floating
-  serve-sim frame, toggled from the palette (`m`). Do not wire it into
+- **Local simulator** (`src/sim-overlay.js`): optional floating serve-sim frame,
+  toggled from the palette (`m`). The palette always lists `m`; off localhost
+  it renders disabled with a “localhost only” note. Do not wire it into
   individual slides — keep cloud-hosted decks free of simulator coupling.
 
 ## Verify

--- a/slides/README.md
+++ b/slides/README.md
@@ -20,9 +20,10 @@ Run `cd ../website && pnpm prepare:docs` once if those bundles are missing.
 For live presenting on your Mac, the Vite **dev** server mounts
 [serve-sim](https://github.com/EvanBacon/serve-sim) at **`/.sim`**. A floating,
 draggable simulator frame can sit above any slide — toggle it from the command
-palette (`⌘K` / `/` → **`m`**). The palette entry and overlay only appear on
-**localhost** / `127.0.0.1`, so cloud-hosted decks (examples, Vercel previews)
-are unaffected. Production builds never include the middleware.
+palette (`⌘K` / `/` → **`m`**). The palette always shows **`m`**; off
+**localhost** / `127.0.0.1` the entry is disabled with a “localhost only” note,
+and the overlay never mounts — so cloud-hosted decks stay unaffected.
+Production builds never include the middleware.
 
 ```bash
 # macOS + Xcode, with a simulator already booted (e.g. Lynx Explorer):
@@ -56,7 +57,7 @@ Inside the palette (`⌘K` search or `/` then the key):
 | `]` | Last slide          | `d` | DevTool panel            |
 | `s` | Open speaker view   | `f` | Toggle fullscreen        |
 | `o` | Overview grid       | `b` | Blackout audience screen |
-| `m` | Simulator overlay   |     | *(localhost only)*       |
+| `m` | Simulator overlay   |     | disabled off localhost   |
 
 Jump to any slide by title from the palette's **Slides** section (type to
 filter, `↑`/`↓` or `←`/`→` to move, `Enter` to go).

--- a/slides/src/framework/command.js
+++ b/slides/src/framework/command.js
@@ -10,8 +10,9 @@ import { icon } from './icons.js';
 export function initCommand(api, { devtool } = {}) {
   if (api.embed()) return null;
 
-  // Action = { section, key, label, icon, run }. `label` may be a function.
-  // Localhost-only presenter tools (serve-sim overlay) are appended when available.
+  // Action = { section, key, label, icon, run, disabled?, note? }.
+  // `label` / `disabled` / `note` may be functions. Disabled items stay visible
+  // (greyed out) but never run — used for localhost-only tools on cloud hosts.
   const ACTIONS = [
     { section: 'Navigate', key: 'n', label: 'Next slide', icon: 'arrowRight', run: api.next },
     { section: 'Navigate', key: 'p', label: 'Previous slide', icon: 'arrowLeft', run: api.prev },
@@ -22,6 +23,17 @@ export function initCommand(api, { devtool } = {}) {
     { section: 'Presenter', key: 'o', label: () => `Overview: ${api.overview() ? 'on' : 'off'}`, icon: 'grid', run: api.toggleOverview },
     { section: 'Presenter', key: 'b', label: () => `Blackout: ${api.isBlackout() ? 'on' : 'off'}`, icon: 'eye', run: api.blackout },
     { section: 'Presenter', key: 'f', label: 'Toggle fullscreen', icon: 'maximize', run: api.fullscreen },
+    {
+      section: 'Presenter',
+      key: 'm',
+      label: () => (api.simAvailable?.()
+        ? `Simulator: ${api.simOpen?.() ? 'on' : 'off'}`
+        : 'Simulator'),
+      icon: 'smartphone',
+      disabled: () => !api.simAvailable?.(),
+      note: () => (api.simAvailable?.() ? '' : 'localhost only'),
+      run: () => api.toggleSim?.(),
+    },
 
     { section: 'Settings', key: 't', label: () => `Theme: ${api.theme()}`, icon: 'moon', run: api.toggleTheme },
     { section: 'Settings', key: 'l', label: () => `Language: ${api.lang() === 'zh' ? '中文' : 'English'}`, icon: 'languages', run: api.toggleLang },
@@ -30,17 +42,11 @@ export function initCommand(api, { devtool } = {}) {
   ];
 
   const resolveLabel = (a) => (typeof a.label === 'function' ? a.label() : a.label);
-
-  function localActions() {
-    if (!api.simAvailable?.()) return [];
-    return [{
-      section: 'Presenter',
-      key: 'm',
-      label: () => `Simulator: ${api.simOpen?.() ? 'on' : 'off'}`,
-      icon: 'smartphone',
-      run: () => api.toggleSim?.(),
-    }];
-  }
+  const isDisabled = (a) => !!(typeof a.disabled === 'function' ? a.disabled() : a.disabled);
+  const resolveNote = (a) => {
+    const n = typeof a.note === 'function' ? a.note() : a.note;
+    return n || '';
+  };
 
   function slideActions() {
     return api.meta().map((m, i) => ({
@@ -58,21 +64,17 @@ export function initCommand(api, { devtool } = {}) {
   let selected = 0;
 
   function allActions() {
-    // Insert localhost simulator next to other Presenter actions.
-    const base = [...ACTIONS];
-    const locals = localActions();
-    if (locals.length) {
-      const i = base.findIndex((a) => a.section === 'Settings');
-      base.splice(i === -1 ? base.length : i, 0, ...locals);
-    }
-    return [...base, ...slideActions()];
+    return [...ACTIONS, ...slideActions()];
   }
 
   function visibleActions() {
     const all = allActions();
     if (!query) return all;
     const q = query.toLowerCase();
-    return all.filter((a) => resolveLabel(a).toLowerCase().includes(q));
+    return all.filter((a) => {
+      const hay = `${resolveLabel(a)} ${resolveNote(a)}`.toLowerCase();
+      return hay.includes(q);
+    });
   }
 
   function render() {
@@ -92,9 +94,13 @@ export function initCommand(api, { devtool } = {}) {
         section = a.section;
         html += `<div class="cmdk__section">${section}</div>`;
       }
-      html += `<div class="cmdk__item" role="option" data-idx="${idx}" ` +
-        `aria-selected="${idx === selected}">${icon(a.icon)}` +
-        `<span class="cmdk__label">${resolveLabel(a)}</span>` +
+      const disabled = isDisabled(a);
+      const note = resolveNote(a);
+      html += `<div class="cmdk__item${disabled ? ' is-disabled' : ''}" role="option" data-idx="${idx}" ` +
+        `aria-selected="${idx === selected}" aria-disabled="${disabled}">${icon(a.icon)}` +
+        `<span class="cmdk__label">${resolveLabel(a)}` +
+        (note ? `<span class="cmdk__note">${note}</span>` : '') +
+        `</span>` +
         (a.key ? `<span class="cmdk__hint">${a.key}</span>` : '') + `</div>`;
     });
     list.innerHTML = html;
@@ -103,8 +109,10 @@ export function initCommand(api, { devtool } = {}) {
   }
 
   function run(action) {
+    // Disabled items stay visible (e.g. Simulator off localhost) but never fire.
+    if (!action || isDisabled(action)) return;
     close();
-    action?.run?.();
+    action.run?.();
   }
 
   function open(slashMode = false) {
@@ -201,7 +209,7 @@ export function initCommand(api, { devtool } = {}) {
       if (e.key === 'Backspace') { e.preventDefault(); setSlash(false); return; }
       if (e.key.length === 1) {
         const a = allActions().find((x) => x.key === e.key.toLowerCase());
-        if (a) { e.preventDefault(); run(a); }
+        if (a) { e.preventDefault(); run(a); } // run() no-ops when disabled
       }
       return;
     }

--- a/slides/src/framework/framework.css
+++ b/slides/src/framework/framework.css
@@ -127,9 +127,33 @@
   color: var(--ink);
 }
 .cmdk__item[aria-selected="true"] .sys-ic { color: var(--vue-green); }
-.cmdk__label { flex: 1; font-size: 15px; }
+.cmdk__label {
+  flex: 1;
+  font-size: 15px;
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+}
+.cmdk__note {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  color: var(--ink-faint);
+  white-space: nowrap;
+}
 .cmdk__hint { font-family: var(--mono); font-size: 12px; color: var(--ink-faint); }
 .cmdk__item[aria-selected="true"] .cmdk__hint { color: var(--ink-mute); }
+.cmdk__item.is-disabled {
+  opacity: 0.42;
+  cursor: not-allowed;
+}
+.cmdk__item.is-disabled[aria-selected="true"] {
+  background: transparent;
+  color: var(--ink-soft);
+}
+.cmdk__item.is-disabled[aria-selected="true"] .sys-ic { color: var(--ink-mute); }
+.cmdk__item.is-disabled .cmdk__note { color: var(--ink-mute); }
 
 /* =========================================================
    DevTool panel (top-right, Next.js-devtools style)

--- a/slides/src/main.js
+++ b/slides/src/main.js
@@ -12,7 +12,7 @@ import { attachDeviceControls, DECK_PRESETS } from './framework/device.js';
 import { registerVlDemo } from './demo.js';
 import { initEmbeds } from './embeds.js';
 import { initQRCodes } from './qrcodes.js';
-import { initSimOverlay } from './sim-overlay.js';
+import { initSimOverlay, isLocalHost } from './sim-overlay.js';
 
 // =========================================================
 // URL flags — ?embed=1 locks the deck to a single slide and
@@ -741,10 +741,10 @@ const deckApi = {
 };
 
 // Optional localhost-only floating iOS Simulator (serve-sim at /.sim).
-// Cloud / non-loopback hosts get null — no palette entry, no overlay.
+// The palette always shows `m`; off loopback it's disabled ("localhost only").
 const sim = initSimOverlay({ embed: embedMode });
 Object.assign(deckApi, {
-  simAvailable: () => !!sim?.available?.(),
+  simAvailable: () => !embedMode && isLocalHost() && !!sim?.available?.(),
   simOpen: () => !!sim?.isOpen?.(),
   toggleSim: () => sim?.toggle?.(),
 });

--- a/slides/src/sim-overlay.js
+++ b/slides/src/sim-overlay.js
@@ -2,9 +2,10 @@
 // Local iOS Simulator overlay — optional localhost presenter tool.
 //
 // Streams Evan Bacon's serve-sim preview (Vite mounts /.sim in `pnpm dev`) as a
-// floating, draggable frame above any slide. Cloud / non-localhost hosts never
-// see the command or the overlay — examples and the deck stay cloud-safe.
-// Toggle from the command palette (⌘K / `/` → `m`).
+// floating, draggable frame above any slide. The palette always lists `m`; on
+// cloud / non-localhost hosts the entry is disabled ("localhost only") and the
+// overlay never mounts — examples and the deck stay cloud-safe.
+// Toggle from the command palette (⌘K / `/` → `m`) when on loopback.
 // =============================================================================
 
 import { icon } from './framework/icons.js';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #283: the command palette always shows **`m` · Simulator**.

- On **localhost**: toggles the floating serve-sim overlay (unchanged)
- Off localhost (cloud / Vercel): entry stays visible but **disabled**, with a “localhost only” note — click / Enter / slash `m` do nothing

## Test plan

- [x] `pnpm build`
- [x] localhost: `/` → `m` still opens `.sim-float`
- [x] Disabled item CSS (`.cmdk__item.is-disabled`) present in built styles
- [ ] On a Vercel preview: palette lists Simulator greyed out with “localhost only”; selecting it does not open an overlay
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92b11556-2a16-4244-810e-64eb40e93ded"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92b11556-2a16-4244-810e-64eb40e93ded"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

