### PR TITLE
feat(plugin): build-time check for background worklets missing a main-thread registration

### DIFF
--- a/.changeset/worklet-registration-check.md
+++ b/.changeset/worklet-registration-check.md
@@ -1,0 +1,5 @@
+---
+"vue-lynx": minor
+---
+
+Add a build-time check that every worklet referenced on the background thread (`_wkltId`) is registered on the main thread (`registerWorkletInternal`). A mismatch is the usual cause of the runtime crash `cannot read property 'bind' of undefined` on first interaction, which nothing surfaced at build time before. Controlled by the new `checkWorkletRegistrations` option (`'warn'` by default, `'error'` to fail the build, `'off'` to disable).

--- a/packages/testing-library/src/__tests__/worklet-registration-check.test.ts
+++ b/packages/testing-library/src/__tests__/worklet-registration-check.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Unit coverage for the worklet registration cross-check logic.
+ *
+ * The pure functions here are what the WorkletRegistrationCheckPlugin runs
+ * over compilation assets. Fixtures mirror the two real shapes the scan
+ * meets: raw JS chunks (`registerWorkletInternal("main-thread", "h", fn)`,
+ * `_wkltId: "h"`) and JSON-escaped code inside a `.bundle` envelope
+ * (`\"h\"`).
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  collectReferencedIds,
+  collectRegisteredIds,
+  findUnresolvedWorklets,
+  formatUnresolvedMessage,
+} from '../../../vue-lynx/plugin/src/plugins/worklet-registration-check-plugin.js';
+
+const mtChunk = (ids: string[]) =>
+  ids
+    .map((id) => `registerWorkletInternal("main-thread", "${id}", function() {});`)
+    .join('\n');
+
+const bgChunk = (ids: string[]) =>
+  ids.map((id) => `var o = { _wkltId: "${id}", _c: {} };`).join('\n');
+
+describe('worklet registration cross-check', () => {
+  it('extracts registered and referenced ids from raw JS', () => {
+    expect([...collectRegisteredIds([mtChunk(['a:1', 'b:2'])])]).toEqual([
+      'a:1',
+      'b:2',
+    ]);
+    expect([...collectReferencedIds([bgChunk(['a:1', 'b:2'])])]).toEqual([
+      'a:1',
+      'b:2',
+    ]);
+  });
+
+  it('reports nothing when every reference is registered', () => {
+    const unresolved = findUnresolvedWorklets({
+      mtSources: [mtChunk(['a:1', 'b:2', 'c:3'])],
+      allSources: [bgChunk(['a:1', 'b:2', 'c:3'])],
+    });
+    expect(unresolved).toEqual([]);
+  });
+
+  it('flags a background reference missing from the main thread', () => {
+    const unresolved = findUnresolvedWorklets({
+      mtSources: [mtChunk(['a:1', 'c:3'])], // b:2 dropped (the extraction bug)
+      allSources: [bgChunk(['a:1', 'b:2', 'c:3'])],
+    });
+    expect(unresolved).toEqual(['b:2']);
+  });
+
+  it('reads ids through JSON-escaped bundle envelopes', () => {
+    // A .lynx/.web.bundle embeds chunk code as an escaped JSON string.
+    const escaped = mtChunk(['a:1']).replace(/"/g, '\\"');
+    expect([...collectRegisteredIds([escaped])]).toEqual(['a:1']);
+  });
+
+  it('bails when nothing is registered at all (wrong-stage guard)', () => {
+    // References but zero registrations means the scan hit already-packaged
+    // output; reporting all of them would be a false alarm, not a diagnosis.
+    const unresolved = findUnresolvedWorklets({
+      mtSources: [],
+      allSources: [bgChunk(['a:1', 'b:2'])],
+    });
+    expect(unresolved).toEqual([]);
+  });
+
+  it('writes an actionable message naming the runtime symptom', () => {
+    const msg = formatUnresolvedMessage(['b:2']);
+    expect(msg).toContain('b:2');
+    expect(msg).toContain("bind' of undefined");
+    expect(msg).toContain('includeWorkletPackages');
+  });
+});

--- a/packages/vue-lynx/plugin/src/entry.ts
+++ b/packages/vue-lynx/plugin/src/entry.ts
@@ -22,11 +22,16 @@ import {
 } from './loaders/worklet-utils.js';
 import { vueScopeStripCSSPlugin } from './plugins/vue-scope-strip-css-plugin.js';
 import { VueScopedCSSIdPlugin } from './plugins/vue-scoped-cssid-plugin.js';
+import {
+  type WorkletCheckSeverity,
+  WorkletRegistrationCheckPlugin,
+} from './plugins/worklet-registration-check-plugin.js';
 
 const PLUGIN_TEMPLATE = 'lynx:vue-template';
 const PLUGIN_RUNTIME_WRAPPER = 'lynx:vue-runtime-wrapper';
 const PLUGIN_ENCODE = 'lynx:vue-encode';
 const PLUGIN_MARK_MAIN_THREAD = 'lynx:vue-mark-main-thread';
+const PLUGIN_WORKLET_CHECK = 'lynx:vue-worklet-registration-check';
 // worklet-runtime is now bundled directly into main-thread.js (no separate chunk).
 const PLUGIN_WEB_ENCODE = 'lynx:vue-web-encode';
 
@@ -219,6 +224,8 @@ export interface ApplyEntryOptions {
   /** Element templates: preserve template registrations on the MT layer. */
   enableElementTemplates: boolean;
   includeWorkletPackages?: ReadonlyArray<string | RegExp>;
+  /** Build-time check for BG-referenced worklets missing from the MT bundle. */
+  checkWorkletRegistrations?: WorkletCheckSeverity;
 }
 
 export function applyEntry(
@@ -603,6 +610,19 @@ export function applyEntry(
         .plugin(PLUGIN_MARK_MAIN_THREAD)
         .use(VueMarkMainThreadPlugin, [mainThreadFilenames])
         .end();
+
+      // Diff BG-referenced worklet ids against MT-registered ones and report
+      // the drift that otherwise only shows up as a runtime bind-of-undefined.
+      const checkSeverity = opts.checkWorkletRegistrations ?? 'warn';
+      if (checkSeverity !== 'off') {
+        chain
+          .plugin(PLUGIN_WORKLET_CHECK)
+          .use(WorkletRegistrationCheckPlugin, [
+            mainThreadFilenames,
+            checkSeverity,
+          ])
+          .end();
+      }
     }
 
     // ------------------------------------------------------------------

--- a/packages/vue-lynx/plugin/src/index.ts
+++ b/packages/vue-lynx/plugin/src/index.ts
@@ -192,6 +192,21 @@ export interface PluginVueLynxOptions {
    * @defaultValue []
    */
   includeWorkletPackages?: ReadonlyArray<string | RegExp>;
+
+  /**
+   * Build-time check that every worklet referenced on the background thread
+   * (`_wkltId`) is registered on the main thread (`registerWorkletInternal`).
+   * A mismatch is the usual cause of the runtime crash `cannot read property
+   * 'bind' of undefined` on first interaction, which nothing surfaces at build
+   * time otherwise.
+   *
+   *   - `'warn'` — report the drift as a build warning (default);
+   *   - `'error'` — fail the build;
+   *   - `'off'` — disable the check.
+   *
+   * @defaultValue 'warn'
+   */
+  checkWorkletRegistrations?: 'error' | 'warn' | 'off';
 }
 
 /**
@@ -217,6 +232,7 @@ export function pluginVueLynx(
     autoPixelUnit = true,
     enableIFR = false,
     includeWorkletPackages = [],
+    checkWorkletRegistrations = 'warn',
   } = options;
   const enableElementTemplates = resolveElementTemplatesFlag(options);
 
@@ -342,6 +358,7 @@ export function pluginVueLynx(
           enableIFR,
           enableElementTemplates,
           includeWorkletPackages,
+          checkWorkletRegistrations,
         });
       },
     },

--- a/packages/vue-lynx/plugin/src/plugins/worklet-registration-check-plugin.ts
+++ b/packages/vue-lynx/plugin/src/plugins/worklet-registration-check-plugin.ts
@@ -1,0 +1,141 @@
+// Copyright 2026 Xuan Huang (huxpro). All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * Build-time check for worklets that the background thread references but the
+ * main thread never registers.
+ *
+ * Every `'main thread'` worklet becomes a background-thread object carrying a
+ * `_wkltId: "<hash>"` and a matching main-thread
+ * `registerWorkletInternal("main-thread", "<hash>", fn)`. When the two sets
+ * drift — a module the MT loader never reached, an extraction bug, a package
+ * missing from `includeWorkletPackages` — the background id resolves to
+ * nothing and the app crashes on first interaction with
+ * `cannot read property 'bind' of undefined`. That crash is the single most
+ * common worklet failure, and nothing surfaces it at build time today.
+ *
+ * The check runs on the raw JS chunk assets before LynxTemplatePlugin packages
+ * them into the `.lynx.bundle` binary (where registrations are no longer text).
+ * It uses the same main-thread filename list the mark plugin gets, so it never
+ * has to guess which asset is which.
+ */
+
+const PLUGIN_NAME = 'vue-lynx:worklet-registration-check';
+
+/** How the check reports a drift. */
+export type WorkletCheckSeverity = 'error' | 'warn' | 'off';
+
+// Hashes are the second argument of registerWorkletInternal(type, hash, fn)
+// and the value of a `_wkltId` property. Sources may be raw JS or a
+// JSON-escaped code string inside a bundle envelope, so a leading backslash
+// before each quote is tolerated (see normalize()).
+const REGISTERED_RE = /registerWorkletInternal\(\s*"[^"]*"\s*,\s*"([^"]+)"/g;
+const REFERENCED_RE = /_wkltId\s*:\s*"([^"]+)"/g;
+
+/** Collapse `\"` to `"` so escaped bundle envelopes and raw JS scan alike. */
+function normalize(code: string): string {
+  return code.includes('\\"') ? code.replace(/\\"/g, '"') : code;
+}
+
+function collect(re: RegExp, sources: readonly string[]): Set<string> {
+  const ids = new Set<string>();
+  for (const raw of sources) {
+    const code = normalize(raw);
+    re.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(code)) !== null) ids.add(m[1]!);
+  }
+  return ids;
+}
+
+/** Worklet ids registered on the main thread. */
+export function collectRegisteredIds(mtSources: readonly string[]): Set<string> {
+  return collect(REGISTERED_RE, mtSources);
+}
+
+/** Worklet ids referenced by any thread's `_wkltId`. */
+export function collectReferencedIds(sources: readonly string[]): Set<string> {
+  return collect(REFERENCED_RE, sources);
+}
+
+/**
+ * Referenced-but-unregistered worklet ids, sorted for stable output.
+ *
+ * Returns `[]` (no finding) when nothing is registered at all: a build with
+ * references but zero registrations means the check ran against already
+ * packaged output rather than the raw chunks, and reporting every id as
+ * unresolved would be a false alarm, not a diagnosis.
+ */
+export function findUnresolvedWorklets(input: {
+  mtSources: readonly string[];
+  allSources: readonly string[];
+}): string[] {
+  const registered = collectRegisteredIds(input.mtSources);
+  const referenced = collectReferencedIds(input.allSources);
+  if (registered.size === 0) return [];
+  const unresolved: string[] = [];
+  for (const id of referenced) {
+    if (!registered.has(id)) unresolved.push(id);
+  }
+  return unresolved.sort();
+}
+
+/** Human-readable, actionable build message for a set of unresolved ids. */
+export function formatUnresolvedMessage(unresolved: readonly string[]): string {
+  const shown = unresolved.slice(0, 20);
+  const more = unresolved.length - shown.length;
+  const list = shown.map((id) => `  - ${id}`).join('\n')
+    + (more > 0 ? `\n  …and ${more} more` : '');
+  return `[vue-lynx] ${unresolved.length} worklet(s) are referenced on the `
+    + `background thread but never registered on the main thread:\n${list}\n`
+    + `This crashes at runtime with "cannot read property 'bind' of undefined" `
+    + `on first interaction. Common causes: a 'main thread' module the MT loader `
+    + `never reached (add its package to includeWorkletPackages), or a worklet `
+    + `that failed to extract into the MT bundle.`;
+}
+
+export class WorkletRegistrationCheckPlugin {
+  constructor(
+    private readonly mainThreadFilenames: readonly string[],
+    private readonly severity: Exclude<WorkletCheckSeverity, 'off'> = 'warn',
+  ) {}
+
+  // biome-ignore lint/suspicious/noExplicitAny: rspack/webpack compiler type not importable
+  apply(compiler: any): void {
+    const mtSet = new Set(this.mainThreadFilenames);
+    // biome-ignore lint/suspicious/noExplicitAny: rspack/webpack compilation type not importable
+    compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation: any) => {
+      compilation.hooks.processAssets.tap(
+        {
+          name: PLUGIN_NAME,
+          // After chunks are generated but before LynxTemplatePlugin encodes
+          // them into the binary bundle, where registrations stop being text.
+          stage: compiler.webpack.Compilation.PROCESS_ASSETS_STAGE_ANALYSE,
+        },
+        () => {
+          const mtSources: string[] = [];
+          const allSources: string[] = [];
+          // biome-ignore lint/suspicious/noExplicitAny: rspack/webpack asset type not importable
+          for (const asset of compilation.getAssets() as any[]) {
+            const name: string = asset.name;
+            if (!name.endsWith('.js')) continue;
+            const src = asset.source?.source?.();
+            if (src == null) continue;
+            const code = typeof src === 'string' ? src : src.toString('utf8');
+            allSources.push(code);
+            if (mtSet.has(name)) mtSources.push(code);
+          }
+
+          const unresolved = findUnresolvedWorklets({ mtSources, allSources });
+          if (unresolved.length === 0) return;
+
+          const error = new Error(formatUnresolvedMessage(unresolved));
+          error.name = 'WorkletRegistrationError';
+          if (this.severity === 'error') compilation.errors.push(error);
+          else compilation.warnings.push(error);
+        },
+      );
+    });
+  }
+}


### PR DESCRIPTION
> **Draft.** The id-diff logic is unit-tested and validated against a real built app, but the plugin's `processAssets` timing needs one confirming dual-thread build on device before this leaves draft. Details under Validation.

## What this adds

A `'main thread'` worklet becomes a background-thread object carrying `_wkltId: "<hash>"` and a matching main-thread `registerWorkletInternal("main-thread", "<hash>", fn)`. When the two sets drift — a module the MT loader never reached, an extraction bug, a package missing from `includeWorkletPackages` — the background id resolves to nothing and the app crashes on first interaction with `cannot read property 'bind' of undefined`. Nothing surfaces that at build time today.

This PR diffs the two id sets during the build and reports any background reference that has no main-thread registration.

## Why it's needed

That runtime crash is the most common worklet failure, and every existing mitigation is a workaround for the absence of this check. The message it emits names the ids, the runtime symptom, and the usual fixes, so a developer sees the cause at build time instead of bisecting a bind-of-undefined on device.

## How it works

`WorkletRegistrationCheckPlugin` hooks `processAssets` at `PROCESS_ASSETS_STAGE_ANALYSE`, after chunks are generated but before `LynxTemplatePlugin` encodes them into the binary `.lynx.bundle` (where registrations stop being text). It reuses the same main-thread filename list `VueMarkMainThreadPlugin` already receives, so it never guesses which asset is which:

- registered ids come from `registerWorkletInternal(type, hash, fn)` in the MT chunks;
- referenced ids come from `_wkltId: "hash"` across all JS chunks;
- the difference is reported.

Sources are unescaped (`\"` → `"`) before scanning so a raw JS chunk and a JSON-escaped bundle envelope read identically. If references exist but zero registrations are found anywhere, the scan is looking at already-packaged output rather than raw chunks, so it reports nothing rather than flagging every id — a false alarm is worse than silence.

## API

New `checkWorkletRegistrations` option:

- `'warn'` — report drift as a build warning (default);
- `'error'` — fail the build;
- `'off'` — disable.

The default is `'warn'` deliberately: the check is new, and a warning surfaces the problem without risking a false-positive build break until it has run against more real builds. Escalate to `'error'` once it has proven itself on your project.

## Validation

- The core id-diff logic is pure and unit-tested against both shapes it meets in practice — raw JS chunks and JSON-escaped bundle envelopes — including the healthy case, a dropped-registration case, and the wrong-stage guard.
- Extraction was validated against a real built app (vyui kit-demo): unescape-then-scan over the emitted bundles recovers 166 referenced and 166 registered ids with zero unresolved, matching a healthy build.
- Full testing-library suite passes (204 tests).

Still open, and the reason this is a draft: I have not confirmed on device that `PROCESS_ASSETS_STAGE_ANALYSE` sees the raw MT JS chunk (rather than the already-encoded `.lynx.bundle`) in a production Lynx build. The wrong-stage guard makes a mis-timed hook fail safe (it reports nothing instead of false-flagging), but a real dual-thread build should confirm the check actually fires on a genuine drift before this merges. Happy to pair on that.

## Relationship to the extraction fix

This is the general-purpose net. The extraction bug fixed in the worklet-loader-mt PR was one cause of the drift this catches; this check would have flagged it at build time regardless of the underlying cause.
