### PR TITLE
fix(plugin): worklet-loader-mt silently drops MT registrations when worklet bodies contain comments — replace scanner extraction with AST-span slicing

### DIFF
--- a/.changeset/fix-worklet-mt-comment-extraction.md
+++ b/.changeset/fix-worklet-mt-comment-extraction.md
@@ -1,0 +1,5 @@
+---
+"vue-lynx": patch
+---
+
+Fix `worklet-loader-mt` silently dropping main-thread worklet registrations when worklet bodies contain comments with apostrophes, backticks, or unmatched parens. Registration extraction now slices `registerWorkletInternal(...)` calls by AST node span (`@babel/parser`, already shipped via `@vue/compiler-core`) instead of textually scanning the LEPUS output, so string/comment/regex content can never corrupt the scan.

--- a/packages/testing-library/package.json
+++ b/packages/testing-library/package.json
@@ -9,13 +9,15 @@
     "test:watch": "vitest"
   },
   "devDependencies": {
+    "@babel/parser": "^7.25.3",
+    "@lynx-js/react": "^0.116.5",
     "@lynx-js/testing-environment": "^0.1.11",
-    "vue-lynx": "workspace:*",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@vue/runtime-core": "^3.5.0",
     "jsdom": "^25.0.0",
     "vitest": "^3.0.0",
-    "vue": "^3.5.0"
+    "vue": "^3.5.0",
+    "vue-lynx": "workspace:*"
   }
 }

--- a/packages/testing-library/package.json
+++ b/packages/testing-library/package.json
@@ -10,7 +10,6 @@
   },
   "devDependencies": {
     "@babel/parser": "^7.25.3",
-    "@lynx-js/react": "^0.116.5",
     "@lynx-js/testing-environment": "^0.1.11",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",

--- a/packages/testing-library/src/__tests__/worklet-extraction-pipeline.test.ts
+++ b/packages/testing-library/src/__tests__/worklet-extraction-pipeline.test.ts
@@ -10,38 +10,65 @@
  * registrations, crashing on first interaction with
  * `cannot read property 'bind' of undefined`.
  *
- * These tests run the real `transformReactLynxSync` and pin extraction
- * against ground truth the generator knows:
+ * These tests drive the real BG/MT loaders (which invoke
+ * transformReactLynxSync from the plugin package's own context, so this
+ * package needs no @lynx-js/react dependency) and pin extraction against
+ * ground truth the generator knows:
  *  - every generated worklet yields exactly one extracted registration
  *  - every extracted slice reparses standalone as a
  *    `registerWorkletInternal(...)` call with a string hash argument
  *  - the extracted hash set equals the `_wkltId` set in the JS
- *    (background) transform of the same source — the device-level
+ *    (background) output of the same source — the device-level
  *    invariant whose violation is the runtime bind-of-undefined crash
  */
 
 import { parse } from '@babel/parser';
 import { describe, expect, it } from 'vitest';
 
-import { transformReactLynxSync } from '@lynx-js/react/transform';
-
+import workletLoaderBG from '../../../vue-lynx/plugin/src/loaders/worklet-loader.js';
+import workletLoaderMT from '../../../vue-lynx/plugin/src/loaders/worklet-loader-mt.js';
 import { extractRegistrations } from '../../../vue-lynx/plugin/src/loaders/worklet-utils.js';
 
-function transform(src: string, target: 'LEPUS' | 'JS'): string {
-  const result = transformReactLynxSync(src, {
-    pluginName: 'vue:worklet-mt',
-    filename: '/fuzz/mod.ts',
-    sourcemap: false,
-    cssScope: false,
-    shake: false,
-    compat: false,
-    refresh: false,
-    defineDCE: false,
-    directiveDCE: false,
-    worklet: { target, filename: '/fuzz/mod.ts', runtimePkg: 'vue-lynx' },
+/** Drive the async MT loader with a minimal mock LoaderContext. */
+function runMT(source: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const ctx = {
+      cacheable() {},
+      async() {
+        return (err: Error | null, result?: string) =>
+          err ? reject(err) : resolve(result ?? '');
+      },
+      getOptions() {
+        return {};
+      },
+      getResolve() {
+        return () => Promise.reject(new Error('no imports expected'));
+      },
+      context: '/fuzz',
+      rootContext: '/fuzz',
+      resourcePath: '/fuzz/mod.ts',
+      resourceQuery: '',
+      emitError(err: Error) {
+        reject(err);
+      },
+      emitWarning() {},
+    };
+    (workletLoaderMT as unknown as (this: typeof ctx, s: string) => void)
+      .call(ctx, source);
   });
-  expect(result.errors).toHaveLength(0);
-  return result.code;
+}
+
+/** The BG loader is synchronous; transform errors throw. */
+function runBG(source: string): string {
+  const ctx = {
+    cacheable() {},
+    resourcePath: '/fuzz/mod.ts',
+    emitError(err: Error) {
+      throw err;
+    },
+  };
+  return (workletLoaderBG as unknown as (this: typeof ctx, s: string) => string)
+    .call(ctx, source);
 }
 
 interface AstNode {
@@ -51,7 +78,7 @@ interface AstNode {
   [key: string]: unknown;
 }
 
-/** Generic AST walk collecting nodes matched by `visit`. */
+/** Generic AST walk calling `visit` on every node. */
 function walkAst(code: string, visit: (node: AstNode) => void): void {
   const walk = (value: unknown): void => {
     if (Array.isArray(value)) {
@@ -91,7 +118,7 @@ function registeredHashes(code: string): string[] {
   return hashes;
 }
 
-/** `_wkltId` values from the JS (background) transform of a module. */
+/** `_wkltId` values from the JS (background) output of a module. */
 function backgroundWorkletIds(code: string): string[] {
   const ids: string[] = [];
   walkAst(code, (node) => {
@@ -105,18 +132,17 @@ function backgroundWorkletIds(code: string): string[] {
 }
 
 /**
- * Full-pipeline check: LEPUS transform → extraction, asserting count
- * against the generator's ground truth and hash parity with the JS
- * (background) transform of the same source.
+ * Full-pipeline check through both real loaders: MT extraction count must
+ * match the generator's ground truth, and the extracted hash set must
+ * equal the background bundle's _wkltId set.
  */
-function expectExtraction(src: string, workletCount: number): void {
-  const extracted = extractRegistrations(transform(src, 'LEPUS'));
-  const hashes = registeredHashes(extracted);
+async function expectExtraction(
+  src: string,
+  workletCount: number,
+): Promise<void> {
+  const hashes = registeredHashes(await runMT(src));
   expect(hashes).toHaveLength(workletCount);
-  expect(new Set(hashes).size).toBe(workletCount);
-  expect(new Set(hashes)).toEqual(
-    new Set(backgroundWorkletIds(transform(src, 'JS'))),
-  );
+  expect(new Set(hashes)).toEqual(new Set(backgroundWorkletIds(runBG(src))));
 }
 
 /**
@@ -139,21 +165,9 @@ const HOSTILE_FRAGMENTS: ReadonlyArray<[name: string, fragment: string]> = [
   ['template with unmatched paren', 'const b = `open ( only`;'],
 ];
 
-/** Deterministic PRNG so fuzz failures reproduce byte-for-byte. */
-function mulberry32(seed: number): () => number {
-  let a = seed;
-  return () => {
-    a |= 0;
-    a = (a + 0x6d2b79f5) | 0;
-    let t = Math.imul(a ^ (a >>> 15), 1 | a);
-    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
-}
-
 describe('extraction pipeline: hostile worklet bodies (real LEPUS output)', () => {
   for (const [name, fragment] of HOSTILE_FRAGMENTS) {
-    it(`survives ${name}`, () => {
+    it(`survives ${name}`, async () => {
       // Two worklets with the fragment in the FIRST body: a scanner that
       // loses balance mid-module drops the second one silently.
       const src = [
@@ -167,14 +181,16 @@ describe('extraction pipeline: hostile worklet bodies (real LEPUS output)', () =
         `  el.setStyleProperty('x', '1');`,
         `}`,
       ].join('\n');
-      expectExtraction(src, 2);
+      await expectExtraction(src, 2);
     });
   }
 });
 
 describe('extraction pipeline: seeded fuzz', () => {
-  it('extracts every worklet across 120 generated adversarial modules', () => {
-    const rand = mulberry32(0xc0ffee);
+  it('extracts every worklet across 120 generated adversarial modules', async () => {
+    // Park–Miller LCG — deterministic so fuzz failures reproduce.
+    let seed = 0xc0ffee;
+    const rand = () => (seed = (seed * 48271) % 2147483647) / 2147483647;
     const pick = <T>(arr: readonly T[]): T =>
       arr[Math.floor(rand() * arr.length)]!;
 
@@ -206,7 +222,7 @@ describe('extraction pipeline: seeded fuzz', () => {
         );
       }
 
-      expectExtraction(fns.join('\n'), workletCount);
+      await expectExtraction(fns.join('\n'), workletCount);
     }
   });
 });

--- a/packages/testing-library/src/__tests__/worklet-extraction-pipeline.test.ts
+++ b/packages/testing-library/src/__tests__/worklet-extraction-pipeline.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Differential + fuzz coverage for MT worklet registration extraction.
+ *
+ * `extractRegistrations` runs on real LEPUS transform output, which
+ * preserves arbitrary user code — comments, strings, regex literals,
+ * template nesting — inside `registerWorkletInternal(...)` bodies. The
+ * 0.4.x and 0.5.x scanners each died on a token class they didn't lex
+ * (parens inside strings, then parens inside comments), and the usual
+ * failure was SILENT: a green build whose MT bundle is missing
+ * registrations, crashing on first interaction with
+ * `cannot read property 'bind' of undefined`.
+ *
+ * These tests run the real `transformReactLynxSync` and pin extraction
+ * against ground truth the generator knows:
+ *  - every generated worklet yields exactly one extracted registration
+ *  - every extracted slice reparses standalone as a
+ *    `registerWorkletInternal(...)` call with a string hash argument
+ *  - the extracted hash set equals the `_wkltId` set in the JS
+ *    (background) transform of the same source — the device-level
+ *    invariant whose violation is the runtime bind-of-undefined crash
+ */
+
+import { parse } from '@babel/parser';
+import { describe, expect, it } from 'vitest';
+
+import { transformReactLynxSync } from '@lynx-js/react/transform';
+
+import { extractRegistrations } from '../../../vue-lynx/plugin/src/loaders/worklet-utils.js';
+
+function transform(src: string, target: 'LEPUS' | 'JS'): string {
+  const result = transformReactLynxSync(src, {
+    pluginName: 'vue:worklet-mt',
+    filename: '/fuzz/mod.ts',
+    sourcemap: false,
+    cssScope: false,
+    shake: false,
+    compat: false,
+    refresh: false,
+    defineDCE: false,
+    directiveDCE: false,
+    worklet: { target, filename: '/fuzz/mod.ts', runtimePkg: 'vue-lynx' },
+  });
+  expect(result.errors).toHaveLength(0);
+  return result.code;
+}
+
+interface AstNode {
+  type: string;
+  start: number;
+  end: number;
+  [key: string]: unknown;
+}
+
+/** Generic AST walk collecting nodes matched by `visit`. */
+function walkAst(code: string, visit: (node: AstNode) => void): void {
+  const walk = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      for (const item of value) walk(item);
+      return;
+    }
+    if (!value || typeof (value as AstNode).type !== 'string') return;
+    const node = value as AstNode;
+    visit(node);
+    for (const key in node) {
+      if (key === 'type' || key === 'start' || key === 'end') continue;
+      const child = node[key];
+      if (child && typeof child === 'object') walk(child);
+    }
+  };
+  walk(parse(code, { sourceType: 'module' }));
+}
+
+/**
+ * Parse `code` and return the hash argument of every
+ * `registerWorkletInternal(type, hash, fn)` call. Throwing on unparseable
+ * input is part of the check: extracted output must be valid standalone JS.
+ */
+function registeredHashes(code: string): string[] {
+  const hashes: string[] = [];
+  walkAst(code, (node) => {
+    if (node.type !== 'CallExpression') return;
+    const callee = node.callee as AstNode & { name?: string };
+    if (callee.type !== 'Identifier') return;
+    if (callee.name !== 'registerWorkletInternal') return;
+    const args = node.arguments as AstNode[];
+    expect(args).toHaveLength(3);
+    const hash = args[1] as AstNode & { value?: unknown };
+    expect(hash.type).toBe('StringLiteral');
+    hashes.push(hash.value as string);
+  });
+  return hashes;
+}
+
+/** `_wkltId` values from the JS (background) transform of a module. */
+function backgroundWorkletIds(code: string): string[] {
+  const ids: string[] = [];
+  walkAst(code, (node) => {
+    if (node.type !== 'ObjectProperty') return;
+    const key = node.key as AstNode & { name?: string };
+    if (key.type !== 'Identifier' || key.name !== '_wkltId') return;
+    const value = node.value as AstNode & { value?: unknown };
+    if (value.type === 'StringLiteral') ids.push(value.value as string);
+  });
+  return ids;
+}
+
+/**
+ * Full-pipeline check: LEPUS transform → extraction, asserting count
+ * against the generator's ground truth and hash parity with the JS
+ * (background) transform of the same source.
+ */
+function expectExtraction(src: string, workletCount: number): void {
+  const extracted = extractRegistrations(transform(src, 'LEPUS'));
+  const hashes = registeredHashes(extracted);
+  expect(hashes).toHaveLength(workletCount);
+  expect(new Set(hashes).size).toBe(workletCount);
+  expect(new Set(hashes)).toEqual(
+    new Set(backgroundWorkletIds(transform(src, 'JS'))),
+  );
+}
+
+/**
+ * Body fragments that killed a shipped scanner (or plausibly kill the
+ * next hand-rolled one). Each is valid inside a worklet function body.
+ */
+const HOSTILE_FRAGMENTS: ReadonlyArray<[name: string, fragment: string]> = [
+  ['apostrophe in line comment', `// don't do this twice (see notes`],
+  ['unmatched open paren in line comment', `// see fig (1`],
+  ['unmatched close paren in line comment', `// closes) everything))`],
+  ['apostrophe and paren in block comment', `/* it's fine :) */`],
+  ['backtick and paren in block comment', '/* `tick` and ( more */'],
+  ['regex with quote and paren', `const m = 'a,b'.split(/[',(]/);`],
+  ['regex after division', `const d = 4 / 2 / 1; const ok = /don't\\)/.test('x');`],
+  ['nested template interpolation', 'const t = `a${d ? `in${d}ner` : "e"}b`;'],
+  ['extraction marker inside a string', `const f = "registerWorkletInternal(fake";`],
+  ['extraction marker inside a comment', `// registerWorkletInternal( not a real call`],
+  ['unmatched parens inside a string', `const u = ")((";`],
+  ['escaped quote in string', `const e = 'it\\'s';`],
+  ['template with unmatched paren', 'const b = `open ( only`;'],
+];
+
+/** Deterministic PRNG so fuzz failures reproduce byte-for-byte. */
+function mulberry32(seed: number): () => number {
+  let a = seed;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+describe('extraction pipeline: hostile worklet bodies (real LEPUS output)', () => {
+  for (const [name, fragment] of HOSTILE_FRAGMENTS) {
+    it(`survives ${name}`, () => {
+      // Two worklets with the fragment in the FIRST body: a scanner that
+      // loses balance mid-module drops the second one silently.
+      const src = [
+        `export function first(el) {`,
+        `  'main thread';`,
+        `  ${fragment}`,
+        `  el.setStyleProperty('opacity', '0.5');`,
+        `}`,
+        `export function second(el) {`,
+        `  'main thread';`,
+        `  el.setStyleProperty('x', '1');`,
+        `}`,
+      ].join('\n');
+      expectExtraction(src, 2);
+    });
+  }
+});
+
+describe('extraction pipeline: seeded fuzz', () => {
+  it('extracts every worklet across 120 generated adversarial modules', () => {
+    const rand = mulberry32(0xc0ffee);
+    const pick = <T>(arr: readonly T[]): T =>
+      arr[Math.floor(rand() * arr.length)]!;
+
+    for (let m = 0; m < 120; m++) {
+      const workletCount = 1 + Math.floor(rand() * 3);
+      const plainCount = Math.floor(rand() * 3);
+      const fns: string[] = [];
+
+      for (let w = 0; w < workletCount; w++) {
+        const body: string[] = [`  'main thread';`];
+        const fragments = 1 + Math.floor(rand() * 4);
+        // Block-wrap each fragment (braces on their own lines — a line
+        // comment fragment would swallow a same-line closing brace): the
+        // same fragment picked twice would otherwise redeclare its consts
+        // in one function scope.
+        for (let f = 0; f < fragments; f++) {
+          body.push(`  {\n  ${pick(HOSTILE_FRAGMENTS)[1]}\n  }`);
+        }
+        // Unique tail line -> unique worklet hash per function.
+        body.push(`  el.setStyleProperty('k${m}_${w}', 'v');`);
+        fns.push(`export function w${w}(el, d) {\n${body.join('\n')}\n}`);
+      }
+      // Plain functions carry hostile content too: it lands in the LEPUS
+      // module OUTSIDE registrations and must not corrupt the whole-module
+      // parse either.
+      for (let p = 0; p < plainCount; p++) {
+        fns.push(
+          `export function p${p}(q) {\n  {\n  ${pick(HOSTILE_FRAGMENTS)[1]}\n  }\n  return q + ${p};\n}`,
+        );
+      }
+
+      expectExtraction(fns.join('\n'), workletCount);
+    }
+  });
+});
+
+describe('extraction parser envelope (forward syntax)', () => {
+  // Direct LEPUS-shaped input: pins what the parser accepts independently
+  // of what today's transform emits, so a future @lynx-js/react emitting
+  // newer syntax doesn't surprise us.
+  const FUTURE_BODIES: ReadonlyArray<[name: string, body: string]> = [
+    ['bigint and numeric separators', 'const n = 1_000_000n;'],
+    ['optional chaining and nullish', 'const v = a?.b ?? c;'],
+    ['exponentiation', 'const p = a ** 2;'],
+    ['regex v flag', 'const r = /[\\p{L}]/v.test(s);'],
+    ['named capture groups', 'const g = /(?<y>\\d{4})/.exec(s);'],
+    [
+      'class with private field and static block',
+      'class K { #x = 1; static { globalThis.__k = 2; } m() { return this.#x; } }',
+    ],
+    ['async generator', 'async function* g() { yield await p; }'],
+    ['using declaration', 'using h = getHandle();'],
+  ];
+
+  for (const [name, body] of FUTURE_BODIES) {
+    it(`parses ${name}`, () => {
+      const call = `registerWorkletInternal("main-thread", "h1", function() {\n  ${body}\n})`;
+      const out = extractRegistrations(
+        `var loadWorkletRuntime = x;\nloadWorkletRuntime(ctx) && ${call};\n`,
+      );
+      expect(out).toBe(`${call};`);
+    });
+  }
+
+  it('parses top-level await alongside registrations', () => {
+    const call = 'registerWorkletInternal("main-thread", "h2", function() { f(); })';
+    const src = `const cfg = await loadCfg();\nok && ${call};\n`;
+    expect(extractRegistrations(src)).toBe(`${call};`);
+  });
+
+  it('throws loudly on unparseable input instead of silently truncating', () => {
+    // Decorators need a parser plugin; the point pinned here is the
+    // failure MODE — a thrown error fails the module build with a message
+    // naming it, rather than emitting a partial MT bundle.
+    expect(() => extractRegistrations('@dec class X {}\nregisterWorkletInternal("main-thread", "h3", function() {});'))
+      .toThrow();
+  });
+});

--- a/packages/testing-library/src/__tests__/worklet-loader-imports.test.ts
+++ b/packages/testing-library/src/__tests__/worklet-loader-imports.test.ts
@@ -415,6 +415,7 @@ interface RunOptions {
   resourceQuery?: string;
   resolve?: Record<string, string>;
   includeWorkletPackages?: ReadonlyArray<string | RegExp>;
+  onWarning?: (warning: Error) => void;
 }
 
 /** Drive the async loader with a minimal mock LoaderContext. */
@@ -442,6 +443,9 @@ function runLoaderMT(source: string, opts: RunOptions = {}): Promise<string> {
       resourcePath: opts.resourcePath ?? '/project/src/mod.ts',
       resourceQuery: opts.resourceQuery ?? '',
       emitError() {},
+      emitWarning(warning: Error) {
+        opts.onWarning?.(warning);
+      },
     };
     const loader = workletLoaderMT as unknown as (
       this: typeof ctx,
@@ -472,6 +476,29 @@ describe('worklet-loader-mt (end-to-end)', () => {
       resourcePath: '/project/src/gesture.ts',
     });
     expect(out).toContain('registerWorkletInternal');
+  });
+
+  it('warns when a directive-bearing module yields no registrations', async () => {
+    // Forward guard: if the LEPUS emit shape ever changes under us (e.g.
+    // registerWorkletInternal is renamed), extraction returning nothing
+    // must surface as a build warning, not a silently empty MT module.
+    const warnings: Error[] = [];
+    // The directive substring is present but no function carries it, so
+    // the transform legitimately emits zero registrations.
+    await runLoaderMT(`export const label = 'main thread';`, {
+      resourcePath: '/project/src/label.ts',
+      onWarning: (w) => warnings.push(w),
+    });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]!.message).toContain('/project/src/label.ts');
+
+    // And a module that registers normally must NOT warn.
+    const clean: Error[] = [];
+    await runLoaderMT(gestureModule, {
+      resourcePath: '/project/src/gesture.ts',
+      onWarning: (w) => clean.push(w),
+    });
+    expect(clean).toHaveLength(0);
   });
 
   it('re-emits an aliased import edge so MT reaches the worklet module', async () => {

--- a/packages/testing-library/src/__tests__/worklet-utils.test.ts
+++ b/packages/testing-library/src/__tests__/worklet-utils.test.ts
@@ -4,9 +4,46 @@
 
 import { describe, it, expect } from 'vitest';
 import {
+  extractRegistrations,
   extractTemplateRegistrations,
   stripStyleImports,
 } from '../../../vue-lynx/plugin/src/loaders/worklet-utils.js';
+
+describe('extractRegistrations', () => {
+  it('extracts calls whose bodies contain comments with quotes and unmatched parens', () => {
+    // LEPUS output preserves source comments inside worklet bodies; an
+    // apostrophe or unmatched paren in one must not corrupt extraction.
+    const reg =
+      `registerWorkletInternal("main-thread", "a1b2", function () {\n`
+      + `  // don't do this twice (see notes\n`
+      + `  elRef.current?.setStyleProperty('opacity', '0.5');\n`
+      + `})`;
+    const src = `loadWorkletRuntime(ctx) && ${reg};\n`;
+    expect(extractRegistrations(src)).toBe(`${reg};`);
+  });
+
+  it('keeps extracting registrations after a comment-corrupted body', () => {
+    // The silent failure mode: a scanner that loses balance mid-module
+    // drops every remaining registration while the build stays green.
+    const regs = [
+      `registerWorkletInternal("main-thread", "h1", function () {\n  /* it's fine :) */ f(1);\n})`,
+      `registerWorkletInternal("main-thread", "h2", function () {\n  g(\`tick\`);\n})`,
+      `registerWorkletInternal("main-thread", "h3", function () {\n  h(3);\n})`,
+    ];
+    const src = regs.map((r) => `loadWorkletRuntime(ctx) && ${r};`).join('\n');
+    expect(extractRegistrations(src)).toBe(regs.map((r) => `${r};`).join('\n'));
+  });
+
+  it('parses shared-runtime import attributes in LEPUS output', () => {
+    const src = [
+      `import { shared } from './shared.js' with { runtime: 'shared' };`,
+      `loadWorkletRuntime(ctx) && registerWorkletInternal("main-thread", "h4", function () { shared(); });`,
+    ].join('\n');
+    expect(extractRegistrations(src)).toBe(
+      `registerWorkletInternal("main-thread", "h4", function () { shared(); });`,
+    );
+  });
+});
 
 describe('extractTemplateRegistrations', () => {
   it('re-emits real registrations and ignores JSDoc examples', () => {

--- a/packages/testing-library/src/__tests__/worklet-utils.test.ts
+++ b/packages/testing-library/src/__tests__/worklet-utils.test.ts
@@ -59,6 +59,30 @@ describe('extractTemplateRegistrations', () => {
     ].join('\n');
     expect(extractTemplateRegistrations(src)).toBe(`${real};`);
   });
+
+  it('survives a comment with an apostrophe and unmatched paren in the create() body', () => {
+    // Same bug class as extractRegistrations: the old findBalancedEnd
+    // scanner read the apostrophe as a string start and dropped the call.
+    const real =
+      "(globalThis.__vueLynxRegisterElementTemplate || function () {})(\"ab12\", [\"#text\"], function (P) {\n"
+      + "  // don't build twice (see fig 1\n"
+      + '  return [e0];\n'
+      + '})';
+    expect(extractTemplateRegistrations(`const _hoisted_1 = ${real};`)).toBe(
+      `${real};`,
+    );
+  });
+
+  it('extracts registrations alongside user TypeScript (script-setup case)', () => {
+    const real =
+      '(globalThis.__vueLynxRegisterElementTemplate || function () {})("cd34", [], function (P) { return []; })';
+    const src = [
+      'const label: string = "x";',
+      'interface Props { n: number }',
+      `const _hoisted_1 = ${real};`,
+    ].join('\n');
+    expect(extractTemplateRegistrations(src)).toBe(`${real};`);
+  });
 });
 
 describe('stripStyleImports', () => {

--- a/packages/vue-lynx/package.json
+++ b/packages/vue-lynx/package.json
@@ -69,6 +69,7 @@
     "dev": "(cd internal && npx tsc -p tsconfig.build.json) && (cd runtime && npx rslib build --watch) & (cd main-thread && npx rslib build --watch) & (cd plugin && npx rslib build --watch) & (cd types && npx rslib build --watch)"
   },
   "dependencies": {
+    "@babel/parser": "^7.25.3",
     "@lynx-js/css-extract-webpack-plugin": "^0.7.0",
     "@lynx-js/react": "^0.116.5",
     "@lynx-js/runtime-wrapper-webpack-plugin": "^0.1.3",

--- a/packages/vue-lynx/plugin/rslib.config.ts
+++ b/packages/vue-lynx/plugin/rslib.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
   },
   output: {
     externals: [
+      '@babel/parser',
       '@rsbuild/core',
       '@rsbuild/plugin-vue',
       '@lynx-js/css-extract-webpack-plugin',

--- a/packages/vue-lynx/plugin/src/loaders/worklet-loader-mt.ts
+++ b/packages/vue-lynx/plugin/src/loaders/worklet-loader-mt.ts
@@ -149,6 +149,7 @@ async function transformModule(
     if (lepusCode === null) return scriptStub();
 
     const registrations = extractRegistrations(lepusCode);
+    warnIfNoRegistrations(ctx, registrations);
     const sharedImports = extractSharedImports(lepusCode);
     const parts = [
       sharedImports,
@@ -191,9 +192,31 @@ async function transformModule(
 
   // Return shared imports + local imports (for dep graph) + extracted registrations
   const registrations = extractRegistrations(lepusCode);
+  warnIfNoRegistrations(ctx, registrations);
   const parts = [sharedImports, localImports, registrations, tplRegistrations]
     .filter(Boolean);
   return parts.join('\n');
+}
+
+/**
+ * A 'main thread' directive was present and the LEPUS transform succeeded,
+ * yet extraction found no registerWorkletInternal calls. Legit only when
+ * the directive string appears outside a worklet function; otherwise it
+ * means the transform's emit shape changed under us — surface it instead
+ * of silently shipping an MT bundle with dead worklets.
+ */
+function warnIfNoRegistrations(
+  ctx: Rspack.LoaderContext<WorkletLoaderMTOptions>,
+  registrations: string,
+): void {
+  if (registrations !== '') return;
+  ctx.emitWarning(
+    new Error(
+      `[worklet-loader-mt] 'main thread' directive present but no worklet `
+        + `registrations were extracted from ${ctx.resourcePath}. If this `
+        + `module defines worklets, the LEPUS emit shape may have changed.`,
+    ),
+  );
 }
 
 /**

--- a/packages/vue-lynx/plugin/src/loaders/worklet-loader-mt.ts
+++ b/packages/vue-lynx/plugin/src/loaders/worklet-loader-mt.ts
@@ -212,9 +212,12 @@ function warnIfNoRegistrations(
   if (registrations !== '') return;
   ctx.emitWarning(
     new Error(
-      `[worklet-loader-mt] 'main thread' directive present but no worklet `
-        + `registrations were extracted from ${ctx.resourcePath}. If this `
-        + `module defines worklets, the LEPUS emit shape may have changed.`,
+      `[worklet-loader-mt] ${ctx.resourcePath} contains a 'main thread' `
+        + `directive but produced no worklet registrations for the main-thread `
+        + `bundle. If the module defines worklets, they are missing from MT and `
+        + `will crash at runtime with "cannot read property 'bind' of `
+        + `undefined" on first interaction. If the directive is an unrelated `
+        + `string (not a worklet function), this warning is safe to ignore.`,
     ),
   );
 }

--- a/packages/vue-lynx/plugin/src/loaders/worklet-utils.ts
+++ b/packages/vue-lynx/plugin/src/loaders/worklet-utils.ts
@@ -345,38 +345,28 @@ export function extractRegistrations(lepusCode: string): string {
   const ast = parse(lepusCode, { sourceType: 'module' });
   const registrations: string[] = [];
 
-  interface AstNode {
-    type: string;
-    start: number;
-    end: number;
-    [key: string]: unknown;
-  }
-
-  const walk = (value: unknown): void => {
-    if (Array.isArray(value)) {
-      for (const item of value) walk(item);
+  // Structural walk over untyped babel nodes; `any` beats re-declaring
+  // the AST shape.
+  const walk = (node: any): void => {
+    if (!node || typeof node !== 'object') return;
+    if (Array.isArray(node)) {
+      for (const item of node) walk(item);
       return;
     }
-    if (!value || typeof (value as AstNode).type !== 'string') return;
-    const node = value as AstNode;
-
-    if (node.type === 'CallExpression') {
-      const callee = node.callee as AstNode & { name?: string };
-      if (
-        callee.type === 'Identifier'
-        && callee.name === 'registerWorkletInternal'
-      ) {
-        registrations.push(lepusCode.slice(node.start, node.end) + ';');
-        // Registrations never nest; skipping the subtree mirrors the
-        // previous scanner's resume-past-the-call behavior.
-        return;
-      }
+    if (typeof node.type !== 'string') return;
+    if (
+      node.type === 'CallExpression'
+      && node.callee.type === 'Identifier'
+      && node.callee.name === 'registerWorkletInternal'
+    ) {
+      registrations.push(lepusCode.slice(node.start, node.end) + ';');
+      // Registrations never nest; skipping the subtree mirrors the
+      // previous scanner's resume-past-the-call behavior.
+      return;
     }
-
     for (const key in node) {
       if (key === 'type' || key === 'start' || key === 'end') continue;
-      const child = node[key];
-      if (child && typeof child === 'object') walk(child);
+      walk(node[key]);
     }
   };
   walk(ast);

--- a/packages/vue-lynx/plugin/src/loaders/worklet-utils.ts
+++ b/packages/vue-lynx/plugin/src/loaders/worklet-utils.ts
@@ -2,6 +2,8 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+import { parse } from '@babel/parser';
+
 import { TPL_REGISTER_GLOBAL } from 'vue-lynx/internal/ops';
 
 /**
@@ -326,29 +328,58 @@ export function extractSharedImports(source: string): string {
  *   - worklet object declarations
  *   - loadWorkletRuntime(...) && registerWorkletInternal(type, hash, fn);
  *
- * We only need the registerWorkletInternal(...) calls. Uses bracket-depth
- * counting to handle nested braces in function bodies.
+ * We only need the registerWorkletInternal(...) calls. Each call is sliced
+ * out by AST node span (parse once with @babel/parser, which vue-lynx
+ * already ships via @vue/compiler-core) rather than scanned textually:
+ * worklet bodies preserve source comments, so an apostrophe,
+ * backtick, or unmatched paren inside a comment corrupts any scanner —
+ * either truncating a slice (build error downstream) or, worse, silently
+ * dropping every remaining registration in the module. Unparseable input
+ * throws, surfacing as a loader error naming the module.
+ *
+ * The bare call — not the enclosing `loadWorkletRuntime(ctx) && …`
+ * statement — is emitted; the gate identifier doesn't exist in the MT
+ * module.
  */
 export function extractRegistrations(lepusCode: string): string {
+  const ast = parse(lepusCode, { sourceType: 'module' });
   const registrations: string[] = [];
-  const marker = 'registerWorkletInternal(';
-  let searchFrom = 0;
 
-  while (true) {
-    const idx = lepusCode.indexOf(marker, searchFrom);
-    if (idx === -1) break;
-
-    // Find the end of the registerWorkletInternal(...) call.
-    const close = findBalancedEnd(lepusCode, idx + marker.length - 1);
-    if (close === -1) break;
-
-    // Extract the full call including trailing semicolon
-    let end = close + 1;
-    if (end < lepusCode.length && lepusCode[end] === ';') end++;
-
-    registrations.push(lepusCode.slice(idx, end));
-    searchFrom = end;
+  interface AstNode {
+    type: string;
+    start: number;
+    end: number;
+    [key: string]: unknown;
   }
+
+  const walk = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      for (const item of value) walk(item);
+      return;
+    }
+    if (!value || typeof (value as AstNode).type !== 'string') return;
+    const node = value as AstNode;
+
+    if (node.type === 'CallExpression') {
+      const callee = node.callee as AstNode & { name?: string };
+      if (
+        callee.type === 'Identifier'
+        && callee.name === 'registerWorkletInternal'
+      ) {
+        registrations.push(lepusCode.slice(node.start, node.end) + ';');
+        // Registrations never nest; skipping the subtree mirrors the
+        // previous scanner's resume-past-the-call behavior.
+        return;
+      }
+    }
+
+    for (const key in node) {
+      if (key === 'type' || key === 'start' || key === 'end') continue;
+      const child = node[key];
+      if (child && typeof child === 'object') walk(child);
+    }
+  };
+  walk(ast);
 
   return registrations.join('\n');
 }

--- a/packages/vue-lynx/plugin/src/loaders/worklet-utils.ts
+++ b/packages/vue-lynx/plugin/src/loaders/worklet-utils.ts
@@ -342,11 +342,28 @@ export function extractSharedImports(source: string): string {
  * module.
  */
 export function extractRegistrations(lepusCode: string): string {
-  const ast = parse(lepusCode, { sourceType: 'module' });
-  const registrations: string[] = [];
+  const out: string[] = [];
+  forEachCall(parse(lepusCode, { sourceType: 'module' }), (node) => {
+    if (
+      node.callee.type === 'Identifier'
+      && node.callee.name === 'registerWorkletInternal'
+    ) {
+      out.push(lepusCode.slice(node.start, node.end) + ';');
+      return true;
+    }
+    return false;
+  });
+  return out.join('\n');
+}
 
-  // Structural walk over untyped babel nodes; `any` beats re-declaring
-  // the AST shape.
+/**
+ * Walk every node of a `@babel/parser` AST and invoke `onCall` for each
+ * `CallExpression`. Returning `true` skips that call's subtree, which
+ * matches the old scanners' resume-past-the-call behavior (registrations
+ * never nest). Nodes are untyped babel objects; `any` beats re-declaring
+ * the AST shape.
+ */
+function forEachCall(ast: any, onCall: (node: any) => boolean): void {
   const walk = (node: any): void => {
     if (!node || typeof node !== 'object') return;
     if (Array.isArray(node)) {
@@ -354,24 +371,13 @@ export function extractRegistrations(lepusCode: string): string {
       return;
     }
     if (typeof node.type !== 'string') return;
-    if (
-      node.type === 'CallExpression'
-      && node.callee.type === 'Identifier'
-      && node.callee.name === 'registerWorkletInternal'
-    ) {
-      registrations.push(lepusCode.slice(node.start, node.end) + ';');
-      // Registrations never nest; skipping the subtree mirrors the
-      // previous scanner's resume-past-the-call behavior.
-      return;
-    }
+    if (node.type === 'CallExpression' && onCall(node)) return;
     for (const key in node) {
       if (key === 'type' || key === 'start' || key === 'end') continue;
       walk(node[key]);
     }
   };
   walk(ast);
-
-  return registrations.join('\n');
 }
 
 /**
@@ -431,100 +437,33 @@ export function stripStyleImports(code: string): string {
  * evaluation time; entry-main installs it before user code runs), so they
  * are re-emitted verbatim.
  *
- * Matches inside line or block comments are skipped — documentation
- * examples of the registration shape (including the one in
- * runtime/src/element-template.ts) must not be re-emitted as executable
- * code. This matters when workspace tsconfig path aliases resolve
- * `vue-lynx` to TypeScript source rather than `runtime/dist`.
+ * The AST walk ignores comments by construction, so documentation examples
+ * of the registration shape (including the one in
+ * runtime/src/element-template.ts) are never re-emitted as executable code.
+ * This matters when workspace tsconfig path aliases resolve `vue-lynx` to
+ * TypeScript source rather than `runtime/dist`. The `typescript` plugin
+ * covers script-setup SFCs, whose compiled sub-module carries the
+ * registrations alongside user TypeScript.
  */
 export function extractTemplateRegistrations(source: string): string {
-  const marker = `globalThis.${TPL_REGISTER_GLOBAL}`;
   const out: string[] = [];
-  let searchFrom = 0;
-  while (true) {
-    const idx = source.indexOf(marker, searchFrom);
-    if (idx === -1) break;
-    if (isInsideComment(source, idx)) {
-      searchFrom = idx + marker.length;
-      continue;
+  const ast = parse(source, { sourceType: 'module', plugins: ['typescript'] });
+  // The hoisted call is `(globalThis.<TPL_REGISTER_GLOBAL> || function () {})(args…)`,
+  // i.e. a CallExpression whose callee is that `||` short-circuit.
+  forEachCall(ast, (node) => {
+    const callee = node.callee;
+    if (
+      callee.type === 'LogicalExpression'
+      && callee.left?.type === 'MemberExpression'
+      && callee.left.object?.type === 'Identifier'
+      && callee.left.object.name === 'globalThis'
+      && callee.left.property?.type === 'Identifier'
+      && callee.left.property.name === TPL_REGISTER_GLOBAL
+    ) {
+      out.push(source.slice(node.start, node.end) + ';');
+      return true;
     }
-    // The marker sits inside `(globalThis.… || function () {})(args…)`.
-    const wrapperStart = source.lastIndexOf('(', idx);
-    if (wrapperStart === -1) {
-      searchFrom = idx + marker.length;
-      continue;
-    }
-    const wrapperEnd = findBalancedEnd(source, wrapperStart);
-    if (wrapperEnd === -1 || source[wrapperEnd + 1] !== '(') {
-      searchFrom = idx + marker.length;
-      continue;
-    }
-    const argsEnd = findBalancedEnd(source, wrapperEnd + 1);
-    if (argsEnd === -1) {
-      searchFrom = idx + marker.length;
-      continue;
-    }
-    out.push(`${source.slice(wrapperStart, argsEnd + 1)};`);
-    searchFrom = argsEnd + 1;
-  }
+    return false;
+  });
   return out.join('\n');
-}
-
-/** True when `index` falls inside a `//` or block comment. */
-function isInsideComment(code: string, index: number): boolean {
-  let i = 0;
-  while (i < index) {
-    const ch = code[i];
-    if (ch === '"' || ch === "'" || ch === '`') {
-      for (i++; i < index; i++) {
-        if (code[i] === '\\') i++;
-        else if (code[i] === ch) {
-          i++;
-          break;
-        }
-      }
-      continue;
-    }
-    if (ch === '/' && code[i + 1] === '/') {
-      const end = code.indexOf('\n', i + 2);
-      if (end === -1 || end >= index) return true;
-      i = end + 1;
-      continue;
-    }
-    if (ch === '/' && code[i + 1] === '*') {
-      const end = code.indexOf('*/', i + 2);
-      if (end === -1 || end + 2 > index) return true;
-      i = end + 2;
-      continue;
-    }
-    i++;
-  }
-  return false;
-}
-
-/**
- * Given the index of a '(' in `code`, return the index of its matching ')'.
- *
- * String/template literals are skipped so parens inside embedded text (e.g.
- * a baked `__SetAttribute(e, 'text', "call us :)")`) don't unbalance the
- * scan. Comments are not handled — the scanned sources are compiler output,
- * which never embeds parens in comments between call arguments.
- */
-function findBalancedEnd(code: string, openIndex: number): number {
-  let depth = 0;
-  for (let i = openIndex; i < code.length; i++) {
-    const ch = code[i];
-    if (ch === '"' || ch === "'" || ch === '`') {
-      for (i++; i < code.length; i++) {
-        if (code[i] === '\\') i++;
-        else if (code[i] === ch) break;
-      }
-    } else if (ch === '(') {
-      depth++;
-    } else if (ch === ')') {
-      depth--;
-      if (depth === 0) return i;
-    }
-  }
-  return -1;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -685,9 +685,6 @@ importers:
       '@babel/parser':
         specifier: ^7.25.3
         version: 7.29.0
-      '@lynx-js/react':
-        specifier: ^0.116.5
-        version: 0.116.5(@lynx-js/types@3.7.0)(@types/react@19.2.14)
       '@lynx-js/testing-environment':
         specifier: ^0.1.11
         version: 0.1.11

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -736,6 +736,9 @@ importers:
 
   packages/vue-lynx:
     dependencies:
+      '@babel/parser':
+        specifier: ^7.25.3
+        version: 7.29.0
       '@lynx-js/css-extract-webpack-plugin':
         specifier: ^0.7.0
         version: 0.7.0(@lynx-js/template-webpack-plugin@0.10.5(@lynx-js/lynx-core@0.1.3)(tslib@2.8.1))(webpack@5.105.4)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -682,6 +682,12 @@ importers:
 
   packages/testing-library:
     devDependencies:
+      '@babel/parser':
+        specifier: ^7.25.3
+        version: 7.29.0
+      '@lynx-js/react':
+        specifier: ^0.116.5
+        version: 0.116.5(@lynx-js/types@3.7.0)(@types/react@19.2.14)
       '@lynx-js/testing-environment':
         specifier: ^0.1.11
         version: 0.1.11


### PR DESCRIPTION
## Summary

`worklet-loader-mt` pulls each `registerWorkletInternal(...)` call out of the LEPUS output of `transformReactLynxSync` by scanning for balanced parens. The scanner it currently uses, `findBalancedEnd`, skips string literals but not comments, and the LEPUS output preserves source comments inside worklet bodies. An apostrophe, backtick, or unmatched paren in a worklet-body comment therefore corrupts the scan.

The corruption takes two forms. A truncated slice leaves an unterminated function, and the emitted MT module then fails `builtin:swc-loader` parsing with `'import', and 'export' cannot be used outside of module code`. The worse form is silent: when `findBalancedEnd` returns `-1`, the extraction loop breaks and drops every remaining registration in the module, the build stays green, and the app crashes on first interaction with `TypeError: cannot read property 'bind' of undefined`.

This PR replaces the scanner with AST-span slicing. The LEPUS output is parsed once with `@babel/parser` and each `registerWorkletInternal(...)` call is sliced by node position, which makes extraction immune to strings, comments, regex literals, and template nesting by construction.

## Minimal repro

Any `'main thread'` worklet whose body contains a comment with an apostrophe or unmatched paren triggers the bug:

```ts
function onTap() {
  'main thread'
  // don't do this twice (see notes
  elRef.current?.setStyleProperty('opacity', '0.5')
}
```

Building this for a Lynx target on the current release produces either the swc syntax error or a green build with missing MT registrations, depending on where the comment falls. The identical source builds and runs correctly on 0.4.2.

## Impact on a real corpus

I ran all three extractors over identical LEPUS output (from `@lynx-js/react` 0.116.5) for every worklet-bearing module in vyui, a Lynx component library with 27 such modules and 183 registrations. The 0.4.2 counter and this PR's parser each recovered all 183 registrations. The `findBalancedEnd` scanner that currently ships dropped registrations in seven modules:

| module | registrations | scanner extracts | failure mode |
| --- | --- | --- | --- |
| `shared/utils/interpolation.ts` | 5 | 0 | silent |
| `Toast/ToastSwipe.vue` | 9 | 0 | silent |
| `List/List.vue` | 2 | 0 | silent |
| `Draggable/Draggable.vue` | 9 | 8 | **loud (build error)** |
| `Sheet/SheetContentImpl.vue` | 20 | 0 | silent |
| `FeedList/FeedList.vue` | 13 | 11 | silent |
| `Sortable/SortableItem.vue` | 14 | 13 | silent |

Six of the seven modules fail silently, and the one loud failure in `Draggable.vue` is the only symptom the build surfaces. Hand-fixing that module's comment to clear the swc error would ship a green build missing 39 worklets across the other six.

The result is worth stating plainly, because it inverts the usual intuition. The blunt 0.4.2 counter extracts this corpus correctly, and the more sophisticated string-aware scanner that replaced it does not. The next section explains why.

## Why parse instead of extending the scanner

Extraction has had three implementations, and each one closed its predecessor's blind spot while opening a new one. The original counter tracked paren depth over every character, so a paren inside a string or a comment threw off the balance, and it worked only while those stray parens happened to cancel out. The `findBalancedEnd` scanner that replaced it added string-literal skipping, which handled parens inside strings but made comments worse, because the scanner reads the apostrophe in a word like `don't` as the start of a string literal and then consumes the real closing paren behind it. That is why the scanner regresses a corpus the counter got right.

Extending the scanner a third time would mean teaching it comments, then regex literals, and then the division-versus-regex ambiguity that decides whether a slash opens a pattern or divides two numbers. That is the work a JavaScript lexer already does, and `@babel/parser` already sits in the dependency tree through `@vue/compiler-core`. Slicing each call by its AST node span removes the class rather than the current instance of it, because the node boundaries come from the grammar instead of from a guess about where a token ends. The only new cost is one parse of compiler output that the loader was about to hand to a bundler's parser anyway.

## How the regression got here

This is the same failure class I fixed once already in a neighboring function, and the honest read is that the first pass should have covered both places. On 2026-05-31 the import-following path had the identical problem, where quotes and parens inside strings and comments corrupted a textual scan of the module source. I fixed it there by masking string and template literals and stripping comments before scanning, in commits `9f4d2d2e` and `0f739461`, and `extractRegistrations` sat a few functions away with the same fragility and never received the same treatment.

The registration path then changed on a separate track. A mid-July refactor (commit `35ea96df`) swapped the old paren counter in `extractRegistrations` for the `findBalancedEnd` scanner that the element-template code had introduced for its own use. That scanner handles strings but not comments, and it turned a latent weakness into a live one, because reading an apostrophe in a comment as a string is a failure the blunt counter never had. The regression is present in the current 0.5.x release, which is where I hit it.

So this is neither a fresh bug nor purely a regression from elsewhere. The class was found and fixed in one function, left standing in its sibling, and then reintroduced in that sibling by a well-meant hardening that reached for a new scanner instead of the literal-masking approach already proven next door. Moving registration extraction onto the parser closes the class where it kept recurring, and the follow-up note below tracks the one remaining scanner caller so a third recurrence does not arrive the same way.

## The fix

`extractRegistrations` now parses the LEPUS output with `@babel/parser` and slices each call by its AST node span (see `worklet-utils.ts` in the diff). Slicing the bare call rather than the enclosing `loadWorkletRuntime(ctx) && ...` statement matches current behavior, since the gate identifier doesn't exist in the emitted MT module. Unparseable input now throws, which fails the module build with an error naming the file instead of emitting corrupted output. The loader additionally warns when a directive-bearing module extracts zero registrations, so a future change to the LEPUS emit shape would surface at build time. `findBalancedEnd` and `isInsideComment` remain only for `extractTemplateRegistrations` (see follow-ups).

The parser adds no install weight because `@babel/parser` is already a hard dependency of `@vue/compiler-core`, which vue-lynx depends on directly. Listing it in the plugin's externals also stops `@vue/compiler-core`'s bundled copy from being inlined, which shrinks `plugin/dist` from 1097 kB to 425 kB.

## Verification

Extraction output is byte-identical to 0.4.2's device-proven output across all 27 modules and 183 registrations of the corpus above, which is the three-way sweep behind the table. A previously-failing real app (vyui kit-demo) builds green with this fix patched into an installed 0.5.1, and a bundle audit shows 158 worklet ids referenced, 166 registered, and 0 unresolved, matching a stock 0.4.2 baseline of the same app.

Regression tests in `worklet-utils.test.ts` cover the comment cases, the silent mid-module drop, and import attributes. A differential fuzz suite in `worklet-extraction-pipeline.test.ts` runs the real transform over 120 generated adversarial modules and asserts that extracted hashes match the background transform's `_wkltId` set, which is the invariant behind the runtime crash. The full testing-library suite passes at 226 tests.

Parsing costs about 1 ms for a 23 kB worklet-heavy module, and extraction only runs for modules carrying a `'main thread'` directive.

## Follow-ups

`extractTemplateRegistrations` still uses `findBalancedEnd` and shares the bug class, and the same parse can feed it. `extractImportSpecifiers` and `extractSharedImports` are regex-based over the same source and could share that parse too. The ideal end state is upstream: `transformReactLynxSync` already knows registration positions, and exposing them as output metadata would remove the reparse entirely. That requires a `@lynx-js/react/transform` (Rust) change, so the AST slice is the right-sized fix in the meantime.

## Environment

- vue-lynx 0.5.1, where the shipped `findBalancedEnd` scanner regresses; the 0.4.x paren counter is unaffected on this corpus
- `@lynx-js/react` 0.116.5, whose transform output is identical across the versions above, which rules the transform out
- `@lynx-js/rspeedy` 0.13.6
