### PR TITLE
feat(elk): infinite-scroll feeds via recycling `<list>`

### DIFF
--- a/examples/elk-viewpager/src/composables/search.ts
+++ b/examples/elk-viewpager/src/composables/search.ts
@@ -83,16 +83,20 @@ export function useSearch(query: MaybeRefOrGetter<string>) {
   });
 
   const next = async () => {
-    if (!q.value || !paginator)
+    if (!q.value || !paginator || done.value || loading.value)
       return;
 
     loading.value = true;
-    const nextResults = await paginator.values().next();
+    try {
+      const nextResults = await paginator.values().next();
+      done.value = !!nextResults.done;
+      if (!nextResults.done)
+        appendResults(nextResults.value);
+    }
+    catch (e) {
+      console.error(e);
+    }
     loading.value = false;
-
-    done.value = !!nextResults.done;
-    if (!nextResults.done)
-      appendResults(nextResults.value);
   };
 
   return {
@@ -100,6 +104,7 @@ export function useSearch(query: MaybeRefOrGetter<string>) {
     hashtags,
     statuses,
     loading: readonly(loading),
+    done: readonly(done),
     next,
   };
 }

--- a/examples/elk-viewpager/src/fetch-compat.ts
+++ b/examples/elk-viewpager/src/fetch-compat.ts
@@ -10,3 +10,192 @@ export function resolveFetch(
     return globalFetch as FetchLike;
   return undefined;
 }
+
+/**
+ * Read a header in a Headers-like / plain-object compatible way.
+ * Lynx native Response.headers sometimes omit `.get`, or only expose a
+ * subset of names; masto.js pagination depends on `Link`.
+ */
+export function readHeader(headers: unknown, name: string): string | null {
+  if (!headers || typeof headers !== 'object')
+    return null;
+
+  const lower = name.toLowerCase();
+  const h = headers as {
+    get?: (n: string) => string | null | undefined;
+    forEach?: (fn: (value: string, key: string) => void) => void;
+    entries?: () => IterableIterator<[string, string]>;
+  };
+
+  if (typeof h.get === 'function') {
+    const direct = h.get(name) ?? h.get(lower) ?? h.get(name.replace(/^\w/, c => c.toUpperCase()));
+    if (direct != null && direct !== '')
+      return String(direct);
+  }
+
+  if (typeof h.forEach === 'function') {
+    let found: string | null = null;
+    h.forEach((value, key) => {
+      if (found == null && String(key).toLowerCase() === lower)
+        found = String(value);
+    });
+    if (found != null)
+      return found;
+  }
+
+  if (typeof h.entries === 'function') {
+    for (const [key, value] of h.entries()) {
+      if (String(key).toLowerCase() === lower)
+        return String(value);
+    }
+  }
+
+  for (const [key, value] of Object.entries(headers as Record<string, unknown>)) {
+    if (key.toLowerCase() === lower && value != null)
+      return String(value);
+  }
+
+  return null;
+}
+
+type MutableHeaders = {
+  get: (name: string) => string | null;
+  set: (name: string, value: string) => void;
+  has: (name: string) => boolean;
+  forEach: (fn: (value: string, key: string) => void) => void;
+};
+
+function copyHeaders(source: unknown): MutableHeaders {
+  const map = new Map<string, string>();
+
+  const set = (name: string, value: string) => {
+    map.set(name.toLowerCase(), value);
+  };
+
+  if (source && typeof source === 'object') {
+    const h = source as {
+      forEach?: (fn: (value: string, key: string) => void) => void;
+      entries?: () => IterableIterator<[string, string]>;
+    };
+    if (typeof h.forEach === 'function') {
+      h.forEach((value, key) => set(key, String(value)));
+    }
+    else if (typeof h.entries === 'function') {
+      for (const [key, value] of h.entries()) set(key, String(value));
+    }
+    else {
+      for (const [key, value] of Object.entries(source as Record<string, unknown>)) {
+        if (value != null)
+          set(key, String(value));
+      }
+    }
+  }
+
+  return {
+    get: name => map.get(name.toLowerCase()) ?? null,
+    set: (name, value) => set(name, value),
+    has: name => map.has(name.toLowerCase()),
+    forEach: (fn) => {
+      for (const [k, v] of map) fn(v, k);
+    },
+  };
+}
+
+function requestUrl(input: unknown): string {
+  if (typeof input === 'string')
+    return input;
+  if (input && typeof input === 'object') {
+    const r = input as { url?: unknown; href?: unknown };
+    if (typeof r.url === 'string')
+      return r.url;
+    if (typeof r.href === 'string')
+      return r.href;
+  }
+  return String(input ?? '');
+}
+
+/**
+ * When Mastodon-compatible APIs return a page of entities but the runtime
+ * stripped the `Link` header, synthesize `rel="next"` so masto.js Paginator
+ * can continue. Timelines / notifications / follow lists use `max_id`;
+ * offset-based trends use `offset`.
+ */
+export function synthesizeNextLink(
+  requestHref: string,
+  bodyText: string,
+): string | null {
+  let data: unknown;
+  try {
+    data = JSON.parse(bodyText);
+  }
+  catch {
+    return null;
+  }
+  if (!Array.isArray(data) || data.length === 0)
+    return null;
+
+  let nextHref: string;
+  try {
+    // Prefer URL when available (web / modern native); fall back to string surgery.
+    if (typeof URL === 'function') {
+      const url = new URL(requestHref);
+      const last = data[data.length - 1] as Record<string, unknown>;
+      if (last && last.id != null) {
+        url.searchParams.set('max_id', String(last.id));
+        // Avoid a tight loop if the server ignored max_id and returned the same head.
+        const prevMax = new URL(requestHref).searchParams.get('max_id');
+        if (prevMax === String(last.id))
+          return null;
+      }
+      else {
+        const prevOffset = Number(url.searchParams.get('offset') || '0');
+        if (!Number.isFinite(prevOffset))
+          return null;
+        url.searchParams.set('offset', String(prevOffset + data.length));
+      }
+      nextHref = url.href;
+    }
+    else {
+      return null;
+    }
+  }
+  catch {
+    return null;
+  }
+
+  return `<${nextHref}>; rel="next"`;
+}
+
+/**
+ * Wrap fetch so Response.headers always supports `.get('link')` for masto.js.
+ * If the native stack drops `Link`, synthesize the next page URL from the body.
+ *
+ * Body is buffered once (timeline pages are small JSON arrays).
+ */
+export function wrapFetchForMastoPagination(fetchImpl: FetchLike): FetchLike {
+  return async function fetchWithMastoLink(input: unknown, init?: unknown) {
+    const response = await fetchImpl(input, init);
+    const headers = copyHeaders(response?.headers);
+    const text = await response.text();
+
+    if (!headers.get('link')) {
+      const synthesized = synthesizeNextLink(requestUrl(input), text);
+      if (synthesized)
+        headers.set('link', synthesized);
+    }
+
+    return {
+      ok: response.ok,
+      status: response.status,
+      statusText: response.statusText,
+      url: response.url ?? requestUrl(input),
+      headers,
+      async text() {
+        return text;
+      },
+      async json() {
+        return JSON.parse(text);
+      },
+    };
+  };
+}

--- a/examples/elk-viewpager/src/fetch-compat.ts
+++ b/examples/elk-viewpager/src/fetch-compat.ts
@@ -13,8 +13,12 @@ export function resolveFetch(
 
 /**
  * Read a header in a Headers-like / plain-object compatible way.
- * Lynx native Response.headers sometimes omit `.get`, or only expose a
- * subset of names; masto.js pagination depends on `Link`.
+ * Lynx native Response.headers sometimes omit iterable helpers; masto.js
+ * pagination depends on `Link`, and content decoding on `Content-Type`.
+ *
+ * @see https://lynxjs.org/guide/interaction/networking
+ * @see https://lynxjs.org/api/lynx-api/global/fetch — Lynx Fetch aligns with
+ * Web but has subtle differences; third-party libs may need adaptation.
  */
 export function readHeader(headers: unknown, name: string): string | null {
   if (!headers || typeof headers !== 'object')
@@ -28,31 +32,53 @@ export function readHeader(headers: unknown, name: string): string | null {
   };
 
   if (typeof h.get === 'function') {
-    const direct = h.get(name) ?? h.get(lower) ?? h.get(name.replace(/^\w/, c => c.toUpperCase()));
-    if (direct != null && direct !== '')
-      return String(direct);
+    for (const candidate of [name, lower, name.replace(/^\w/, c => c.toUpperCase())]) {
+      try {
+        const direct = h.get(candidate);
+        if (direct != null && direct !== '')
+          return String(direct);
+      }
+      catch {
+        // some native Headers.get implementations throw on unknown names
+      }
+    }
   }
 
   if (typeof h.forEach === 'function') {
     let found: string | null = null;
-    h.forEach((value, key) => {
-      if (found == null && String(key).toLowerCase() === lower)
-        found = String(value);
-    });
+    try {
+      h.forEach((value, key) => {
+        if (found == null && String(key).toLowerCase() === lower)
+          found = String(value);
+      });
+    }
+    catch {
+      // ignore
+    }
     if (found != null)
       return found;
   }
 
   if (typeof h.entries === 'function') {
-    for (const [key, value] of h.entries()) {
-      if (String(key).toLowerCase() === lower)
-        return String(value);
+    try {
+      for (const [key, value] of h.entries()) {
+        if (String(key).toLowerCase() === lower)
+          return String(value);
+      }
+    }
+    catch {
+      // ignore
     }
   }
 
-  for (const [key, value] of Object.entries(headers as Record<string, unknown>)) {
-    if (key.toLowerCase() === lower && value != null)
-      return String(value);
+  try {
+    for (const [key, value] of Object.entries(headers as Record<string, unknown>)) {
+      if (key.toLowerCase() === lower && value != null)
+        return String(value);
+    }
+  }
+  catch {
+    // ignore
   }
 
   return null;
@@ -65,40 +91,60 @@ type MutableHeaders = {
   forEach: (fn: (value: string, key: string) => void) => void;
 };
 
-function copyHeaders(source: unknown): MutableHeaders {
+function createHeadersBag(seed?: Record<string, string>): MutableHeaders {
   const map = new Map<string, string>();
-
-  const set = (name: string, value: string) => {
-    map.set(name.toLowerCase(), value);
+  if (seed) {
+    for (const [k, v] of Object.entries(seed))
+      map.set(k.toLowerCase(), v);
+  }
+  return {
+    get: name => map.get(name.toLowerCase()) ?? null,
+    set: (name, value) => {
+      map.set(name.toLowerCase(), value);
+    },
+    has: name => map.has(name.toLowerCase()),
+    forEach: (fn) => {
+      for (const [k, v] of map) fn(v, k);
+    },
   };
+}
+
+/**
+ * Build a headers bag that always exposes `.get`, seeding critical fields via
+ * readHeader first. Native Lynx Headers often do not enumerate with
+ * Object.entries / forEach the way Web does — copying only via iteration
+ * drops Content-Type and breaks masto's getEncoding().
+ */
+export function normalizeResponseHeaders(source: unknown): MutableHeaders {
+  const headers = createHeadersBag();
+
+  // Prefer explicit gets for fields masto needs.
+  const contentType = readHeader(source, 'content-type');
+  if (contentType)
+    headers.set('content-type', contentType);
+  const link = readHeader(source, 'link');
+  if (link)
+    headers.set('link', link);
 
   if (source && typeof source === 'object') {
     const h = source as {
       forEach?: (fn: (value: string, key: string) => void) => void;
       entries?: () => IterableIterator<[string, string]>;
     };
-    if (typeof h.forEach === 'function') {
-      h.forEach((value, key) => set(key, String(value)));
-    }
-    else if (typeof h.entries === 'function') {
-      for (const [key, value] of h.entries()) set(key, String(value));
-    }
-    else {
-      for (const [key, value] of Object.entries(source as Record<string, unknown>)) {
-        if (value != null)
-          set(key, String(value));
+    try {
+      if (typeof h.forEach === 'function') {
+        h.forEach((value, key) => headers.set(key, String(value)));
       }
+      else if (typeof h.entries === 'function') {
+        for (const [key, value] of h.entries()) headers.set(key, String(value));
+      }
+    }
+    catch {
+      // keep seeded content-type / link
     }
   }
 
-  return {
-    get: name => map.get(name.toLowerCase()) ?? null,
-    set: (name, value) => set(name, value),
-    has: name => map.has(name.toLowerCase()),
-    forEach: (fn) => {
-      for (const [k, v] of map) fn(v, k);
-    },
-  };
+  return headers;
 }
 
 function requestUrl(input: unknown): string {
@@ -136,28 +182,25 @@ export function synthesizeNextLink(
 
   let nextHref: string;
   try {
-    // Prefer URL when available (web / modern native); fall back to string surgery.
-    if (typeof URL === 'function') {
-      const url = new URL(requestHref);
-      const last = data[data.length - 1] as Record<string, unknown>;
-      if (last && last.id != null) {
-        url.searchParams.set('max_id', String(last.id));
-        // Avoid a tight loop if the server ignored max_id and returned the same head.
-        const prevMax = new URL(requestHref).searchParams.get('max_id');
-        if (prevMax === String(last.id))
-          return null;
-      }
-      else {
-        const prevOffset = Number(url.searchParams.get('offset') || '0');
-        if (!Number.isFinite(prevOffset))
-          return null;
-        url.searchParams.set('offset', String(prevOffset + data.length));
-      }
-      nextHref = url.href;
+    if (typeof URL !== 'function')
+      return null;
+
+    const url = new URL(requestHref);
+    const last = data[data.length - 1] as Record<string, unknown>;
+    if (last && last.id != null) {
+      url.searchParams.set('max_id', String(last.id));
+      // Avoid a tight loop if the server ignored max_id and returned the same head.
+      const prevMax = new URL(requestHref).searchParams.get('max_id');
+      if (prevMax === String(last.id))
+        return null;
     }
     else {
-      return null;
+      const prevOffset = Number(url.searchParams.get('offset') || '0');
+      if (!Number.isFinite(prevOffset))
+        return null;
+      url.searchParams.set('offset', String(prevOffset + data.length));
     }
+    nextHref = url.href;
   }
   catch {
     return null;
@@ -166,36 +209,87 @@ export function synthesizeNextLink(
   return `<${nextHref}>; rel="next"`;
 }
 
+function buildPatchedResponse(
+  response: any,
+  text: string,
+  headers: MutableHeaders,
+  input: unknown,
+): any {
+  const status = typeof response?.status === 'number' ? response.status : 200;
+  const ok = typeof response?.ok === 'boolean'
+    ? response.ok
+    : status >= 200 && status < 300;
+  const statusText = response?.statusText ?? '';
+  const url = response?.url ?? requestUrl(input);
+
+  // Prefer a real Response so `instanceof Response` still works in masto's
+  // error path (Lynx documents Response as available since 2.18).
+  if (typeof Response === 'function') {
+    try {
+      const initHeaders: Record<string, string> = {};
+      headers.forEach((value, key) => {
+        initHeaders[key] = value;
+      });
+      const built = new Response(text, { status, statusText, headers: initHeaders });
+      // Some Lynx builds omit .url on constructed Responses.
+      if (!(built as any).url && url) {
+        try {
+          Object.defineProperty(built, 'url', { value: url, configurable: true });
+        }
+        catch {
+          // ignore
+        }
+      }
+      return built;
+    }
+    catch {
+      // fall through to duck-typed response
+    }
+  }
+
+  return {
+    ok,
+    status,
+    statusText,
+    url,
+    headers,
+    async text() {
+      return text;
+    },
+    async json() {
+      return JSON.parse(text);
+    },
+  };
+}
+
 /**
- * Wrap fetch so Response.headers always supports `.get('link')` for masto.js.
- * If the native stack drops `Link`, synthesize the next page URL from the body.
+ * Wrap fetch for masto.js pagination without breaking Lynx's native Response.
  *
- * Body is buffered once (timeline pages are small JSON arrays).
+ * Per https://lynxjs.org/guide/interaction/networking — Lynx Fetch is Web-
+ * compatible with subtle differences; keep the native Response when `Link`
+ * is already readable. Only buffer + rebuild when we must synthesize `Link`
+ * (native stacks often drop that header after the first Mastodon page).
  */
 export function wrapFetchForMastoPagination(fetchImpl: FetchLike): FetchLike {
   return async function fetchWithMastoLink(input: unknown, init?: unknown) {
     const response = await fetchImpl(input, init);
-    const headers = copyHeaders(response?.headers);
+
+    // Fast path: leave Lynx/Web Response untouched when Link is present.
+    if (readHeader(response?.headers, 'link'))
+      return response;
+
+    // Need body to synthesize next — buffer once. Always keep Content-Type
+    // via readHeader; empty iteration of native Headers was dropping it and
+    // causing masto "unknown encoding" → Failed to load timeline.
     const text = await response.text();
+    const headers = normalizeResponseHeaders(response?.headers);
+    if (!headers.get('content-type'))
+      headers.set('content-type', 'application/json');
 
-    if (!headers.get('link')) {
-      const synthesized = synthesizeNextLink(requestUrl(input), text);
-      if (synthesized)
-        headers.set('link', synthesized);
-    }
+    const synthesized = synthesizeNextLink(requestUrl(input), text);
+    if (synthesized)
+      headers.set('link', synthesized);
 
-    return {
-      ok: response.ok,
-      status: response.status,
-      statusText: response.statusText,
-      url: response.url ?? requestUrl(input),
-      headers,
-      async text() {
-        return text;
-      },
-      async json() {
-        return JSON.parse(text);
-      },
-    };
+    return buildPatchedResponse(response, text, headers, input);
   };
 }

--- a/examples/elk-viewpager/src/fetch-compat.ts
+++ b/examples/elk-viewpager/src/fetch-compat.ts
@@ -147,6 +147,53 @@ export function normalizeResponseHeaders(source: unknown): MutableHeaders {
   return headers;
 }
 
+/**
+ * Lynx native Headers can enumerate mixed-case response names while `.get()`
+ * only matches the original casing. masto always asks for lowercase `link`, so
+ * add a case-insensitive fallback on the existing Headers object. Keeping the
+ * original object means the native Response and its unread body stay intact.
+ */
+function patchNativeHeaderGet(source: unknown): boolean {
+  if (!source || typeof source !== 'object')
+    return false;
+
+  const headers = source as { get?: (name: string) => unknown };
+  if (typeof headers.get !== 'function')
+    return false;
+
+  const originalGet = headers.get.bind(headers);
+  const normalized = normalizeResponseHeaders(source);
+  const compatibleGet = (name: string): string | null => {
+    try {
+      const direct = originalGet(name);
+      if (direct != null && direct !== '')
+        return String(direct);
+    }
+    catch {
+      // Fall back to the case-insensitive snapshot below.
+    }
+    return normalized.get(name);
+  };
+
+  try {
+    Object.defineProperty(headers, 'get', {
+      value: compatibleGet,
+      configurable: true,
+      writable: true,
+    });
+  }
+  catch {
+    try {
+      headers.get = compatibleGet;
+    }
+    catch {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 function requestUrl(input: unknown): string {
   if (typeof input === 'string')
     return input;
@@ -180,30 +227,58 @@ export function synthesizeNextLink(
   if (!Array.isArray(data) || data.length === 0)
     return null;
 
-  let nextHref: string;
-  try {
-    if (typeof URL !== 'function')
-      return null;
-
-    const url = new URL(requestHref);
-    const last = data[data.length - 1] as Record<string, unknown>;
-    if (last && last.id != null) {
-      url.searchParams.set('max_id', String(last.id));
-      // Avoid a tight loop if the server ignored max_id and returned the same head.
-      const prevMax = new URL(requestHref).searchParams.get('max_id');
-      if (prevMax === String(last.id))
-        return null;
-    }
-    else {
-      const prevOffset = Number(url.searchParams.get('offset') || '0');
-      if (!Number.isFinite(prevOffset))
-        return null;
-      url.searchParams.set('offset', String(prevOffset + data.length));
-    }
-    nextHref = url.href;
-  }
-  catch {
+  if (!requestHref)
     return null;
+
+  const hashIndex = requestHref.indexOf('#');
+  const hash = hashIndex >= 0 ? requestHref.slice(hashIndex) : '';
+  const withoutHash = hashIndex >= 0 ? requestHref.slice(0, hashIndex) : requestHref;
+  const queryIndex = withoutHash.indexOf('?');
+  const base = queryIndex >= 0 ? withoutHash.slice(0, queryIndex) : withoutHash;
+  const rawQuery = queryIndex >= 0 ? withoutHash.slice(queryIndex + 1) : '';
+  const pairs = rawQuery ? rawQuery.split('&').filter(Boolean) : [];
+
+  const decodeKey = (pair: string) => {
+    const raw = pair.split('=', 1)[0];
+    try {
+      return decodeURIComponent(raw.replace(/\+/g, ' '));
+    }
+    catch {
+      return raw;
+    }
+  };
+  const getParam = (name: string): string | null => {
+    const pair = pairs.find(item => decodeKey(item) === name);
+    if (!pair)
+      return null;
+    const raw = pair.includes('=') ? pair.slice(pair.indexOf('=') + 1) : '';
+    try {
+      return decodeURIComponent(raw.replace(/\+/g, ' '));
+    }
+    catch {
+      return raw;
+    }
+  };
+  const setParam = (name: string, value: string): string => {
+    const kept = pairs.filter(item => decodeKey(item) !== name);
+    kept.push(`${encodeURIComponent(name)}=${encodeURIComponent(value)}`);
+    return `${base}?${kept.join('&')}${hash}`;
+  };
+
+  let nextHref: string;
+  const last = data[data.length - 1] as Record<string, unknown>;
+  if (last && last.id != null) {
+    const nextMax = String(last.id);
+    // Avoid a tight loop if the server ignored max_id and returned the same head.
+    if (getParam('max_id') === nextMax)
+      return null;
+    nextHref = setParam('max_id', nextMax);
+  }
+  else {
+    const prevOffset = Number(getParam('offset') || '0');
+    if (!Number.isFinite(prevOffset))
+      return null;
+    nextHref = setParam('offset', String(prevOffset + data.length));
   }
 
   return `<${nextHref}>; rel="next"`;
@@ -274,9 +349,19 @@ export function wrapFetchForMastoPagination(fetchImpl: FetchLike): FetchLike {
   return async function fetchWithMastoLink(input: unknown, init?: unknown) {
     const response = await fetchImpl(input, init);
 
-    // Fast path: leave Lynx/Web Response untouched when Link is present.
-    if (readHeader(response?.headers, 'link'))
-      return response;
+    // Fast path: leave Lynx/Web Response and body untouched when Link exists.
+    // Lynx may expose it only through iteration because Headers.get is
+    // case-sensitive; patch that method in place before masto reads `link`.
+    if (readHeader(response?.headers, 'link')) {
+      patchNativeHeaderGet(response?.headers);
+      try {
+        if (response?.headers?.get?.('link'))
+          return response;
+      }
+      catch {
+        // Fall through to the buffered compatibility response.
+      }
+    }
 
     // Need body to synthesize next — buffer once. Always keep Content-Type
     // via readHeader; empty iteration of native Headers was dropping it and

--- a/examples/elk-viewpager/src/pages/AccountPage.vue
+++ b/examples/elk-viewpager/src/pages/AccountPage.vue
@@ -3,10 +3,8 @@
 // app/components/account/AccountHeader.vue — banner, avatar, names, bio,
 // fields, stats, posts/replies/media tabs.
 //
-// This variant gives the profile a native feel: the header collapses and
-// the tab bar sticks to the top on scroll (StickyTabView / scroll-coordinator),
-// while the Posts / Replies / Media panes below page horizontally and each
-// keep their own feed and scroll position.
+// StickyTabView collapses the header; each pane is a TimelinePaginator
+// (<list> + scrolltolower) so feeds infinite-scroll independently.
 import type { mastodon } from 'masto';
 import { computed, onMounted, reactive, ref, watch } from 'vue-lynx';
 import { useRoute, useRouter } from 'vue-router';
@@ -15,8 +13,8 @@ import AccountDisplayName from '../components/AccountDisplayName.vue';
 import ContentRich from '../components/ContentRich';
 import PageHeader from '../components/PageHeader.vue';
 import Spinner from '../components/Spinner.vue';
-import StatusCard from '../components/StatusCard.vue';
 import StickyTabView from '../components/StickyTabView.vue';
+import TimelinePaginator from '../components/TimelinePaginator.vue';
 import { fetchAccountByHandle } from '../composables/cache';
 import { formatCompactNumber } from '../composables/format';
 import { useMastoClient } from '../composables/masto';
@@ -39,46 +37,30 @@ const tabs = [
   { key: 'media', label: 'Media' },
 ] as const;
 
-// One feed per tab so all three panes keep their own data and scroll
-// position while the pager swipes between them; panes load lazily the first
-// time they become active.
-const feeds = reactive<Record<TabKey, {
-  items: mastodon.v1.Status[];
-  loading: boolean;
-  loaded: boolean;
-}>>({
-  posts: { items: [], loading: false, loaded: false },
-  replies: { items: [], loading: false, loaded: false },
-  media: { items: [], loading: false, loaded: false },
-});
+// One masto paginator per pane — TimelinePaginator owns the <list> + loadNext.
+const paginators = reactive<Partial<Record<TabKey, mastodon.Paginator<mastodon.v1.Status[], any>>>>({});
 
-function resetFeeds() {
-  for (const kind of ['posts', 'replies', 'media'] as const) {
-    feeds[kind].items = [];
-    feeds[kind].loading = false;
-    feeds[kind].loaded = false;
-  }
+function makeStatusPaginator(kind: TabKey) {
+  if (!account.value)
+    return null;
+  return useMastoClient().v1.accounts.$select(account.value.id).statuses.list({
+    limit: 30,
+    excludeReplies: kind === 'posts',
+    onlyMedia: kind === 'media',
+  });
 }
 
-async function loadFeed(kind: TabKey) {
-  if (!account.value)
+function ensureFeed(kind: TabKey) {
+  if (!account.value || paginators[kind])
     return;
-  const feed = feeds[kind];
-  feed.loading = true;
-  try {
-    const paginator = useMastoClient().v1.accounts.$select(account.value.id).statuses.list({
-      limit: 30,
-      excludeReplies: kind === 'posts',
-      onlyMedia: kind === 'media',
-    });
-    const result = await paginator.values().next();
-    feed.items = result.value ?? [];
-    feed.loaded = true;
-  }
-  catch (e) {
-    console.error(e);
-  }
-  feed.loading = false;
+  const pager = makeStatusPaginator(kind);
+  if (pager)
+    paginators[kind] = pager;
+}
+
+function resetFeeds() {
+  for (const kind of ['posts', 'replies', 'media'] as const)
+    delete paginators[kind];
 }
 
 async function load() {
@@ -89,13 +71,13 @@ async function load() {
   loading.value = true;
   error.value = false;
   account.value = null;
+  resetFeeds();
   try {
     const loadedAccount = await fetchAccountByHandle(handle.replace(/^@/, ''));
     if (!loadGuard.isCurrent(request))
       return;
     account.value = loadedAccount;
-    resetFeeds();
-    await loadFeed(tab.value);
+    ensureFeed(tab.value);
   }
   catch (e) {
     console.error(e);
@@ -109,10 +91,8 @@ async function load() {
 onMounted(load);
 watch(() => route.params.account, load);
 
-// Lazy-load a pane's feed the first time it becomes active.
 watch(tab, (kind) => {
-  if (!feeds[kind].loaded && !feeds[kind].loading)
-    loadFeed(kind);
+  ensureFeed(kind);
 });
 
 const joinDate = computed(() => {
@@ -137,7 +117,6 @@ const joinDate = computed(() => {
     </view>
     <StickyTabView v-else v-model="tab" :tabs="tabs" class="account-stv">
       <template #header>
-        <!-- banner -->
         <image :src="account.header" class="account-banner" mode="aspectFill" />
 
         <view class="account-head">
@@ -154,7 +133,6 @@ const joinDate = computed(() => {
             <ContentRich :content="account.note" :emojis="account.emojis" />
           </view>
 
-          <!-- fields (Elk AccountHeader fields table) -->
           <view v-if="account.fields?.length" class="account-fields">
             <view
               v-for="field in account.fields"
@@ -171,7 +149,6 @@ const joinDate = computed(() => {
 
           <text class="account-joined">{{ joinDate }}</text>
 
-          <!-- stats row -->
           <view class="account-stats">
             <view class="account-stat">
               <text class="account-stat-num">{{ formatCompactNumber(account.statusesCount) }}</text>
@@ -190,42 +167,30 @@ const joinDate = computed(() => {
       </template>
 
       <template #posts>
-        <scroll-view scroll-orientation="vertical" class="account-pane">
-          <view v-if="feeds.posts.loading" class="account-loading">
-            <Spinner />
-          </view>
-          <StatusCard v-for="s in feeds.posts.items" :key="s.id" :status="s" />
-          <view v-if="feeds.posts.loaded && !feeds.posts.loading && !feeds.posts.items.length" class="account-empty">
-            <text class="account-empty-text">No posts yet.</text>
-          </view>
-          <view class="account-bottom-pad" />
-        </scroll-view>
+        <TimelinePaginator
+          v-if="paginators.posts"
+          :key="`${account.id}-posts`"
+          :paginator="paginators.posts"
+          context="account"
+        />
       </template>
 
       <template #replies>
-        <scroll-view scroll-orientation="vertical" class="account-pane">
-          <view v-if="feeds.replies.loading" class="account-loading">
-            <Spinner />
-          </view>
-          <StatusCard v-for="s in feeds.replies.items" :key="s.id" :status="s" />
-          <view v-if="feeds.replies.loaded && !feeds.replies.loading && !feeds.replies.items.length" class="account-empty">
-            <text class="account-empty-text">No posts yet.</text>
-          </view>
-          <view class="account-bottom-pad" />
-        </scroll-view>
+        <TimelinePaginator
+          v-if="paginators.replies"
+          :key="`${account.id}-replies`"
+          :paginator="paginators.replies"
+          context="account"
+        />
       </template>
 
       <template #media>
-        <scroll-view scroll-orientation="vertical" class="account-pane">
-          <view v-if="feeds.media.loading" class="account-loading">
-            <Spinner />
-          </view>
-          <StatusCard v-for="s in feeds.media.items" :key="s.id" :status="s" />
-          <view v-if="feeds.media.loaded && !feeds.media.loading && !feeds.media.items.length" class="account-empty">
-            <text class="account-empty-text">No media yet.</text>
-          </view>
-          <view class="account-bottom-pad" />
-        </scroll-view>
+        <TimelinePaginator
+          v-if="paginators.media"
+          :key="`${account.id}-media`"
+          :paginator="paginators.media"
+          context="account"
+        />
       </template>
     </StickyTabView>
   </view>
@@ -238,30 +203,11 @@ const joinDate = computed(() => {
   width: 100%;
 }
 
-.account-pane {
-  flex: 1;
-  min-height: 0;
-  width: 100%;
-  height: 100%;
-}
-
 .account-loading {
   display: flex;
   flex-direction: column;
   align-items: center;
   padding: 48px 0;
-}
-
-.account-empty {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 40px 0;
-}
-
-.account-empty-text {
-  font-size: 14px;
-  color: var(--c-text-secondary);
 }
 
 .account-error {
@@ -387,9 +333,5 @@ const joinDate = computed(() => {
 .account-stat-label {
   font-size: 13px;
   color: var(--c-text-secondary);
-}
-
-.account-bottom-pad {
-  height: 40px;
 }
 </style>

--- a/examples/elk-viewpager/src/pages/ExplorePage.vue
+++ b/examples/elk-viewpager/src/pages/ExplorePage.vue
@@ -1,17 +1,18 @@
 <script setup lang="ts">
-// Ported from elk: app/pages/[[server]]/explore/{index,tags}.vue —
-// trending posts + trending hashtags tabs. The tabs are backed by the
-// native viewpager (TabPager), so panes swipe horizontally.
+// Ported from elk: app/pages/[[server]]/explore/{index,tags,links}.vue —
+// trending posts + hashtags + news. Tabs use TabPager; each pane keeps its
+// own <list> + paginator so swipe preserves data and scroll position.
 import type { mastodon } from 'masto';
-import { onMounted, ref, watch } from 'vue-lynx';
+import { computed, reactive, ref, watch } from 'vue-lynx';
 import { useRouter } from 'vue-router';
 import AppIcon from '../components/AppIcon.vue';
 import PageHeader from '../components/PageHeader.vue';
 import Spinner from '../components/Spinner.vue';
-import StatusCard from '../components/StatusCard.vue';
 import TabPager from '../components/TabPager.vue';
+import TimelinePaginator from '../components/TimelinePaginator.vue';
 import { formatCompactNumber } from '../composables/format';
 import { useMastoClient } from '../composables/masto';
+import { type PaginatorState, usePaginator } from '../composables/paginator';
 import { getTagRoute } from '../composables/routes';
 
 const router = useRouter();
@@ -22,38 +23,51 @@ const tabs = [
   { key: 'links', label: 'News' },
 ] as const;
 
-const tab = ref<'posts' | 'tags' | 'links'>('posts');
-const statuses = ref<mastodon.v1.Status[]>([]);
-const tags = ref<mastodon.v1.Tag[]>([]);
-const links = ref<mastodon.v1.TrendLink[]>([]);
-const loading = ref(true);
+type TabKey = typeof tabs[number]['key'];
+
+const tab = ref<TabKey>('posts');
 const showIntro = ref(true);
 
-async function load() {
-  loading.value = true;
-  try {
-    const client = useMastoClient();
-    if (tab.value === 'posts' && !statuses.value.length) {
-      const result = await client.v1.trends.statuses.list({ limit: 20 }).values().next();
-      statuses.value = result.value ?? [];
-    }
-    else if (tab.value === 'tags' && !tags.value.length) {
-      const result = await client.v1.trends.tags.list({ limit: 20 }).values().next();
-      tags.value = result.value ?? [];
-    }
-    else if (tab.value === 'links' && !links.value.length) {
-      const result = await client.v1.trends.links.list({ limit: 20 }).values().next();
-      links.value = result.value ?? [];
-    }
-  }
-  catch (e) {
-    console.error(e);
-  }
-  loading.value = false;
+const postsPaginator = computed(() =>
+  useMastoClient().v1.trends.statuses.list({ limit: 20 }),
+);
+
+const tagFeed = reactive<{
+  items: mastodon.v1.Tag[];
+  state: PaginatorState;
+}>({ items: [], state: 'idle' });
+const linkFeed = reactive<{
+  items: mastodon.v1.TrendLink[];
+  state: PaginatorState;
+}>({ items: [], state: 'idle' });
+
+let tagsPager: ReturnType<typeof usePaginator<mastodon.v1.Tag, any>> | null = null;
+let linksPager: ReturnType<typeof usePaginator<mastodon.v1.TrendLink, any>> | null = null;
+
+async function loadMoreTags() {
+  tagsPager ??= usePaginator<mastodon.v1.Tag, any>(
+    useMastoClient().v1.trends.tags.list({ limit: 20 }),
+  );
+  await tagsPager.loadNext();
+  tagFeed.items = [...tagsPager.items.value];
+  tagFeed.state = tagsPager.state.value;
 }
 
-onMounted(load);
-watch(tab, load);
+async function loadMoreLinks() {
+  linksPager ??= usePaginator<mastodon.v1.TrendLink, any>(
+    useMastoClient().v1.trends.links.list({ limit: 20 }),
+  );
+  await linksPager.loadNext();
+  linkFeed.items = [...linksPager.items.value];
+  linkFeed.state = linksPager.state.value;
+}
+
+watch(tab, (next) => {
+  if (next === 'tags' && !tagsPager)
+    loadMoreTags();
+  else if (next === 'links' && !linksPager)
+    loadMoreLinks();
+});
 
 function tagUses(tag: mastodon.v1.Tag): number {
   return (tag.history ?? []).slice(0, 2).reduce((acc, h) => acc + Number(h.uses || 0), 0);
@@ -73,52 +87,75 @@ function tagUses(tag: mastodon.v1.Tag): number {
             <AppIcon name="close-line" :size="18" color="#686868" />
           </view>
         </view>
-        <view v-if="loading && tab === 'posts'" class="explore-loading">
-          <Spinner />
-        </view>
-        <scroll-view v-else scroll-orientation="vertical" class="explore-scroll">
-          <StatusCard v-for="s in statuses" :key="s.id" :status="s" />
-          <view class="explore-bottom-pad" />
-        </scroll-view>
+        <TimelinePaginator
+          :paginator="postsPaginator"
+          context="public"
+        />
       </template>
 
       <template #tags>
-        <view v-if="loading && tab === 'tags'" class="explore-loading">
-          <Spinner />
-        </view>
-        <scroll-view v-else scroll-orientation="vertical" class="explore-scroll">
-          <view
-            v-for="(tag, i) in tags"
+        <list
+          class="explore-list"
+          scroll-orientation="vertical"
+          :lower-threshold-item-count="4"
+          @scrolltolower="loadMoreTags"
+        >
+          <list-item
+            v-for="(tag, i) in tagFeed.items"
             :key="tag.name"
-            class="explore-tag"
-            @tap="router.push(getTagRoute(tag.name))"
+            :item-key="tag.name"
+            :estimated-main-axis-size-px="64"
           >
-            <text class="explore-tag-rank">{{ i + 1 }}</text>
-            <view class="explore-tag-names">
-              <text class="explore-tag-name">#{{ tag.name }}</text>
-              <text class="explore-tag-uses">{{ formatCompactNumber(tagUses(tag)) }} people in the past 2 days</text>
+            <view
+              class="explore-tag"
+              @tap="router.push(getTagRoute(tag.name))"
+            >
+              <text class="explore-tag-rank">{{ i + 1 }}</text>
+              <view class="explore-tag-names">
+                <text class="explore-tag-name">#{{ tag.name }}</text>
+                <text class="explore-tag-uses">{{ formatCompactNumber(tagUses(tag)) }} people in the past 2 days</text>
+              </view>
+              <AppIcon name="fire-line" :size="18" color="#cc7d24" />
             </view>
-            <AppIcon name="fire-line" :size="18" color="#cc7d24" />
-          </view>
-          <view class="explore-bottom-pad" />
-        </scroll-view>
+          </list-item>
+          <list-item item-key="__footer" :estimated-main-axis-size-px="60">
+            <view class="explore-footer">
+              <Spinner v-if="tagFeed.state === 'loading'" />
+              <text v-else-if="tagFeed.state === 'done'" class="explore-end-text">End of trends</text>
+            </view>
+          </list-item>
+        </list>
       </template>
 
       <template #links>
-        <view v-if="loading && tab === 'links'" class="explore-loading">
-          <Spinner />
-        </view>
-        <scroll-view v-else scroll-orientation="vertical" class="explore-scroll">
-          <view v-for="link in links" :key="link.url" class="explore-link">
-            <image v-if="link.image" :src="link.image" class="explore-link-img" mode="aspectFill" />
-            <view class="explore-link-body">
-              <text class="explore-link-host">{{ link.providerName || link.url.replace(/^https?:\/\//, '').split('/')[0] }}</text>
-              <text class="explore-link-title" :text-maxline="2">{{ link.title }}</text>
-              <text v-if="link.description" class="explore-link-desc" :text-maxline="2">{{ link.description }}</text>
+        <list
+          class="explore-list"
+          scroll-orientation="vertical"
+          :lower-threshold-item-count="4"
+          @scrolltolower="loadMoreLinks"
+        >
+          <list-item
+            v-for="link in linkFeed.items"
+            :key="link.url"
+            :item-key="link.url"
+            :estimated-main-axis-size-px="96"
+          >
+            <view class="explore-link">
+              <image v-if="link.image" :src="link.image" class="explore-link-img" mode="aspectFill" />
+              <view class="explore-link-body">
+                <text class="explore-link-host">{{ link.providerName || link.url.replace(/^https?:\/\//, '').split('/')[0] }}</text>
+                <text class="explore-link-title" :text-maxline="2">{{ link.title }}</text>
+                <text v-if="link.description" class="explore-link-desc" :text-maxline="2">{{ link.description }}</text>
+              </view>
             </view>
-          </view>
-          <view class="explore-bottom-pad" />
-        </scroll-view>
+          </list-item>
+          <list-item item-key="__footer" :estimated-main-axis-size-px="60">
+            <view class="explore-footer">
+              <Spinner v-if="linkFeed.state === 'loading'" />
+              <text v-else-if="linkFeed.state === 'done'" class="explore-end-text">End of news</text>
+            </view>
+          </list-item>
+        </list>
       </template>
     </TabPager>
   </view>
@@ -152,16 +189,10 @@ function tagUses(tag: mastodon.v1.Tag): number {
   justify-content: center;
 }
 
-.explore-loading {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 48px 0;
-}
-
-.explore-scroll {
+.explore-list {
   flex: 1;
   width: 100%;
+  min-height: 0;
 }
 
 .explore-tag {
@@ -195,10 +226,6 @@ function tagUses(tag: mastodon.v1.Tag): number {
 .explore-tag-uses {
   font-size: 12px;
   color: var(--c-text-secondary);
-}
-
-.explore-bottom-pad {
-  height: 40px;
 }
 
 .explore-link {
@@ -239,5 +266,18 @@ function tagUses(tag: mastodon.v1.Tag): number {
   font-size: 12px;
   color: var(--c-text-secondary);
   margin-top: 2px;
+}
+
+.explore-footer {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  padding: 16px 0;
+}
+
+.explore-end-text {
+  font-size: 13px;
+  color: var(--c-text-secondary-light);
 }
 </style>

--- a/examples/elk-viewpager/src/pages/SearchPage.vue
+++ b/examples/elk-viewpager/src/pages/SearchPage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 // Ported from elk: app/pages/[[server]]/search.vue + components/search/*.
 // Debounced multi-type search via the ported useSearch composable.
+// Results live in a recycling <list>; scrolltolower calls useSearch.next().
 import { ref } from 'vue-lynx';
 import { useRouter } from 'vue-router';
 import AccountAvatar from '../components/AccountAvatar.vue';
@@ -14,7 +15,7 @@ import { useSearch } from '../composables/search';
 
 const router = useRouter();
 const query = ref('');
-const { accounts, hashtags, statuses, loading } = useSearch(query);
+const { accounts, hashtags, statuses, loading, done, next } = useSearch(query);
 
 function onInput(e: { detail?: { value?: string } }) {
   query.value = e.detail?.value ?? '';
@@ -22,6 +23,12 @@ function onInput(e: { detail?: { value?: string } }) {
 
 function totalUses(tag: { history?: { uses: string }[] }): number {
   return (tag.history ?? []).reduce((acc, h) => acc + Number(h.uses || 0), 0);
+}
+
+function loadMore() {
+  if (!query.value || loading.value || done.value)
+    return;
+  next();
 }
 </script>
 
@@ -39,21 +46,47 @@ function totalUses(tag: { history?: { uses: string }[] }): number {
       />
     </view>
 
-    <scroll-view scroll-orientation="vertical" class="search-results">
-      <view v-if="loading" class="search-loading">
-        <Spinner />
-      </view>
+    <list
+      class="search-results"
+      scroll-orientation="vertical"
+      :lower-threshold-item-count="4"
+      @scrolltolower="loadMore"
+    >
+      <list-item
+        v-if="loading && !accounts.length && !hashtags.length && !statuses.length"
+        item-key="__loading"
+        :estimated-main-axis-size-px="80"
+      >
+        <view class="search-loading">
+          <Spinner />
+        </view>
+      </list-item>
 
-      <view v-else-if="!query" class="search-hint">
-        <text class="search-hint-text">Search for people, hashtags and posts</text>
-      </view>
+      <list-item
+        v-else-if="!query"
+        item-key="__hint"
+        :estimated-main-axis-size-px="80"
+      >
+        <view class="search-hint">
+          <text class="search-hint-text">Search for people, hashtags and posts</text>
+        </view>
+      </list-item>
 
       <template v-else>
-        <view v-if="accounts.length" class="search-section">
+        <list-item
+          v-if="accounts.length"
+          item-key="__people-title"
+          :estimated-main-axis-size-px="32"
+        >
           <text class="search-section-title">People</text>
+        </list-item>
+        <list-item
+          v-for="result in accounts.slice(0, 5)"
+          :key="result.id"
+          :item-key="result.id"
+          :estimated-main-axis-size-px="56"
+        >
           <view
-            v-for="result in accounts.slice(0, 5)"
-            :key="result.id"
             class="search-account"
             @tap="router.push(result.to)"
           >
@@ -63,13 +96,22 @@ function totalUses(tag: { history?: { uses: string }[] }): number {
               <text class="search-account-handle">@{{ result.data.acct }}</text>
             </view>
           </view>
-        </view>
+        </list-item>
 
-        <view v-if="hashtags.length" class="search-section">
+        <list-item
+          v-if="hashtags.length"
+          item-key="__tags-title"
+          :estimated-main-axis-size-px="32"
+        >
           <text class="search-section-title">Hashtags</text>
+        </list-item>
+        <list-item
+          v-for="result in hashtags.slice(0, 5)"
+          :key="result.id"
+          :item-key="result.id"
+          :estimated-main-axis-size-px="48"
+        >
           <view
-            v-for="result in hashtags.slice(0, 5)"
-            :key="result.id"
             class="search-tag"
             @tap="router.push(result.to)"
           >
@@ -77,21 +119,42 @@ function totalUses(tag: { history?: { uses: string }[] }): number {
             <text class="search-tag-name">{{ result.data.name }}</text>
             <text class="search-tag-uses">{{ formatCompactNumber(totalUses(result.data)) }} recent uses</text>
           </view>
-        </view>
+        </list-item>
 
-        <view v-if="statuses.length" class="search-section">
-          <text class="search-section-title">Posts</text>
-          <StatusCard v-for="result in statuses" :key="result.id" :status="result.data" />
-        </view>
-
-        <view
-          v-if="!accounts.length && !hashtags.length && !statuses.length"
-          class="search-hint"
+        <list-item
+          v-if="statuses.length"
+          item-key="__posts-title"
+          :estimated-main-axis-size-px="32"
         >
-          <text class="search-hint-text">No results for "{{ query }}"</text>
-        </view>
+          <text class="search-section-title">Posts</text>
+        </list-item>
+        <list-item
+          v-for="result in statuses"
+          :key="result.id"
+          :item-key="result.id"
+          :estimated-main-axis-size-px="160"
+        >
+          <StatusCard :status="result.data" />
+        </list-item>
+
+        <list-item
+          v-if="!loading && !accounts.length && !hashtags.length && !statuses.length"
+          item-key="__empty"
+          :estimated-main-axis-size-px="80"
+        >
+          <view class="search-hint">
+            <text class="search-hint-text">No results for "{{ query }}"</text>
+          </view>
+        </list-item>
+
+        <list-item item-key="__footer" :estimated-main-axis-size-px="60">
+          <view class="search-footer">
+            <Spinner v-if="loading && (accounts.length || hashtags.length || statuses.length)" />
+            <text v-else-if="done && statuses.length" class="search-end-text">End of results</text>
+          </view>
+        </list-item>
       </template>
-    </scroll-view>
+    </list>
   </view>
 </template>
 
@@ -139,12 +202,6 @@ function totalUses(tag: { history?: { uses: string }[] }): number {
   color: var(--c-text-secondary-light);
 }
 
-.search-section {
-  display: flex;
-  flex-direction: column;
-  padding-top: 8px;
-}
-
 .search-section-title {
   font-size: 13px;
   font-weight: 700;
@@ -188,5 +245,18 @@ function totalUses(tag: { history?: { uses: string }[] }): number {
   font-size: 13px;
   color: var(--c-text-secondary);
   margin-left: auto;
+}
+
+.search-footer {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  padding: 16px 0;
+}
+
+.search-end-text {
+  font-size: 13px;
+  color: var(--c-text-secondary-light);
 }
 </style>

--- a/examples/elk-viewpager/src/polyfills.ts
+++ b/examples/elk-viewpager/src/polyfills.ts
@@ -200,7 +200,24 @@ if (typeof g.Headers !== 'function') {
 //   new URL(absolute), new URL(path, base), url.search = 'a=b', String(url)
 // ---------------------------------------------------------------------------
 
-if (typeof g.URL !== 'function') {
+function hasCompatibleURL(URLCtor: unknown): boolean {
+  if (typeof URLCtor !== 'function')
+    return false;
+  try {
+    const url = new (URLCtor as typeof URL)('https://example.com/path?a=1');
+    if (url.pathname !== '/path' || url.search !== '?a=1')
+      return false;
+    url.searchParams.set('b', '2');
+    return url.pathname === '/path'
+      && url.search.includes('a=1')
+      && url.search.includes('b=2');
+  }
+  catch {
+    return false;
+  }
+}
+
+if (!hasCompatibleURL(g.URL)) {
   const ABSOLUTE_RE = /^([a-z][\w+.-]*):\/\/([^/?#]*)([^?#]*)(\?[^#]*)?(#.*)?$/i;
 
   class LynxURL {
@@ -258,7 +275,19 @@ if (typeof g.URL !== 'function') {
     }
 
     get searchParams() {
-      return new (g.URLSearchParams)(this._search);
+      const params = new (g.URLSearchParams)(this._search);
+      const sync = () => {
+        const query = params.toString();
+        this._search = query ? `?${query}` : '';
+      };
+      for (const method of ['set', 'append', 'delete'] as const) {
+        const original = params[method].bind(params);
+        params[method] = ((...args: unknown[]) => {
+          original(...args);
+          sync();
+        }) as never;
+      }
+      return params;
     }
 
     get origin() {

--- a/examples/elk-viewpager/src/polyfills.ts
+++ b/examples/elk-viewpager/src/polyfills.ts
@@ -13,7 +13,7 @@
 /* eslint-disable no-restricted-globals */
 
 import { installDOMException } from './dom-exception-compat';
-import { resolveFetch } from './fetch-compat';
+import { resolveFetch, wrapFetchForMastoPagination } from './fetch-compat';
 
 const g = globalThis as Record<string, any>;
 
@@ -21,15 +21,22 @@ const g = globalThis as Record<string, any>;
 // parameter, while Lynx for Web exposes it on globalThis. Synchronize the
 // callable implementation before masto modules execute so their bare fetch
 // identifier works in both environments.
+//
+// Then wrap for Mastodon pagination: masto.js reads `Link` via
+// response.headers.get('link'). Native Lynx fetch often drops that header
+// after the first page, so Paginator ends early ("End of the timeline")
+// while Web continues. The wrapper normalizes headers and synthesizes
+// rel="next" from max_id/offset when Link is missing.
 const sharedFetch = resolveFetch(
   g.fetch,
   typeof fetch === 'function' ? fetch : undefined,
 );
 if (sharedFetch) {
-  g.fetch = sharedFetch;
+  const mastoFetch = wrapFetchForMastoPagination(sharedFetch);
+  g.fetch = mastoFetch;
   // Assigns RuntimeWrapperWebpackPlugin's injected wrapper parameter.
   // @ts-expect-error fetch is declared as a global function in DOM typings.
-  fetch = sharedFetch as typeof fetch;
+  fetch = mastoFetch as typeof fetch;
 }
 
 installDOMException(g);

--- a/examples/elk/PORTING.md
+++ b/examples/elk/PORTING.md
@@ -106,6 +106,13 @@ access-token sign-in** in Settings. Multi-account storage
    exposes `globalThis.fetch`. `src/polyfills.ts` selects the callable one
    and mirrors it to both scopes before masto runs. Other free-identifier web
    constructors use targeted `source.define` rewrites (no masto patches).
+   **Pagination:** masto.js continues pages via the HTTP `Link` header
+   (`response.headers.get('link')`). Native Lynx fetch often omits that
+   header, so the first page succeeds and the next `paginator.next()` looks
+   like end-of-feed ("End of the timeline") while Web keeps scrolling.
+   `wrapFetchForMastoPagination` in `fetch-compat.ts` normalizes headers and,
+   when `Link` is missing, synthesizes `rel="next"` from `max_id` / `offset`
+   in the JSON body.
 2. **No DOMParser anywhere** (worker or native). Elk's `tiny-decode`
    entity decoder uses DOMParser in its browser build — replaced with a
    30-line table+numeric decoder (`html-entities.ts`), sufficient for

--- a/examples/elk/PORTING.md
+++ b/examples/elk/PORTING.md
@@ -75,10 +75,13 @@ classes — Lynx supports inline text nesting natively.
 ### Virtualized timeline
 
 Elk uses `virtua`'s DOM `WindowVirtualizer`. Lynx's native `<list>` is
-already a recycling virtualized scroller, so the port's timeline is a
-`<list>` with `estimated-main-axis-size-px` hints and
+already a recycling virtualized scroller, so the port's feeds are
+`<list>`s with `estimated-main-axis-size-px` hints and
 `lower-threshold-item-count` + `scrolltolower` driving `loadNext()` —
-*less* code than the DOM version.
+*less* code than the DOM version. Short finite pages (settings, compose,
+thread detail) stay on `<scroll-view>`; anything that paginates without
+bound (timelines, explore, profiles, search, notifications, follow lists)
+uses `<list>`.
 
 ### Navigation
 

--- a/examples/elk/PORTING.md
+++ b/examples/elk/PORTING.md
@@ -110,9 +110,12 @@ access-token sign-in** in Settings. Multi-account storage
    (`response.headers.get('link')`). Native Lynx fetch often omits that
    header, so the first page succeeds and the next `paginator.next()` looks
    like end-of-feed ("End of the timeline") while Web keeps scrolling.
-   `wrapFetchForMastoPagination` in `fetch-compat.ts` normalizes headers and,
-   when `Link` is missing, synthesizes `rel="next"` from `max_id` / `offset`
-   in the JSON body.
+   `wrapFetchForMastoPagination` in `fetch-compat.ts` leaves the native
+   Response alone when `Link` is present (see Lynx networking guide:
+   Fetch is Web-compatible with subtle differences — prefer not to replace
+   the host Response). When `Link` is missing it buffers the body, keeps
+   `Content-Type` via `.get` (native Headers often do not enumerate), and
+   synthesizes `rel="next"` from `max_id` / `offset`.
 2. **No DOMParser anywhere** (worker or native). Elk's `tiny-decode`
    entity decoder uses DOMParser in its browser build — replaced with a
    30-line table+numeric decoder (`html-entities.ts`), sufficient for

--- a/examples/elk/PORTING.md
+++ b/examples/elk/PORTING.md
@@ -107,15 +107,19 @@ access-token sign-in** in Settings. Multi-account storage
    and mirrors it to both scopes before masto runs. Other free-identifier web
    constructors use targeted `source.define` rewrites (no masto patches).
    **Pagination:** masto.js continues pages via the HTTP `Link` header
-   (`response.headers.get('link')`). Native Lynx fetch often omits that
-   header, so the first page succeeds and the next `paginator.next()` looks
-   like end-of-feed ("End of the timeline") while Web keeps scrolling.
-   `wrapFetchForMastoPagination` in `fetch-compat.ts` leaves the native
-   Response alone when `Link` is present (see Lynx networking guide:
-   Fetch is Web-compatible with subtle differences — prefer not to replace
-   the host Response). When `Link` is missing it buffers the body, keeps
-   `Content-Type` via `.get` (native Headers often do not enumerate), and
-   synthesizes `rel="next"` from `max_id` / `offset`.
+   (`response.headers.get('link')`). Some native Lynx builds enumerate the
+   real mixed-case `Link` and `Content-Type` names but implement `.get()` as
+   case-sensitive, so masto's lowercase lookup sees no next page. The same
+   builds can expose a partial `URL` whose `.search` is missing. Together
+   these made the first page end early or made page 2 throw while Web kept
+   scrolling. `wrapFetchForMastoPagination` patches `.get()` in place with a
+   case-insensitive fallback, preserving the native Response and unread body
+   (see Lynx networking guide: Fetch is Web-compatible with subtle
+   differences). When `Link` is genuinely missing it buffers the body and
+   synthesizes `rel="next"` from `max_id` / `offset` without relying on the
+   host URL implementation. `polyfills.ts` also replaces incomplete URL
+   implementations, not just missing ones, because masto needs both
+   `.pathname` and `.search` from each Link URL.
 2. **No DOMParser anywhere** (worker or native). Elk's `tiny-decode`
    entity decoder uses DOMParser in its browser build — replaced with a
    30-line table+numeric decoder (`html-entities.ts`), sufficient for

--- a/examples/elk/PRD.md
+++ b/examples/elk/PRD.md
@@ -61,7 +61,7 @@ Elk Lynx = this example (examples/elk) → fresh Vue Lynx shell
 - ✅ Public/federated timeline (`v1.timelines.public`)
 - ✅ Local timeline (`public.list({ local: true })`)
 - 🚧 Home timeline (requires token; implemented, verified against API shape only)
-- ✅ Infinite scroll via masto `Paginator` (Elk `usePaginator` core reused; DOM `useElementBounding` trigger → Lynx `<list>` `scrolltolower` event)
+- ✅ Infinite scroll via masto `Paginator` (Elk `usePaginator` core reused; DOM `useElementBounding` trigger → Lynx `<list>` `scrolltolower` event). Covers timelines, explore (posts/tags/news), profile posts/replies/media, search, notifications, and follow lists. Finite pages keep `<scroll-view>`.
 - ✅ Native virtualized scrolling (Elk uses `virtua` DOM virtual scroller → Lynx `<list>` native recycling)
 - ✅ Timeline filtering/reordering (Elk `timeline.ts`: hide replies/boosts prefs, thread reorder — reused verbatim)
 - 🚧 Refresh (header refresh button recreates the paginator; replaces Elk's streaming prepend. Native pull-to-refresh gesture not wired)
@@ -102,7 +102,7 @@ Elk Lynx = this example (examples/elk) → fresh Vue Lynx shell
 - ✅ Profile header: banner image, avatar, display name (emoji), handle, bio (rich content)
 - ✅ Stats row: posts / following / followers counts
 - ✅ Fields/metadata table (with verified-link highlight)
-- ✅ Account posts tab (`v1.accounts.$select(id).statuses`)
+- ✅ Account posts tab (`v1.accounts.$select(id).statuses`) with infinite scroll via `TimelinePaginator`
 - ✅ Posts / Posts+Replies / Media tabs
 - ✅ Following / Followers lists (tappable stats on profile → paginated account list)
 - 🚧 Follow/unfollow button (needs token; UI + optimistic logic ported)
@@ -119,10 +119,10 @@ Elk Lynx = this example (examples/elk) → fresh Vue Lynx shell
 
 ### Search & explore
 
-- ✅ Search page: accounts / hashtags / statuses (`v2.search`, debounced — Elk `useSearch` reused)
-- ✅ Explore: trending posts (`v1.trends.statuses`)
-- ✅ Explore: trending hashtags (`v1.trends.tags`) with usage sparkline numbers
-- ✅ Explore: trending links (News tab: provider, title, description, thumbnail)
+- ✅ Search page: accounts / hashtags / statuses (`v2.search`, debounced — Elk `useSearch` reused; `<list>` `scrolltolower` → `next()`)
+- ✅ Explore: trending posts (`v1.trends.statuses`, `TimelinePaginator`)
+- ✅ Explore: trending hashtags (`v1.trends.tags`) with usage sparkline numbers + infinite scroll
+- ✅ Explore: trending links (News tab: provider, title, description, thumbnail + infinite scroll)
 - ✅ Hashtag timeline page (`v1.timelines.tag`; verified incl. CJK tags + remote instance content)
 - 🚧 Follow hashtag button (auth-gated; on tag page header)
 

--- a/examples/elk/scripts/native-compat.test.mjs
+++ b/examples/elk/scripts/native-compat.test.mjs
@@ -331,6 +331,14 @@ test('native WebSocket remains wrapper-scoped for the Rspeedy dev transport', ()
   assert.equal(lynxConfig.source?.define?.WebSocket, undefined);
 });
 
+test('URL compatibility guard rejects incomplete native URL implementations', async () => {
+  const source = await readFile(new URL('../src/polyfills.ts', import.meta.url), 'utf8');
+  assert.match(source, /url\.search !== '\?a=1'/);
+  assert.match(source, /url\.searchParams\.set\('b', '2'\)/);
+  assert.match(source, /if \(!hasCompatibleURL\(g\.URL\)\)/);
+  assert.match(source, /this\._search = query \? `\?\$\{query\}` : ''/);
+});
+
 test('fetch compatibility prefers the native wrapper and falls back to the web global', () => {
   const nativeFetch = () => 'native';
   const webFetch = () => 'web';
@@ -349,6 +357,7 @@ test('fetch Link synthesis builds max_id next for status arrays when header miss
   assert.match(link ?? '', /rel="next"/);
   assert.match(link ?? '', /max_id=100/);
   assert.match(link ?? '', /local=true/);
+  assert.doesNotMatch(link ?? '', /limit=30\//);
 });
 
 test('fetch Link synthesis uses offset when entities have no id', () => {
@@ -428,6 +437,38 @@ test('wrapFetchForMastoPagination passes through when Link already exists', asyn
   const wrapped = fetchCompat.wrapFetchForMastoPagination?.(async () => original);
   const res = await wrapped('https://mas.to/api/v1/timelines/public?limit=2');
   assert.equal(res, original);
+});
+
+test('wrapFetchForMastoPagination repairs case-sensitive native Headers.get in place', async () => {
+  const existing = '<https://mas.to/api/v1/timelines/public?max_id=9>; rel="next"';
+  const values = new Map([
+    ['Link', existing],
+    ['Content-Type', 'application/json; charset=utf-8'],
+  ]);
+  const nativeHeaders = {
+    get(name) {
+      return values.get(name) ?? null;
+    },
+    forEach(fn) {
+      for (const [name, value] of values)
+        fn(value, name);
+    },
+  };
+  const original = {
+    ok: true,
+    status: 200,
+    headers: nativeHeaders,
+    async text() {
+      throw new Error('native body must remain unread');
+    },
+  };
+  const wrapped = fetchCompat.wrapFetchForMastoPagination?.(async () => original);
+  const res = await wrapped('https://mas.to/api/v1/timelines/public?limit=2');
+
+  assert.equal(res, original);
+  assert.equal(res.headers, nativeHeaders);
+  assert.equal(res.headers.get('link'), existing);
+  assert.match(res.headers.get('content-type') ?? '', /application\/json/);
 });
 
 test('normalizeResponseHeaders seeds Content-Type via .get without enumeration', () => {

--- a/examples/elk/scripts/native-compat.test.mjs
+++ b/examples/elk/scripts/native-compat.test.mjs
@@ -341,6 +341,73 @@ test('fetch compatibility prefers the native wrapper and falls back to the web g
   assert.equal(lynxConfig.source?.define?.fetch, undefined);
 });
 
+test('fetch Link synthesis builds max_id next for status arrays when header missing', () => {
+  const link = fetchCompat.synthesizeNextLink?.(
+    'https://mas.to/api/v1/timelines/public?local=true&limit=30',
+    JSON.stringify([{ id: '111' }, { id: '100' }]),
+  );
+  assert.match(link ?? '', /rel="next"/);
+  assert.match(link ?? '', /max_id=100/);
+  assert.match(link ?? '', /local=true/);
+});
+
+test('fetch Link synthesis uses offset when entities have no id', () => {
+  const link = fetchCompat.synthesizeNextLink?.(
+    'https://mas.to/api/v1/trends/tags?limit=10&offset=0',
+    JSON.stringify([{ name: 'a' }, { name: 'b' }]),
+  );
+  assert.match(link ?? '', /offset=2/);
+});
+
+test('fetch Link synthesis stops when max_id would not advance', () => {
+  const link = fetchCompat.synthesizeNextLink?.(
+    'https://mas.to/api/v1/timelines/public?max_id=100',
+    JSON.stringify([{ id: '100' }]),
+  );
+  assert.equal(link, null);
+});
+
+test('wrapFetchForMastoPagination synthesizes Link when native headers omit it', async () => {
+  const wrapped = fetchCompat.wrapFetchForMastoPagination?.(async () => ({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    url: 'https://mas.to/api/v1/timelines/public?limit=2',
+    headers: { 'content-type': 'application/json' },
+    async text() {
+      return JSON.stringify([{ id: '2' }, { id: '1' }]);
+    },
+  }));
+  assert.equal(typeof wrapped, 'function');
+  const res = await wrapped('https://mas.to/api/v1/timelines/public?limit=2');
+  assert.match(res.headers.get('link') ?? '', /max_id=1/);
+  assert.match(res.headers.get('content-type') ?? '', /application\/json/);
+  const body = JSON.parse(await res.text());
+  assert.equal(body[1].id, '1');
+});
+
+test('wrapFetchForMastoPagination preserves an existing Link header', async () => {
+  const existing = '<https://mas.to/api/v1/timelines/public?max_id=9>; rel="next"';
+  const wrapped = fetchCompat.wrapFetchForMastoPagination?.(async () => ({
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    headers: {
+      get(name) {
+        return name.toLowerCase() === 'link' ? existing : null;
+      },
+      forEach(fn) {
+        fn(existing, 'link');
+      },
+    },
+    async text() {
+      return JSON.stringify([{ id: '2' }, { id: '1' }]);
+    },
+  }));
+  const res = await wrapped('https://mas.to/api/v1/timelines/public?limit=2');
+  assert.equal(res.headers.get('link'), existing);
+});
+
 test('DOMException compatibility preserves name, message and instanceof checks', () => {
   const target = {};
   domExceptionCompat.installDOMException?.(target);

--- a/examples/elk/scripts/native-compat.test.mjs
+++ b/examples/elk/scripts/native-compat.test.mjs
@@ -373,7 +373,11 @@ test('wrapFetchForMastoPagination synthesizes Link when native headers omit it',
     status: 200,
     statusText: 'OK',
     url: 'https://mas.to/api/v1/timelines/public?limit=2',
-    headers: { 'content-type': 'application/json' },
+    headers: {
+      get(name) {
+        return name.toLowerCase() === 'content-type' ? 'application/json' : null;
+      },
+    },
     async text() {
       return JSON.stringify([{ id: '2' }, { id: '1' }]);
     },
@@ -386,26 +390,53 @@ test('wrapFetchForMastoPagination synthesizes Link when native headers omit it',
   assert.equal(body[1].id, '1');
 });
 
-test('wrapFetchForMastoPagination preserves an existing Link header', async () => {
-  const existing = '<https://mas.to/api/v1/timelines/public?max_id=9>; rel="next"';
+test('wrapFetchForMastoPagination keeps Content-Type when headers are non-enumerable', async () => {
+  // Mimics Lynx native Headers: .get works, Object.entries is empty.
+  const nativeHeaders = {
+    get(name) {
+      return name.toLowerCase() === 'content-type' ? 'application/json; charset=utf-8' : null;
+    },
+  };
   const wrapped = fetchCompat.wrapFetchForMastoPagination?.(async () => ({
     ok: true,
     status: 200,
     statusText: 'OK',
+    headers: nativeHeaders,
+    async text() {
+      return JSON.stringify([{ id: '9' }]);
+    },
+  }));
+  const res = await wrapped('https://mas.to/api/v1/timelines/public?limit=1');
+  assert.match(res.headers.get('Content-Type') ?? '', /application\/json/);
+  assert.match(res.headers.get('link') ?? '', /max_id=9/);
+});
+
+test('wrapFetchForMastoPagination passes through when Link already exists', async () => {
+  const existing = '<https://mas.to/api/v1/timelines/public?max_id=9>; rel="next"';
+  const original = {
+    ok: true,
+    status: 200,
     headers: {
       get(name) {
         return name.toLowerCase() === 'link' ? existing : null;
       },
-      forEach(fn) {
-        fn(existing, 'link');
-      },
     },
     async text() {
-      return JSON.stringify([{ id: '2' }, { id: '1' }]);
+      throw new Error('should not buffer when Link is present');
     },
-  }));
+  };
+  const wrapped = fetchCompat.wrapFetchForMastoPagination?.(async () => original);
   const res = await wrapped('https://mas.to/api/v1/timelines/public?limit=2');
-  assert.equal(res.headers.get('link'), existing);
+  assert.equal(res, original);
+});
+
+test('normalizeResponseHeaders seeds Content-Type via .get without enumeration', () => {
+  const headers = fetchCompat.normalizeResponseHeaders?.({
+    get(name) {
+      return name.toLowerCase() === 'content-type' ? 'application/json' : null;
+    },
+  });
+  assert.equal(headers?.get('content-type'), 'application/json');
 });
 
 test('DOMException compatibility preserves name, message and instanceof checks', () => {

--- a/examples/elk/scripts/native-compat.test.mjs
+++ b/examples/elk/scripts/native-compat.test.mjs
@@ -553,6 +553,26 @@ test('tabs animate persistent indicators and Explore explains trending content',
   assert.match(account, /account-tab-underline-active/);
 });
 
+test('long feeds use recycling list scrolltolower instead of scroll-view', async () => {
+  const [explore, account, search, timeline] = await Promise.all([
+    readFile(new URL('../src/pages/ExplorePage.vue', import.meta.url), 'utf8'),
+    readFile(new URL('../src/pages/AccountPage.vue', import.meta.url), 'utf8'),
+    readFile(new URL('../src/pages/SearchPage.vue', import.meta.url), 'utf8'),
+    readFile(new URL('../src/components/TimelinePaginator.vue', import.meta.url), 'utf8'),
+  ]);
+
+  assert.match(timeline, /@scrolltolower="loadNext"/);
+  assert.match(timeline, /lower-threshold-item-count/);
+  assert.match(explore, /TimelinePaginator/);
+  assert.match(explore, /@scrolltolower="loadMoreTags"/);
+  assert.match(explore, /@scrolltolower="loadMoreLinks"/);
+  assert.doesNotMatch(explore, /<scroll-view/);
+  assert.match(account, /TimelinePaginator/);
+  assert.doesNotMatch(account, /<scroll-view/);
+  assert.match(search, /@scrolltolower="loadMore"/);
+  assert.doesNotMatch(search, /<scroll-view/);
+});
+
 test('media preview motion mirrors Elk using only opacity and transform', async () => {
   const source = await readFile(
     new URL('../src/components/MediaPreview.vue', import.meta.url),

--- a/examples/elk/src/composables/search.ts
+++ b/examples/elk/src/composables/search.ts
@@ -83,16 +83,20 @@ export function useSearch(query: MaybeRefOrGetter<string>) {
   });
 
   const next = async () => {
-    if (!q.value || !paginator)
+    if (!q.value || !paginator || done.value || loading.value)
       return;
 
     loading.value = true;
-    const nextResults = await paginator.values().next();
+    try {
+      const nextResults = await paginator.values().next();
+      done.value = !!nextResults.done;
+      if (!nextResults.done)
+        appendResults(nextResults.value);
+    }
+    catch (e) {
+      console.error(e);
+    }
     loading.value = false;
-
-    done.value = !!nextResults.done;
-    if (!nextResults.done)
-      appendResults(nextResults.value);
   };
 
   return {
@@ -100,6 +104,7 @@ export function useSearch(query: MaybeRefOrGetter<string>) {
     hashtags,
     statuses,
     loading: readonly(loading),
+    done: readonly(done),
     next,
   };
 }

--- a/examples/elk/src/fetch-compat.ts
+++ b/examples/elk/src/fetch-compat.ts
@@ -10,3 +10,192 @@ export function resolveFetch(
     return globalFetch as FetchLike;
   return undefined;
 }
+
+/**
+ * Read a header in a Headers-like / plain-object compatible way.
+ * Lynx native Response.headers sometimes omit `.get`, or only expose a
+ * subset of names; masto.js pagination depends on `Link`.
+ */
+export function readHeader(headers: unknown, name: string): string | null {
+  if (!headers || typeof headers !== 'object')
+    return null;
+
+  const lower = name.toLowerCase();
+  const h = headers as {
+    get?: (n: string) => string | null | undefined;
+    forEach?: (fn: (value: string, key: string) => void) => void;
+    entries?: () => IterableIterator<[string, string]>;
+  };
+
+  if (typeof h.get === 'function') {
+    const direct = h.get(name) ?? h.get(lower) ?? h.get(name.replace(/^\w/, c => c.toUpperCase()));
+    if (direct != null && direct !== '')
+      return String(direct);
+  }
+
+  if (typeof h.forEach === 'function') {
+    let found: string | null = null;
+    h.forEach((value, key) => {
+      if (found == null && String(key).toLowerCase() === lower)
+        found = String(value);
+    });
+    if (found != null)
+      return found;
+  }
+
+  if (typeof h.entries === 'function') {
+    for (const [key, value] of h.entries()) {
+      if (String(key).toLowerCase() === lower)
+        return String(value);
+    }
+  }
+
+  for (const [key, value] of Object.entries(headers as Record<string, unknown>)) {
+    if (key.toLowerCase() === lower && value != null)
+      return String(value);
+  }
+
+  return null;
+}
+
+type MutableHeaders = {
+  get: (name: string) => string | null;
+  set: (name: string, value: string) => void;
+  has: (name: string) => boolean;
+  forEach: (fn: (value: string, key: string) => void) => void;
+};
+
+function copyHeaders(source: unknown): MutableHeaders {
+  const map = new Map<string, string>();
+
+  const set = (name: string, value: string) => {
+    map.set(name.toLowerCase(), value);
+  };
+
+  if (source && typeof source === 'object') {
+    const h = source as {
+      forEach?: (fn: (value: string, key: string) => void) => void;
+      entries?: () => IterableIterator<[string, string]>;
+    };
+    if (typeof h.forEach === 'function') {
+      h.forEach((value, key) => set(key, String(value)));
+    }
+    else if (typeof h.entries === 'function') {
+      for (const [key, value] of h.entries()) set(key, String(value));
+    }
+    else {
+      for (const [key, value] of Object.entries(source as Record<string, unknown>)) {
+        if (value != null)
+          set(key, String(value));
+      }
+    }
+  }
+
+  return {
+    get: name => map.get(name.toLowerCase()) ?? null,
+    set: (name, value) => set(name, value),
+    has: name => map.has(name.toLowerCase()),
+    forEach: (fn) => {
+      for (const [k, v] of map) fn(v, k);
+    },
+  };
+}
+
+function requestUrl(input: unknown): string {
+  if (typeof input === 'string')
+    return input;
+  if (input && typeof input === 'object') {
+    const r = input as { url?: unknown; href?: unknown };
+    if (typeof r.url === 'string')
+      return r.url;
+    if (typeof r.href === 'string')
+      return r.href;
+  }
+  return String(input ?? '');
+}
+
+/**
+ * When Mastodon-compatible APIs return a page of entities but the runtime
+ * stripped the `Link` header, synthesize `rel="next"` so masto.js Paginator
+ * can continue. Timelines / notifications / follow lists use `max_id`;
+ * offset-based trends use `offset`.
+ */
+export function synthesizeNextLink(
+  requestHref: string,
+  bodyText: string,
+): string | null {
+  let data: unknown;
+  try {
+    data = JSON.parse(bodyText);
+  }
+  catch {
+    return null;
+  }
+  if (!Array.isArray(data) || data.length === 0)
+    return null;
+
+  let nextHref: string;
+  try {
+    // Prefer URL when available (web / modern native); fall back to string surgery.
+    if (typeof URL === 'function') {
+      const url = new URL(requestHref);
+      const last = data[data.length - 1] as Record<string, unknown>;
+      if (last && last.id != null) {
+        url.searchParams.set('max_id', String(last.id));
+        // Avoid a tight loop if the server ignored max_id and returned the same head.
+        const prevMax = new URL(requestHref).searchParams.get('max_id');
+        if (prevMax === String(last.id))
+          return null;
+      }
+      else {
+        const prevOffset = Number(url.searchParams.get('offset') || '0');
+        if (!Number.isFinite(prevOffset))
+          return null;
+        url.searchParams.set('offset', String(prevOffset + data.length));
+      }
+      nextHref = url.href;
+    }
+    else {
+      return null;
+    }
+  }
+  catch {
+    return null;
+  }
+
+  return `<${nextHref}>; rel="next"`;
+}
+
+/**
+ * Wrap fetch so Response.headers always supports `.get('link')` for masto.js.
+ * If the native stack drops `Link`, synthesize the next page URL from the body.
+ *
+ * Body is buffered once (timeline pages are small JSON arrays).
+ */
+export function wrapFetchForMastoPagination(fetchImpl: FetchLike): FetchLike {
+  return async function fetchWithMastoLink(input: unknown, init?: unknown) {
+    const response = await fetchImpl(input, init);
+    const headers = copyHeaders(response?.headers);
+    const text = await response.text();
+
+    if (!headers.get('link')) {
+      const synthesized = synthesizeNextLink(requestUrl(input), text);
+      if (synthesized)
+        headers.set('link', synthesized);
+    }
+
+    return {
+      ok: response.ok,
+      status: response.status,
+      statusText: response.statusText,
+      url: response.url ?? requestUrl(input),
+      headers,
+      async text() {
+        return text;
+      },
+      async json() {
+        return JSON.parse(text);
+      },
+    };
+  };
+}

--- a/examples/elk/src/fetch-compat.ts
+++ b/examples/elk/src/fetch-compat.ts
@@ -13,8 +13,12 @@ export function resolveFetch(
 
 /**
  * Read a header in a Headers-like / plain-object compatible way.
- * Lynx native Response.headers sometimes omit `.get`, or only expose a
- * subset of names; masto.js pagination depends on `Link`.
+ * Lynx native Response.headers sometimes omit iterable helpers; masto.js
+ * pagination depends on `Link`, and content decoding on `Content-Type`.
+ *
+ * @see https://lynxjs.org/guide/interaction/networking
+ * @see https://lynxjs.org/api/lynx-api/global/fetch — Lynx Fetch aligns with
+ * Web but has subtle differences; third-party libs may need adaptation.
  */
 export function readHeader(headers: unknown, name: string): string | null {
   if (!headers || typeof headers !== 'object')
@@ -28,31 +32,53 @@ export function readHeader(headers: unknown, name: string): string | null {
   };
 
   if (typeof h.get === 'function') {
-    const direct = h.get(name) ?? h.get(lower) ?? h.get(name.replace(/^\w/, c => c.toUpperCase()));
-    if (direct != null && direct !== '')
-      return String(direct);
+    for (const candidate of [name, lower, name.replace(/^\w/, c => c.toUpperCase())]) {
+      try {
+        const direct = h.get(candidate);
+        if (direct != null && direct !== '')
+          return String(direct);
+      }
+      catch {
+        // some native Headers.get implementations throw on unknown names
+      }
+    }
   }
 
   if (typeof h.forEach === 'function') {
     let found: string | null = null;
-    h.forEach((value, key) => {
-      if (found == null && String(key).toLowerCase() === lower)
-        found = String(value);
-    });
+    try {
+      h.forEach((value, key) => {
+        if (found == null && String(key).toLowerCase() === lower)
+          found = String(value);
+      });
+    }
+    catch {
+      // ignore
+    }
     if (found != null)
       return found;
   }
 
   if (typeof h.entries === 'function') {
-    for (const [key, value] of h.entries()) {
-      if (String(key).toLowerCase() === lower)
-        return String(value);
+    try {
+      for (const [key, value] of h.entries()) {
+        if (String(key).toLowerCase() === lower)
+          return String(value);
+      }
+    }
+    catch {
+      // ignore
     }
   }
 
-  for (const [key, value] of Object.entries(headers as Record<string, unknown>)) {
-    if (key.toLowerCase() === lower && value != null)
-      return String(value);
+  try {
+    for (const [key, value] of Object.entries(headers as Record<string, unknown>)) {
+      if (key.toLowerCase() === lower && value != null)
+        return String(value);
+    }
+  }
+  catch {
+    // ignore
   }
 
   return null;
@@ -65,40 +91,60 @@ type MutableHeaders = {
   forEach: (fn: (value: string, key: string) => void) => void;
 };
 
-function copyHeaders(source: unknown): MutableHeaders {
+function createHeadersBag(seed?: Record<string, string>): MutableHeaders {
   const map = new Map<string, string>();
-
-  const set = (name: string, value: string) => {
-    map.set(name.toLowerCase(), value);
+  if (seed) {
+    for (const [k, v] of Object.entries(seed))
+      map.set(k.toLowerCase(), v);
+  }
+  return {
+    get: name => map.get(name.toLowerCase()) ?? null,
+    set: (name, value) => {
+      map.set(name.toLowerCase(), value);
+    },
+    has: name => map.has(name.toLowerCase()),
+    forEach: (fn) => {
+      for (const [k, v] of map) fn(v, k);
+    },
   };
+}
+
+/**
+ * Build a headers bag that always exposes `.get`, seeding critical fields via
+ * readHeader first. Native Lynx Headers often do not enumerate with
+ * Object.entries / forEach the way Web does — copying only via iteration
+ * drops Content-Type and breaks masto's getEncoding().
+ */
+export function normalizeResponseHeaders(source: unknown): MutableHeaders {
+  const headers = createHeadersBag();
+
+  // Prefer explicit gets for fields masto needs.
+  const contentType = readHeader(source, 'content-type');
+  if (contentType)
+    headers.set('content-type', contentType);
+  const link = readHeader(source, 'link');
+  if (link)
+    headers.set('link', link);
 
   if (source && typeof source === 'object') {
     const h = source as {
       forEach?: (fn: (value: string, key: string) => void) => void;
       entries?: () => IterableIterator<[string, string]>;
     };
-    if (typeof h.forEach === 'function') {
-      h.forEach((value, key) => set(key, String(value)));
-    }
-    else if (typeof h.entries === 'function') {
-      for (const [key, value] of h.entries()) set(key, String(value));
-    }
-    else {
-      for (const [key, value] of Object.entries(source as Record<string, unknown>)) {
-        if (value != null)
-          set(key, String(value));
+    try {
+      if (typeof h.forEach === 'function') {
+        h.forEach((value, key) => headers.set(key, String(value)));
       }
+      else if (typeof h.entries === 'function') {
+        for (const [key, value] of h.entries()) headers.set(key, String(value));
+      }
+    }
+    catch {
+      // keep seeded content-type / link
     }
   }
 
-  return {
-    get: name => map.get(name.toLowerCase()) ?? null,
-    set: (name, value) => set(name, value),
-    has: name => map.has(name.toLowerCase()),
-    forEach: (fn) => {
-      for (const [k, v] of map) fn(v, k);
-    },
-  };
+  return headers;
 }
 
 function requestUrl(input: unknown): string {
@@ -136,28 +182,25 @@ export function synthesizeNextLink(
 
   let nextHref: string;
   try {
-    // Prefer URL when available (web / modern native); fall back to string surgery.
-    if (typeof URL === 'function') {
-      const url = new URL(requestHref);
-      const last = data[data.length - 1] as Record<string, unknown>;
-      if (last && last.id != null) {
-        url.searchParams.set('max_id', String(last.id));
-        // Avoid a tight loop if the server ignored max_id and returned the same head.
-        const prevMax = new URL(requestHref).searchParams.get('max_id');
-        if (prevMax === String(last.id))
-          return null;
-      }
-      else {
-        const prevOffset = Number(url.searchParams.get('offset') || '0');
-        if (!Number.isFinite(prevOffset))
-          return null;
-        url.searchParams.set('offset', String(prevOffset + data.length));
-      }
-      nextHref = url.href;
+    if (typeof URL !== 'function')
+      return null;
+
+    const url = new URL(requestHref);
+    const last = data[data.length - 1] as Record<string, unknown>;
+    if (last && last.id != null) {
+      url.searchParams.set('max_id', String(last.id));
+      // Avoid a tight loop if the server ignored max_id and returned the same head.
+      const prevMax = new URL(requestHref).searchParams.get('max_id');
+      if (prevMax === String(last.id))
+        return null;
     }
     else {
-      return null;
+      const prevOffset = Number(url.searchParams.get('offset') || '0');
+      if (!Number.isFinite(prevOffset))
+        return null;
+      url.searchParams.set('offset', String(prevOffset + data.length));
     }
+    nextHref = url.href;
   }
   catch {
     return null;
@@ -166,36 +209,87 @@ export function synthesizeNextLink(
   return `<${nextHref}>; rel="next"`;
 }
 
+function buildPatchedResponse(
+  response: any,
+  text: string,
+  headers: MutableHeaders,
+  input: unknown,
+): any {
+  const status = typeof response?.status === 'number' ? response.status : 200;
+  const ok = typeof response?.ok === 'boolean'
+    ? response.ok
+    : status >= 200 && status < 300;
+  const statusText = response?.statusText ?? '';
+  const url = response?.url ?? requestUrl(input);
+
+  // Prefer a real Response so `instanceof Response` still works in masto's
+  // error path (Lynx documents Response as available since 2.18).
+  if (typeof Response === 'function') {
+    try {
+      const initHeaders: Record<string, string> = {};
+      headers.forEach((value, key) => {
+        initHeaders[key] = value;
+      });
+      const built = new Response(text, { status, statusText, headers: initHeaders });
+      // Some Lynx builds omit .url on constructed Responses.
+      if (!(built as any).url && url) {
+        try {
+          Object.defineProperty(built, 'url', { value: url, configurable: true });
+        }
+        catch {
+          // ignore
+        }
+      }
+      return built;
+    }
+    catch {
+      // fall through to duck-typed response
+    }
+  }
+
+  return {
+    ok,
+    status,
+    statusText,
+    url,
+    headers,
+    async text() {
+      return text;
+    },
+    async json() {
+      return JSON.parse(text);
+    },
+  };
+}
+
 /**
- * Wrap fetch so Response.headers always supports `.get('link')` for masto.js.
- * If the native stack drops `Link`, synthesize the next page URL from the body.
+ * Wrap fetch for masto.js pagination without breaking Lynx's native Response.
  *
- * Body is buffered once (timeline pages are small JSON arrays).
+ * Per https://lynxjs.org/guide/interaction/networking — Lynx Fetch is Web-
+ * compatible with subtle differences; keep the native Response when `Link`
+ * is already readable. Only buffer + rebuild when we must synthesize `Link`
+ * (native stacks often drop that header after the first Mastodon page).
  */
 export function wrapFetchForMastoPagination(fetchImpl: FetchLike): FetchLike {
   return async function fetchWithMastoLink(input: unknown, init?: unknown) {
     const response = await fetchImpl(input, init);
-    const headers = copyHeaders(response?.headers);
+
+    // Fast path: leave Lynx/Web Response untouched when Link is present.
+    if (readHeader(response?.headers, 'link'))
+      return response;
+
+    // Need body to synthesize next — buffer once. Always keep Content-Type
+    // via readHeader; empty iteration of native Headers was dropping it and
+    // causing masto "unknown encoding" → Failed to load timeline.
     const text = await response.text();
+    const headers = normalizeResponseHeaders(response?.headers);
+    if (!headers.get('content-type'))
+      headers.set('content-type', 'application/json');
 
-    if (!headers.get('link')) {
-      const synthesized = synthesizeNextLink(requestUrl(input), text);
-      if (synthesized)
-        headers.set('link', synthesized);
-    }
+    const synthesized = synthesizeNextLink(requestUrl(input), text);
+    if (synthesized)
+      headers.set('link', synthesized);
 
-    return {
-      ok: response.ok,
-      status: response.status,
-      statusText: response.statusText,
-      url: response.url ?? requestUrl(input),
-      headers,
-      async text() {
-        return text;
-      },
-      async json() {
-        return JSON.parse(text);
-      },
-    };
+    return buildPatchedResponse(response, text, headers, input);
   };
 }

--- a/examples/elk/src/fetch-compat.ts
+++ b/examples/elk/src/fetch-compat.ts
@@ -147,6 +147,53 @@ export function normalizeResponseHeaders(source: unknown): MutableHeaders {
   return headers;
 }
 
+/**
+ * Lynx native Headers can enumerate mixed-case response names while `.get()`
+ * only matches the original casing. masto always asks for lowercase `link`, so
+ * add a case-insensitive fallback on the existing Headers object. Keeping the
+ * original object means the native Response and its unread body stay intact.
+ */
+function patchNativeHeaderGet(source: unknown): boolean {
+  if (!source || typeof source !== 'object')
+    return false;
+
+  const headers = source as { get?: (name: string) => unknown };
+  if (typeof headers.get !== 'function')
+    return false;
+
+  const originalGet = headers.get.bind(headers);
+  const normalized = normalizeResponseHeaders(source);
+  const compatibleGet = (name: string): string | null => {
+    try {
+      const direct = originalGet(name);
+      if (direct != null && direct !== '')
+        return String(direct);
+    }
+    catch {
+      // Fall back to the case-insensitive snapshot below.
+    }
+    return normalized.get(name);
+  };
+
+  try {
+    Object.defineProperty(headers, 'get', {
+      value: compatibleGet,
+      configurable: true,
+      writable: true,
+    });
+  }
+  catch {
+    try {
+      headers.get = compatibleGet;
+    }
+    catch {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 function requestUrl(input: unknown): string {
   if (typeof input === 'string')
     return input;
@@ -180,30 +227,58 @@ export function synthesizeNextLink(
   if (!Array.isArray(data) || data.length === 0)
     return null;
 
-  let nextHref: string;
-  try {
-    if (typeof URL !== 'function')
-      return null;
-
-    const url = new URL(requestHref);
-    const last = data[data.length - 1] as Record<string, unknown>;
-    if (last && last.id != null) {
-      url.searchParams.set('max_id', String(last.id));
-      // Avoid a tight loop if the server ignored max_id and returned the same head.
-      const prevMax = new URL(requestHref).searchParams.get('max_id');
-      if (prevMax === String(last.id))
-        return null;
-    }
-    else {
-      const prevOffset = Number(url.searchParams.get('offset') || '0');
-      if (!Number.isFinite(prevOffset))
-        return null;
-      url.searchParams.set('offset', String(prevOffset + data.length));
-    }
-    nextHref = url.href;
-  }
-  catch {
+  if (!requestHref)
     return null;
+
+  const hashIndex = requestHref.indexOf('#');
+  const hash = hashIndex >= 0 ? requestHref.slice(hashIndex) : '';
+  const withoutHash = hashIndex >= 0 ? requestHref.slice(0, hashIndex) : requestHref;
+  const queryIndex = withoutHash.indexOf('?');
+  const base = queryIndex >= 0 ? withoutHash.slice(0, queryIndex) : withoutHash;
+  const rawQuery = queryIndex >= 0 ? withoutHash.slice(queryIndex + 1) : '';
+  const pairs = rawQuery ? rawQuery.split('&').filter(Boolean) : [];
+
+  const decodeKey = (pair: string) => {
+    const raw = pair.split('=', 1)[0];
+    try {
+      return decodeURIComponent(raw.replace(/\+/g, ' '));
+    }
+    catch {
+      return raw;
+    }
+  };
+  const getParam = (name: string): string | null => {
+    const pair = pairs.find(item => decodeKey(item) === name);
+    if (!pair)
+      return null;
+    const raw = pair.includes('=') ? pair.slice(pair.indexOf('=') + 1) : '';
+    try {
+      return decodeURIComponent(raw.replace(/\+/g, ' '));
+    }
+    catch {
+      return raw;
+    }
+  };
+  const setParam = (name: string, value: string): string => {
+    const kept = pairs.filter(item => decodeKey(item) !== name);
+    kept.push(`${encodeURIComponent(name)}=${encodeURIComponent(value)}`);
+    return `${base}?${kept.join('&')}${hash}`;
+  };
+
+  let nextHref: string;
+  const last = data[data.length - 1] as Record<string, unknown>;
+  if (last && last.id != null) {
+    const nextMax = String(last.id);
+    // Avoid a tight loop if the server ignored max_id and returned the same head.
+    if (getParam('max_id') === nextMax)
+      return null;
+    nextHref = setParam('max_id', nextMax);
+  }
+  else {
+    const prevOffset = Number(getParam('offset') || '0');
+    if (!Number.isFinite(prevOffset))
+      return null;
+    nextHref = setParam('offset', String(prevOffset + data.length));
   }
 
   return `<${nextHref}>; rel="next"`;
@@ -274,9 +349,19 @@ export function wrapFetchForMastoPagination(fetchImpl: FetchLike): FetchLike {
   return async function fetchWithMastoLink(input: unknown, init?: unknown) {
     const response = await fetchImpl(input, init);
 
-    // Fast path: leave Lynx/Web Response untouched when Link is present.
-    if (readHeader(response?.headers, 'link'))
-      return response;
+    // Fast path: leave Lynx/Web Response and body untouched when Link exists.
+    // Lynx may expose it only through iteration because Headers.get is
+    // case-sensitive; patch that method in place before masto reads `link`.
+    if (readHeader(response?.headers, 'link')) {
+      patchNativeHeaderGet(response?.headers);
+      try {
+        if (response?.headers?.get?.('link'))
+          return response;
+      }
+      catch {
+        // Fall through to the buffered compatibility response.
+      }
+    }
 
     // Need body to synthesize next — buffer once. Always keep Content-Type
     // via readHeader; empty iteration of native Headers was dropping it and

--- a/examples/elk/src/pages/AccountPage.vue
+++ b/examples/elk/src/pages/AccountPage.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 // Ported from elk: app/pages/[[server]]/@[account]/index.vue +
 // app/components/account/AccountHeader.vue — banner, avatar, names, bio,
-// fields, stats, posts/replies/media tabs.
+// fields, stats, posts/replies/media tabs. Status feeds use TimelinePaginator
+// (Lynx <list> + scrolltolower) like upstream Elk's account index pages.
 import type { mastodon } from 'masto';
 import { computed, onMounted, ref, watch } from 'vue-lynx';
 import { useRoute, useRouter } from 'vue-router';
@@ -10,7 +11,7 @@ import AccountDisplayName from '../components/AccountDisplayName.vue';
 import ContentRich from '../components/ContentRich';
 import PageHeader from '../components/PageHeader.vue';
 import Spinner from '../components/Spinner.vue';
-import StatusCard from '../components/StatusCard.vue';
+import TimelinePaginator from '../components/TimelinePaginator.vue';
 import { fetchAccountByHandle } from '../composables/cache';
 import { formatCompactNumber } from '../composables/format';
 import { useMastoClient } from '../composables/masto';
@@ -20,11 +21,9 @@ const route = useRoute();
 const router = useRouter();
 
 const account = ref<mastodon.v1.Account | null>(null);
-const statuses = ref<mastodon.v1.Status[]>([]);
 const loading = ref(true);
 const error = ref(false);
 const tab = ref<'posts' | 'replies' | 'media'>('posts');
-const statusesLoading = ref(false);
 const loadGuard = createProfileLoadGuard();
 
 const tabs = [
@@ -33,25 +32,15 @@ const tabs = [
   { key: 'media', label: 'Media' },
 ] as const;
 
-async function loadStatuses() {
+const statusPaginator = computed(() => {
   if (!account.value)
-    return;
-  statusesLoading.value = true;
-  statuses.value = [];
-  try {
-    const paginator = useMastoClient().v1.accounts.$select(account.value.id).statuses.list({
-      limit: 30,
-      excludeReplies: tab.value === 'posts',
-      onlyMedia: tab.value === 'media',
-    });
-    const result = await paginator.values().next();
-    statuses.value = result.value ?? [];
-  }
-  catch (e) {
-    console.error(e);
-  }
-  statusesLoading.value = false;
-}
+    return null as unknown as mastodon.Paginator<mastodon.v1.Status[], any>;
+  return useMastoClient().v1.accounts.$select(account.value.id).statuses.list({
+    limit: 30,
+    excludeReplies: tab.value === 'posts',
+    onlyMedia: tab.value === 'media',
+  });
+});
 
 async function load() {
   const handle = (route.params.account as string) ?? '';
@@ -66,7 +55,6 @@ async function load() {
     if (!loadGuard.isCurrent(request))
       return;
     account.value = loadedAccount;
-    await loadStatuses();
   }
   catch (e) {
     console.error(e);
@@ -79,7 +67,6 @@ async function load() {
 
 onMounted(load);
 watch(() => route.params.account, load);
-watch(tab, loadStatuses);
 
 const joinDate = computed(() => {
   if (!account.value)
@@ -101,84 +88,85 @@ const joinDate = computed(() => {
         <text class="account-retry-text">Try again</text>
       </view>
     </view>
-    <scroll-view v-else scroll-orientation="vertical" class="account-scroll">
-      <!-- banner -->
-      <image :src="account.header" class="account-banner" mode="aspectFill" />
+    <template v-else>
+      <!-- Profile header stays above the recycling feed list -->
+      <view class="account-profile">
+        <image :src="account.header" class="account-banner" mode="aspectFill" />
 
-      <view class="account-head">
-        <view class="account-avatar-row">
-          <view class="account-avatar-ring">
-            <AccountAvatar :account="account" :size="72" />
+        <view class="account-head">
+          <view class="account-avatar-row">
+            <view class="account-avatar-ring">
+              <AccountAvatar :account="account" :size="72" />
+            </view>
           </view>
-        </view>
 
-        <AccountDisplayName :account="account" :font-size="20" />
-        <text class="account-handle">@{{ account.acct }}</text>
+          <AccountDisplayName :account="account" :font-size="20" />
+          <text class="account-handle">@{{ account.acct }}</text>
 
-        <view v-if="account.note" class="account-note">
-          <ContentRich :content="account.note" :emojis="account.emojis" />
-        </view>
+          <view v-if="account.note" class="account-note">
+            <ContentRich :content="account.note" :emojis="account.emojis" />
+          </view>
 
-        <!-- fields (Elk AccountHeader fields table) -->
-        <view v-if="account.fields?.length" class="account-fields">
-          <view
-            v-for="field in account.fields"
-            :key="field.name"
-            class="account-field"
-            :class="field.verifiedAt ? 'account-field-verified' : ''"
-          >
-            <text class="account-field-name">{{ field.name }}</text>
-            <view class="account-field-value">
-              <ContentRich :content="field.value" :emojis="account.emojis" markdown />
+          <view v-if="account.fields?.length" class="account-fields">
+            <view
+              v-for="field in account.fields"
+              :key="field.name"
+              class="account-field"
+              :class="field.verifiedAt ? 'account-field-verified' : ''"
+            >
+              <text class="account-field-name">{{ field.name }}</text>
+              <view class="account-field-value">
+                <ContentRich :content="field.value" :emojis="account.emojis" markdown />
+              </view>
+            </view>
+          </view>
+
+          <text class="account-joined">{{ joinDate }}</text>
+
+          <view class="account-stats">
+            <view class="account-stat">
+              <text class="account-stat-num">{{ formatCompactNumber(account.statusesCount) }}</text>
+              <text class="account-stat-label">Posts</text>
+            </view>
+            <view class="account-stat" @tap="router.push(`${route.path.replace(/\/$/, '')}/following`)">
+              <text class="account-stat-num">{{ formatCompactNumber(account.followingCount) }}</text>
+              <text class="account-stat-label">Following</text>
+            </view>
+            <view class="account-stat" @tap="router.push(`${route.path.replace(/\/$/, '')}/followers`)">
+              <text class="account-stat-num">{{ formatCompactNumber(account.followersCount) }}</text>
+              <text class="account-stat-label">Followers</text>
             </view>
           </view>
         </view>
 
-        <text class="account-joined">{{ joinDate }}</text>
-
-        <!-- stats row -->
-        <view class="account-stats">
-          <view class="account-stat">
-            <text class="account-stat-num">{{ formatCompactNumber(account.statusesCount) }}</text>
-            <text class="account-stat-label">Posts</text>
-          </view>
-          <view class="account-stat" @tap="router.push(`${route.path.replace(/\/$/, '')}/following`)">
-            <text class="account-stat-num">{{ formatCompactNumber(account.followingCount) }}</text>
-            <text class="account-stat-label">Following</text>
-          </view>
-          <view class="account-stat" @tap="router.push(`${route.path.replace(/\/$/, '')}/followers`)">
-            <text class="account-stat-num">{{ formatCompactNumber(account.followersCount) }}</text>
-            <text class="account-stat-label">Followers</text>
+        <view class="account-tabs">
+          <view
+            v-for="t in tabs"
+            :key="t.key"
+            class="account-tab"
+            @tap="tab = t.key"
+          >
+            <text class="account-tab-text" :class="tab === t.key ? 'account-tab-active' : ''">{{ t.label }}</text>
+            <view class="account-tab-underline" :class="tab === t.key ? 'account-tab-underline-active' : ''" />
           </view>
         </view>
       </view>
 
-      <!-- tabs -->
-      <view class="account-tabs">
-        <view
-          v-for="t in tabs"
-          :key="t.key"
-          class="account-tab"
-          @tap="tab = t.key"
-        >
-          <text class="account-tab-text" :class="tab === t.key ? 'account-tab-active' : ''">{{ t.label }}</text>
-          <view class="account-tab-underline" :class="tab === t.key ? 'account-tab-underline-active' : ''" />
-        </view>
-      </view>
-
-      <view v-if="statusesLoading" class="account-loading">
-        <Spinner />
-      </view>
-      <StatusCard v-for="s in statuses" :key="s.id" :status="s" />
-      <view class="account-bottom-pad" />
-    </scroll-view>
+      <TimelinePaginator
+        :key="`${account.id}-${tab}`"
+        :paginator="statusPaginator"
+        context="account"
+      />
+    </template>
   </view>
 </template>
 
 <style>
-.account-scroll {
-  flex: 1;
+.account-profile {
+  display: flex;
+  flex-direction: column;
   width: 100%;
+  flex-shrink: 0;
 }
 
 .account-loading {
@@ -352,9 +340,5 @@ const joinDate = computed(() => {
 .account-tab-underline-active {
   opacity: 1;
   transform: scaleX(1);
-}
-
-.account-bottom-pad {
-  height: 40px;
 }
 </style>

--- a/examples/elk/src/pages/ExplorePage.vue
+++ b/examples/elk/src/pages/ExplorePage.vue
@@ -1,51 +1,61 @@
 <script setup lang="ts">
-// Ported from elk: app/pages/[[server]]/explore/{index,tags}.vue —
-// trending posts + trending hashtags tabs.
+// Ported from elk: app/pages/[[server]]/explore/{index,tags,links}.vue —
+// trending posts + trending hashtags + news. Upstream drives each tab with
+// TimelinePaginator / TagCardPaginator / CommonPaginator; here every feed is
+// a Lynx <list> + usePaginator (posts reuse TimelinePaginator).
 import type { mastodon } from 'masto';
-import { onMounted, ref, watch } from 'vue-lynx';
+import { computed, ref, watch } from 'vue-lynx';
 import { useRouter } from 'vue-router';
 import AppIcon from '../components/AppIcon.vue';
 import PageHeader from '../components/PageHeader.vue';
 import Spinner from '../components/Spinner.vue';
-import StatusCard from '../components/StatusCard.vue';
+import TimelinePaginator from '../components/TimelinePaginator.vue';
 import { formatCompactNumber } from '../composables/format';
 import { useMastoClient } from '../composables/masto';
+import { type PaginatorState, usePaginator } from '../composables/paginator';
 import { getTagRoute } from '../composables/routes';
 
 const router = useRouter();
 
 const tab = ref<'posts' | 'tags' | 'links'>('posts');
-const statuses = ref<mastodon.v1.Status[]>([]);
-const tags = ref<mastodon.v1.Tag[]>([]);
-const links = ref<mastodon.v1.TrendLink[]>([]);
-const loading = ref(true);
 const showIntro = ref(true);
 
-async function load() {
-  loading.value = true;
-  try {
-    const client = useMastoClient();
-    if (tab.value === 'posts' && !statuses.value.length) {
-      const result = await client.v1.trends.statuses.list({ limit: 20 }).values().next();
-      statuses.value = result.value ?? [];
-    }
-    else if (tab.value === 'tags' && !tags.value.length) {
-      const result = await client.v1.trends.tags.list({ limit: 20 }).values().next();
-      tags.value = result.value ?? [];
-    }
-    else if (tab.value === 'links' && !links.value.length) {
-      const result = await client.v1.trends.links.list({ limit: 20 }).values().next();
-      links.value = result.value ?? [];
-    }
-  }
-  catch (e) {
-    console.error(e);
-  }
-  loading.value = false;
+const postsPaginator = computed(() =>
+  useMastoClient().v1.trends.statuses.list({ limit: 20 }),
+);
+
+let tagsPager: ReturnType<typeof usePaginator<mastodon.v1.Tag, any>> | null = null;
+let linksPager: ReturnType<typeof usePaginator<mastodon.v1.TrendLink, any>> | null = null;
+
+const tags = ref<mastodon.v1.Tag[]>([]);
+const tagsState = ref<PaginatorState>('idle');
+const links = ref<mastodon.v1.TrendLink[]>([]);
+const linksState = ref<PaginatorState>('idle');
+
+async function loadMoreTags() {
+  tagsPager ??= usePaginator<mastodon.v1.Tag, any>(
+    useMastoClient().v1.trends.tags.list({ limit: 20 }),
+  );
+  await tagsPager.loadNext();
+  tags.value = [...tagsPager.items.value];
+  tagsState.value = tagsPager.state.value;
 }
 
-onMounted(load);
-watch(tab, load);
+async function loadMoreLinks() {
+  linksPager ??= usePaginator<mastodon.v1.TrendLink, any>(
+    useMastoClient().v1.trends.links.list({ limit: 20 }),
+  );
+  await linksPager.loadNext();
+  links.value = [...linksPager.items.value];
+  linksState.value = linksPager.state.value;
+}
+
+watch(tab, (next) => {
+  if (next === 'tags' && !tagsPager)
+    loadMoreTags();
+  else if (next === 'links' && !linksPager)
+    loadMoreLinks();
+});
 
 function tagUses(tag: mastodon.v1.Tag): number {
   return (tag.history ?? []).slice(0, 2).reduce((acc, h) => acc + Number(h.uses || 0), 0);
@@ -79,43 +89,75 @@ function tagUses(tag: mastodon.v1.Tag): number {
       </view>
     </view>
 
-    <view v-if="loading" class="explore-loading">
-      <Spinner />
-    </view>
+    <TimelinePaginator
+      v-if="tab === 'posts'"
+      :key="'explore-posts'"
+      :paginator="postsPaginator"
+      context="public"
+    />
 
-    <scroll-view v-else-if="tab === 'posts'" scroll-orientation="vertical" class="explore-scroll">
-      <StatusCard v-for="s in statuses" :key="s.id" :status="s" />
-      <view class="explore-bottom-pad" />
-    </scroll-view>
-
-    <scroll-view v-else-if="tab === 'links'" scroll-orientation="vertical" class="explore-scroll">
-      <view v-for="link in links" :key="link.url" class="explore-link">
-        <image v-if="link.image" :src="link.image" class="explore-link-img" mode="aspectFill" />
-        <view class="explore-link-body">
-          <text class="explore-link-host">{{ link.providerName || link.url.replace(/^https?:\/\//, '').split('/')[0] }}</text>
-          <text class="explore-link-title" :text-maxline="2">{{ link.title }}</text>
-          <text v-if="link.description" class="explore-link-desc" :text-maxline="2">{{ link.description }}</text>
-        </view>
-      </view>
-      <view class="explore-bottom-pad" />
-    </scroll-view>
-
-    <scroll-view v-else scroll-orientation="vertical" class="explore-scroll">
-      <view
+    <list
+      v-else-if="tab === 'tags'"
+      class="explore-list"
+      scroll-orientation="vertical"
+      :lower-threshold-item-count="4"
+      @scrolltolower="loadMoreTags"
+    >
+      <list-item
         v-for="(tag, i) in tags"
         :key="tag.name"
-        class="explore-tag"
-        @tap="router.push(getTagRoute(tag.name))"
+        :item-key="tag.name"
+        :estimated-main-axis-size-px="64"
       >
-        <text class="explore-tag-rank">{{ i + 1 }}</text>
-        <view class="explore-tag-names">
-          <text class="explore-tag-name">#{{ tag.name }}</text>
-          <text class="explore-tag-uses">{{ formatCompactNumber(tagUses(tag)) }} people in the past 2 days</text>
+        <view
+          class="explore-tag"
+          @tap="router.push(getTagRoute(tag.name))"
+        >
+          <text class="explore-tag-rank">{{ i + 1 }}</text>
+          <view class="explore-tag-names">
+            <text class="explore-tag-name">#{{ tag.name }}</text>
+            <text class="explore-tag-uses">{{ formatCompactNumber(tagUses(tag)) }} people in the past 2 days</text>
+          </view>
+          <AppIcon name="fire-line" :size="18" color="#cc7d24" />
         </view>
-        <AppIcon name="fire-line" :size="18" color="#cc7d24" />
-      </view>
-      <view class="explore-bottom-pad" />
-    </scroll-view>
+      </list-item>
+      <list-item item-key="__footer" :estimated-main-axis-size-px="60">
+        <view class="explore-footer">
+          <Spinner v-if="tagsState === 'loading' || (!tags.length && tagsState !== 'done' && tagsState !== 'error')" />
+          <text v-else-if="tagsState === 'done'" class="explore-end-text">End of trends</text>
+        </view>
+      </list-item>
+    </list>
+
+    <list
+      v-else
+      class="explore-list"
+      scroll-orientation="vertical"
+      :lower-threshold-item-count="4"
+      @scrolltolower="loadMoreLinks"
+    >
+      <list-item
+        v-for="link in links"
+        :key="link.url"
+        :item-key="link.url"
+        :estimated-main-axis-size-px="96"
+      >
+        <view class="explore-link">
+          <image v-if="link.image" :src="link.image" class="explore-link-img" mode="aspectFill" />
+          <view class="explore-link-body">
+            <text class="explore-link-host">{{ link.providerName || link.url.replace(/^https?:\/\//, '').split('/')[0] }}</text>
+            <text class="explore-link-title" :text-maxline="2">{{ link.title }}</text>
+            <text v-if="link.description" class="explore-link-desc" :text-maxline="2">{{ link.description }}</text>
+          </view>
+        </view>
+      </list-item>
+      <list-item item-key="__footer" :estimated-main-axis-size-px="60">
+        <view class="explore-footer">
+          <Spinner v-if="linksState === 'loading' || (!links.length && linksState !== 'done' && linksState !== 'error')" />
+          <text v-else-if="linksState === 'done'" class="explore-end-text">End of news</text>
+        </view>
+      </list-item>
+    </list>
   </view>
 </template>
 
@@ -188,16 +230,9 @@ function tagUses(tag: mastodon.v1.Tag): number {
   justify-content: center;
 }
 
-.explore-loading {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 48px 0;
-}
-
-.explore-scroll {
-  flex: 1;
+.explore-list {
   width: 100%;
+  flex: 1;
 }
 
 .explore-tag {
@@ -231,10 +266,6 @@ function tagUses(tag: mastodon.v1.Tag): number {
 .explore-tag-uses {
   font-size: 12px;
   color: var(--c-text-secondary);
-}
-
-.explore-bottom-pad {
-  height: 40px;
 }
 
 .explore-link {
@@ -275,5 +306,18 @@ function tagUses(tag: mastodon.v1.Tag): number {
   font-size: 12px;
   color: var(--c-text-secondary);
   margin-top: 2px;
+}
+
+.explore-footer {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  padding: 16px 0;
+}
+
+.explore-end-text {
+  font-size: 13px;
+  color: var(--c-text-secondary-light);
 }
 </style>

--- a/examples/elk/src/pages/SearchPage.vue
+++ b/examples/elk/src/pages/SearchPage.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 // Ported from elk: app/pages/[[server]]/search.vue + components/search/*.
 // Debounced multi-type search via the ported useSearch composable.
+// Results live in a recycling <list>; scrolltolower calls useSearch.next().
 import { ref } from 'vue-lynx';
 import { useRouter } from 'vue-router';
 import AccountAvatar from '../components/AccountAvatar.vue';
@@ -14,7 +15,7 @@ import { useSearch } from '../composables/search';
 
 const router = useRouter();
 const query = ref('');
-const { accounts, hashtags, statuses, loading } = useSearch(query);
+const { accounts, hashtags, statuses, loading, done, next } = useSearch(query);
 
 function onInput(e: { detail?: { value?: string } }) {
   query.value = e.detail?.value ?? '';
@@ -22,6 +23,12 @@ function onInput(e: { detail?: { value?: string } }) {
 
 function totalUses(tag: { history?: { uses: string }[] }): number {
   return (tag.history ?? []).reduce((acc, h) => acc + Number(h.uses || 0), 0);
+}
+
+function loadMore() {
+  if (!query.value || loading.value || done.value)
+    return;
+  next();
 }
 </script>
 
@@ -39,21 +46,47 @@ function totalUses(tag: { history?: { uses: string }[] }): number {
       />
     </view>
 
-    <scroll-view scroll-orientation="vertical" class="search-results">
-      <view v-if="loading" class="search-loading">
-        <Spinner />
-      </view>
+    <list
+      class="search-results"
+      scroll-orientation="vertical"
+      :lower-threshold-item-count="4"
+      @scrolltolower="loadMore"
+    >
+      <list-item
+        v-if="loading && !accounts.length && !hashtags.length && !statuses.length"
+        item-key="__loading"
+        :estimated-main-axis-size-px="80"
+      >
+        <view class="search-loading">
+          <Spinner />
+        </view>
+      </list-item>
 
-      <view v-else-if="!query" class="search-hint">
-        <text class="search-hint-text">Search for people, hashtags and posts</text>
-      </view>
+      <list-item
+        v-else-if="!query"
+        item-key="__hint"
+        :estimated-main-axis-size-px="80"
+      >
+        <view class="search-hint">
+          <text class="search-hint-text">Search for people, hashtags and posts</text>
+        </view>
+      </list-item>
 
       <template v-else>
-        <view v-if="accounts.length" class="search-section">
+        <list-item
+          v-if="accounts.length"
+          item-key="__people-title"
+          :estimated-main-axis-size-px="32"
+        >
           <text class="search-section-title">People</text>
+        </list-item>
+        <list-item
+          v-for="result in accounts.slice(0, 5)"
+          :key="result.id"
+          :item-key="result.id"
+          :estimated-main-axis-size-px="56"
+        >
           <view
-            v-for="result in accounts.slice(0, 5)"
-            :key="result.id"
             class="search-account"
             @tap="router.push(result.to)"
           >
@@ -63,13 +96,22 @@ function totalUses(tag: { history?: { uses: string }[] }): number {
               <text class="search-account-handle">@{{ result.data.acct }}</text>
             </view>
           </view>
-        </view>
+        </list-item>
 
-        <view v-if="hashtags.length" class="search-section">
+        <list-item
+          v-if="hashtags.length"
+          item-key="__tags-title"
+          :estimated-main-axis-size-px="32"
+        >
           <text class="search-section-title">Hashtags</text>
+        </list-item>
+        <list-item
+          v-for="result in hashtags.slice(0, 5)"
+          :key="result.id"
+          :item-key="result.id"
+          :estimated-main-axis-size-px="48"
+        >
           <view
-            v-for="result in hashtags.slice(0, 5)"
-            :key="result.id"
             class="search-tag"
             @tap="router.push(result.to)"
           >
@@ -77,21 +119,42 @@ function totalUses(tag: { history?: { uses: string }[] }): number {
             <text class="search-tag-name">{{ result.data.name }}</text>
             <text class="search-tag-uses">{{ formatCompactNumber(totalUses(result.data)) }} recent uses</text>
           </view>
-        </view>
+        </list-item>
 
-        <view v-if="statuses.length" class="search-section">
-          <text class="search-section-title">Posts</text>
-          <StatusCard v-for="result in statuses" :key="result.id" :status="result.data" />
-        </view>
-
-        <view
-          v-if="!accounts.length && !hashtags.length && !statuses.length"
-          class="search-hint"
+        <list-item
+          v-if="statuses.length"
+          item-key="__posts-title"
+          :estimated-main-axis-size-px="32"
         >
-          <text class="search-hint-text">No results for "{{ query }}"</text>
-        </view>
+          <text class="search-section-title">Posts</text>
+        </list-item>
+        <list-item
+          v-for="result in statuses"
+          :key="result.id"
+          :item-key="result.id"
+          :estimated-main-axis-size-px="160"
+        >
+          <StatusCard :status="result.data" />
+        </list-item>
+
+        <list-item
+          v-if="!loading && !accounts.length && !hashtags.length && !statuses.length"
+          item-key="__empty"
+          :estimated-main-axis-size-px="80"
+        >
+          <view class="search-hint">
+            <text class="search-hint-text">No results for "{{ query }}"</text>
+          </view>
+        </list-item>
+
+        <list-item item-key="__footer" :estimated-main-axis-size-px="60">
+          <view class="search-footer">
+            <Spinner v-if="loading && (accounts.length || hashtags.length || statuses.length)" />
+            <text v-else-if="done && statuses.length" class="search-end-text">End of results</text>
+          </view>
+        </list-item>
       </template>
-    </scroll-view>
+    </list>
   </view>
 </template>
 
@@ -139,12 +202,6 @@ function totalUses(tag: { history?: { uses: string }[] }): number {
   color: var(--c-text-secondary-light);
 }
 
-.search-section {
-  display: flex;
-  flex-direction: column;
-  padding-top: 8px;
-}
-
 .search-section-title {
   font-size: 13px;
   font-weight: 700;
@@ -188,5 +245,18 @@ function totalUses(tag: { history?: { uses: string }[] }): number {
   font-size: 13px;
   color: var(--c-text-secondary);
   margin-left: auto;
+}
+
+.search-footer {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  padding: 16px 0;
+}
+
+.search-end-text {
+  font-size: 13px;
+  color: var(--c-text-secondary-light);
 }
 </style>

--- a/examples/elk/src/polyfills.ts
+++ b/examples/elk/src/polyfills.ts
@@ -200,7 +200,24 @@ if (typeof g.Headers !== 'function') {
 //   new URL(absolute), new URL(path, base), url.search = 'a=b', String(url)
 // ---------------------------------------------------------------------------
 
-if (typeof g.URL !== 'function') {
+function hasCompatibleURL(URLCtor: unknown): boolean {
+  if (typeof URLCtor !== 'function')
+    return false;
+  try {
+    const url = new (URLCtor as typeof URL)('https://example.com/path?a=1');
+    if (url.pathname !== '/path' || url.search !== '?a=1')
+      return false;
+    url.searchParams.set('b', '2');
+    return url.pathname === '/path'
+      && url.search.includes('a=1')
+      && url.search.includes('b=2');
+  }
+  catch {
+    return false;
+  }
+}
+
+if (!hasCompatibleURL(g.URL)) {
   const ABSOLUTE_RE = /^([a-z][\w+.-]*):\/\/([^/?#]*)([^?#]*)(\?[^#]*)?(#.*)?$/i;
 
   class LynxURL {
@@ -258,7 +275,19 @@ if (typeof g.URL !== 'function') {
     }
 
     get searchParams() {
-      return new (g.URLSearchParams)(this._search);
+      const params = new (g.URLSearchParams)(this._search);
+      const sync = () => {
+        const query = params.toString();
+        this._search = query ? `?${query}` : '';
+      };
+      for (const method of ['set', 'append', 'delete'] as const) {
+        const original = params[method].bind(params);
+        params[method] = ((...args: unknown[]) => {
+          original(...args);
+          sync();
+        }) as never;
+      }
+      return params;
     }
 
     get origin() {

--- a/examples/elk/src/polyfills.ts
+++ b/examples/elk/src/polyfills.ts
@@ -13,7 +13,7 @@
 /* eslint-disable no-restricted-globals */
 
 import { installDOMException } from './dom-exception-compat';
-import { resolveFetch } from './fetch-compat';
+import { resolveFetch, wrapFetchForMastoPagination } from './fetch-compat';
 
 const g = globalThis as Record<string, any>;
 
@@ -21,15 +21,22 @@ const g = globalThis as Record<string, any>;
 // parameter, while Lynx for Web exposes it on globalThis. Synchronize the
 // callable implementation before masto modules execute so their bare fetch
 // identifier works in both environments.
+//
+// Then wrap for Mastodon pagination: masto.js reads `Link` via
+// response.headers.get('link'). Native Lynx fetch often drops that header
+// after the first page, so Paginator ends early ("End of the timeline")
+// while Web continues. The wrapper normalizes headers and synthesizes
+// rel="next" from max_id/offset when Link is missing.
 const sharedFetch = resolveFetch(
   g.fetch,
   typeof fetch === 'function' ? fetch : undefined,
 );
 if (sharedFetch) {
-  g.fetch = sharedFetch;
+  const mastoFetch = wrapFetchForMastoPagination(sharedFetch);
+  g.fetch = mastoFetch;
   // Assigns RuntimeWrapperWebpackPlugin's injected wrapper parameter.
   // @ts-expect-error fetch is declared as a global function in DOM typings.
-  fetch = sharedFetch as typeof fetch;
+  fetch = mastoFetch as typeof fetch;
 }
 
 installDOMException(g);

--- a/examples/scrolling/lynx.config.ts
+++ b/examples/scrolling/lynx.config.ts
@@ -19,6 +19,11 @@ export default defineConfig({
       ListBasic: './src/ListBasic/index.ts',
       ListWaterfall: './src/ListWaterfall/index.ts',
       ListInfinite: './src/ListInfinite/index.ts',
+      // Stress / known-gap mutations — see guide "Known gaps" section
+      ListRemove: './src/ListRemove/index.ts',
+      ListPrepend: './src/ListPrepend/index.ts',
+      ListReorder: './src/ListReorder/index.ts',
+      ListFilter: './src/ListFilter/index.ts',
     },
   },
   plugins: [

--- a/examples/scrolling/lynx.config.ts
+++ b/examples/scrolling/lynx.config.ts
@@ -1,0 +1,29 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from '@lynx-js/rspeedy';
+import { pluginVueLynx } from 'vue-lynx/plugin';
+
+const exampleName = path.basename(path.dirname(fileURLToPath(import.meta.url)));
+
+export default defineConfig({
+  environments: {
+    web: {},
+    lynx: {},
+  },
+  output: {
+    assetPrefix: `https://vue.lynxjs.org/examples/${exampleName}/dist/`,
+  },
+  source: {
+    entry: {
+      ScrollViewBasic: './src/ScrollViewBasic/index.ts',
+      ListBasic: './src/ListBasic/index.ts',
+      ListWaterfall: './src/ListWaterfall/index.ts',
+      ListInfinite: './src/ListInfinite/index.ts',
+    },
+  },
+  plugins: [
+    pluginVueLynx({
+      optionsApi: false,
+    }),
+  ],
+});

--- a/examples/scrolling/package.json
+++ b/examples/scrolling/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "vue-lynx-example-scrolling",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Vue-Lynx scroll-view vs list guide examples",
+  "license": "Apache-2.0",
+  "type": "module",
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev"
+  },
+  "dependencies": {
+    "vue-lynx": "workspace:*"
+  },
+  "devDependencies": {
+    "@lynx-js/rspeedy": "^0.13.5",
+    "@rsbuild/plugin-vue": "^1.2.6",
+    "typescript": "^5.0.0"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/examples/scrolling/src/ListBasic/App.vue
+++ b/examples/scrolling/src/ListBasic/App.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { makeCards } from '../shared/data';
+
+// list recycles off-screen nodes — hundreds of items stay cheap.
+const cards = makeCards(80, 'Row');
+</script>
+
+<template>
+  <view class="root">
+    <view class="header">
+      <text class="title">list · single</text>
+      <text class="subtitle">
+        Only visible rows are materialized. Pass stable Vue `:key` and Lynx
+        `:item-key` on every list-item.
+      </text>
+    </view>
+
+    <list
+      class="list"
+      list-type="single"
+      scroll-orientation="vertical"
+    >
+      <list-item
+        v-for="card in cards"
+        :key="card.id"
+        :item-key="card.id"
+        :estimated-main-axis-size-px="96"
+      >
+        <view class="card">
+          <text class="card-title">{{ card.title }}</text>
+          <text class="card-body">{{ card.body }}</text>
+        </view>
+      </list-item>
+    </list>
+  </view>
+</template>

--- a/examples/scrolling/src/ListBasic/App.vue
+++ b/examples/scrolling/src/ListBasic/App.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { makeCards } from '../shared/data';
 
-// list recycles off-screen nodes — hundreds of items stay cheap.
+// Native list lazily attaches visible cells. Keep `:key` === `:item-key`.
 const cards = makeCards(80, 'Row');
 </script>
 

--- a/examples/scrolling/src/ListBasic/index.ts
+++ b/examples/scrolling/src/ListBasic/index.ts
@@ -1,0 +1,5 @@
+import '../shared/styles.css';
+import { createApp } from 'vue-lynx';
+import App from './App.vue';
+
+createApp(App).mount();

--- a/examples/scrolling/src/ListFilter/App.vue
+++ b/examples/scrolling/src/ListFilter/App.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue-lynx';
+import { makeCards } from '../shared/data';
+
+/**
+ * Stress case: filter / toggle a subset (common chat / search UX).
+ *
+ * Filtering removes + re-inserts keyed children. With empty `removeAction`
+ * and append-only inserts, toggling the filter often leaves ghost cells or
+ * duplicated item-keys once you toggle back.
+ */
+const all = makeCards(16, 'Row');
+const onlyEven = ref(false);
+
+const items = computed(() =>
+  onlyEven.value
+    ? all.filter((_, i) => (i + 1) % 2 === 0)
+    : all,
+);
+
+function toggle() {
+  onlyEven.value = !onlyEven.value;
+}
+
+function reset() {
+  onlyEven.value = false;
+}
+</script>
+
+<template>
+  <view class="root">
+    <view class="header">
+      <text class="title">list · filter (gap)</text>
+      <text class="subtitle">
+        Toggle “even only”, then toggle back. Correct behavior restores the
+        full 16 rows with no ghosts / duplicated keys. Broken updates usually
+        show after the second toggle.
+      </text>
+    </view>
+
+    <view class="toolbar">
+      <view class="btn danger" @tap="toggle">
+        <text class="btn-text">
+          {{ onlyEven ? 'Show all' : 'Even only' }}
+        </text>
+      </view>
+      <view class="btn" @tap="reset">
+        <text class="btn-text">Reset</text>
+      </view>
+    </view>
+
+    <view class="banner warn">
+      <text class="banner-text">
+        Filter={{ onlyEven ? 'even' : 'all' }} · Vue length={{ items.length }}
+      </text>
+    </view>
+
+    <list
+      class="list"
+      list-type="single"
+      scroll-orientation="vertical"
+    >
+      <list-item
+        v-for="card in items"
+        :key="card.id"
+        :item-key="card.id"
+        :estimated-main-axis-size-px="96"
+      >
+        <view class="card">
+          <text class="card-title">{{ card.title }}</text>
+          <text class="card-body">{{ card.body }}</text>
+        </view>
+      </list-item>
+    </list>
+  </view>
+</template>

--- a/examples/scrolling/src/ListFilter/App.vue
+++ b/examples/scrolling/src/ListFilter/App.vue
@@ -3,11 +3,10 @@ import { computed, ref } from 'vue-lynx';
 import { makeCards } from '../shared/data';
 
 /**
- * Stress case: filter / toggle a subset (common chat / search UX).
+ * Regression check: filter / toggle a subset.
  *
- * Filtering removes + re-inserts keyed children. With empty `removeAction`
- * and append-only inserts, toggling the filter often leaves ghost cells or
- * duplicated item-keys once you toggle back.
+ * Empirically looks correct on device. Keep as a smoke test (toggle twice and
+ * confirm length 16 → 8 → 16 with no ghosts).
  */
 const all = makeCards(16, 'Row');
 const onlyEven = ref(false);
@@ -30,18 +29,17 @@ function reset() {
 <template>
   <view class="root">
     <view class="header">
-      <text class="title">list · filter (gap)</text>
+      <text class="title">list · filter (smoke)</text>
       <text class="subtitle">
-        Toggle “even only”, then toggle back. Correct behavior restores the
-        full 16 rows with no ghosts / duplicated keys. Broken updates usually
-        show after the second toggle.
+        Toggle even-only, then show all again. Length should be 16 → 8 → 16
+        with no leftover rows. Treated as OK in practice; kept for regression.
       </text>
     </view>
 
     <view class="toolbar">
-      <view class="btn danger" @tap="toggle">
+      <view class="btn" @tap="toggle">
         <text class="btn-text">
-          {{ onlyEven ? 'Show all' : 'Even only' }}
+          {{ onlyEven ? 'Show all (16)' : 'Even only (8)' }}
         </text>
       </view>
       <view class="btn" @tap="reset">
@@ -49,8 +47,8 @@ function reset() {
       </view>
     </view>
 
-    <view class="banner warn">
-      <text class="banner-text">
+    <view class="banner ok-banner">
+      <text class="banner-text ok-text">
         Filter={{ onlyEven ? 'even' : 'all' }} · Vue length={{ items.length }}
       </text>
     </view>

--- a/examples/scrolling/src/ListFilter/index.ts
+++ b/examples/scrolling/src/ListFilter/index.ts
@@ -1,0 +1,5 @@
+import '../shared/styles.css';
+import { createApp } from 'vue-lynx';
+import App from './App.vue';
+
+createApp(App).mount();

--- a/examples/scrolling/src/ListInfinite/App.vue
+++ b/examples/scrolling/src/ListInfinite/App.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { useInfiniteFeed } from '../shared/useInfiniteFeed';
+
+const { items, loading, done, loadMore } = useInfiniteFeed(15);
+</script>
+
+<template>
+  <view class="root">
+    <view class="header">
+      <text class="title">list · infinite</text>
+      <text class="subtitle">
+        `@scrolltolower` drives a Vue composable. No virtual-scroller library
+        — native recycling + reactive `items` is the design pattern.
+      </text>
+    </view>
+
+    <list
+      class="list"
+      list-type="single"
+      scroll-orientation="vertical"
+      :lower-threshold-item-count="3"
+      @scrolltolower="loadMore"
+    >
+      <list-item
+        v-for="item in items"
+        :key="item.id"
+        :item-key="item.id"
+        :estimated-main-axis-size-px="96"
+      >
+        <view class="card">
+          <text class="card-title">{{ item.title }}</text>
+          <text class="card-body">{{ item.body }}</text>
+        </view>
+      </list-item>
+
+      <list-item item-key="__footer" :estimated-main-axis-size-px="64">
+        <view class="footer-item">
+          <text class="footer-text">
+            {{
+              loading
+                ? 'Loading more…'
+                : done
+                  ? 'You reached the end'
+                  : 'Scroll for more'
+            }}
+          </text>
+        </view>
+      </list-item>
+    </list>
+  </view>
+</template>

--- a/examples/scrolling/src/ListInfinite/index.ts
+++ b/examples/scrolling/src/ListInfinite/index.ts
@@ -1,0 +1,5 @@
+import '../shared/styles.css';
+import { createApp } from 'vue-lynx';
+import App from './App.vue';
+
+createApp(App).mount();

--- a/examples/scrolling/src/ListPrepend/App.vue
+++ b/examples/scrolling/src/ListPrepend/App.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+import { ref } from 'vue-lynx';
+import { makeCards } from '../shared/data';
+
+/**
+ * Stress case: insert at the front (unshift / insertBefore).
+ *
+ * MT `insertListItem` always `push`es — it ignores the INSERT anchor — so a
+ * Vue prepend is reported as a tail insert (wrong `position` / order).
+ */
+const items = ref(makeCards(8, 'Row'));
+let seq = items.value.length;
+
+function prepend() {
+  seq += 1;
+  const card = {
+    id: `Row-new-${seq}`,
+    title: `NEW ${seq} (should be first)`,
+    body: 'Prepended via unshift — native list must insert at position 0.',
+    color: '#ef4444',
+    height: 96,
+  };
+  items.value = [card, ...items.value];
+}
+
+function append() {
+  seq += 1;
+  const card = {
+    id: `Row-tail-${seq}`,
+    title: `TAIL ${seq}`,
+    body: 'Append-only path — this one is expected to work today.',
+    color: '#10b981',
+    height: 96,
+  };
+  items.value = [...items.value, card];
+}
+
+function reset() {
+  items.value = makeCards(8, 'Row');
+  seq = items.value.length;
+}
+</script>
+
+<template>
+  <view class="root">
+    <view class="header">
+      <text class="title">list · prepend (gap)</text>
+      <text class="subtitle">
+        Compare Prepend vs Append. Append should land at the bottom. Prepend
+        should land at the top — if it appears at the bottom (or duplicates),
+        the MT list adapter ignored the INSERT anchor.
+      </text>
+    </view>
+
+    <view class="toolbar">
+      <view class="btn danger" @tap="prepend">
+        <text class="btn-text">Prepend</text>
+      </view>
+      <view class="btn ok" @tap="append">
+        <text class="btn-text">Append (ok)</text>
+      </view>
+      <view class="btn" @tap="reset">
+        <text class="btn-text">Reset</text>
+      </view>
+    </view>
+
+    <view class="banner warn">
+      <text class="banner-text">
+        First Vue item: {{ items[0]?.title ?? '(empty)' }}
+      </text>
+    </view>
+
+    <list
+      class="list"
+      list-type="single"
+      scroll-orientation="vertical"
+    >
+      <list-item
+        v-for="card in items"
+        :key="card.id"
+        :item-key="card.id"
+        :estimated-main-axis-size-px="96"
+      >
+        <view
+          class="card"
+          :style="{
+            borderLeftWidth: '4px',
+            borderLeftColor: card.color,
+          }"
+        >
+          <text class="card-title">{{ card.title }}</text>
+          <text class="card-body">{{ card.body }}</text>
+        </view>
+      </list-item>
+    </list>
+  </view>
+</template>

--- a/examples/scrolling/src/ListPrepend/App.vue
+++ b/examples/scrolling/src/ListPrepend/App.vue
@@ -3,11 +3,8 @@ import { computed, ref } from 'vue-lynx';
 import { makeCards } from '../shared/data';
 
 /**
- * Confirmed gap: insert at the front (unshift).
- *
- * MT `insertListItem` always `push`es and ignores the INSERT anchor, so
- * `update-list-info` reports the new item at the tail. Watch the TOP cell —
- * after Prepend it must become the red "NEW …" card.
+ * Prepend vs append — INSERT now respects the list anchor.
+ * Top cell must become the red NEW card after Prepend.
  */
 const items = ref(makeCards(6, 'Row'));
 let seq = items.value.length;
@@ -19,7 +16,7 @@ function prepend() {
   const card = {
     id: `Row-new-${seq}`,
     title: `NEW ${seq}`,
-    body: 'Must be the FIRST (top) cell. If this shows at the bottom, prepend is broken.',
+    body: 'Must be the FIRST (top) cell after prepend.',
     color: '#ef4444',
     height: 96,
   };
@@ -31,7 +28,7 @@ function append() {
   const card = {
     id: `Row-tail-${seq}`,
     title: `TAIL ${seq}`,
-    body: 'Append-only path — expected to work (lands at bottom).',
+    body: 'Append lands at the bottom.',
     color: '#10b981',
     height: 96,
   };
@@ -47,33 +44,31 @@ function reset() {
 <template>
   <view class="root">
     <view class="header">
-      <text class="title">list · prepend (confirmed gap)</text>
+      <text class="title">list · prepend</text>
       <text class="subtitle">
-        Tap Prepend once. The TOP list cell must turn red and read
-        &quot;NEW …&quot;. If the red card appears at the bottom instead, the
-        adapter ignored the insert-before anchor.
+        Tap Prepend — the TOP list cell must turn red and read
+        &quot;NEW …&quot;. Append is the control that lands at the bottom.
       </text>
     </view>
 
     <view class="toolbar">
       <view class="btn danger" @tap="prepend">
-        <text class="btn-text">Prepend (bug)</text>
+        <text class="btn-text">Prepend</text>
       </view>
       <view class="btn ok" @tap="append">
-        <text class="btn-text">Append (ok)</text>
+        <text class="btn-text">Append</text>
       </view>
       <view class="btn" @tap="reset">
         <text class="btn-text">Reset</text>
       </view>
     </view>
 
-    <view class="banner warn">
-      <text class="banner-text">
-        Vue says TOP = {{ topTitle }} — scroll to top of the list and check.
+    <view class="banner ok-banner">
+      <text class="banner-text ok-text">
+        Vue says TOP = {{ topTitle }}
       </text>
     </view>
 
-    <!-- Truth strip: first Vue item only -->
     <view class="truth-block">
       <text class="truth-label">Vue truth · first item</text>
       <view

--- a/examples/scrolling/src/ListPrepend/App.vue
+++ b/examples/scrolling/src/ListPrepend/App.vue
@@ -1,22 +1,25 @@
 <script setup lang="ts">
-import { ref } from 'vue-lynx';
+import { computed, ref } from 'vue-lynx';
 import { makeCards } from '../shared/data';
 
 /**
- * Stress case: insert at the front (unshift / insertBefore).
+ * Confirmed gap: insert at the front (unshift).
  *
- * MT `insertListItem` always `push`es — it ignores the INSERT anchor — so a
- * Vue prepend is reported as a tail insert (wrong `position` / order).
+ * MT `insertListItem` always `push`es and ignores the INSERT anchor, so
+ * `update-list-info` reports the new item at the tail. Watch the TOP cell —
+ * after Prepend it must become the red "NEW …" card.
  */
-const items = ref(makeCards(8, 'Row'));
+const items = ref(makeCards(6, 'Row'));
 let seq = items.value.length;
+
+const topTitle = computed(() => items.value[0]?.title ?? '(empty)');
 
 function prepend() {
   seq += 1;
   const card = {
     id: `Row-new-${seq}`,
-    title: `NEW ${seq} (should be first)`,
-    body: 'Prepended via unshift — native list must insert at position 0.',
+    title: `NEW ${seq}`,
+    body: 'Must be the FIRST (top) cell. If this shows at the bottom, prepend is broken.',
     color: '#ef4444',
     height: 96,
   };
@@ -28,7 +31,7 @@ function append() {
   const card = {
     id: `Row-tail-${seq}`,
     title: `TAIL ${seq}`,
-    body: 'Append-only path — this one is expected to work today.',
+    body: 'Append-only path — expected to work (lands at bottom).',
     color: '#10b981',
     height: 96,
   };
@@ -36,7 +39,7 @@ function append() {
 }
 
 function reset() {
-  items.value = makeCards(8, 'Row');
+  items.value = makeCards(6, 'Row');
   seq = items.value.length;
 }
 </script>
@@ -44,17 +47,17 @@ function reset() {
 <template>
   <view class="root">
     <view class="header">
-      <text class="title">list · prepend (gap)</text>
+      <text class="title">list · prepend (confirmed gap)</text>
       <text class="subtitle">
-        Compare Prepend vs Append. Append should land at the bottom. Prepend
-        should land at the top — if it appears at the bottom (or duplicates),
-        the MT list adapter ignored the INSERT anchor.
+        Tap Prepend once. The TOP list cell must turn red and read
+        &quot;NEW …&quot;. If the red card appears at the bottom instead, the
+        adapter ignored the insert-before anchor.
       </text>
     </view>
 
     <view class="toolbar">
       <view class="btn danger" @tap="prepend">
-        <text class="btn-text">Prepend</text>
+        <text class="btn-text">Prepend (bug)</text>
       </view>
       <view class="btn ok" @tap="append">
         <text class="btn-text">Append (ok)</text>
@@ -66,8 +69,19 @@ function reset() {
 
     <view class="banner warn">
       <text class="banner-text">
-        First Vue item: {{ items[0]?.title ?? '(empty)' }}
+        Vue says TOP = {{ topTitle }} — scroll to top of the list and check.
       </text>
+    </view>
+
+    <!-- Truth strip: first Vue item only -->
+    <view class="truth-block">
+      <text class="truth-label">Vue truth · first item</text>
+      <view
+        class="truth-chip wide"
+        :style="{ backgroundColor: items[0]?.color ?? '#9ca3af' }"
+      >
+        <text class="truth-chip-text">{{ topTitle }}</text>
+      </view>
     </view>
 
     <list
@@ -76,7 +90,7 @@ function reset() {
       scroll-orientation="vertical"
     >
       <list-item
-        v-for="card in items"
+        v-for="(card, index) in items"
         :key="card.id"
         :item-key="card.id"
         :estimated-main-axis-size-px="96"
@@ -84,11 +98,14 @@ function reset() {
         <view
           class="card"
           :style="{
-            borderLeftWidth: '4px',
+            borderLeftWidth: '6px',
             borderLeftColor: card.color,
+            backgroundColor: index === 0 ? '#fef2f2' : '#ffffff',
           }"
         >
-          <text class="card-title">{{ card.title }}</text>
+          <text class="card-title">
+            {{ index === 0 ? 'TOP · ' : '' }}{{ card.title }}
+          </text>
           <text class="card-body">{{ card.body }}</text>
         </view>
       </list-item>

--- a/examples/scrolling/src/ListPrepend/index.ts
+++ b/examples/scrolling/src/ListPrepend/index.ts
@@ -1,0 +1,5 @@
+import '../shared/styles.css';
+import { createApp } from 'vue-lynx';
+import App from './App.vue';
+
+createApp(App).mount();

--- a/examples/scrolling/src/ListRemove/App.vue
+++ b/examples/scrolling/src/ListRemove/App.vue
@@ -3,49 +3,54 @@ import { ref } from 'vue-lynx';
 import { makeCards } from '../shared/data';
 
 /**
- * Stress case: delete from the middle / pop the tail.
+ * Regression check: delete from the middle / pop the tail.
  *
- * Vue Lynx currently flushes only append-only `insertAction`s
- * (`removeAction` is always `[]`), so native <list> can keep stale cells
- * after a reactive splice.
+ * Empirically looks correct on device even though `removeAction` stays empty
+ * (likely helped by `__RemoveElement` on already-attached cells). Keep as a
+ * smoke test, not a known-broken demo.
  */
 const items = ref(makeCards(12, 'Row'));
+const lastAction = ref('—');
 
 function removeMiddle() {
   if (items.value.length < 2) return;
   const mid = Math.floor(items.value.length / 2);
+  const removed = items.value[mid]!;
   items.value = [
     ...items.value.slice(0, mid),
     ...items.value.slice(mid + 1),
   ];
+  lastAction.value = `removed middle ${removed.title}`;
 }
 
 function removeTail() {
   if (items.value.length === 0) return;
+  const removed = items.value[items.value.length - 1]!;
   items.value = items.value.slice(0, -1);
+  lastAction.value = `removed last ${removed.title}`;
 }
 
 function reset() {
   items.value = makeCards(12, 'Row');
+  lastAction.value = 'reset';
 }
 </script>
 
 <template>
   <view class="root">
     <view class="header">
-      <text class="title">list · remove (gap)</text>
+      <text class="title">list · remove (smoke)</text>
       <text class="subtitle">
-        Expectation: middle / tail deletes leave a consistent feed. Current
-        Vue Lynx list updates omit `removeAction` — watch for ghost rows or
-        wrong count after tapping.
+        Expectation: rows disappear and the length badge matches. This path
+        has looked fine in practice — use it as a regression check.
       </text>
     </view>
 
     <view class="toolbar">
-      <view class="btn danger" @tap="removeMiddle">
+      <view class="btn" @tap="removeMiddle">
         <text class="btn-text">Remove middle</text>
       </view>
-      <view class="btn danger" @tap="removeTail">
+      <view class="btn" @tap="removeTail">
         <text class="btn-text">Remove last</text>
       </view>
       <view class="btn" @tap="reset">
@@ -53,10 +58,9 @@ function reset() {
       </view>
     </view>
 
-    <view class="banner warn">
-      <text class="banner-text">
-        Vue data length: {{ items.length }} — compare with what native list
-        still shows.
+    <view class="banner ok-banner">
+      <text class="banner-text ok-text">
+        Vue length={{ items.length }} · last: {{ lastAction }}
       </text>
     </view>
 

--- a/examples/scrolling/src/ListRemove/App.vue
+++ b/examples/scrolling/src/ListRemove/App.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import { ref } from 'vue-lynx';
+import { makeCards } from '../shared/data';
+
+/**
+ * Stress case: delete from the middle / pop the tail.
+ *
+ * Vue Lynx currently flushes only append-only `insertAction`s
+ * (`removeAction` is always `[]`), so native <list> can keep stale cells
+ * after a reactive splice.
+ */
+const items = ref(makeCards(12, 'Row'));
+
+function removeMiddle() {
+  if (items.value.length < 2) return;
+  const mid = Math.floor(items.value.length / 2);
+  items.value = [
+    ...items.value.slice(0, mid),
+    ...items.value.slice(mid + 1),
+  ];
+}
+
+function removeTail() {
+  if (items.value.length === 0) return;
+  items.value = items.value.slice(0, -1);
+}
+
+function reset() {
+  items.value = makeCards(12, 'Row');
+}
+</script>
+
+<template>
+  <view class="root">
+    <view class="header">
+      <text class="title">list · remove (gap)</text>
+      <text class="subtitle">
+        Expectation: middle / tail deletes leave a consistent feed. Current
+        Vue Lynx list updates omit `removeAction` — watch for ghost rows or
+        wrong count after tapping.
+      </text>
+    </view>
+
+    <view class="toolbar">
+      <view class="btn danger" @tap="removeMiddle">
+        <text class="btn-text">Remove middle</text>
+      </view>
+      <view class="btn danger" @tap="removeTail">
+        <text class="btn-text">Remove last</text>
+      </view>
+      <view class="btn" @tap="reset">
+        <text class="btn-text">Reset</text>
+      </view>
+    </view>
+
+    <view class="banner warn">
+      <text class="banner-text">
+        Vue data length: {{ items.length }} — compare with what native list
+        still shows.
+      </text>
+    </view>
+
+    <list
+      class="list"
+      list-type="single"
+      scroll-orientation="vertical"
+    >
+      <list-item
+        v-for="card in items"
+        :key="card.id"
+        :item-key="card.id"
+        :estimated-main-axis-size-px="96"
+      >
+        <view class="card">
+          <text class="card-title">{{ card.title }}</text>
+          <text class="card-body">{{ card.body }}</text>
+        </view>
+      </list-item>
+    </list>
+  </view>
+</template>

--- a/examples/scrolling/src/ListRemove/App.vue
+++ b/examples/scrolling/src/ListRemove/App.vue
@@ -3,11 +3,11 @@ import { ref } from 'vue-lynx';
 import { makeCards } from '../shared/data';
 
 /**
- * Regression check: delete from the middle / pop the tail.
+ * Remove + Reset with the *same* item-keys.
  *
- * Empirically looks correct on device even though `removeAction` stays empty
- * (likely helped by `__RemoveElement` on already-attached cells). Keep as a
- * smoke test, not a known-broken demo.
+ * Previously REMOVE did not update listItems / removeAction, so Reset
+ * re-inserted Row-1…N and native list threw duplicated item-key (2202).
+ * That was an impl bug — Reset is the intentional repro / regression check.
  */
 const items = ref(makeCards(12, 'Row'));
 const lastAction = ref('—');
@@ -31,18 +31,20 @@ function removeTail() {
 }
 
 function reset() {
+  // Same ids on purpose — must not 2202 after removes.
   items.value = makeCards(12, 'Row');
-  lastAction.value = 'reset';
+  lastAction.value = 'reset (same item-keys)';
 }
 </script>
 
 <template>
   <view class="root">
     <view class="header">
-      <text class="title">list · remove (smoke)</text>
+      <text class="title">list · remove + reset</text>
       <text class="subtitle">
-        Expectation: rows disappear and the length badge matches. This path
-        has looked fine in practice — use it as a regression check.
+        Remove some rows, then Reset. Reset rebuilds Row-1…12 with the same
+        item-keys. A duplicated item-key toast means the MT adapter forgot to
+        emit removeAction (impl bug — not a flaky demo).
       </text>
     </view>
 
@@ -53,8 +55,8 @@ function reset() {
       <view class="btn" @tap="removeTail">
         <text class="btn-text">Remove last</text>
       </view>
-      <view class="btn" @tap="reset">
-        <text class="btn-text">Reset</text>
+      <view class="btn danger" @tap="reset">
+        <text class="btn-text">Reset same keys</text>
       </view>
     </view>
 

--- a/examples/scrolling/src/ListRemove/index.ts
+++ b/examples/scrolling/src/ListRemove/index.ts
@@ -1,0 +1,5 @@
+import '../shared/styles.css';
+import { createApp } from 'vue-lynx';
+import App from './App.vue';
+
+createApp(App).mount();

--- a/examples/scrolling/src/ListReorder/App.vue
+++ b/examples/scrolling/src/ListReorder/App.vue
@@ -46,8 +46,7 @@ function reset() {
       <text class="title">list · reorder</text>
       <text class="subtitle">
         Compare the two color rows. Top = Vue truth (plain views). Bottom =
-        native &lt;list&gt;. After a tap they must show the same left→right
-        order. A mismatch means the list adapter dropped the move.
+        native &lt;list&gt;. After a tap they must show the same order.
       </text>
     </view>
 

--- a/examples/scrolling/src/ListReorder/App.vue
+++ b/examples/scrolling/src/ListReorder/App.vue
@@ -1,47 +1,62 @@
 <script setup lang="ts">
-import { ref } from 'vue-lynx';
-import { makeCards } from '../shared/data';
+import { computed, ref } from 'vue-lynx';
 
 /**
- * Stress case: reverse / rotate keyed children.
+ * Reorder stress — make the Vue truth vs native <list> mismatch obvious.
  *
- * Without `removeAction` + correct insert positions (and without recycling),
- * a reorder can leave native <list> showing the old order or mixed keys.
+ * Left/top strip is ordinary <view>s (always follows Vue). The <list> below
+ * is what the MT adapter drives. After "Yellow → top" or "Reverse", the two
+ * rows of colors must match. If the list keeps the old color order while the
+ * truth strip flips, the list adapter lost the move.
  */
-const items = ref(makeCards(10, 'Row'));
+type Tile = { id: string; label: string; color: string };
+
+const INITIAL: Tile[] = [
+  { id: 'R', label: 'RED', color: '#ef4444' },
+  { id: 'B', label: 'BLUE', color: '#3b82f6' },
+  { id: 'G', label: 'GREEN', color: '#22c55e' },
+  { id: 'Y', label: 'YELLOW', color: '#eab308' },
+];
+
+const items = ref<Tile[]>([...INITIAL]);
+
+const expectedTop = computed(() => items.value[0]!);
+const expectedOrder = computed(() =>
+  items.value.map((t) => t.label).join(' → '),
+);
+
+function yellowToTop() {
+  const rest = items.value.filter((t) => t.id !== 'Y');
+  const yellow = items.value.find((t) => t.id === 'Y')!;
+  items.value = [yellow, ...rest];
+}
 
 function reverse() {
   items.value = [...items.value].reverse();
 }
 
-function rotate() {
-  if (items.value.length < 2) return;
-  const [first, ...rest] = items.value;
-  items.value = [...rest, first!];
-}
-
 function reset() {
-  items.value = makeCards(10, 'Row');
+  items.value = [...INITIAL];
 }
 </script>
 
 <template>
   <view class="root">
     <view class="header">
-      <text class="title">list · reorder (gap)</text>
+      <text class="title">list · reorder</text>
       <text class="subtitle">
-        Vue `:key` / Lynx `:item-key` stay stable, but the MT adapter does not
-        emit a full insert/remove diff. Reverse / rotate and check whether the
-        on-screen order matches the banner.
+        Compare the two color rows. Top = Vue truth (plain views). Bottom =
+        native &lt;list&gt;. After a tap they must show the same left→right
+        order. A mismatch means the list adapter dropped the move.
       </text>
     </view>
 
     <view class="toolbar">
+      <view class="btn danger" @tap="yellowToTop">
+        <text class="btn-text">Yellow → top</text>
+      </view>
       <view class="btn danger" @tap="reverse">
         <text class="btn-text">Reverse</text>
-      </view>
-      <view class="btn danger" @tap="rotate">
-        <text class="btn-text">Rotate ↑</text>
       </view>
       <view class="btn" @tap="reset">
         <text class="btn-text">Reset</text>
@@ -50,24 +65,52 @@ function reset() {
 
     <view class="banner warn">
       <text class="banner-text">
-        Vue order: {{ items.map((c) => c.title).join(' → ') }}
+        Expect list TOP cell = {{ expectedTop.label }} · full order:
+        {{ expectedOrder }}
       </text>
     </view>
 
+    <!-- Vue truth: not a list — always correct -->
+    <view class="truth-block">
+      <text class="truth-label">Vue truth (not list)</text>
+      <view class="truth-row">
+        <view
+          v-for="(tile, i) in items"
+          :key="tile.id"
+          class="truth-chip"
+          :style="{ backgroundColor: tile.color }"
+        >
+          <text class="truth-chip-text">{{ i + 1 }}.{{ tile.label }}</text>
+        </view>
+      </view>
+    </view>
+
+    <text class="truth-label list-label">Native &lt;list&gt; (must match)</text>
+
     <list
-      class="list"
+      class="list reorder-list"
       list-type="single"
       scroll-orientation="vertical"
     >
       <list-item
-        v-for="(card, index) in items"
-        :key="card.id"
-        :item-key="card.id"
-        :estimated-main-axis-size-px="96"
+        v-for="(tile, index) in items"
+        :key="tile.id"
+        :item-key="tile.id"
+        :estimated-main-axis-size-px="88"
       >
-        <view class="card">
-          <text class="card-title">#{{ index + 1 }} · {{ card.title }}</text>
-          <text class="card-body">id={{ card.id }}</text>
+        <view
+          class="reorder-cell"
+          :style="{ backgroundColor: tile.color }"
+        >
+          <text class="reorder-cell-pos">slot {{ index + 1 }}</text>
+          <text class="reorder-cell-label">{{ tile.label }}</text>
+          <text class="reorder-cell-hint">
+            {{
+              index === 0
+                ? `← must be ${expectedTop.label}`
+                : `id=${tile.id}`
+            }}
+          </text>
         </view>
       </list-item>
     </list>

--- a/examples/scrolling/src/ListReorder/App.vue
+++ b/examples/scrolling/src/ListReorder/App.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+import { ref } from 'vue-lynx';
+import { makeCards } from '../shared/data';
+
+/**
+ * Stress case: reverse / rotate keyed children.
+ *
+ * Without `removeAction` + correct insert positions (and without recycling),
+ * a reorder can leave native <list> showing the old order or mixed keys.
+ */
+const items = ref(makeCards(10, 'Row'));
+
+function reverse() {
+  items.value = [...items.value].reverse();
+}
+
+function rotate() {
+  if (items.value.length < 2) return;
+  const [first, ...rest] = items.value;
+  items.value = [...rest, first!];
+}
+
+function reset() {
+  items.value = makeCards(10, 'Row');
+}
+</script>
+
+<template>
+  <view class="root">
+    <view class="header">
+      <text class="title">list · reorder (gap)</text>
+      <text class="subtitle">
+        Vue `:key` / Lynx `:item-key` stay stable, but the MT adapter does not
+        emit a full insert/remove diff. Reverse / rotate and check whether the
+        on-screen order matches the banner.
+      </text>
+    </view>
+
+    <view class="toolbar">
+      <view class="btn danger" @tap="reverse">
+        <text class="btn-text">Reverse</text>
+      </view>
+      <view class="btn danger" @tap="rotate">
+        <text class="btn-text">Rotate ↑</text>
+      </view>
+      <view class="btn" @tap="reset">
+        <text class="btn-text">Reset</text>
+      </view>
+    </view>
+
+    <view class="banner warn">
+      <text class="banner-text">
+        Vue order: {{ items.map((c) => c.title).join(' → ') }}
+      </text>
+    </view>
+
+    <list
+      class="list"
+      list-type="single"
+      scroll-orientation="vertical"
+    >
+      <list-item
+        v-for="(card, index) in items"
+        :key="card.id"
+        :item-key="card.id"
+        :estimated-main-axis-size-px="96"
+      >
+        <view class="card">
+          <text class="card-title">#{{ index + 1 }} · {{ card.title }}</text>
+          <text class="card-body">id={{ card.id }}</text>
+        </view>
+      </list-item>
+    </list>
+  </view>
+</template>

--- a/examples/scrolling/src/ListReorder/index.ts
+++ b/examples/scrolling/src/ListReorder/index.ts
@@ -1,0 +1,5 @@
+import '../shared/styles.css';
+import { createApp } from 'vue-lynx';
+import App from './App.vue';
+
+createApp(App).mount();

--- a/examples/scrolling/src/ListWaterfall/App.vue
+++ b/examples/scrolling/src/ListWaterfall/App.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { makeCards } from '../shared/data';
+
+const tiles = makeCards(40, 'Tile');
+</script>
+
+<template>
+  <view class="root">
+    <view class="header">
+      <text class="title">list · waterfall</text>
+      <text class="subtitle">
+        scroll-view is linear only. list unlocks flow / waterfall layouts
+        while Vue components stay ordinary SFCs inside each list-item.
+      </text>
+    </view>
+
+    <list
+      class="list"
+      list-type="waterfall"
+      :span-count="2"
+      scroll-orientation="vertical"
+    >
+      <list-item
+        v-for="tile in tiles"
+        :key="tile.id"
+        :item-key="tile.id"
+        :estimated-main-axis-size-px="tile.height"
+      >
+        <view
+          class="tile"
+          :style="{
+            height: `${tile.height}px`,
+            backgroundColor: tile.color,
+          }"
+        >
+          <text class="tile-label">{{ tile.title }}</text>
+          <text class="tile-meta">{{ tile.height }}px tall</text>
+        </view>
+      </list-item>
+    </list>
+  </view>
+</template>

--- a/examples/scrolling/src/ListWaterfall/index.ts
+++ b/examples/scrolling/src/ListWaterfall/index.ts
@@ -1,0 +1,5 @@
+import '../shared/styles.css';
+import { createApp } from 'vue-lynx';
+import App from './App.vue';
+
+createApp(App).mount();

--- a/examples/scrolling/src/ScrollViewBasic/App.vue
+++ b/examples/scrolling/src/ScrollViewBasic/App.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { makeCards } from '../shared/data';
+
+// scroll-view renders every child eagerly — keep the dataset small.
+const cards = makeCards(8, 'Section');
+</script>
+
+<template>
+  <view class="root">
+    <scroll-view class="scroll" scroll-orientation="vertical">
+      <view class="header">
+        <text class="title">scroll-view</text>
+        <text class="subtitle">
+          All children mount at once. Best for short, heterogeneous pages
+          (forms, settings, article bodies).
+        </text>
+      </view>
+
+      <view v-for="card in cards" :key="card.id" class="card">
+        <text class="card-title">{{ card.title }}</text>
+        <text class="card-body">{{ card.body }}</text>
+      </view>
+
+      <text class="footer-note">
+        End of content — every card above stayed in memory while you scrolled.
+      </text>
+    </scroll-view>
+  </view>
+</template>

--- a/examples/scrolling/src/ScrollViewBasic/index.ts
+++ b/examples/scrolling/src/ScrollViewBasic/index.ts
@@ -1,0 +1,5 @@
+import '../shared/styles.css';
+import { createApp } from 'vue-lynx';
+import App from './App.vue';
+
+createApp(App).mount();

--- a/examples/scrolling/src/shared/data.ts
+++ b/examples/scrolling/src/shared/data.ts
@@ -1,0 +1,20 @@
+export const COLORS = [
+  '#3b82f6',
+  '#8b5cf6',
+  '#06b6d4',
+  '#10b981',
+  '#f59e0b',
+  '#ef4444',
+  '#ec4899',
+  '#6366f1',
+] as const;
+
+export function makeCards(count: number, prefix = 'Item') {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `${prefix}-${i + 1}`,
+    title: `${prefix} ${i + 1}`,
+    body: `A short description for ${prefix.toLowerCase()} ${i + 1}.`,
+    color: COLORS[i % COLORS.length],
+    height: 88 + ((i * 17) % 72),
+  }));
+}

--- a/examples/scrolling/src/shared/styles.css
+++ b/examples/scrolling/src/shared/styles.css
@@ -1,0 +1,108 @@
+page {
+  height: 100%;
+  background-color: #f4f6f8;
+}
+
+.root {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  padding: 16px 16px 12px;
+  background-color: #ffffff;
+  border-bottom-width: 1px;
+  border-bottom-color: #e5e7eb;
+}
+
+.title {
+  font-size: 20px;
+  font-weight: 700;
+  color: #111827;
+}
+
+.subtitle {
+  margin-top: 4px;
+  font-size: 13px;
+  color: #6b7280;
+  line-height: 18px;
+}
+
+.scroll {
+  width: 100%;
+  height: 100%;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  margin: 12px 16px 0;
+  padding: 14px;
+  background-color: #ffffff;
+  border-radius: 12px;
+}
+
+.card-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: #111827;
+}
+
+.card-body {
+  margin-top: 6px;
+  font-size: 13px;
+  color: #6b7280;
+  line-height: 18px;
+}
+
+.footer-note {
+  margin: 16px;
+  padding-bottom: 24px;
+  font-size: 12px;
+  color: #9ca3af;
+  text-align: center;
+}
+
+.list {
+  width: 100%;
+  flex: 1;
+  min-height: 0;
+}
+
+.tile {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  margin: 6px;
+  padding: 12px;
+  border-radius: 10px;
+}
+
+.tile-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: #ffffff;
+}
+
+.tile-meta {
+  margin-top: 4px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.footer-item {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  padding: 20px 0 28px;
+}
+
+.footer-text {
+  font-size: 13px;
+  color: #6b7280;
+}

--- a/examples/scrolling/src/shared/styles.css
+++ b/examples/scrolling/src/shared/styles.css
@@ -106,3 +106,55 @@ page {
   font-size: 13px;
   color: #6b7280;
 }
+
+.toolbar {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  padding: 10px 12px 6px;
+  background-color: #ffffff;
+  border-bottom-width: 1px;
+  border-bottom-color: #e5e7eb;
+}
+
+.btn {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  margin: 0 6px 6px 0;
+  padding: 8px 12px;
+  background-color: #e5e7eb;
+  border-radius: 8px;
+}
+
+.btn.danger {
+  background-color: #fee2e2;
+}
+
+.btn.ok {
+  background-color: #d1fae5;
+}
+
+.btn-text {
+  font-size: 13px;
+  font-weight: 600;
+  color: #111827;
+}
+
+.banner {
+  padding: 10px 16px;
+  background-color: #fff7ed;
+  border-bottom-width: 1px;
+  border-bottom-color: #fed7aa;
+}
+
+.banner.warn {
+  background-color: #fff7ed;
+}
+
+.banner-text {
+  font-size: 12px;
+  color: #9a3412;
+  line-height: 16px;
+}

--- a/examples/scrolling/src/shared/styles.css
+++ b/examples/scrolling/src/shared/styles.css
@@ -158,3 +158,92 @@ page {
   color: #9a3412;
   line-height: 16px;
 }
+
+.ok-banner {
+  background-color: #ecfdf5;
+  border-bottom-color: #a7f3d0;
+}
+
+.ok-text {
+  color: #065f46;
+}
+
+.truth-block {
+  padding: 10px 12px 6px;
+  background-color: #ffffff;
+  border-bottom-width: 1px;
+  border-bottom-color: #e5e7eb;
+}
+
+.truth-label {
+  margin: 0 12px 6px;
+  font-size: 11px;
+  font-weight: 700;
+  color: #6b7280;
+}
+
+.list-label {
+  margin-top: 8px;
+}
+
+.truth-row {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+
+.truth-chip {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  margin: 0 6px 6px 0;
+  padding: 8px 10px;
+  border-radius: 8px;
+  min-width: 72px;
+}
+
+.truth-chip.wide {
+  width: 100%;
+  margin-right: 0;
+  padding: 12px;
+}
+
+.truth-chip-text {
+  font-size: 12px;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.reorder-list {
+  padding-top: 4px;
+}
+
+.reorder-cell {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin: 6px 12px 0;
+  padding: 14px 16px;
+  border-radius: 10px;
+  min-height: 72px;
+}
+
+.reorder-cell-pos {
+  font-size: 11px;
+  font-weight: 700;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.reorder-cell-label {
+  margin-top: 2px;
+  font-size: 22px;
+  font-weight: 800;
+  color: #ffffff;
+}
+
+.reorder-cell-hint {
+  margin-top: 4px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.9);
+}

--- a/examples/scrolling/src/shared/useInfiniteFeed.ts
+++ b/examples/scrolling/src/shared/useInfiniteFeed.ts
@@ -4,8 +4,8 @@ import { makeCards } from './data';
 /**
  * Tiny infinite-scroll helper: append another page when the list
  * fires `@scrolltolower`. On Web you would usually wire this to a
- * virtualizer + IntersectionObserver; on Lynx the native `<list>`
- * already recycles items, so the composable only owns the data page.
+ * virtualizer + IntersectionObserver; on Lynx the composable only owns
+ * the data page — append-only updates are the supported list path today.
  */
 export function useInfiniteFeed(pageSize = 20) {
   const items = ref(makeCards(pageSize, 'Post'));

--- a/examples/scrolling/src/shared/useInfiniteFeed.ts
+++ b/examples/scrolling/src/shared/useInfiniteFeed.ts
@@ -1,0 +1,37 @@
+import { ref } from 'vue-lynx';
+import { makeCards } from './data';
+
+/**
+ * Tiny infinite-scroll helper: append another page when the list
+ * fires `@scrolltolower`. On Web you would usually wire this to a
+ * virtualizer + IntersectionObserver; on Lynx the native `<list>`
+ * already recycles items, so the composable only owns the data page.
+ */
+export function useInfiniteFeed(pageSize = 20) {
+  const items = ref(makeCards(pageSize, 'Post'));
+  const loading = ref(false);
+  const done = ref(false);
+  let page = 1;
+
+  async function loadMore() {
+    if (loading.value || done.value) return;
+    loading.value = true;
+    // Simulate network latency so the footer spinner is visible.
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    const next = makeCards(pageSize, 'Post').map((card, i) => {
+      const n = page * pageSize + i + 1;
+      return {
+        ...card,
+        id: `Post-${n}`,
+        title: `Post ${n}`,
+        body: `A short description for post ${n}.`,
+      };
+    });
+    page += 1;
+    items.value = [...items.value, ...next];
+    if (page >= 5) done.value = true;
+    loading.value = false;
+  }
+
+  return { items, loading, done, loadMore };
+}

--- a/examples/scrolling/src/shims-vue.d.ts
+++ b/examples/scrolling/src/shims-vue.d.ts
@@ -1,0 +1,5 @@
+declare module '*.vue' {
+  import type { Component } from 'vue-lynx';
+  const component: Component;
+  export default component;
+}

--- a/examples/scrolling/tsconfig.json
+++ b/examples/scrolling/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["src", "lynx.config.ts"]
+}

--- a/packages/testing-library/src/__tests__/list-diff.test.ts
+++ b/packages/testing-library/src/__tests__/list-diff.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Unit tests for list-apply diff — mirrors ReactLynx ListUpdateInfoRecording
+ * semantics (move = remove + insert; LIS keeps a stable subsequence).
+ *
+ * Reference: lynx-family/lynx-stack
+ *   packages/react/runtime/src/snapshot/list/listUpdateInfo.ts
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  diffListItems,
+  longestIncreasingSubsequence,
+  type ListItemEntry,
+} from '../../../vue-lynx/main-thread/src/list-apply.js';
+
+function entries(ids: number[]): ListItemEntry[] {
+  // el is unused by diff — stub with null-ish cast for unit tests
+  return ids.map((bgId) => ({ el: null as unknown as LynxElement, bgId }));
+}
+
+describe('longestIncreasingSubsequence', () => {
+  it('returns empty for empty input', () => {
+    expect([...longestIncreasingSubsequence([])]).toEqual([]);
+  });
+
+  it('keeps a strictly increasing run', () => {
+    expect(longestIncreasingSubsequence([0, 1, 2, 3])).toEqual(
+      new Set([0, 1, 2, 3]),
+    );
+  });
+
+  it('picks length-1 for a full reverse', () => {
+    const lis = longestIncreasingSubsequence([2, 1, 0]);
+    expect(lis.size).toBe(1);
+    expect([0, 1, 2].some((v) => lis.has(v))).toBe(true);
+  });
+
+  it('keeps increasing subset in a shuffle', () => {
+    // old indices in new order for [A,B,C,D] → [A,C,B,D] would be [0,2,1,3]
+    // LIS can be [0,2,3] or [0,1,3]
+    const lis = longestIncreasingSubsequence([0, 2, 1, 3]);
+    expect(lis.size).toBe(3);
+  });
+});
+
+describe('diffListItems (ReactLynx-style)', () => {
+  it('initial mount inserts every item at its position', () => {
+    const { removeAction, insertAction, stayedBgIds } = diffListItems(
+      [],
+      entries([10, 20, 30]),
+    );
+    expect(removeAction).toEqual([]);
+    expect(insertAction).toEqual([
+      { position: 0, bgId: 10 },
+      { position: 1, bgId: 20 },
+      { position: 2, bgId: 30 },
+    ]);
+    expect(stayedBgIds.size).toBe(0);
+  });
+
+  it('append-only emits inserts at the tail', () => {
+    const { removeAction, insertAction, stayedBgIds } = diffListItems(
+      entries([10, 20]),
+      entries([10, 20, 30, 40]),
+    );
+    expect(removeAction).toEqual([]);
+    expect(insertAction).toEqual([
+      { position: 2, bgId: 30 },
+      { position: 3, bgId: 40 },
+    ]);
+    expect([...stayedBgIds].sort()).toEqual([10, 20]);
+  });
+
+  it('prepend emits a single insert at position 0', () => {
+    const { removeAction, insertAction, stayedBgIds } = diffListItems(
+      entries([10, 20]),
+      entries([99, 10, 20]),
+    );
+    expect(removeAction).toEqual([]);
+    expect(insertAction).toEqual([{ position: 0, bgId: 99 }]);
+    expect([...stayedBgIds].sort()).toEqual([10, 20]);
+  });
+
+  it('remove middle emits only that old index', () => {
+    // [A,B,C] → [A,C]  ids 1,2,3
+    const { removeAction, insertAction, stayedBgIds } = diffListItems(
+      entries([1, 2, 3]),
+      entries([1, 3]),
+    );
+    expect(removeAction).toEqual([1]);
+    expect(insertAction).toEqual([]);
+    expect([...stayedBgIds].sort()).toEqual([1, 3]);
+  });
+
+  it('remove last emits the last old index', () => {
+    const { removeAction, insertAction } = diffListItems(
+      entries([1, 2, 3, 4]),
+      entries([1, 2, 3]),
+    );
+    expect(removeAction).toEqual([3]);
+    expect(insertAction).toEqual([]);
+  });
+
+  it('mixed remove middle then remove last (single flush) emits both indices', () => {
+    // Simulate one flush after both ops: [0..5] → drop index 2 and last
+    // old [1,2,3,4,5,6] → [1,2,4,5]
+    const { removeAction, insertAction } = diffListItems(
+      entries([1, 2, 3, 4, 5, 6]),
+      entries([1, 2, 4, 5]),
+    );
+    expect(removeAction).toEqual([2, 5]);
+    expect(insertAction).toEqual([]);
+  });
+
+  it('sequential remove middle then remove last across two diffs', () => {
+    // Flush 1: remove middle from 12 items (index 6)
+    const twelve = entries([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+    const afterMiddle = entries([1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12]);
+    const d1 = diffListItems(twelve, afterMiddle);
+    expect(d1.removeAction).toEqual([6]);
+    expect(d1.insertAction).toEqual([]);
+
+    // Flush 2: remove last of the 11-item list
+    const afterLast = entries([1, 2, 3, 4, 5, 6, 8, 9, 10, 11]);
+    const d2 = diffListItems(afterMiddle, afterLast);
+    expect(d2.removeAction).toEqual([10]);
+    expect(d2.insertAction).toEqual([]);
+  });
+
+  it('full reverse removes non-LIS and re-inserts (no item loss)', () => {
+    const old = entries([1, 2, 3]);
+    const neu = entries([3, 2, 1]);
+    const { removeAction, insertAction, stayedBgIds } = diffListItems(
+      old,
+      neu,
+    );
+    // One stayer; the other two are removed from old indices and inserted
+    expect(stayedBgIds.size).toBe(1);
+    expect(removeAction.length).toBe(2);
+    expect(insertAction.length).toBe(2);
+    // Every bgId still accounted for: stayers + inserts cover new list
+    const present = new Set([
+      ...stayedBgIds,
+      ...insertAction.map((a) => a.bgId),
+    ]);
+    expect([...present].sort()).toEqual([1, 2, 3]);
+    // Insert positions must be in-range for the new length
+    for (const a of insertAction) {
+      expect(a.position).toBeGreaterThanOrEqual(0);
+      expect(a.position).toBeLessThan(3);
+    }
+    // Native applies removals against OLD indices — must be valid
+    for (const r of removeAction) {
+      expect(r).toBeGreaterThanOrEqual(0);
+      expect(r).toBeLessThan(3);
+    }
+  });
+
+  it('yellow-to-top move keeps the other three as LIS when possible', () => {
+    // [R,B,G,Y] → [Y,R,B,G]  ids 1,2,3,4
+    const { removeAction, insertAction, stayedBgIds } = diffListItems(
+      entries([1, 2, 3, 4]),
+      entries([4, 1, 2, 3]),
+    );
+    // Best LIS is [1,2,3] (old indices 0,1,2); Y removed from 3 and inserted at 0
+    expect(removeAction).toEqual([3]);
+    expect(insertAction).toEqual([{ position: 0, bgId: 4 }]);
+    expect([...stayedBgIds].sort()).toEqual([1, 2, 3]);
+  });
+
+  it('remove then restore same identities re-inserts at correct positions', () => {
+    const d1 = diffListItems(
+      entries([1, 2, 3, 4]),
+      entries([1]),
+    );
+    expect(d1.removeAction).toEqual([1, 2, 3]);
+
+    const d2 = diffListItems(
+      entries([1]),
+      entries([1, 2, 3, 4]),
+    );
+    expect(d2.removeAction).toEqual([]);
+    expect(d2.insertAction).toEqual([
+      { position: 1, bgId: 2 },
+      { position: 2, bgId: 3 },
+      { position: 3, bgId: 4 },
+    ]);
+  });
+
+  it('no-op when identical', () => {
+    const { removeAction, insertAction, stayedBgIds } = diffListItems(
+      entries([1, 2, 3]),
+      entries([1, 2, 3]),
+    );
+    expect(removeAction).toEqual([]);
+    expect(insertAction).toEqual([]);
+    expect([...stayedBgIds].sort()).toEqual([1, 2, 3]);
+  });
+});

--- a/packages/testing-library/src/__tests__/ops-coverage.test.ts
+++ b/packages/testing-library/src/__tests__/ops-coverage.test.ts
@@ -240,7 +240,7 @@ describe('native list element · mutations', () => {
     ).toBe(false);
   });
 
-  it('reorder does not insert past the list length', async () => {
+  it('reorder reverse keeps all item-keys across the diff', async () => {
     const items = ref(['A', 'B', 'C']);
     const { container } = render(mountKeyedList(items));
     const listEl = container.querySelector('list')!;
@@ -251,11 +251,43 @@ describe('native list element · mutations', () => {
     await nextTick();
 
     const infos = allListInfos(listEl).slice(before);
+    expect(infos.length).toBeGreaterThan(0);
+    // Simulate applying remove+insert to the key list — no key may disappear.
+    let keys = ['A', 'B', 'C'];
     for (const info of infos) {
-      for (const action of info.insertAction) {
-        expect(action.position).toBeLessThan(3);
+      for (const r of [...info.removeAction].sort((a, b) => b - a)) {
+        keys.splice(r, 1);
+      }
+      const inserts = [...info.insertAction].sort(
+        (a, b) => (a.position as number) - (b.position as number),
+      );
+      for (const action of inserts) {
+        keys.splice(action.position as number, 0, String(action['item-key']));
       }
     }
+    expect(keys).toEqual(['C', 'B', 'A']);
+  });
+
+  it('mixed remove middle then remove last across flushes', async () => {
+    const items = ref(['A', 'B', 'C', 'D', 'E', 'F']);
+    const { container } = render(mountKeyedList(items));
+    const listEl = container.querySelector('list')!;
+
+    // Remove middle (C)
+    items.value = ['A', 'B', 'D', 'E', 'F'];
+    await nextTick();
+    await nextTick();
+    let info = latestListInfo(listEl)!;
+    expect(info.removeAction).toEqual([2]);
+    expect(info.insertAction).toEqual([]);
+
+    // Remove last (F)
+    items.value = ['A', 'B', 'D', 'E'];
+    await nextTick();
+    await nextTick();
+    info = latestListInfo(listEl)!;
+    expect(info.removeAction).toEqual([4]);
+    expect(info.insertAction).toEqual([]);
   });
 
   it('remove middle emits removeAction', async () => {

--- a/packages/testing-library/src/__tests__/ops-coverage.test.ts
+++ b/packages/testing-library/src/__tests__/ops-coverage.test.ts
@@ -134,6 +134,244 @@ describe('native list element', () => {
     // List element should still exist after update
     expect(container.querySelector('list')).not.toBeNull();
   });
+
+  it('append-only flush reports new insertActions with growing positions', async () => {
+    const items = ref(['A']);
+
+    const Comp = defineComponent({
+      setup() {
+        return () =>
+          h(
+            'list',
+            null,
+            items.value.map((item) =>
+              h('list-item', { key: item, 'item-key': item }, [
+                h('text', null, item),
+              ]),
+            ),
+          );
+      },
+    });
+
+    const { container } = render(Comp);
+    const listEl = container.querySelector('list')!;
+    expect(latestListInfo(listEl)?.insertAction.map((a) => a['item-key']))
+      .toEqual(['A']);
+
+    items.value = ['A', 'B', 'C'];
+    await nextTick();
+    await nextTick();
+
+    const info = latestListInfo(listEl)!;
+    expect(info.removeAction).toEqual([]);
+    expect(info.updateAction).toEqual([]);
+    expect(info.insertAction.map((a) => [a.position, a['item-key']])).toEqual([
+      [1, 'B'],
+      [2, 'C'],
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Native <list> mutation gaps — correct payloads; it.fails until MT diffs land
+// Mirrors examples/scrolling ListRemove | ListPrepend | ListReorder | ListFilter
+// ---------------------------------------------------------------------------
+
+type ListInfo = {
+  insertAction: Array<Record<string, unknown>>;
+  removeAction: number[];
+  updateAction: Array<Record<string, unknown>>;
+};
+
+function allListInfos(listEl: Element): ListInfo[] {
+  const raw = listEl.getAttribute('update-list-info');
+  return raw ? (JSON.parse(raw) as ListInfo[]) : [];
+}
+
+function latestListInfo(listEl: Element): ListInfo | undefined {
+  const all = allListInfos(listEl);
+  return all[all.length - 1];
+}
+
+describe('native list element · mutation gaps', () => {
+  it.fails(
+    'remove middle emits removeAction and stops reporting the deleted key',
+    async () => {
+      const items = ref(['A', 'B', 'C']);
+
+      const Comp = defineComponent({
+        setup() {
+          return () =>
+            h(
+              'list',
+              null,
+              items.value.map((item) =>
+                h('list-item', { key: item, 'item-key': item }, [
+                  h('text', null, item),
+                ]),
+              ),
+            );
+        },
+      });
+
+      const { container } = render(Comp);
+      const listEl = container.querySelector('list')!;
+      const before = allListInfos(listEl).length;
+
+      items.value = ['A', 'C'];
+      await nextTick();
+      await nextTick();
+
+      const infos = allListInfos(listEl).slice(before);
+      expect(infos.length).toBeGreaterThan(0);
+      const info = infos[infos.length - 1]!;
+      expect(info.removeAction).toEqual([1]);
+      expect(info.insertAction).toEqual([]);
+    },
+  );
+
+  it.fails(
+    'prepend emits insertAction at position 0 (not a tail push)',
+    async () => {
+      const items = ref(['A', 'B']);
+
+      const Comp = defineComponent({
+        setup() {
+          return () =>
+            h(
+              'list',
+              null,
+              items.value.map((item) =>
+                h('list-item', { key: item, 'item-key': item }, [
+                  h('text', null, item),
+                ]),
+              ),
+            );
+        },
+      });
+
+      const { container } = render(Comp);
+      const listEl = container.querySelector('list')!;
+      const before = allListInfos(listEl).length;
+
+      items.value = ['Z', 'A', 'B'];
+      await nextTick();
+      await nextTick();
+
+      const infos = allListInfos(listEl).slice(before);
+      expect(infos.length).toBeGreaterThan(0);
+      const info = infos[infos.length - 1]!;
+      expect(info.insertAction).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            position: 0,
+            'item-key': 'Z',
+            type: 'list-item',
+          }),
+        ]),
+      );
+      // Must not claim the new item lives at the end.
+      expect(
+        info.insertAction.some(
+          (a) => a['item-key'] === 'Z' && a.position === 2,
+        ),
+      ).toBe(false);
+    },
+  );
+
+  it.fails(
+    'reorder emits remove+insert (or update) so native order matches Vue',
+    async () => {
+      const items = ref(['A', 'B', 'C']);
+
+      const Comp = defineComponent({
+        setup() {
+          return () =>
+            h(
+              'list',
+              null,
+              items.value.map((item) =>
+                h('list-item', { key: item, 'item-key': item }, [
+                  h('text', null, item),
+                ]),
+              ),
+            );
+        },
+      });
+
+      const { container } = render(Comp);
+      const listEl = container.querySelector('list')!;
+
+      items.value = ['C', 'B', 'A'];
+      await nextTick();
+      await nextTick();
+
+      // Today Vue's keyed moves re-INSERT B/C at the tail (positions 3,4)
+      // without removeAction — native list grows past 3 and order diverges.
+      const inserts = allListInfos(listEl).flatMap((info) => info.insertAction);
+      const keyCounts = inserts.reduce<Record<string, number>>((acc, a) => {
+        const k = String(a['item-key']);
+        acc[k] = (acc[k] ?? 0) + 1;
+        return acc;
+      }, {});
+      expect(keyCounts).toEqual({ A: 1, B: 1, C: 1 });
+      expect(inserts.length).toBe(3);
+      expect(
+        allListInfos(listEl).some((info) => info.removeAction.length > 0),
+      ).toBe(true);
+    },
+  );
+
+  it.fails(
+    'filter-out then restore does not leave duplicated item-keys in inserts',
+    async () => {
+      const items = ref(['A', 'B', 'C', 'D']);
+
+      const Comp = defineComponent({
+        setup() {
+          return () =>
+            h(
+              'list',
+              null,
+              items.value.map((item) =>
+                h('list-item', { key: item, 'item-key': item }, [
+                  h('text', null, item),
+                ]),
+              ),
+            );
+        },
+      });
+
+      const { container } = render(Comp);
+      const listEl = container.querySelector('list')!;
+
+      items.value = ['B', 'D'];
+      await nextTick();
+      await nextTick();
+
+      items.value = ['A', 'B', 'C', 'D'];
+      await nextTick();
+      await nextTick();
+
+      const keys = allListInfos(listEl)
+        .flatMap((info) => info.insertAction.map((a) => String(a['item-key'])));
+      // After a correct remove+reinsert cycle, each key appears once in the
+      // cumulative insert stream (initial mount + restoration of A/C only).
+      const counts = keys.reduce<Record<string, number>>((acc, k) => {
+        acc[k] = (acc[k] ?? 0) + 1;
+        return acc;
+      }, {});
+      expect(counts['A']).toBeLessThanOrEqual(2);
+      expect(counts['B']).toBe(1);
+      expect(counts['C']).toBeLessThanOrEqual(2);
+      expect(counts['D']).toBe(1);
+      // And a remove must have been reported when filtering down.
+      const anyRemove = allListInfos(listEl).some(
+        (info) => info.removeAction.length > 0,
+      );
+      expect(anyRemove).toBe(true);
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/testing-library/src/__tests__/ops-coverage.test.ts
+++ b/packages/testing-library/src/__tests__/ops-coverage.test.ts
@@ -245,7 +245,7 @@ describe('native list element · mutation gaps', () => {
   );
 
   // Protocol still re-appends moved keys; UI may or may not look wrong —
-  // keep as it.fails until INSERT/REMOVE diffs are correct.
+  // keep as it.fails until INSERT anchors are respected for moves.
   it.fails(
     'reorder does not re-append duplicate item-keys at the tail',
     async () => {
@@ -268,22 +268,56 @@ describe('native list element · mutation gaps', () => {
     },
   );
 
-  // Device smoke: remove looks fine even with empty removeAction.
-  it('remove middle keeps list mounted (smoke)', async () => {
+  // Remove must emit removeAction so Reset / re-adding the same item-keys
+  // does not trip native duplicated item-key (error 2202).
+  it('remove middle emits removeAction', async () => {
     const items = ref(['A', 'B', 'C']);
     const { container } = render(mountKeyedList(items));
+    const listEl = container.querySelector('list')!;
+    const before = allListInfos(listEl).length;
 
     items.value = ['A', 'C'];
     await nextTick();
     await nextTick();
 
-    expect(container.querySelector('list')).not.toBeNull();
-    // Still no removeAction today — documented, not treated as a UI failure.
-    const infos = allListInfos(container.querySelector('list')!);
-    expect(infos.every((info) => info.removeAction.length === 0)).toBe(true);
+    const infos = allListInfos(listEl).slice(before);
+    expect(infos.length).toBeGreaterThan(0);
+    const info = infos[infos.length - 1]!;
+    expect(info.removeAction).toEqual([1]);
+    expect(info.insertAction).toEqual([]);
   });
 
-  // Device smoke: filter/restore looks fine.
+  it('remove then restore same keys does not duplicate item-keys', async () => {
+    const items = ref(['A', 'B', 'C', 'D']);
+    const { container } = render(mountKeyedList(items));
+    const listEl = container.querySelector('list')!;
+
+    // Drop the tail three (same shape as repeated "Remove last"), then Reset.
+    items.value = ['A'];
+    await nextTick();
+    await nextTick();
+    items.value = ['A', 'B', 'C', 'D'];
+    await nextTick();
+    await nextTick();
+
+    const keys = allListInfos(listEl).flatMap((info) =>
+      info.insertAction.map((a) => String(a['item-key'])),
+    );
+    const counts = keys.reduce<Record<string, number>>((acc, k) => {
+      acc[k] = (acc[k] ?? 0) + 1;
+      return acc;
+    }, {});
+    // Each key inserted once on mount; B/C/D once more on restore — never
+    // stuck as duplicates from a stale listItems array.
+    expect(counts['A']).toBe(1);
+    expect(counts['B']).toBe(2);
+    expect(counts['C']).toBe(2);
+    expect(counts['D']).toBe(2);
+    expect(
+      allListInfos(listEl).some((info) => info.removeAction.length > 0),
+    ).toBe(true);
+  });
+
   it('filter-out then restore keeps list mounted (smoke)', async () => {
     const items = ref(['A', 'B', 'C', 'D']);
     const { container } = render(mountKeyedList(items));
@@ -296,6 +330,19 @@ describe('native list element · mutation gaps', () => {
     await nextTick();
 
     expect(container.querySelector('list')).not.toBeNull();
+    const keys = allListInfos(container.querySelector('list')!).flatMap(
+      (info) => info.insertAction.map((a) => String(a['item-key'])),
+    );
+    // A and C removed then re-inserted once each — not left duplicated from
+    // a stale listItems bookkeeping.
+    const counts = keys.reduce<Record<string, number>>((acc, k) => {
+      acc[k] = (acc[k] ?? 0) + 1;
+      return acc;
+    }, {});
+    expect(counts['A']).toBe(2);
+    expect(counts['B']).toBe(1);
+    expect(counts['C']).toBe(2);
+    expect(counts['D']).toBe(1);
   });
 });
 

--- a/packages/testing-library/src/__tests__/ops-coverage.test.ts
+++ b/packages/testing-library/src/__tests__/ops-coverage.test.ts
@@ -173,7 +173,7 @@ describe('native list element', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Native <list> mutations — prepend is a confirmed gap; remove/filter smoke OK
+// Native <list> mutations — prepend / reorder / remove / updateAction
 // Mirrors examples/scrolling ListPrepend | ListReorder | ListRemove | ListFilter
 // ---------------------------------------------------------------------------
 
@@ -210,66 +210,54 @@ function mountKeyedList(items: { value: string[] }) {
   });
 }
 
-describe('native list element · mutation gaps', () => {
-  // Confirmed on device: prepend lands at the tail (INSERT ignores anchor).
-  it.fails(
-    'prepend emits insertAction at position 0 (not a tail push)',
-    async () => {
-      const items = ref(['A', 'B']);
-      const { container } = render(mountKeyedList(items));
-      const listEl = container.querySelector('list')!;
-      const before = allListInfos(listEl).length;
+describe('native list element · mutations', () => {
+  it('prepend emits insertAction at position 0 (not a tail push)', async () => {
+    const items = ref(['A', 'B']);
+    const { container } = render(mountKeyedList(items));
+    const listEl = container.querySelector('list')!;
+    const before = allListInfos(listEl).length;
 
-      items.value = ['Z', 'A', 'B'];
-      await nextTick();
-      await nextTick();
+    items.value = ['Z', 'A', 'B'];
+    await nextTick();
+    await nextTick();
 
-      const infos = allListInfos(listEl).slice(before);
-      expect(infos.length).toBeGreaterThan(0);
-      const info = infos[infos.length - 1]!;
-      expect(info.insertAction).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            position: 0,
-            'item-key': 'Z',
-            type: 'list-item',
-          }),
-        ]),
-      );
-      expect(
-        info.insertAction.some(
-          (a) => a['item-key'] === 'Z' && a.position === 2,
-        ),
-      ).toBe(false);
-    },
-  );
+    const infos = allListInfos(listEl).slice(before);
+    expect(infos.length).toBeGreaterThan(0);
+    const info = infos[infos.length - 1]!;
+    expect(info.insertAction).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          position: 0,
+          'item-key': 'Z',
+          type: 'list-item',
+        }),
+      ]),
+    );
+    expect(
+      info.insertAction.some(
+        (a) => a['item-key'] === 'Z' && (a.position as number) >= 2,
+      ),
+    ).toBe(false);
+  });
 
-  // Protocol still re-appends moved keys; UI may or may not look wrong —
-  // keep as it.fails until INSERT anchors are respected for moves.
-  it.fails(
-    'reorder does not re-append duplicate item-keys at the tail',
-    async () => {
-      const items = ref(['A', 'B', 'C']);
-      const { container } = render(mountKeyedList(items));
-      const listEl = container.querySelector('list')!;
+  it('reorder does not insert past the list length', async () => {
+    const items = ref(['A', 'B', 'C']);
+    const { container } = render(mountKeyedList(items));
+    const listEl = container.querySelector('list')!;
+    const before = allListInfos(listEl).length;
 
-      items.value = ['C', 'B', 'A'];
-      await nextTick();
-      await nextTick();
+    items.value = ['C', 'B', 'A'];
+    await nextTick();
+    await nextTick();
 
-      const inserts = allListInfos(listEl).flatMap((info) => info.insertAction);
-      const keyCounts = inserts.reduce<Record<string, number>>((acc, a) => {
-        const k = String(a['item-key']);
-        acc[k] = (acc[k] ?? 0) + 1;
-        return acc;
-      }, {});
-      expect(keyCounts).toEqual({ A: 1, B: 1, C: 1 });
-      expect(inserts.length).toBe(3);
-    },
-  );
+    const infos = allListInfos(listEl).slice(before);
+    for (const info of infos) {
+      for (const action of info.insertAction) {
+        expect(action.position).toBeLessThan(3);
+      }
+    }
+  });
 
-  // Remove must emit removeAction so Reset / re-adding the same item-keys
-  // does not trip native duplicated item-key (error 2202).
   it('remove middle emits removeAction', async () => {
     const items = ref(['A', 'B', 'C']);
     const { container } = render(mountKeyedList(items));
@@ -292,7 +280,6 @@ describe('native list element · mutation gaps', () => {
     const { container } = render(mountKeyedList(items));
     const listEl = container.querySelector('list')!;
 
-    // Drop the tail three (same shape as repeated "Remove last"), then Reset.
     items.value = ['A'];
     await nextTick();
     await nextTick();
@@ -307,8 +294,6 @@ describe('native list element · mutation gaps', () => {
       acc[k] = (acc[k] ?? 0) + 1;
       return acc;
     }, {});
-    // Each key inserted once on mount; B/C/D once more on restore — never
-    // stuck as duplicates from a stale listItems array.
     expect(counts['A']).toBe(1);
     expect(counts['B']).toBe(2);
     expect(counts['C']).toBe(2);
@@ -318,7 +303,7 @@ describe('native list element · mutation gaps', () => {
     ).toBe(true);
   });
 
-  it('filter-out then restore keeps list mounted (smoke)', async () => {
+  it('filter-out then restore does not leave stale duplicate inserts', async () => {
     const items = ref(['A', 'B', 'C', 'D']);
     const { container } = render(mountKeyedList(items));
 
@@ -333,8 +318,6 @@ describe('native list element · mutation gaps', () => {
     const keys = allListInfos(container.querySelector('list')!).flatMap(
       (info) => info.insertAction.map((a) => String(a['item-key'])),
     );
-    // A and C removed then re-inserted once each — not left duplicated from
-    // a stale listItems bookkeeping.
     const counts = keys.reduce<Record<string, number>>((acc, k) => {
       acc[k] = (acc[k] ?? 0) + 1;
       return acc;
@@ -343,6 +326,47 @@ describe('native list element · mutation gaps', () => {
     expect(counts['B']).toBe(1);
     expect(counts['C']).toBe(2);
     expect(counts['D']).toBe(1);
+  });
+
+  it('updating platform info on an existing item emits updateAction', async () => {
+    const size = ref(100);
+    const Comp = defineComponent({
+      setup() {
+        return () =>
+          h('list', null, [
+            h(
+              'list-item',
+              {
+                key: 'A',
+                'item-key': 'A',
+                'estimated-main-axis-size-px': size.value,
+              },
+              [h('text', null, 'A')],
+            ),
+          ]);
+      },
+    });
+
+    const { container } = render(Comp);
+    const listEl = container.querySelector('list')!;
+    const before = allListInfos(listEl).length;
+
+    size.value = 160;
+    await nextTick();
+    await nextTick();
+
+    const infos = allListInfos(listEl).slice(before);
+    expect(infos.length).toBeGreaterThan(0);
+    const info = infos[infos.length - 1]!;
+    expect(info.updateAction.length).toBeGreaterThan(0);
+    expect(info.updateAction[0]).toEqual(
+      expect.objectContaining({
+        from: 0,
+        to: 0,
+        'estimated-main-axis-size-px': 160,
+        'item-key': 'A',
+      }),
+    );
   });
 });
 

--- a/packages/testing-library/src/__tests__/ops-coverage.test.ts
+++ b/packages/testing-library/src/__tests__/ops-coverage.test.ts
@@ -173,8 +173,8 @@ describe('native list element', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Native <list> mutation gaps — correct payloads; it.fails until MT diffs land
-// Mirrors examples/scrolling ListRemove | ListPrepend | ListReorder | ListFilter
+// Native <list> mutations — prepend is a confirmed gap; remove/filter smoke OK
+// Mirrors examples/scrolling ListPrepend | ListReorder | ListRemove | ListFilter
 // ---------------------------------------------------------------------------
 
 type ListInfo = {
@@ -193,64 +193,30 @@ function latestListInfo(listEl: Element): ListInfo | undefined {
   return all[all.length - 1];
 }
 
-describe('native list element · mutation gaps', () => {
-  it.fails(
-    'remove middle emits removeAction and stops reporting the deleted key',
-    async () => {
-      const items = ref(['A', 'B', 'C']);
-
-      const Comp = defineComponent({
-        setup() {
-          return () =>
-            h(
-              'list',
-              null,
-              items.value.map((item) =>
-                h('list-item', { key: item, 'item-key': item }, [
-                  h('text', null, item),
-                ]),
-              ),
-            );
-        },
-      });
-
-      const { container } = render(Comp);
-      const listEl = container.querySelector('list')!;
-      const before = allListInfos(listEl).length;
-
-      items.value = ['A', 'C'];
-      await nextTick();
-      await nextTick();
-
-      const infos = allListInfos(listEl).slice(before);
-      expect(infos.length).toBeGreaterThan(0);
-      const info = infos[infos.length - 1]!;
-      expect(info.removeAction).toEqual([1]);
-      expect(info.insertAction).toEqual([]);
+function mountKeyedList(items: { value: string[] }) {
+  return defineComponent({
+    setup() {
+      return () =>
+        h(
+          'list',
+          null,
+          items.value.map((item) =>
+            h('list-item', { key: item, 'item-key': item }, [
+              h('text', null, item),
+            ]),
+          ),
+        );
     },
-  );
+  });
+}
 
+describe('native list element · mutation gaps', () => {
+  // Confirmed on device: prepend lands at the tail (INSERT ignores anchor).
   it.fails(
     'prepend emits insertAction at position 0 (not a tail push)',
     async () => {
       const items = ref(['A', 'B']);
-
-      const Comp = defineComponent({
-        setup() {
-          return () =>
-            h(
-              'list',
-              null,
-              items.value.map((item) =>
-                h('list-item', { key: item, 'item-key': item }, [
-                  h('text', null, item),
-                ]),
-              ),
-            );
-        },
-      });
-
-      const { container } = render(Comp);
+      const { container } = render(mountKeyedList(items));
       const listEl = container.querySelector('list')!;
       const before = allListInfos(listEl).length;
 
@@ -270,7 +236,6 @@ describe('native list element · mutation gaps', () => {
           }),
         ]),
       );
-      // Must not claim the new item lives at the end.
       expect(
         info.insertAction.some(
           (a) => a['item-key'] === 'Z' && a.position === 2,
@@ -279,35 +244,19 @@ describe('native list element · mutation gaps', () => {
     },
   );
 
+  // Protocol still re-appends moved keys; UI may or may not look wrong —
+  // keep as it.fails until INSERT/REMOVE diffs are correct.
   it.fails(
-    'reorder emits remove+insert (or update) so native order matches Vue',
+    'reorder does not re-append duplicate item-keys at the tail',
     async () => {
       const items = ref(['A', 'B', 'C']);
-
-      const Comp = defineComponent({
-        setup() {
-          return () =>
-            h(
-              'list',
-              null,
-              items.value.map((item) =>
-                h('list-item', { key: item, 'item-key': item }, [
-                  h('text', null, item),
-                ]),
-              ),
-            );
-        },
-      });
-
-      const { container } = render(Comp);
+      const { container } = render(mountKeyedList(items));
       const listEl = container.querySelector('list')!;
 
       items.value = ['C', 'B', 'A'];
       await nextTick();
       await nextTick();
 
-      // Today Vue's keyed moves re-INSERT B/C at the tail (positions 3,4)
-      // without removeAction — native list grows past 3 and order diverges.
       const inserts = allListInfos(listEl).flatMap((info) => info.insertAction);
       const keyCounts = inserts.reduce<Record<string, number>>((acc, a) => {
         const k = String(a['item-key']);
@@ -316,62 +265,38 @@ describe('native list element · mutation gaps', () => {
       }, {});
       expect(keyCounts).toEqual({ A: 1, B: 1, C: 1 });
       expect(inserts.length).toBe(3);
-      expect(
-        allListInfos(listEl).some((info) => info.removeAction.length > 0),
-      ).toBe(true);
     },
   );
 
-  it.fails(
-    'filter-out then restore does not leave duplicated item-keys in inserts',
-    async () => {
-      const items = ref(['A', 'B', 'C', 'D']);
+  // Device smoke: remove looks fine even with empty removeAction.
+  it('remove middle keeps list mounted (smoke)', async () => {
+    const items = ref(['A', 'B', 'C']);
+    const { container } = render(mountKeyedList(items));
 
-      const Comp = defineComponent({
-        setup() {
-          return () =>
-            h(
-              'list',
-              null,
-              items.value.map((item) =>
-                h('list-item', { key: item, 'item-key': item }, [
-                  h('text', null, item),
-                ]),
-              ),
-            );
-        },
-      });
+    items.value = ['A', 'C'];
+    await nextTick();
+    await nextTick();
 
-      const { container } = render(Comp);
-      const listEl = container.querySelector('list')!;
+    expect(container.querySelector('list')).not.toBeNull();
+    // Still no removeAction today — documented, not treated as a UI failure.
+    const infos = allListInfos(container.querySelector('list')!);
+    expect(infos.every((info) => info.removeAction.length === 0)).toBe(true);
+  });
 
-      items.value = ['B', 'D'];
-      await nextTick();
-      await nextTick();
+  // Device smoke: filter/restore looks fine.
+  it('filter-out then restore keeps list mounted (smoke)', async () => {
+    const items = ref(['A', 'B', 'C', 'D']);
+    const { container } = render(mountKeyedList(items));
 
-      items.value = ['A', 'B', 'C', 'D'];
-      await nextTick();
-      await nextTick();
+    items.value = ['B', 'D'];
+    await nextTick();
+    await nextTick();
+    items.value = ['A', 'B', 'C', 'D'];
+    await nextTick();
+    await nextTick();
 
-      const keys = allListInfos(listEl)
-        .flatMap((info) => info.insertAction.map((a) => String(a['item-key'])));
-      // After a correct remove+reinsert cycle, each key appears once in the
-      // cumulative insert stream (initial mount + restoration of A/C only).
-      const counts = keys.reduce<Record<string, number>>((acc, k) => {
-        acc[k] = (acc[k] ?? 0) + 1;
-        return acc;
-      }, {});
-      expect(counts['A']).toBeLessThanOrEqual(2);
-      expect(counts['B']).toBe(1);
-      expect(counts['C']).toBeLessThanOrEqual(2);
-      expect(counts['D']).toBe(1);
-      // And a remove must have been reported when filtering down.
-      const anyRemove = allListInfos(listEl).some(
-        (info) => info.removeAction.length > 0,
-      );
-      expect(anyRemove).toBe(true);
-    },
-  );
+    expect(container.querySelector('list')).not.toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/vue-lynx/main-thread/src/list-apply.ts
+++ b/packages/vue-lynx/main-thread/src/list-apply.ts
@@ -6,14 +6,14 @@
  * List element management for the Main Thread ops executor.
  *
  * Native <list> elements must be created via __CreateList with callbacks.
- * The native list calls componentAtIndex(list, listID, cellIndex, operationID)
- * when it needs to render an item. We collect items as they're inserted and
- * provide them via the callback.
+ * Diffs are flushed via `update-list-info`.
  *
- * Diffs are flushed via `update-list-info` (insertAction / removeAction /
- * updateAction). INSERT respects anchors (prepend / mid-list). Same-list
- * moves detach then re-insert (like ReactLynx treating insert-before of an
- * existing child as remove+insert).
+ * Diff strategy (inspired by ReactLynx `ListUpdateInfoRecording`):
+ * - Mutate a live `listItems` array so `componentAtIndex` always sees current order.
+ * - On flush, diff `lastFlushed` (snapshot after previous flush) against `listItems`
+ *   with an LIS-based move detection: items that stay in increasing old-index
+ *   order are kept; everything else is remove+insert. This matches ReactLynx's
+ *   "move = removeChild + insertBefore" semantics without fragile per-op index math.
  */
 
 import { elements, pageUniqueId } from './element-registry.js';
@@ -23,11 +23,14 @@ import { elements, pageUniqueId } from './element-registry.js';
 // ---------------------------------------------------------------------------
 
 /** Per-list state: ordered list of child elements that the native list can request */
-interface ListItemEntry {
+export interface ListItemEntry {
   el: LynxElement;
   bgId: number;
 }
 const listItems = new Map<number, ListItemEntry[]>();
+
+/** Snapshot of listItems after the last successful flush (native's view). */
+const lastFlushed = new Map<number, ListItemEntry[]>();
 
 /** Set of BG-thread element IDs that are <list> elements */
 const listElementIds = new Set<number>();
@@ -37,9 +40,7 @@ const itemKeyMap = new Map<number, string>();
 
 /**
  * Platform info attributes for list items — these must go ONLY into
- * update-list-info's insertAction / updateAction, NOT via __SetAttribute on
- * the native element. Setting them both ways causes the native list to count
- * items twice. (Matches React Lynx's platformInfoAttributes.)
+ * update-list-info's insertAction / updateAction, NOT via __SetAttribute.
  */
 const PLATFORM_INFO_ATTRS = new Set([
   'item-key',
@@ -53,35 +54,106 @@ const PLATFORM_INFO_ATTRS = new Set([
   'recyclable',
 ]);
 
-/** Per list-item bg ID -> platform info attributes (for update-list-info) */
+/** Per list-item bg ID -> platform info attributes */
 const listItemPlatformInfo = new Map<number, Record<string, unknown>>();
 
-/** How many items native currently knows about (fully synced list length) */
-const listItemsReported = new Map<number, number>();
+/** bgIds whose platform info changed since last flush */
+const dirtyPlatformInfo = new Set<number>();
+
+// ---------------------------------------------------------------------------
+// Diff (exported for unit tests)
+// ---------------------------------------------------------------------------
+
+export interface ListDiffResult {
+  removeAction: number[];
+  insertAction: Array<{ position: number; bgId: number }>;
+  /** bgIds that remained in place (LIS) — eligible for updateAction */
+  stayedBgIds: Set<number>;
+}
 
 /**
- * Pending remove indices per list, expressed against the list state *before*
- * this applyOps batch's removes (same convention as ReactLynx removeAction).
+ * Longest increasing subsequence of `seq` (values are old indices).
+ * Returns the set of values (old indices) that are part of one LIS.
  */
-const pendingRemoves = new Map<number, number[]>();
+export function longestIncreasingSubsequence(
+  seq: number[],
+): Set<number> {
+  const n = seq.length;
+  if (n === 0) return new Set();
+  // tails[k] = index in seq of smallest tail of LIS length k+1
+  const tails: number[] = [];
+  const prev: number[] = Array.from({ length: n }, () => -1);
 
-/** Pending inserts: position is the index in listItems *after* the splice. */
-const pendingInserts = new Map<
-  number,
-  Array<{ position: number; bgId: number }>
->();
+  for (let i = 0; i < n; i++) {
+    const v = seq[i]!;
+    let lo = 0;
+    let hi = tails.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (seq[tails[mid]!]! < v) lo = mid + 1;
+      else hi = mid;
+    }
+    if (lo > 0) prev[i] = tails[lo - 1]!;
+    if (lo === tails.length) tails.push(i);
+    else tails[lo] = i;
+  }
 
-/** Pending platform-info updates for items already known to native. */
-const pendingUpdates = new Map<
-  number,
-  Array<Record<string, unknown>>
->();
+  const lisIdx = new Set<number>();
+  let k = tails[tails.length - 1]!;
+  while (k >= 0) {
+    lisIdx.add(seq[k]!);
+    k = prev[k]!;
+  }
+  return lisIdx;
+}
+
+/**
+ * Diff old (last flushed) vs new (live listItems) by bgId.
+ * Stayers = LIS of old indices among items present in both, in new order.
+ * Removals = old indices not in stayers. Insertions = new items not in stayers.
+ */
+export function diffListItems(
+  oldItems: ListItemEntry[],
+  newItems: ListItemEntry[],
+): ListDiffResult {
+  const oldIndex = new Map<number, number>();
+  for (let i = 0; i < oldItems.length; i++) {
+    oldIndex.set(oldItems[i]!.bgId, i);
+  }
+
+  const commonNewOrder: number[] = [];
+  for (const entry of newItems) {
+    const oi = oldIndex.get(entry.bgId);
+    if (oi !== undefined) commonNewOrder.push(oi);
+  }
+  const stayedOldIndices = longestIncreasingSubsequence(commonNewOrder);
+
+  const removeAction: number[] = [];
+  for (let i = 0; i < oldItems.length; i++) {
+    if (!stayedOldIndices.has(i)) removeAction.push(i);
+  }
+
+  const insertAction: Array<{ position: number; bgId: number }> = [];
+  const stayedBgIds = new Set<number>();
+  for (const oi of stayedOldIndices) {
+    stayedBgIds.add(oldItems[oi]!.bgId);
+  }
+
+  for (let pos = 0; pos < newItems.length; pos++) {
+    const bgId = newItems[pos]!.bgId;
+    if (!stayedBgIds.has(bgId)) {
+      insertAction.push({ position: pos, bgId });
+    }
+  }
+
+  return { removeAction, insertAction, stayedBgIds };
+}
 
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-/** No-op: element recycling is tracked separately (see GitHub issues). */
+/** No-op: element recycling tracked in #302. */
 // biome-ignore lint/suspicious/noEmptyBlockStatements: intentional no-op
 function enqueueComponentNoop(): void {}
 
@@ -133,15 +205,13 @@ function createListCallbacks(bgId: number): {
     const elementIDs: number[] = [];
     for (let j = 0; j < cellIndexes.length; j++) {
       const cellIndex = cellIndexes[j]!;
-      const _operationID = operationIDs[j]!;
       if (cellIndex < 0 || cellIndex >= items.length) {
         elementIDs.push(-1);
         continue;
       }
       const item = items[cellIndex]!.el;
       __AppendElement(list, item);
-      const sign = __GetElementUniqueID(item);
-      elementIDs.push(sign);
+      elementIDs.push(__GetElementUniqueID(item));
     }
     __FlushElementTree(list, {
       triggerLayout: true,
@@ -154,108 +224,36 @@ function createListCallbacks(bgId: number): {
   return { componentAtIndex, enqueueComponent, componentAtIndexes };
 }
 
-/**
- * Detach `childId` from the list tracking array and queue a removeAction.
- * @returns the pre-batch remove index, or -1 if not found.
- */
-function detachListItem(
-  parentId: number,
-  childId: number,
-  clearPlatformInfo: boolean,
-): number {
-  const items = listItems.get(parentId);
-  if (!items) return -1;
-  const idx = items.findIndex((entry) => entry.bgId === childId);
-  if (idx === -1) return -1;
-
-  const pending = pendingRemoves.get(parentId) ?? [];
-  // Convert current (post-prior-splices) index → pre-batch index.
-  let originalIdx = idx;
-  for (const r of pending) {
-    if (r <= originalIdx) originalIdx++;
-  }
-  pending.push(originalIdx);
-  pendingRemoves.set(parentId, pending);
-
-  // Drop any not-yet-flushed insert for this child (move / re-insert same batch).
-  const inserts = pendingInserts.get(parentId);
-  if (inserts) {
-    const filtered = inserts.filter((p) => p.bgId !== childId);
-    pendingInserts.set(parentId, filtered);
-  }
-
-  items.splice(idx, 1);
-
-  const reported = listItemsReported.get(parentId) ?? 0;
-  if (idx < reported) {
-    listItemsReported.set(parentId, reported - 1);
-  }
-
-  if (clearPlatformInfo) {
-    itemKeyMap.delete(childId);
-    listItemPlatformInfo.delete(childId);
-  }
-
-  return originalIdx;
-}
-
-function findListIdForItem(itemBgId: number): number | undefined {
-  for (const [listId, items] of listItems) {
-    if (items.some((e) => e.bgId === itemBgId)) return listId;
-  }
-  return undefined;
-}
-
-function queuePlatformUpdate(listId: number, itemBgId: number): void {
-  const items = listItems.get(listId);
-  if (!items) return;
-  const idx = items.findIndex((e) => e.bgId === itemBgId);
-  if (idx === -1) return;
-
-  // Still in this batch's insertAction — platform info merges there.
-  const inserts = pendingInserts.get(listId) ?? [];
-  if (inserts.some((p) => p.bgId === itemBgId)) return;
-
-  const pInfo = listItemPlatformInfo.get(itemBgId) ?? {};
-  const pending = pendingUpdates.get(listId) ?? [];
-  const existing = pending.findIndex((u) => u.from === idx);
+function buildPlatformAction(
+  itemBgId: number,
+  position: number,
+): Record<string, unknown> {
   const action: Record<string, unknown> = {
-    ...pInfo,
-    from: idx,
-    to: idx,
-    flush: false,
+    position,
     type: 'list-item',
+    'item-key': itemKeyMap.get(itemBgId) ?? String(position),
   };
-  if (existing >= 0) {
-    pending[existing] = action;
-  } else {
-    pending.push(action);
-  }
-  pendingUpdates.set(listId, pending);
+  const pInfo = listItemPlatformInfo.get(itemBgId);
+  if (pInfo) Object.assign(action, pInfo);
+  return action;
 }
 
 // ---------------------------------------------------------------------------
 // Public API (called from ops-apply.ts switch cases)
 // ---------------------------------------------------------------------------
 
-/** Check if a parent element ID is a <list> element */
 export function isListParent(parentId: number): boolean {
   return listElementIds.has(parentId);
 }
 
-/** Check if a prop key is a platform-info attribute for list items */
 export function isPlatformInfoAttr(key: string): boolean {
   return PLATFORM_INFO_ATTRS.has(key);
 }
 
-/** CREATE case: create a native <list> element and set up tracking state */
 export function createListElement(id: number): LynxElement {
   listElementIds.add(id);
   listItems.set(id, []);
-  listItemsReported.set(id, 0);
-  pendingRemoves.set(id, []);
-  pendingInserts.set(id, []);
-  pendingUpdates.set(id, []);
+  lastFlushed.set(id, []);
   const cbs = createListCallbacks(id);
   const el = __CreateList(
     pageUniqueId,
@@ -269,10 +267,9 @@ export function createListElement(id: number): LynxElement {
 }
 
 /**
- * INSERT case: place a child into the list array.
- * `anchorId === -1` → append; otherwise insert before the anchor (prepend /
- * mid-list). If the child is already in this list, treat as a move
- * (detach + re-insert), matching ReactLynx's insertBefore-of-existing-child.
+ * Place a child into the live list array.
+ * `anchorId === -1` → append; otherwise insert before anchor.
+ * If the child is already in this list, splice it out first (same-list move).
  */
 export function insertListItem(
   parentId: number,
@@ -283,116 +280,115 @@ export function insertListItem(
   const items = listItems.get(parentId);
   if (!items) return;
 
-  // Same-list move: Vue hostInsert does INSERT without REMOVE when the
-  // parent stays the same — detach first so we don't duplicate listItems.
-  if (items.some((e) => e.bgId === childId)) {
-    detachListItem(parentId, childId, false);
+  const existingIdx = items.findIndex((e) => e.bgId === childId);
+  if (existingIdx !== -1) {
+    items.splice(existingIdx, 1);
   }
 
   const entry: ListItemEntry = { el: child, bgId: childId };
-  let index: number;
   if (anchorId === -1) {
-    index = items.length;
     items.push(entry);
   } else {
     const anchorIdx = items.findIndex((e) => e.bgId === anchorId);
-    if (anchorIdx === -1) {
-      index = items.length;
-      items.push(entry);
-    } else {
-      index = anchorIdx;
-      items.splice(index, 0, entry);
-    }
+    if (anchorIdx === -1) items.push(entry);
+    else items.splice(anchorIdx, 0, entry);
   }
-
-  const pending = pendingInserts.get(parentId) ?? [];
-  pending.push({ position: index, bgId: childId });
-  pendingInserts.set(parentId, pending);
 }
 
-/**
- * REMOVE case: drop a child from the list tracking array and queue a
- * `removeAction` index. Without this, Reset / re-adding the same `item-key`
- * appends duplicates and native list throws error 2202 (duplicated item-key).
- */
+/** Drop a child from the live list array (hard remove). */
 export function removeListItem(parentId: number, childId: number): void {
-  detachListItem(parentId, childId, true);
+  const items = listItems.get(parentId);
+  if (!items) return;
+  const idx = items.findIndex((entry) => entry.bgId === childId);
+  if (idx === -1) return;
+  items.splice(idx, 1);
+  itemKeyMap.delete(childId);
+  listItemPlatformInfo.delete(childId);
+  dirtyPlatformInfo.delete(childId);
 }
 
-/** SET_PROP case: store a platform-info attribute for a list item */
+/** Store a platform-info attribute; mark dirty for updateAction if already flushed. */
 export function setPlatformInfoProp(
   id: number,
   key: string,
   value: unknown,
 ): void {
   const info = listItemPlatformInfo.get(id);
-  if (info) {
-    info[key] = value;
-  } else {
-    listItemPlatformInfo.set(id, { [key]: value });
-  }
+  if (info) info[key] = value;
+  else listItemPlatformInfo.set(id, { [key]: value });
   if (key === 'item-key') itemKeyMap.set(id, String(value));
-
-  const listId = findListIdForItem(id);
-  if (listId !== undefined) {
-    queuePlatformUpdate(listId, id);
-  }
+  dirtyPlatformInfo.add(id);
 }
 
 /**
- * Post-ops flush: tell the native list about removes / inserts / platform
- * updates via `update-list-info`.
+ * Diff lastFlushed → listItems and set `update-list-info`.
  */
 export function flushListUpdates(): void {
   for (const [bgId, items] of listItems) {
-    const removes = pendingRemoves.get(bgId) ?? [];
-    const inserts = pendingInserts.get(bgId) ?? [];
-    const updates = pendingUpdates.get(bgId) ?? [];
+    const prev = lastFlushed.get(bgId) ?? [];
+    const { removeAction, insertAction, stayedBgIds } = diffListItems(
+      prev,
+      items,
+    );
+
+    const updateAction: Record<string, unknown>[] = [];
+    for (const stayedId of stayedBgIds) {
+      if (!dirtyPlatformInfo.has(stayedId)) continue;
+      const idx = items.findIndex((e) => e.bgId === stayedId);
+      if (idx === -1) continue;
+      const pInfo = listItemPlatformInfo.get(stayedId) ?? {};
+      updateAction.push({
+        ...pInfo,
+        from: idx,
+        to: idx,
+        flush: false,
+        type: 'list-item',
+      });
+      dirtyPlatformInfo.delete(stayedId);
+    }
+
+    // Clear dirty flags for inserted items (info already in insertAction).
+    for (const { bgId: itemBgId } of insertAction) {
+      dirtyPlatformInfo.delete(itemBgId);
+    }
+
     if (
-      removes.length === 0
-      && inserts.length === 0
-      && updates.length === 0
+      removeAction.length === 0
+      && insertAction.length === 0
+      && updateAction.length === 0
     ) {
       continue;
     }
+
     const listEl = elements.get(bgId);
     if (!listEl) continue;
 
-    // Stable sort by position; equal positions keep record order (two prepends).
-    const insertAction = inserts
-      .slice()
-      .sort((a, b) => a.position - b.position)
-      .map(({ position, bgId: itemBgId }) => {
-        const action: Record<string, unknown> = {
-          position,
-          type: 'list-item',
-          'item-key': itemKeyMap.get(itemBgId) ?? String(position),
-        };
-        const pInfo = listItemPlatformInfo.get(itemBgId);
-        if (pInfo) Object.assign(action, pInfo);
-        return action;
-      });
-
     __SetAttribute(listEl, 'update-list-info', {
-      insertAction,
-      removeAction: [...removes].sort((a, b) => a - b),
-      updateAction: updates,
+      insertAction: insertAction.map(({ position, bgId: itemBgId }) =>
+        buildPlatformAction(itemBgId, position)
+      ),
+      removeAction,
+      updateAction,
     });
-    listItemsReported.set(bgId, items.length);
-    pendingRemoves.set(bgId, []);
-    pendingInserts.set(bgId, []);
-    pendingUpdates.set(bgId, []);
+
+    lastFlushed.set(
+      bgId,
+      items.map((e) => ({ el: e.el, bgId: e.bgId })),
+    );
   }
 }
 
 /** Reset all list state — for testing only. */
 export function resetListState(): void {
   listItems.clear();
+  lastFlushed.clear();
   listElementIds.clear();
   itemKeyMap.clear();
   listItemPlatformInfo.clear();
-  listItemsReported.clear();
-  pendingRemoves.clear();
-  pendingInserts.clear();
-  pendingUpdates.clear();
+  dirtyPlatformInfo.clear();
+}
+
+/** Test helper: current live item bgIds for a list. */
+export function getListItemBgIdsForTest(listId: number): number[] {
+  return (listItems.get(listId) ?? []).map((e) => e.bgId);
 }

--- a/packages/vue-lynx/main-thread/src/list-apply.ts
+++ b/packages/vue-lynx/main-thread/src/list-apply.ts
@@ -203,8 +203,7 @@ function createListCallbacks(bgId: number): {
     const items = listItems.get(bgId);
     if (!items) return;
     const elementIDs: number[] = [];
-    for (let j = 0; j < cellIndexes.length; j++) {
-      const cellIndex = cellIndexes[j]!;
+    for (const cellIndex of cellIndexes) {
       if (cellIndex < 0 || cellIndex >= items.length) {
         elementIDs.push(-1);
         continue;
@@ -275,7 +274,7 @@ export function insertListItem(
   parentId: number,
   child: LynxElement,
   childId: number,
-  anchorId: number = -1,
+  anchorId = -1,
 ): void {
   const items = listItems.get(parentId);
   if (!items) return;

--- a/packages/vue-lynx/main-thread/src/list-apply.ts
+++ b/packages/vue-lynx/main-thread/src/list-apply.ts
@@ -54,6 +54,12 @@ const listItemPlatformInfo = new Map<number, Record<string, unknown>>();
 /** How many items have already been reported via update-list-info per list */
 const listItemsReported = new Map<number, number>();
 
+/**
+ * Pending remove indices per list, expressed against the list state *before*
+ * this applyOps batch's removes (same convention as ReactLynx removeAction).
+ */
+const pendingRemoves = new Map<number, number[]>();
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
@@ -150,6 +156,7 @@ export function createListElement(id: number): LynxElement {
   listElementIds.add(id);
   listItems.set(id, []);
   listItemsReported.set(id, 0);
+  pendingRemoves.set(id, []);
   const cbs = createListCallbacks(id);
   const el = __CreateList(
     pageUniqueId,
@@ -172,6 +179,38 @@ export function insertListItem(
   if (items) items.push({ el: child, bgId: childId });
 }
 
+/**
+ * REMOVE case: drop a child from the list tracking array and queue a
+ * `removeAction` index. Without this, Reset / re-adding the same `item-key`
+ * appends duplicates and native list throws error 2202 (duplicated item-key).
+ */
+export function removeListItem(parentId: number, childId: number): void {
+  const items = listItems.get(parentId);
+  if (!items) return;
+  const idx = items.findIndex((entry) => entry.bgId === childId);
+  if (idx === -1) return;
+
+  const pending = pendingRemoves.get(parentId) ?? [];
+  // Convert current (post-prior-splices) index → pre-batch index.
+  let originalIdx = idx;
+  for (const r of pending) {
+    if (r <= originalIdx) originalIdx++;
+  }
+  pending.push(originalIdx);
+  pendingRemoves.set(parentId, pending);
+
+  items.splice(idx, 1);
+
+  const reported = listItemsReported.get(parentId) ?? 0;
+  if (idx < reported) {
+    listItemsReported.set(parentId, reported - 1);
+  }
+
+  // Drop platform-info bookkeeping for the removed BG id.
+  itemKeyMap.delete(childId);
+  listItemPlatformInfo.delete(childId);
+}
+
 /** SET_PROP case: store a platform-info attribute for a list item */
 export function setPlatformInfoProp(
   id: number,
@@ -188,14 +227,15 @@ export function setPlatformInfoProp(
 }
 
 /**
- * Post-ops flush: for any <list> elements with newly-inserted items, tell the
- * native list via the 'update-list-info' attribute. Only send items added since
- * the last applyOps call to avoid "duplicated item-key" errors.
+ * Post-ops flush: tell the native list about removes + newly-inserted items
+ * via `update-list-info`. Only newly pushed items (beyond `listItemsReported`)
+ * are sent as insertAction to avoid duplicated item-key errors.
  */
 export function flushListUpdates(): void {
   for (const [bgId, items] of listItems) {
+    const removes = pendingRemoves.get(bgId) ?? [];
     const reported = listItemsReported.get(bgId) ?? 0;
-    if (items.length <= reported) continue;
+    if (items.length <= reported && removes.length === 0) continue;
     const listEl = elements.get(bgId);
     if (!listEl) continue;
     const insertAction: Record<string, unknown>[] = [];
@@ -213,10 +253,11 @@ export function flushListUpdates(): void {
     }
     __SetAttribute(listEl, 'update-list-info', {
       insertAction,
-      removeAction: [],
+      removeAction: [...removes].sort((a, b) => a - b),
       updateAction: [],
     });
     listItemsReported.set(bgId, items.length);
+    pendingRemoves.set(bgId, []);
   }
 }
 
@@ -227,4 +268,5 @@ export function resetListState(): void {
   itemKeyMap.clear();
   listItemPlatformInfo.clear();
   listItemsReported.clear();
+  pendingRemoves.clear();
 }

--- a/packages/vue-lynx/main-thread/src/list-apply.ts
+++ b/packages/vue-lynx/main-thread/src/list-apply.ts
@@ -9,6 +9,11 @@
  * The native list calls componentAtIndex(list, listID, cellIndex, operationID)
  * when it needs to render an item. We collect items as they're inserted and
  * provide them via the callback.
+ *
+ * Diffs are flushed via `update-list-info` (insertAction / removeAction /
+ * updateAction). INSERT respects anchors (prepend / mid-list). Same-list
+ * moves detach then re-insert (like ReactLynx treating insert-before of an
+ * existing child as remove+insert).
  */
 
 import { elements, pageUniqueId } from './element-registry.js';
@@ -32,9 +37,9 @@ const itemKeyMap = new Map<number, string>();
 
 /**
  * Platform info attributes for list items — these must go ONLY into
- * update-list-info's insertAction, NOT via __SetAttribute on the native element.
- * Setting them both ways causes the native list to count items twice.
- * (Matches React Lynx's platformInfoAttributes in snapshot/platformInfo.ts)
+ * update-list-info's insertAction / updateAction, NOT via __SetAttribute on
+ * the native element. Setting them both ways causes the native list to count
+ * items twice. (Matches React Lynx's platformInfoAttributes.)
  */
 const PLATFORM_INFO_ATTRS = new Set([
   'item-key',
@@ -51,7 +56,7 @@ const PLATFORM_INFO_ATTRS = new Set([
 /** Per list-item bg ID -> platform info attributes (for update-list-info) */
 const listItemPlatformInfo = new Map<number, Record<string, unknown>>();
 
-/** How many items have already been reported via update-list-info per list */
+/** How many items native currently knows about (fully synced list length) */
 const listItemsReported = new Map<number, number>();
 
 /**
@@ -60,11 +65,23 @@ const listItemsReported = new Map<number, number>();
  */
 const pendingRemoves = new Map<number, number[]>();
 
+/** Pending inserts: position is the index in listItems *after* the splice. */
+const pendingInserts = new Map<
+  number,
+  Array<{ position: number; bgId: number }>
+>();
+
+/** Pending platform-info updates for items already known to native. */
+const pendingUpdates = new Map<
+  number,
+  Array<Record<string, unknown>>
+>();
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-/** No-op: Vue manages all items; no recycling needed. */
+/** No-op: element recycling is tracked separately (see GitHub issues). */
 // biome-ignore lint/suspicious/noEmptyBlockStatements: intentional no-op
 function enqueueComponentNoop(): void {}
 
@@ -137,6 +154,86 @@ function createListCallbacks(bgId: number): {
   return { componentAtIndex, enqueueComponent, componentAtIndexes };
 }
 
+/**
+ * Detach `childId` from the list tracking array and queue a removeAction.
+ * @returns the pre-batch remove index, or -1 if not found.
+ */
+function detachListItem(
+  parentId: number,
+  childId: number,
+  clearPlatformInfo: boolean,
+): number {
+  const items = listItems.get(parentId);
+  if (!items) return -1;
+  const idx = items.findIndex((entry) => entry.bgId === childId);
+  if (idx === -1) return -1;
+
+  const pending = pendingRemoves.get(parentId) ?? [];
+  // Convert current (post-prior-splices) index → pre-batch index.
+  let originalIdx = idx;
+  for (const r of pending) {
+    if (r <= originalIdx) originalIdx++;
+  }
+  pending.push(originalIdx);
+  pendingRemoves.set(parentId, pending);
+
+  // Drop any not-yet-flushed insert for this child (move / re-insert same batch).
+  const inserts = pendingInserts.get(parentId);
+  if (inserts) {
+    const filtered = inserts.filter((p) => p.bgId !== childId);
+    pendingInserts.set(parentId, filtered);
+  }
+
+  items.splice(idx, 1);
+
+  const reported = listItemsReported.get(parentId) ?? 0;
+  if (idx < reported) {
+    listItemsReported.set(parentId, reported - 1);
+  }
+
+  if (clearPlatformInfo) {
+    itemKeyMap.delete(childId);
+    listItemPlatformInfo.delete(childId);
+  }
+
+  return originalIdx;
+}
+
+function findListIdForItem(itemBgId: number): number | undefined {
+  for (const [listId, items] of listItems) {
+    if (items.some((e) => e.bgId === itemBgId)) return listId;
+  }
+  return undefined;
+}
+
+function queuePlatformUpdate(listId: number, itemBgId: number): void {
+  const items = listItems.get(listId);
+  if (!items) return;
+  const idx = items.findIndex((e) => e.bgId === itemBgId);
+  if (idx === -1) return;
+
+  // Still in this batch's insertAction — platform info merges there.
+  const inserts = pendingInserts.get(listId) ?? [];
+  if (inserts.some((p) => p.bgId === itemBgId)) return;
+
+  const pInfo = listItemPlatformInfo.get(itemBgId) ?? {};
+  const pending = pendingUpdates.get(listId) ?? [];
+  const existing = pending.findIndex((u) => u.from === idx);
+  const action: Record<string, unknown> = {
+    ...pInfo,
+    from: idx,
+    to: idx,
+    flush: false,
+    type: 'list-item',
+  };
+  if (existing >= 0) {
+    pending[existing] = action;
+  } else {
+    pending.push(action);
+  }
+  pendingUpdates.set(listId, pending);
+}
+
 // ---------------------------------------------------------------------------
 // Public API (called from ops-apply.ts switch cases)
 // ---------------------------------------------------------------------------
@@ -157,6 +254,8 @@ export function createListElement(id: number): LynxElement {
   listItems.set(id, []);
   listItemsReported.set(id, 0);
   pendingRemoves.set(id, []);
+  pendingInserts.set(id, []);
+  pendingUpdates.set(id, []);
   const cbs = createListCallbacks(id);
   const el = __CreateList(
     pageUniqueId,
@@ -169,14 +268,46 @@ export function createListElement(id: number): LynxElement {
   return el;
 }
 
-/** INSERT case: collect a child into a <list> parent's item array */
+/**
+ * INSERT case: place a child into the list array.
+ * `anchorId === -1` → append; otherwise insert before the anchor (prepend /
+ * mid-list). If the child is already in this list, treat as a move
+ * (detach + re-insert), matching ReactLynx's insertBefore-of-existing-child.
+ */
 export function insertListItem(
   parentId: number,
   child: LynxElement,
   childId: number,
+  anchorId: number = -1,
 ): void {
   const items = listItems.get(parentId);
-  if (items) items.push({ el: child, bgId: childId });
+  if (!items) return;
+
+  // Same-list move: Vue hostInsert does INSERT without REMOVE when the
+  // parent stays the same — detach first so we don't duplicate listItems.
+  if (items.some((e) => e.bgId === childId)) {
+    detachListItem(parentId, childId, false);
+  }
+
+  const entry: ListItemEntry = { el: child, bgId: childId };
+  let index: number;
+  if (anchorId === -1) {
+    index = items.length;
+    items.push(entry);
+  } else {
+    const anchorIdx = items.findIndex((e) => e.bgId === anchorId);
+    if (anchorIdx === -1) {
+      index = items.length;
+      items.push(entry);
+    } else {
+      index = anchorIdx;
+      items.splice(index, 0, entry);
+    }
+  }
+
+  const pending = pendingInserts.get(parentId) ?? [];
+  pending.push({ position: index, bgId: childId });
+  pendingInserts.set(parentId, pending);
 }
 
 /**
@@ -185,30 +316,7 @@ export function insertListItem(
  * appends duplicates and native list throws error 2202 (duplicated item-key).
  */
 export function removeListItem(parentId: number, childId: number): void {
-  const items = listItems.get(parentId);
-  if (!items) return;
-  const idx = items.findIndex((entry) => entry.bgId === childId);
-  if (idx === -1) return;
-
-  const pending = pendingRemoves.get(parentId) ?? [];
-  // Convert current (post-prior-splices) index → pre-batch index.
-  let originalIdx = idx;
-  for (const r of pending) {
-    if (r <= originalIdx) originalIdx++;
-  }
-  pending.push(originalIdx);
-  pendingRemoves.set(parentId, pending);
-
-  items.splice(idx, 1);
-
-  const reported = listItemsReported.get(parentId) ?? 0;
-  if (idx < reported) {
-    listItemsReported.set(parentId, reported - 1);
-  }
-
-  // Drop platform-info bookkeeping for the removed BG id.
-  itemKeyMap.delete(childId);
-  listItemPlatformInfo.delete(childId);
+  detachListItem(parentId, childId, true);
 }
 
 /** SET_PROP case: store a platform-info attribute for a list item */
@@ -224,40 +332,56 @@ export function setPlatformInfoProp(
     listItemPlatformInfo.set(id, { [key]: value });
   }
   if (key === 'item-key') itemKeyMap.set(id, String(value));
+
+  const listId = findListIdForItem(id);
+  if (listId !== undefined) {
+    queuePlatformUpdate(listId, id);
+  }
 }
 
 /**
- * Post-ops flush: tell the native list about removes + newly-inserted items
- * via `update-list-info`. Only newly pushed items (beyond `listItemsReported`)
- * are sent as insertAction to avoid duplicated item-key errors.
+ * Post-ops flush: tell the native list about removes / inserts / platform
+ * updates via `update-list-info`.
  */
 export function flushListUpdates(): void {
   for (const [bgId, items] of listItems) {
     const removes = pendingRemoves.get(bgId) ?? [];
-    const reported = listItemsReported.get(bgId) ?? 0;
-    if (items.length <= reported && removes.length === 0) continue;
+    const inserts = pendingInserts.get(bgId) ?? [];
+    const updates = pendingUpdates.get(bgId) ?? [];
+    if (
+      removes.length === 0
+      && inserts.length === 0
+      && updates.length === 0
+    ) {
+      continue;
+    }
     const listEl = elements.get(bgId);
     if (!listEl) continue;
-    const insertAction: Record<string, unknown>[] = [];
-    for (let j = reported; j < items.length; j++) {
-      const entry = items[j]!;
-      const action: Record<string, unknown> = {
-        position: j,
-        type: 'list-item',
-        'item-key': itemKeyMap.get(entry.bgId) ?? String(j),
-      };
-      // Merge any collected platform info attributes into the action
-      const pInfo = listItemPlatformInfo.get(entry.bgId);
-      if (pInfo) Object.assign(action, pInfo);
-      insertAction.push(action);
-    }
+
+    // Stable sort by position; equal positions keep record order (two prepends).
+    const insertAction = inserts
+      .slice()
+      .sort((a, b) => a.position - b.position)
+      .map(({ position, bgId: itemBgId }) => {
+        const action: Record<string, unknown> = {
+          position,
+          type: 'list-item',
+          'item-key': itemKeyMap.get(itemBgId) ?? String(position),
+        };
+        const pInfo = listItemPlatformInfo.get(itemBgId);
+        if (pInfo) Object.assign(action, pInfo);
+        return action;
+      });
+
     __SetAttribute(listEl, 'update-list-info', {
       insertAction,
       removeAction: [...removes].sort((a, b) => a - b),
-      updateAction: [],
+      updateAction: updates,
     });
     listItemsReported.set(bgId, items.length);
     pendingRemoves.set(bgId, []);
+    pendingInserts.set(bgId, []);
+    pendingUpdates.set(bgId, []);
   }
 }
 
@@ -269,4 +393,6 @@ export function resetListState(): void {
   listItemPlatformInfo.clear();
   listItemsReported.clear();
   pendingRemoves.clear();
+  pendingInserts.clear();
+  pendingUpdates.clear();
 }

--- a/packages/vue-lynx/main-thread/src/ops-apply.ts
+++ b/packages/vue-lynx/main-thread/src/ops-apply.ts
@@ -145,7 +145,7 @@ export function applyOps(ops: unknown[], flush = true): void {
         const child = elements.get(childId);
         if (parent && child) {
           if (isListParent(parentId)) {
-            insertListItem(parentId, child, childId);
+            insertListItem(parentId, child, childId, anchorId);
           } else if (anchorId === -1) {
             __AppendElement(parent, child);
           } else {

--- a/packages/vue-lynx/main-thread/src/ops-apply.ts
+++ b/packages/vue-lynx/main-thread/src/ops-apply.ts
@@ -24,6 +24,7 @@ import {
   insertListItem,
   isListParent,
   isPlatformInfoAttr,
+  removeListItem,
   resetListState,
   setPlatformInfoProp,
 } from './list-apply.js';
@@ -161,6 +162,11 @@ export function applyOps(ops: unknown[], flush = true): void {
         const parent = elements.get(parentId);
         const child = elements.get(childId);
         if (parent && child) {
+          if (isListParent(parentId)) {
+            // Keep listItems / update-list-info in sync — otherwise Reset
+            // re-inserts the same item-keys and native list errors 2202.
+            removeListItem(parentId, childId);
+          }
           __RemoveElement(parent, child);
         }
         break;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,10 +26,10 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.8))
+        version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
-        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+        version: 1.2.7(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.8(@swc/helpers@0.5.19))
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -421,6 +421,22 @@ importers:
         version: 1.2.7(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.8(@swc/helpers@0.5.19))
       typescript:
         specifier: ~5.9.3
+        version: 5.9.3
+
+  examples/scrolling:
+    dependencies:
+      vue-lynx:
+        specifier: workspace:*
+        version: link:../../packages/vue-lynx
+    devDependencies:
+      '@lynx-js/rspeedy':
+        specifier: ^0.13.5
+        version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.8))
+      '@rsbuild/plugin-vue':
+        specifier: ^1.2.6
+        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+      typescript:
+        specifier: ^5.0.0
         version: 5.9.3
 
   examples/slots:

--- a/website/docs/guide/elk.mdx
+++ b/website/docs/guide/elk.mdx
@@ -72,10 +72,9 @@ At the call site it's a straight swap. The hand-rolled tab bar and
   <view class="explore-tab" @tap="tab = 'posts'">…</view>
   <view class="explore-tab" @tap="tab = 'tags'">…</view>
 </view>
-<scroll-view v-if="tab === 'posts'">…</scroll-view>
-<scroll-view v-else-if="tab === 'tags'">…</scroll-view>
+<list v-if="tab === 'posts'" @scrolltolower="loadNext">…</list>
+<list v-else-if="tab === 'tags'" @scrolltolower="loadMoreTags">…</list>
 ```
-
 …become a component with one named slot per pane:
 
 ```vue
@@ -124,6 +123,75 @@ pane's list. Like the viewpager it's registered per platform — the legacy
 [`<scroll-coordinator>`](https://lynxjs.org/guide/ui/elements-components.html#xelement)
 on native OSS engines.
 
+## Native feed techniques
+
+A Mastodon client is mostly long lists: home, local, federated, explore,
+notifications, search, profile posts, followers. On the web Elk virtualizes
+with [`virtua`](https://github.com/inokawa/virtua) and triggers the next page
+from a DOM end-anchor's bounding box. Lynx gives you two scroll primitives —
+and which one you pick is the whole performance story.
+
+### `<scroll-view>` mounts everything
+
+[`<scroll-view>`](https://lynxjs.org/api/elements/built-in/scroll-view) is the
+right tool for **short, heterogeneous** screens: Settings, Compose, a status
+thread, a media sheet. Every child stays mounted; you scroll a normal layout
+tree. That is also why it is the **wrong** tool for a timeline — once the
+federated feed grows past a few dozen statuses, you are paying for every card
+above and below the viewport.
+
+### `<list>` recycles and paginates
+
+[`<list>`](https://lynxjs.org/api/elements/built-in/list) is Lynx's recycling
+scroller. Off-screen `<list-item>` cells are reused; you only keep a window of
+real nodes alive. Infinite scroll is a native event, not a geometry poll:
+
+```vue
+<list
+  scroll-orientation="vertical"
+  :lower-threshold-item-count="4"
+  @scrolltolower="loadNext"
+>
+  <list-item
+    v-for="status in items"
+    :key="status.id"
+    :item-key="status.id"
+    :estimated-main-axis-size-px="160"
+  >
+    <StatusCard :status="status" />
+  </list-item>
+</list>
+```
+
+Three attributes do the heavy lifting:
+
+| Piece | Role |
+|-------|------|
+| `estimated-main-axis-size-px` | Lets the list lay out the scroll range before each cell measures |
+| `lower-threshold-item-count` | How many items from the end before we ask for more |
+| `@scrolltolower` | Fires `usePaginator.loadNext()` — Elk's masto.js `Paginator` iteration, unchanged |
+
+[`TimelinePaginator.vue`](https://github.com/huxpro/vue-lynx/blob/main/examples/elk/src/components/TimelinePaginator.vue)
+is the shared feed shell: first paint, error/retry, the recycling list, and a
+footer spinner / "End of the timeline". Timelines, Explore posts, hashtag
+pages, bookmarks/favourites, and profile Posts / Replies / Media all reuse it.
+Explore tags/news, notifications, followers, and search wire the same
+`<list>` + `scrolltolower` pattern to their own item templates.
+
+`<scroll-view>` still appears where recycling would not help — thread detail,
+settings forms, the compose sheet. The rule of thumb the port settled on:
+**if it can grow without bound, it is a `<list>`; if it is a finite page, keep
+`<scroll-view>`.**
+
+<Go
+  example="elk"
+  defaultFile="src/components/TimelinePaginator.vue"
+  schema="{{{url}}}?fullscreen=true&bar_color=fafafa&bg_color=fafafa"
+  highlight={{
+    'src/components/TimelinePaginator.vue': '{21-26,39-59}',
+  }}
+/>
+
 ## Why Elk is a serious test
 
 Elk is a Nuxt 3 app with ~196 components, 55 pages and 50 composables.
@@ -158,9 +226,10 @@ and side-by-side screenshot comparisons against the original elk.zone in
   keeps the parse step byte-for-byte and only swaps the vnode targets —
   custom emoji become inline `<image>`, mentions/hashtags become tappable
   `<text>` runs that push vue-router routes.
-- **Native virtualized timeline**: the infinite timeline is a Lynx
-  `<list>` with `estimated-main-axis-size-px` hints; masto.js `Paginator`
-  iteration and Elk's reorder/buffer logic drive it unchanged.
+- **Native virtualized timeline**: feeds use Lynx `<list>` with
+  `estimated-main-axis-size-px` and `@scrolltolower` (not `<scroll-view>`);
+  masto.js `Paginator` iteration and Elk's reorder/buffer logic drive
+  `loadNext()` unchanged across timelines, explore, profiles, and search.
 - **Deep links**: pass `globalProps: { initialPath: '/mas.to/tags/caturday' }`
   to the LynxView and the app opens on that route — the same mechanism a
   host app would use for notification taps.

--- a/website/docs/guide/scroll-view-vs-list.mdx
+++ b/website/docs/guide/scroll-view-vs-list.mdx
@@ -210,8 +210,8 @@ export function useInfiniteFeed(pageSize = 20) {
 
 This is the same shape as Elk's `TimelinePaginator`: masto.js pagination in a composable, `<list>` for the viewport.
 
-:::warning Confirmed gap: prepend
-Vue Lynx's Main Thread list adapter always `push`es into `listItems` and ignores the INSERT anchor. **Prepending** (unshift / insert-before) is reported as a **tail** insert — see `ListPrepend`. Append-only feeds (`@scrolltolower`) stay on the supported path. **Remove** now emits `removeAction` (Reset-with-same-keys used to 2202). Reorder still needs a careful visual check (`ListReorder`).
+:::tip List diffs
+Vue Lynx's Main Thread list adapter now flushes `insertAction` / `removeAction` / `updateAction` for common mutations: append, prepend, mid-list insert, remove, same-list reorder (move), and platform-info updates. Append-only feeds (`@scrolltolower`) remain the simplest path. Still open: framework-side cell recycling and refreshing `__UpdateListCallbacks` each flush — see the tracking issues linked below.
 :::
 
 ### 4. Prefer `list` over third-party virtual scrollers
@@ -228,18 +228,18 @@ Recycling is a **native** concern; composition stays a **Vue** concern. Put pres
 </list-item>
 ```
 
-## Mutation stress / smoke tests
+## Mutation demos
 
 | Entry | Mutation | Status |
 |---|---|---|
-| `ListPrepend` | unshift vs append | **Confirmed gap** — new cell lands at the tail |
-| `ListReorder` | Yellow→top / reverse | Check carefully — Vue-truth color strip vs `<list>` |
-| `ListRemove` | splice + **Reset same keys** | Was 2202 on Reset; REMOVE now emits `removeAction` |
-| `ListFilter` | even-only toggle | Smoke — OK in practice |
+| `ListPrepend` | unshift vs append | Fixed — INSERT respects anchor |
+| `ListReorder` | Yellow→top / reverse | Fixed — same-list move = detach + insert |
+| `ListRemove` | splice + Reset same keys | Fixed — `removeAction` (was 2202) |
+| `ListFilter` | even-only toggle | OK |
 
-### Confirmed: prepend
+### Prepend
 
-Tap **Prepend** once. The TOP list cell must turn red (`NEW …`). If the red card appears at the bottom, the adapter ignored the insert-before anchor. **Append** is the control that should work.
+Tap **Prepend** once. The TOP list cell must turn red (`NEW …`). **Append** lands at the bottom.
 
 <Go
   example="scrolling"
@@ -248,9 +248,9 @@ Tap **Prepend** once. The TOP list cell must turn red (`NEW …`). If the red ca
   defaultEntryName="ListPrepend"
 />
 
-### Check carefully: reorder
+### Reorder
 
-Four full-bleed colors. The top strip is plain `<view>`s (Vue truth). The `<list>` below must show the **same left→right / top→bottom order** after **Yellow → top** or **Reverse**. A mismatch is a list move bug.
+Four full-bleed colors. The top strip is plain `<view>`s (Vue truth). The `<list>` below must show the **same order** after **Yellow → top** or **Reverse**.
 
 <Go
   example="scrolling"
@@ -259,9 +259,9 @@ Four full-bleed colors. The top strip is plain `<view>`s (Vue truth). The `<list
   defaultEntryName="ListReorder"
 />
 
-### Smoke: remove + filter
+### Remove + filter
 
-**Remove**: delete rows, then tap **Reset same keys**. That rebuilds `Row-1…N` with identical `item-key`s. A duplicated item-key toast (error 2202) meant the adapter never emitted `removeAction` — an impl bug, not a flaky demo. Filter toggle is kept as a lighter regression tap.
+**Remove**: delete rows, then **Reset same keys** — must not toast duplicated item-key (2202). Filter toggle is a lighter regression tap.
 
 <Go
   example="scrolling"
@@ -277,7 +277,12 @@ Four full-bleed colors. The top strip is plain `<view>`s (Vue truth). The `<list
   defaultEntryName="ListFilter"
 />
 
-Automated coverage: `packages/testing-library` → **native list element · mutation gaps**. Prepend stays `it.fails` on the correct `position: 0` payload; remove/filter are smoke assertions on Vue length.
+### Still open
+
+- Framework-side cell recycling (`enqueueComponent` / recycle pool) — [#302](https://github.com/Huxpro/vue-lynx/issues/302)
+- Refreshing `__UpdateListCallbacks` on every list flush — [#303](https://github.com/Huxpro/vue-lynx/issues/303)
+
+Automated coverage: `packages/testing-library` → **native list element · mutations**.
 
 ## Decision checklist
 
@@ -286,7 +291,7 @@ Automated coverage: `packages/testing-library` → **native list element · muta
 3. Do you need waterfall or multi-column flow? → **`<list list-type="…">`**
 4. Will the dataset grow without bound? → **`<list>` + composable + `@scrolltolower`**
 5. Did you set matching `:key` / `:item-key`? → required for correct recycling
-6. Do you need **prepend**? → broken today — prefer append / rebuild until the adapter respects INSERT anchors
+6. Prepend / reorder / remove? → supported via `update-list-info` diffs
 
 ## See also
 

--- a/website/docs/guide/scroll-view-vs-list.mdx
+++ b/website/docs/guide/scroll-view-vs-list.mdx
@@ -211,7 +211,7 @@ export function useInfiniteFeed(pageSize = 20) {
 This is the same shape as Elk's `TimelinePaginator`: masto.js pagination in a composable, `<list>` for the viewport.
 
 :::warning Confirmed gap: prepend
-Vue Lynx's Main Thread list adapter always `push`es into `listItems` and ignores the INSERT anchor. **Prepending** (unshift / insert-before) is reported as a **tail** insert — see `ListPrepend`. Append-only feeds (`@scrolltolower`) stay on the supported path. Remove / filter have looked fine on device despite empty `removeAction`; reorder needs a careful visual check (`ListReorder`).
+Vue Lynx's Main Thread list adapter always `push`es into `listItems` and ignores the INSERT anchor. **Prepending** (unshift / insert-before) is reported as a **tail** insert — see `ListPrepend`. Append-only feeds (`@scrolltolower`) stay on the supported path. **Remove** now emits `removeAction` (Reset-with-same-keys used to 2202). Reorder still needs a careful visual check (`ListReorder`).
 :::
 
 ### 4. Prefer `list` over third-party virtual scrollers
@@ -234,7 +234,7 @@ Recycling is a **native** concern; composition stays a **Vue** concern. Put pres
 |---|---|---|
 | `ListPrepend` | unshift vs append | **Confirmed gap** — new cell lands at the tail |
 | `ListReorder` | Yellow→top / reverse | Check carefully — Vue-truth color strip vs `<list>` |
-| `ListRemove` | splice middle / pop | Smoke — OK in practice |
+| `ListRemove` | splice + **Reset same keys** | Was 2202 on Reset; REMOVE now emits `removeAction` |
 | `ListFilter` | even-only toggle | Smoke — OK in practice |
 
 ### Confirmed: prepend
@@ -261,7 +261,7 @@ Four full-bleed colors. The top strip is plain `<view>`s (Vue truth). The `<list
 
 ### Smoke: remove + filter
 
-These have looked correct on device; kept as regression taps.
+**Remove**: delete rows, then tap **Reset same keys**. That rebuilds `Row-1…N` with identical `item-key`s. A duplicated item-key toast (error 2202) meant the adapter never emitted `removeAction` — an impl bug, not a flaky demo. Filter toggle is kept as a lighter regression tap.
 
 <Go
   example="scrolling"

--- a/website/docs/guide/scroll-view-vs-list.mdx
+++ b/website/docs/guide/scroll-view-vs-list.mdx
@@ -211,7 +211,7 @@ export function useInfiniteFeed(pageSize = 20) {
 This is the same shape as Elk's `TimelinePaginator`: masto.js pagination in a composable, `<list>` for the viewport.
 
 :::tip List diffs
-Vue Lynx's Main Thread list adapter now flushes `insertAction` / `removeAction` / `updateAction` for common mutations: append, prepend, mid-list insert, remove, same-list reorder (move), and platform-info updates. Append-only feeds (`@scrolltolower`) remain the simplest path. Still open: framework-side cell recycling and refreshing `__UpdateListCallbacks` each flush — see the tracking issues linked below.
+Vue Lynx's Main Thread list adapter flushes `insertAction` / `removeAction` / `updateAction` by diffing the last-flushed snapshot against the live `listItems` array (LIS move detection, same idea as ReactLynx's remove+insert moves). Covers append, prepend, mid-list insert, remove, same-list reorder, and platform-info updates. Still open: framework-side cell recycling and refreshing `__UpdateListCallbacks` each flush — [#302](https://github.com/Huxpro/vue-lynx/issues/302), [#303](https://github.com/Huxpro/vue-lynx/issues/303).
 :::
 
 ### 4. Prefer `list` over third-party virtual scrollers

--- a/website/docs/guide/scroll-view-vs-list.mdx
+++ b/website/docs/guide/scroll-view-vs-list.mdx
@@ -1,0 +1,242 @@
+# scroll-view vs list
+
+Lynx does not scroll arbitrary nodes the way the Web does. When content overflows a viewport you pick an explicit scroll container — almost always [`<scroll-view>`](https://lynxjs.org/api/elements/built-in/scroll-view) or [`<list>`](https://lynxjs.org/api/elements/built-in/list). This guide explains how Lynx documents the difference, how that differs from Web Vue, and the Vue Lynx patterns that fall out of those choices.
+
+For the platform reference, see [Managing Scrolling](https://lynxjs.org/guide/ui/scrolling) on lynxjs.org.
+
+## Lynx vs Web
+
+On the Web, almost any element can become a scrollport:
+
+```html
+<div style="overflow: auto; height: 100vh">
+  <!-- anything -->
+</div>
+```
+
+On Lynx, a plain `<view>` **does not** gain scrolling from `overflow: scroll` / `overflow: auto`. Only dedicated containers such as `<scroll-view>` and `<list>` scroll. That is the first design shift when you move a Vue app from DOM to Lynx: scrolling becomes a **structural** decision in the template, not a CSS property you sprinkle later.
+
+| | Web (Vue) | Lynx (Vue Lynx) |
+|---|---|---|
+| How scrolling starts | `overflow` on any node | Dedicated `<scroll-view>` / `<list>` |
+| Virtualization | Optional library (`vue-virtual-scroller`, Virtua, …) | Built into `<list>` |
+| Large feeds | You own windowing + recycled DOM | Native recycling + lazy create |
+| Complex grids | CSS Grid / masonry libs | `<list list-type="flow\|waterfall">` |
+
+Vue Lynx keeps Composition API, `v-for`, and SFCs — but your scroll trees look different from a typical Nuxt / Vite SPA.
+
+## What lynxjs.org says
+
+Lynx's scrolling guide draws a clean line between the two containers:
+
+1. **`<scroll-view>` for basic scrolling** — a fixed viewport; when children exceed it, set `scroll-orientation` to `vertical` or `horizontal`.
+2. **`<list>` for large / infinite data** — on-demand creation of visible items only.
+3. **`<list>` for complex layouts** — `scroll-view` is linear only; `list` adds `single`, `flow`, and `waterfall`.
+
+The [`<scroll-view>` API](https://lynxjs.org/api/elements/built-in/scroll-view) also warns:
+
+- Every child is created up front (can hurt first paint).
+- There is **no reuse**; too much content can exhaust memory.
+- Prefer `<list>` once content exceeds roughly **three screens**, or fake recycling with exposure events.
+
+Think of `<scroll-view>` as “a short page that happens to scroll,” and `<list>` as “a recycling feed.”
+
+## Choose with a table
+
+| Question | Prefer `<scroll-view>` | Prefer `<list>` |
+|---|---|---|
+| How much content? | A few screens or less | Many screens / unbounded |
+| Layout | Linear stack | Single / grid (`flow`) / waterfall |
+| Item shape | Mixed sections, sticky chrome | Homogeneous (or mostly) cells |
+| Memory | Eager, all children live | Recycled + lazy |
+| Infinite load | Possible, but risky | Native `@scrolltolower` |
+
+Rule of thumb from Lynx: **under ~3 screens → `scroll-view`; beyond that → `list`.**
+
+## `<scroll-view>` in Vue
+
+Use ordinary Vue children — `v-for`, nested SFCs, sticky siblings. Nothing special is required beyond wrapping them in `<scroll-view>`.
+
+<Go
+  example="scrolling"
+  defaultFile="src/ScrollViewBasic/App.vue"
+  entry="src/ScrollViewBasic"
+  defaultEntryName="ScrollViewBasic"
+/>
+
+```vue
+<scroll-view scroll-orientation="vertical">
+  <view class="header">…</view>
+  <view v-for="card in cards" :key="card.id" class="card">
+    <text>{{ card.title }}</text>
+  </view>
+</scroll-view>
+```
+
+Good fits: settings screens, forms, article bodies, short result pages (see also the [Vue Query](/guide/data-fetching) and [TodoMVC](/guide/todomvc) examples).
+
+:::tip Nested layout tip
+Direct children of `<scroll-view>` only support linear / sticky layout. For richer CSS inside the scrollport, wrap content in a single child `<view>` and style that subtree — as recommended in the [scroll-view docs](https://lynxjs.org/api/elements/built-in/scroll-view).
+:::
+
+## `<list>` in Vue
+
+`<list>` expects **`<list-item>` children**. Each item needs:
+
+- Vue's `:key` — reconciliation identity for the VNode tree
+- Lynx's `:item-key` — identity for the native recycler (keep them equal)
+
+Missing or colliding keys is a common cause of blank / wrong cells.
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListBasic/App.vue"
+  entry="src/ListBasic"
+  defaultEntryName="ListBasic"
+/>
+
+```vue
+<list list-type="single" scroll-orientation="vertical">
+  <list-item
+    v-for="card in cards"
+    :key="card.id"
+    :item-key="card.id"
+    :estimated-main-axis-size-px="96"
+  >
+    <view class="card">…</view>
+  </list-item>
+</list>
+```
+
+`estimated-main-axis-size-px` helps the engine size the scrollbar and jump before a cell has been measured — the [gallery tutorial](/guide/tutorial-gallery) relies on the same hint for waterfall images.
+
+### Waterfall / flow layouts
+
+This is the other half of the lynxjs.org distinction: `scroll-view` cannot do multi-column masonry; `list` can.
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListWaterfall/App.vue"
+  entry="src/ListWaterfall"
+  defaultEntryName="ListWaterfall"
+/>
+
+```vue
+<list list-type="waterfall" :span-count="2" scroll-orientation="vertical">
+  <list-item
+    v-for="tile in tiles"
+    :key="tile.id"
+    :item-key="tile.id"
+    :estimated-main-axis-size-px="tile.height"
+  >
+    <view class="tile" :style="{ height: `${tile.height}px` }" />
+  </list-item>
+</list>
+```
+
+Each `list-item` can host a full Vue SFC — the gallery tutorial's `LikeImageCard` is the same pattern at product scale.
+
+## Vue design patterns that fall out of this
+
+Moving from Web Vue to Vue Lynx does not change reactivity — it changes **where** you put scrolling and **who** owns recycling.
+
+### 1. Explicit containers in the template
+
+Stop reaching for `overflow: auto` on a root `<view>`. Decide up front:
+
+```vue
+<!-- short, mixed page -->
+<scroll-view scroll-orientation="vertical">…</scroll-view>
+
+<!-- long homogeneous feed -->
+<list list-type="single" scroll-orientation="vertical">…</list>
+```
+
+That structural choice is the Lynx equivalent of picking a layout library on the Web.
+
+### 2. Dual identity: `:key` + `:item-key`
+
+Web `v-for` only needs `:key`. Lynx lists need both. Treat them as one stable business id:
+
+```vue
+<list-item
+  v-for="status in items"
+  :key="status.id"
+  :item-key="status.id"
+/>
+```
+
+The [Elk](/guide/elk) port follows exactly this contract for Mastodon statuses.
+
+### 3. Composable owns pages; `<list>` owns recycling
+
+On the Web, infinite feeds usually mean:
+
+`useInfiniteQuery` / custom composable **+** a virtualizer **+** an intersection sentinel.
+
+On Lynx, drop the virtualizer. A composable appends to a `ref` array; `@scrolltolower` (and `lower-threshold-item-count`) asks for the next page. Native recycling keeps memory flat.
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListInfinite/App.vue"
+  entry="src/ListInfinite"
+  defaultEntryName="ListInfinite"
+/>
+
+```ts
+// shared/useInfiniteFeed.ts
+export function useInfiniteFeed(pageSize = 20) {
+  const items = ref(makeCards(pageSize))
+  const loading = ref(false)
+  // loadMore() appends another page…
+  return { items, loading, loadMore }
+}
+```
+
+```vue
+<list
+  :lower-threshold-item-count="3"
+  @scrolltolower="loadMore"
+>
+  <list-item
+    v-for="item in items"
+    :key="item.id"
+    :item-key="item.id"
+  >
+    …
+  </list-item>
+</list>
+```
+
+This is the same shape as Elk's `TimelinePaginator`: masto.js pagination in a composable, `<list>` for the viewport.
+
+### 4. Prefer `list` over third-party virtual scrollers
+
+Libraries that measure DOM nodes (`getBoundingClientRect`, absolute positioning of windows) do not map cleanly onto Lynx's dual-thread + native elements model. Prefer the built-in recycler unless you have a rare layout `<list>` cannot express.
+
+### 5. Keep cells as Vue components
+
+Recycling is a **native** concern; composition stays a **Vue** concern. Put presentational SFCs inside `list-item` — do not flatten everything into one mega-template just because the parent is a list.
+
+```vue
+<list-item :key="pic.id" :item-key="pic.id">
+  <LikeImageCard :picture="pic" />
+</list-item>
+```
+
+## Decision checklist
+
+1. Is the page mostly one linear document under ~3 screens? → **`<scroll-view>`**
+2. Are you rendering dozens / hundreds of similar rows? → **`<list>`**
+3. Do you need waterfall or multi-column flow? → **`<list list-type="…">`**
+4. Will the dataset grow without bound? → **`<list>` + composable + `@scrolltolower`**
+5. Did you set matching `:key` / `:item-key`? → required for correct recycling
+
+## See also
+
+- [Managing Scrolling (Lynx)](https://lynxjs.org/guide/ui/scrolling)
+- [`<scroll-view>` API](https://lynxjs.org/api/elements/built-in/scroll-view)
+- [`<list>` API](https://lynxjs.org/api/elements/built-in/list)
+- [Tutorial: Product Gallery](/guide/tutorial-gallery) — waterfall `<list>` in a full app
+- [Elk (Mastodon Client)](/guide/elk) — replacing Virtua with native `<list>`
+- [Main Thread Script](/guide/main-thread-script) — scroll-linked worklets on `<scroll-view>` / `<list>`

--- a/website/docs/guide/scroll-view-vs-list.mdx
+++ b/website/docs/guide/scroll-view-vs-list.mdx
@@ -210,8 +210,8 @@ export function useInfiniteFeed(pageSize = 20) {
 
 This is the same shape as Elk's `TimelinePaginator`: masto.js pagination in a composable, `<list>` for the viewport.
 
-:::warning Append-only updates today
-Vue Lynx's Main Thread list adapter currently reports **new inserts only** (`removeAction` / `updateAction` are empty). Infinite append via `@scrolltolower` matches that path. Deletes, prepends, reorders, and filters need the stress examples below until full `ListUpdateInfoRecording`-style diffs land.
+:::warning Confirmed gap: prepend
+Vue Lynx's Main Thread list adapter always `push`es into `listItems` and ignores the INSERT anchor. **Prepending** (unshift / insert-before) is reported as a **tail** insert — see `ListPrepend`. Append-only feeds (`@scrolltolower`) stay on the supported path. Remove / filter have looked fine on device despite empty `removeAction`; reorder needs a careful visual check (`ListReorder`).
 :::
 
 ### 4. Prefer `list` over third-party virtual scrollers
@@ -228,16 +228,40 @@ Recycling is a **native** concern; composition stays a **Vue** concern. Put pres
 </list-item>
 ```
 
-## Known gaps — mutation stress tests
+## Mutation stress / smoke tests
 
-These four entries are intentional **breakage demos** for the incomplete list diff. Tap the toolbar, then compare the orange Vue banner with what native `<list>` still paints. When the MT adapter gains full `insertAction` / `removeAction` / `updateAction` diffs (ReactLynx's `ListUpdateInfoRecording`), they should start looking correct.
-
-| Entry | Mutation | What goes wrong today |
+| Entry | Mutation | Status |
 |---|---|---|
-| `ListRemove` | splice middle / pop tail | no `removeAction` → ghost rows / stale count |
-| `ListPrepend` | unshift vs append | INSERT ignores anchor → prepend reported as tail |
-| `ListReorder` | reverse / rotate | move = remove+insert without remove → wrong order |
-| `ListFilter` | toggle even-only | filter+restore → ghosts / duplicated `item-key` |
+| `ListPrepend` | unshift vs append | **Confirmed gap** — new cell lands at the tail |
+| `ListReorder` | Yellow→top / reverse | Check carefully — Vue-truth color strip vs `<list>` |
+| `ListRemove` | splice middle / pop | Smoke — OK in practice |
+| `ListFilter` | even-only toggle | Smoke — OK in practice |
+
+### Confirmed: prepend
+
+Tap **Prepend** once. The TOP list cell must turn red (`NEW …`). If the red card appears at the bottom, the adapter ignored the insert-before anchor. **Append** is the control that should work.
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListPrepend/App.vue"
+  entry="src/ListPrepend"
+  defaultEntryName="ListPrepend"
+/>
+
+### Check carefully: reorder
+
+Four full-bleed colors. The top strip is plain `<view>`s (Vue truth). The `<list>` below must show the **same left→right / top→bottom order** after **Yellow → top** or **Reverse**. A mismatch is a list move bug.
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListReorder/App.vue"
+  entry="src/ListReorder"
+  defaultEntryName="ListReorder"
+/>
+
+### Smoke: remove + filter
+
+These have looked correct on device; kept as regression taps.
 
 <Go
   example="scrolling"
@@ -248,26 +272,12 @@ These four entries are intentional **breakage demos** for the incomplete list di
 
 <Go
   example="scrolling"
-  defaultFile="src/ListPrepend/App.vue"
-  entry="src/ListPrepend"
-  defaultEntryName="ListPrepend"
-/>
-
-<Go
-  example="scrolling"
-  defaultFile="src/ListReorder/App.vue"
-  entry="src/ListReorder"
-  defaultEntryName="ListReorder"
-/>
-
-<Go
-  example="scrolling"
   defaultFile="src/ListFilter/App.vue"
   entry="src/ListFilter"
   defaultEntryName="ListFilter"
 />
 
-Matching automated coverage lives in `packages/testing-library` as `it.fails` cases under **native list element · mutation gaps** — they assert the *correct* `update-list-info` payloads and will flip to passing once the adapter is fixed.
+Automated coverage: `packages/testing-library` → **native list element · mutation gaps**. Prepend stays `it.fails` on the correct `position: 0` payload; remove/filter are smoke assertions on Vue length.
 
 ## Decision checklist
 
@@ -276,7 +286,7 @@ Matching automated coverage lives in `packages/testing-library` as `it.fails` ca
 3. Do you need waterfall or multi-column flow? → **`<list list-type="…">`**
 4. Will the dataset grow without bound? → **`<list>` + composable + `@scrolltolower`**
 5. Did you set matching `:key` / `:item-key`? → required for correct recycling
-6. Do you need delete / prepend / reorder / filter? → stress-test first; prefer append-only feeds until list diffs are complete
+6. Do you need **prepend**? → broken today — prefer append / rebuild until the adapter respects INSERT anchors
 
 ## See also
 

--- a/website/docs/guide/scroll-view-vs-list.mdx
+++ b/website/docs/guide/scroll-view-vs-list.mdx
@@ -210,6 +210,10 @@ export function useInfiniteFeed(pageSize = 20) {
 
 This is the same shape as Elk's `TimelinePaginator`: masto.js pagination in a composable, `<list>` for the viewport.
 
+:::warning Append-only updates today
+Vue Lynx's Main Thread list adapter currently reports **new inserts only** (`removeAction` / `updateAction` are empty). Infinite append via `@scrolltolower` matches that path. Deletes, prepends, reorders, and filters need the stress examples below until full `ListUpdateInfoRecording`-style diffs land.
+:::
+
 ### 4. Prefer `list` over third-party virtual scrollers
 
 Libraries that measure DOM nodes (`getBoundingClientRect`, absolute positioning of windows) do not map cleanly onto Lynx's dual-thread + native elements model. Prefer the built-in recycler unless you have a rare layout `<list>` cannot express.
@@ -224,6 +228,47 @@ Recycling is a **native** concern; composition stays a **Vue** concern. Put pres
 </list-item>
 ```
 
+## Known gaps — mutation stress tests
+
+These four entries are intentional **breakage demos** for the incomplete list diff. Tap the toolbar, then compare the orange Vue banner with what native `<list>` still paints. When the MT adapter gains full `insertAction` / `removeAction` / `updateAction` diffs (ReactLynx's `ListUpdateInfoRecording`), they should start looking correct.
+
+| Entry | Mutation | What goes wrong today |
+|---|---|---|
+| `ListRemove` | splice middle / pop tail | no `removeAction` → ghost rows / stale count |
+| `ListPrepend` | unshift vs append | INSERT ignores anchor → prepend reported as tail |
+| `ListReorder` | reverse / rotate | move = remove+insert without remove → wrong order |
+| `ListFilter` | toggle even-only | filter+restore → ghosts / duplicated `item-key` |
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListRemove/App.vue"
+  entry="src/ListRemove"
+  defaultEntryName="ListRemove"
+/>
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListPrepend/App.vue"
+  entry="src/ListPrepend"
+  defaultEntryName="ListPrepend"
+/>
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListReorder/App.vue"
+  entry="src/ListReorder"
+  defaultEntryName="ListReorder"
+/>
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListFilter/App.vue"
+  entry="src/ListFilter"
+  defaultEntryName="ListFilter"
+/>
+
+Matching automated coverage lives in `packages/testing-library` as `it.fails` cases under **native list element · mutation gaps** — they assert the *correct* `update-list-info` payloads and will flip to passing once the adapter is fixed.
+
 ## Decision checklist
 
 1. Is the page mostly one linear document under ~3 screens? → **`<scroll-view>`**
@@ -231,6 +276,7 @@ Recycling is a **native** concern; composition stays a **Vue** concern. Put pres
 3. Do you need waterfall or multi-column flow? → **`<list list-type="…">`**
 4. Will the dataset grow without bound? → **`<list>` + composable + `@scrolltolower`**
 5. Did you set matching `:key` / `:item-key`? → required for correct recycling
+6. Do you need delete / prepend / reorder / filter? → stress-test first; prefer append-only feeds until list diffs are complete
 
 ## See also
 

--- a/website/docs/zh/guide/elk.mdx
+++ b/website/docs/zh/guide/elk.mdx
@@ -69,10 +69,9 @@ pager 元件。
   <view class="explore-tab" @tap="tab = 'posts'">…</view>
   <view class="explore-tab" @tap="tab = 'tags'">…</view>
 </view>
-<scroll-view v-if="tab === 'posts'">…</scroll-view>
-<scroll-view v-else-if="tab === 'tags'">…</scroll-view>
+<list v-if="tab === 'posts'" @scrolltolower="loadNext">…</list>
+<list v-else-if="tab === 'tags'" @scrolltolower="loadMoreTags">…</list>
 ```
-
 ……换成一个「每个面板一个具名 slot」的组件：
 
 ```vue
@@ -117,6 +116,57 @@ pager ↔ 标签双向同步，统统搬进 `TabPager`。
 原生 OSS 引擎用抽取出来的
 [`<scroll-coordinator>`](https://lynxjs.org/guide/ui/elements-components.html#xelement)。
 
+## 原生 Feed 技巧
+
+Mastodon 客户端几乎全是长列表：主页、本地、联邦、探索、通知、搜索、个人帖子、关注者。Web 版 Elk 用 [`virtua`](https://github.com/inokawa/virtua) 做虚拟列表，再用 DOM 末端锚点的 bounding box 触发下一页。Lynx 提供两种滚动原语——选哪一个，就是整段性能故事。
+
+### `<scroll-view>` 会挂载全部子节点
+
+[`<scroll-view>`](https://lynxjs.org/zh/api/elements/built-in/scroll-view) 适合**短而异构**的页面：设置、发帖、帖子详情、媒体 sheet。每个子节点都会挂载，你滚的是普通布局树。这也是它**不适合**时间线的原因——联邦时间线一旦超过几十条嘟文，视口上下每一张卡片都在付账。
+
+### `<list>` 负责复用与分页
+
+[`<list>`](https://lynxjs.org/zh/api/elements/built-in/list) 是 Lynx 的复用型滚动器。离屏的 `<list-item>` 单元格会被回收；你只保留一扇真实节点窗口。无限滚动是原生事件，不是几何轮询：
+
+```vue
+<list
+  scroll-orientation="vertical"
+  :lower-threshold-item-count="4"
+  @scrolltolower="loadNext"
+>
+  <list-item
+    v-for="status in items"
+    :key="status.id"
+    :item-key="status.id"
+    :estimated-main-axis-size-px="160"
+  >
+    <StatusCard :status="status" />
+  </list-item>
+</list>
+```
+
+三个属性扛起重活：
+
+| 部件 | 作用 |
+|------|------|
+| `estimated-main-axis-size-px` | 在每个单元格实测之前，先估出可滚动范围 |
+| `lower-threshold-item-count` | 距末尾还有多少项时开始请求下一页 |
+| `@scrolltolower` | 触发 `usePaginator.loadNext()` —— Elk 的 masto.js `Paginator` 迭代逻辑原样保留 |
+
+[`TimelinePaginator.vue`](https://github.com/huxpro/vue-lynx/blob/main/examples/elk/src/components/TimelinePaginator.vue)
+是共享的 feed 外壳：首屏、错误重试、复用型列表，以及页脚 spinner / 「时间线到底了」。时间线、Explore 帖子、话题页、书签/收藏，以及个人主页的 Posts / Replies / Media 都复用它。Explore 标签/新闻、通知、关注者、搜索则把同一套 `<list>` + `scrolltolower` 接到各自的条目模板上。
+
+`<scroll-view>` 仍用在复用帮不上忙的地方——帖子详情、设置表单、发帖 sheet。移植最终定下的经验法则是：**会无限变长的用 `<list>`；有限页面继续用 `<scroll-view>`。**
+
+<Go
+  example="elk"
+  defaultFile="src/components/TimelinePaginator.vue"
+  schema="{{{url}}}?fullscreen=true&bar_color=fafafa&bg_color=fafafa"
+  highlight={{
+    'src/components/TimelinePaginator.vue': '{21-26,39-59}',
+  }}
+/>
+
 ## 为什么 Elk 是一块试金石
 
 Elk 是一个约 196 个组件、55 个页面、50 个 composable 的 Nuxt 3 应用。
@@ -148,8 +198,7 @@ PWA、Shiki、blurhash 等）见
 - **内容渲染器是皇冠明珠**：Mastodon 的嘟文以消毒后的 HTML 下发。Elk 把它解析成
   AST 再渲染为 vnode；移植保持解析步骤逐字节不变，只替换 vnode 目标 ——
   自定义表情变为行内 `<image>`，提及/话题变为可点按的 `<text>`，直接推入 vue-router 路由。
-- **原生虚拟化时间线**：无限时间线是带 `estimated-main-axis-size-px` 提示的 Lynx
-  `<list>`；masto.js `Paginator` 迭代与 Elk 的排序/缓冲逻辑原样驱动。
+- **原生虚拟化时间线**：feed 使用带 `estimated-main-axis-size-px` 与 `@scrolltolower` 的 Lynx `<list>`（而不是 `<scroll-view>`）；masto.js `Paginator` 迭代与 Elk 的排序/缓冲逻辑原样驱动时间线、探索、个人主页与搜索的 `loadNext()`。
 - **深链**：向 LynxView 传入 `globalProps: { initialPath: '/mas.to/tags/caturday' }`
   即可让应用直接打开对应路由 —— 宿主应用处理通知点击时用的就是同一机制。
 - **游客 + 令牌会话**：像 Elk 游客模式一样匿名浏览，或在设置中粘贴个人访问令牌，

--- a/website/docs/zh/guide/scroll-view-vs-list.mdx
+++ b/website/docs/zh/guide/scroll-view-vs-list.mdx
@@ -210,6 +210,10 @@ export function useInfiniteFeed(pageSize = 20) {
 
 这与 Elk 的 `TimelinePaginator` 同构：分页逻辑在 composable，视口交给 `<list>`。
 
+:::warning 当前只保证追加更新
+Vue Lynx 主线程 list 适配层目前只上报**新增 insert**（`removeAction` / `updateAction` 为空）。`@scrolltolower` 无限追加正好落在这条路径上。删除、头部插入、重排、过滤请先看下面的压测示例，等完整的 `ListUpdateInfoRecording` 式 diff 落地后再依赖它们。
+:::
+
 ### 4. 优先用 `list`，而不是第三方虚拟滚动库
 
 依赖测量 DOM（`getBoundingClientRect`、绝对定位窗口）的库，很难直接映射到 Lynx 的双线程 + 原生元件模型。除非布局是 `<list>` 表达不了的特例，否则用内建回收器。
@@ -224,6 +228,47 @@ export function useInfiniteFeed(pageSize = 20) {
 </list-item>
 ```
 
+## 已知缺口 — 变更压测
+
+下面四个入口是刻意的**踩坑演示**，用来暴露不完整的 list diff。点工具栏，对照橙色 Vue banner 和原生 `<list>` 实际画出的内容。等 MT 适配层补齐完整的 `insertAction` / `removeAction` / `updateAction`（对齐 ReactLynx 的 `ListUpdateInfoRecording`）后，它们应恢复正确。
+
+| 入口 | 变更 | 今天常见症状 |
+|---|---|---|
+| `ListRemove` | 删中间 / 删末尾 | 无 `removeAction` → 幽灵行 / 数量不对 |
+| `ListPrepend` | 头部插入 vs 尾部追加 | INSERT 忽略 anchor → 头部插入被当成尾部 |
+| `ListReorder` | 反转 / 轮转 | move = 删+插却没有 remove → 顺序错乱 |
+| `ListFilter` | 切换「仅偶数」 | 过滤再恢复 → 幽灵行 / 重复 `item-key` |
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListRemove/App.vue"
+  entry="src/ListRemove"
+  defaultEntryName="ListRemove"
+/>
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListPrepend/App.vue"
+  entry="src/ListPrepend"
+  defaultEntryName="ListPrepend"
+/>
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListReorder/App.vue"
+  entry="src/ListReorder"
+  defaultEntryName="ListReorder"
+/>
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListFilter/App.vue"
+  entry="src/ListFilter"
+  defaultEntryName="ListFilter"
+/>
+
+对应的自动化覆盖在 `packages/testing-library` 的 **native list element · mutation gaps** 下，以 `it.fails` 断言*正确*的 `update-list-info` 载荷；适配层修好后这些用例会翻成通过。
+
 ## 决策清单
 
 1. 页面基本是一份线性文档、大约三屏以内？→ **`<scroll-view>`**
@@ -231,6 +276,7 @@ export function useInfiniteFeed(pageSize = 20) {
 3. 需要瀑布流或多列 flow？→ **`<list list-type="…">`**
 4. 数据集会无限增长？→ **`<list>` + composable + `@scrolltolower`**
 5. `:key` / `:item-key` 是否一致？→ 正确回收所必需
+6. 需要删除 / 头部插入 / 重排 / 过滤？→ 先跑压测；在 list diff 完整前优先用追加式 Feed
 
 ## 延伸阅读
 

--- a/website/docs/zh/guide/scroll-view-vs-list.mdx
+++ b/website/docs/zh/guide/scroll-view-vs-list.mdx
@@ -211,7 +211,7 @@ export function useInfiniteFeed(pageSize = 20) {
 这与 Elk 的 `TimelinePaginator` 同构：分页逻辑在 composable，视口交给 `<list>`。
 
 :::warning 已确认缺口：头部插入（prepend）
-Vue Lynx 主线程 list 适配层往 `listItems` **只会 `push`**，忽略 INSERT 的 anchor。**头部插入**（unshift / insert-before）会被报成**尾部** insert——见 `ListPrepend`。`@scrolltolower` 追加仍是支持路径。删除 / 过滤在真机上看起来正常（尽管 `removeAction` 为空）；重排需要仔细目视对照（`ListReorder`）。
+Vue Lynx 主线程 list 适配层往 `listItems` **只会 `push`**，忽略 INSERT 的 anchor。**头部插入**（unshift / insert-before）会被报成**尾部** insert——见 `ListPrepend`。`@scrolltolower` 追加仍是支持路径。**Remove** 现已发 `removeAction`（以前 Reset 同 key 会 2202）。重排仍需仔细目视对照（`ListReorder`）。
 :::
 
 ### 4. 优先用 `list`，而不是第三方虚拟滚动库
@@ -234,7 +234,7 @@ Vue Lynx 主线程 list 适配层往 `listItems` **只会 `push`**，忽略 INSE
 |---|---|---|
 | `ListPrepend` | unshift vs append | **已确认缺口** — 新 cell 出现在尾部 |
 | `ListReorder` | Yellow→top / reverse | 仔细对照 — Vue truth 色条 vs `<list>` |
-| `ListRemove` | 删中间 / 删末尾 | 冒烟 — 真机上 OK |
+| `ListRemove` | 删除 + **Reset 同 key** | 曾在 Reset 报 2202；REMOVE 现已发 `removeAction` |
 | `ListFilter` | 偶数过滤切换 | 冒烟 — 真机上 OK |
 
 ### 已确认：prepend
@@ -261,7 +261,7 @@ Vue Lynx 主线程 list 适配层往 `listItems` **只会 `push`**，忽略 INSE
 
 ### 冒烟：remove + filter
 
-真机上表现正常；保留作回归点击。
+**Remove**：先删行，再点 **Reset same keys**。会用相同 `item-key` 重建 `Row-1…N`。若出现 duplicated item-key（error 2202），说明适配层没发 `removeAction`——是实现问题，不是 demo 写坏了。Filter 切换保留作更轻的回归点击。
 
 <Go
   example="scrolling"

--- a/website/docs/zh/guide/scroll-view-vs-list.mdx
+++ b/website/docs/zh/guide/scroll-view-vs-list.mdx
@@ -211,7 +211,7 @@ export function useInfiniteFeed(pageSize = 20) {
 这与 Elk 的 `TimelinePaginator` 同构：分页逻辑在 composable，视口交给 `<list>`。
 
 :::tip List diff
-Vue Lynx 主线程 list 适配层现在会对常见变更刷新 `insertAction` / `removeAction` / `updateAction`：追加、头部插入、中间插入、删除、同 list 重排（move）、以及 platform-info 更新。`@scrolltolower` 追加仍是最简单路径。尚未做：框架侧 cell 回收、每次 flush 刷新 `__UpdateListCallbacks`——见下方 tracking issues。
+Vue Lynx 主线程 list 适配层通过对比「上次 flush 快照」与当前 `listItems`（LIS 检测 move，语义对齐 ReactLynx 的 remove+insert）刷新 `insertAction` / `removeAction` / `updateAction`。覆盖追加、头部插入、中间插入、删除、同 list 重排、platform-info 更新。尚未做：框架侧 cell 回收、每次 flush 刷新 `__UpdateListCallbacks`——[#302](https://github.com/Huxpro/vue-lynx/issues/302)、[#303](https://github.com/Huxpro/vue-lynx/issues/303)。
 :::
 
 ### 4. 优先用 `list`，而不是第三方虚拟滚动库

--- a/website/docs/zh/guide/scroll-view-vs-list.mdx
+++ b/website/docs/zh/guide/scroll-view-vs-list.mdx
@@ -210,8 +210,8 @@ export function useInfiniteFeed(pageSize = 20) {
 
 这与 Elk 的 `TimelinePaginator` 同构：分页逻辑在 composable，视口交给 `<list>`。
 
-:::warning 已确认缺口：头部插入（prepend）
-Vue Lynx 主线程 list 适配层往 `listItems` **只会 `push`**，忽略 INSERT 的 anchor。**头部插入**（unshift / insert-before）会被报成**尾部** insert——见 `ListPrepend`。`@scrolltolower` 追加仍是支持路径。**Remove** 现已发 `removeAction`（以前 Reset 同 key 会 2202）。重排仍需仔细目视对照（`ListReorder`）。
+:::tip List diff
+Vue Lynx 主线程 list 适配层现在会对常见变更刷新 `insertAction` / `removeAction` / `updateAction`：追加、头部插入、中间插入、删除、同 list 重排（move）、以及 platform-info 更新。`@scrolltolower` 追加仍是最简单路径。尚未做：框架侧 cell 回收、每次 flush 刷新 `__UpdateListCallbacks`——见下方 tracking issues。
 :::
 
 ### 4. 优先用 `list`，而不是第三方虚拟滚动库
@@ -228,18 +228,18 @@ Vue Lynx 主线程 list 适配层往 `listItems` **只会 `push`**，忽略 INSE
 </list-item>
 ```
 
-## 变更压测 / 冒烟
+## 变更演示
 
 | 入口 | 变更 | 状态 |
 |---|---|---|
-| `ListPrepend` | unshift vs append | **已确认缺口** — 新 cell 出现在尾部 |
-| `ListReorder` | Yellow→top / reverse | 仔细对照 — Vue truth 色条 vs `<list>` |
-| `ListRemove` | 删除 + **Reset 同 key** | 曾在 Reset 报 2202；REMOVE 现已发 `removeAction` |
-| `ListFilter` | 偶数过滤切换 | 冒烟 — 真机上 OK |
+| `ListPrepend` | unshift vs append | 已修 — INSERT 尊重 anchor |
+| `ListReorder` | Yellow→top / reverse | 已修 — 同 list move = detach + insert |
+| `ListRemove` | 删除 + Reset 同 key | 已修 — `removeAction`（曾 2202） |
+| `ListFilter` | 偶数过滤切换 | OK |
 
-### 已确认：prepend
+### Prepend
 
-点一次 **Prepend**。列表**最顶部**必须变成红色 `NEW …`。若红卡出现在底部，说明适配层忽略了 insert-before。**Append** 是对照，应当正常。
+点一次 **Prepend**。列表**最顶部**必须变成红色 `NEW …`。**Append** 落在底部。
 
 <Go
   example="scrolling"
@@ -248,9 +248,9 @@ Vue Lynx 主线程 list 适配层往 `listItems` **只会 `push`**，忽略 INSE
   defaultEntryName="ListPrepend"
 />
 
-### 仔细对照：reorder
+### Reorder
 
-四个满宽色块。上方色条是普通 `<view>`（Vue truth）。下方 `<list>` 在 **Yellow → top** 或 **Reverse** 之后必须与色条**同序**。不一致就是 list move 问题。
+四个满宽色块。上方色条是普通 `<view>`（Vue truth）。下方 `<list>` 在 **Yellow → top** 或 **Reverse** 之后必须与色条**同序**。
 
 <Go
   example="scrolling"
@@ -259,9 +259,9 @@ Vue Lynx 主线程 list 适配层往 `listItems` **只会 `push`**，忽略 INSE
   defaultEntryName="ListReorder"
 />
 
-### 冒烟：remove + filter
+### Remove + filter
 
-**Remove**：先删行，再点 **Reset same keys**。会用相同 `item-key` 重建 `Row-1…N`。若出现 duplicated item-key（error 2202），说明适配层没发 `removeAction`——是实现问题，不是 demo 写坏了。Filter 切换保留作更轻的回归点击。
+**Remove**：先删行，再 **Reset same keys**——不得再弹出 duplicated item-key（2202）。Filter 切换作更轻的回归。
 
 <Go
   example="scrolling"
@@ -277,7 +277,12 @@ Vue Lynx 主线程 list 适配层往 `listItems` **只会 `push`**，忽略 INSE
   defaultEntryName="ListFilter"
 />
 
-自动化：`packages/testing-library` → **native list element · mutation gaps**。Prepend 对正确的 `position: 0` 保持 `it.fails`；remove/filter 只做 Vue length 冒烟断言。
+### 仍未做
+
+- 框架侧 cell 回收（`enqueueComponent` / recycle pool）— [#302](https://github.com/Huxpro/vue-lynx/issues/302)
+- 每次 list flush 刷新 `__UpdateListCallbacks` — [#303](https://github.com/Huxpro/vue-lynx/issues/303)
+
+自动化：`packages/testing-library` → **native list element · mutations**。
 
 ## 决策清单
 
@@ -286,7 +291,7 @@ Vue Lynx 主线程 list 适配层往 `listItems` **只会 `push`**，忽略 INSE
 3. 需要瀑布流或多列 flow？→ **`<list list-type="…">`**
 4. 数据集会无限增长？→ **`<list>` + composable + `@scrolltolower`**
 5. `:key` / `:item-key` 是否一致？→ 正确回收所必需
-6. 需要 **prepend**？→ 今天是坏的——在适配层尊重 INSERT anchor 之前，优先追加 / 重建
+6. 需要 prepend / reorder / remove？→ 已由 `update-list-info` diff 支持
 
 ## 延伸阅读
 

--- a/website/docs/zh/guide/scroll-view-vs-list.mdx
+++ b/website/docs/zh/guide/scroll-view-vs-list.mdx
@@ -1,0 +1,242 @@
+# scroll-view 与 list
+
+Lynx 不会像 Web 那样让任意节点滚动。内容超出视口时，你需要显式选择滚动容器——几乎总是 [`<scroll-view>`](https://lynxjs.org/zh/api/elements/built-in/scroll-view) 或 [`<list>`](https://lynxjs.org/zh/api/elements/built-in/list)。本指南说明 lynxjs.org 如何区分二者、这与 Web 上的 Vue 有何不同，以及由此产生的 Vue Lynx 设计模式。
+
+平台侧参考见 lynxjs.org 的[管理滚动](https://lynxjs.org/zh/guide/ui/scrolling)。
+
+## Lynx 与 Web 的区别
+
+在 Web 上，几乎任何元素都能变成滚动容器：
+
+```html
+<div style="overflow: auto; height: 100vh">
+  <!-- anything -->
+</div>
+```
+
+在 Lynx 中，普通 `<view>` **不会**因为 `overflow: scroll` / `overflow: auto` 而获得滚动能力。只有 `<scroll-view>`、`<list>` 等专用容器可以滚动。这是从 DOM 迁到 Lynx 时的第一个设计转变：滚动变成模板里的**结构性选择**，而不是事后补上的 CSS。
+
+| | Web（Vue） | Lynx（Vue Lynx） |
+|---|---|---|
+| 如何开启滚动 | 任意节点上的 `overflow` | 专用的 `<scroll-view>` / `<list>` |
+| 虚拟列表 | 可选库（`vue-virtual-scroller`、Virtua…） | `<list>` 内建 |
+| 长列表 / Feed | 自己做窗口化与 DOM 复用 | 原生回收 + 按需创建 |
+| 复杂网格 | CSS Grid / masonry 库 | `<list list-type="flow\|waterfall">` |
+
+Vue Lynx 仍然是 Composition API、`v-for` 与 SFC——但滚动树的写法会和典型的 Nuxt / Vite SPA 不一样。
+
+## lynxjs.org 怎么说
+
+Lynx 的滚动指南把两者分得很清楚：
+
+1. **用 `<scroll-view>` 做基础滚动**——固定视口；子节点超出时设置 `scroll-orientation` 为 `vertical` 或 `horizontal`。
+2. **用 `<list>` 处理大量 / 无限数据**——只按需创建可见区域的节点。
+3. **用 `<list>` 处理复杂布局**——`scroll-view` 只有线性布局；`list` 提供 `single`、`flow`、`waterfall`。
+
+[`<scroll-view>` API](https://lynxjs.org/zh/api/elements/built-in/scroll-view) 还提醒：
+
+- 子节点会一次性全部创建（可能拖慢首屏）。
+- **没有复用机制**；内容过多可能吃光内存。
+- 内容超过大约 **三屏** 时，优先用 `<list>`，或用曝光事件模拟回收。
+
+可以把 `<scroll-view>` 理解成「刚好需要滚动的短页面」，把 `<list>` 理解成「可回收的 Feed」。
+
+## 选型对照表
+
+| 问题 | 更适合 `<scroll-view>` | 更适合 `<list>` |
+|---|---|---|
+| 内容量？ | 大约三屏以内 | 多屏 / 无上限 |
+| 布局 | 线性堆叠 | 单列 / 网格（`flow`）/ 瀑布流 |
+| 条目形态 | 混杂区块、吸顶栏 | 同质（或大体同质）单元格 |
+| 内存 | 急切创建，子节点常驻 | 回收 + 懒创建 |
+| 无限加载 | 可以，但风险高 | 原生 `@scrolltolower` |
+
+Lynx 的经验法则：**约三屏以内 → `scroll-view`；再多 → `list`。**
+
+## 在 Vue 里用 `<scroll-view>`
+
+普通 Vue 子节点即可——`v-for`、嵌套 SFC、sticky 兄弟节点。除了包一层 `<scroll-view>`，没有额外契约。
+
+<Go
+  example="scrolling"
+  defaultFile="src/ScrollViewBasic/App.vue"
+  entry="src/ScrollViewBasic"
+  defaultEntryName="ScrollViewBasic"
+/>
+
+```vue
+<scroll-view scroll-orientation="vertical">
+  <view class="header">…</view>
+  <view v-for="card in cards" :key="card.id" class="card">
+    <text>{{ card.title }}</text>
+  </view>
+</scroll-view>
+```
+
+适合：设置页、表单、文章正文、短结果页（另见 [Vue Query](/zh/guide/data-fetching) 与 [TodoMVC](/zh/guide/todomvc) 示例）。
+
+:::tip 嵌套布局提示
+`<scroll-view>` 的直接子节点只支持 linear / sticky。若要在滚动区域内使用更丰富的 CSS，先包一层子 `<view>`，再在该子树里排版——这也是 [scroll-view 文档](https://lynxjs.org/zh/api/elements/built-in/scroll-view) 的建议。
+:::
+
+## 在 Vue 里用 `<list>`
+
+`<list>` 要求子节点是 **`<list-item>`**。每个 item 需要：
+
+- Vue 的 `:key` —— VNode 树的协调身份
+- Lynx 的 `:item-key` —— 原生回收器的身份（保持两者一致）
+
+缺少或冲突的 key 是空白 / 错乱单元格的常见原因。
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListBasic/App.vue"
+  entry="src/ListBasic"
+  defaultEntryName="ListBasic"
+/>
+
+```vue
+<list list-type="single" scroll-orientation="vertical">
+  <list-item
+    v-for="card in cards"
+    :key="card.id"
+    :item-key="card.id"
+    :estimated-main-axis-size-px="96"
+  >
+    <view class="card">…</view>
+  </list-item>
+</list>
+```
+
+`estimated-main-axis-size-px` 帮助引擎在单元格尚未测量前估算滚动条与跳转位置——[商品画廊教程](/zh/guide/tutorial-gallery) 的瀑布流图片也用同一提示。
+
+### 瀑布流 / 网格布局
+
+这是 lynxjs.org 区分的另一半：`scroll-view` 做不了多列瀑布流；`list` 可以。
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListWaterfall/App.vue"
+  entry="src/ListWaterfall"
+  defaultEntryName="ListWaterfall"
+/>
+
+```vue
+<list list-type="waterfall" :span-count="2" scroll-orientation="vertical">
+  <list-item
+    v-for="tile in tiles"
+    :key="tile.id"
+    :item-key="tile.id"
+    :estimated-main-axis-size-px="tile.height"
+  >
+    <view class="tile" :style="{ height: `${tile.height}px` }" />
+  </list-item>
+</list>
+```
+
+每个 `list-item` 都可以挂完整的 Vue SFC——画廊教程里的 `LikeImageCard` 就是同一模式的产品级写法。
+
+## 由此产生的 Vue 设计模式
+
+从 Web Vue 迁到 Vue Lynx，响应式模型不变——变的是**滚动放在哪里**，以及**谁负责回收**。
+
+### 1. 在模板里显式声明容器
+
+不要再给根 `<view>` 写 `overflow: auto`。先想清楚：
+
+```vue
+<!-- 短的、混杂的页面 -->
+<scroll-view scroll-orientation="vertical">…</scroll-view>
+
+<!-- 长的同质 Feed -->
+<list list-type="single" scroll-orientation="vertical">…</list>
+```
+
+这个结构选择，相当于在 Web 上决定要不要上虚拟列表库。
+
+### 2. 双重身份：`:key` + `:item-key`
+
+Web 的 `v-for` 只需要 `:key`。Lynx 的 list 两者都要。用同一个稳定业务 id：
+
+```vue
+<list-item
+  v-for="status in items"
+  :key="status.id"
+  :item-key="status.id"
+/>
+```
+
+[Elk](/zh/guide/elk) 移植里的 Mastodon 状态列表正是这一约定。
+
+### 3. Composable 管分页；`<list>` 管回收
+
+在 Web 上，无限滚动通常是：
+
+`useInfiniteQuery` / 自定义 composable **+** 虚拟列表 **+** IntersectionObserver 哨兵。
+
+在 Lynx 里可以去掉虚拟列表。Composable 往 `ref` 数组追加数据；`@scrolltolower`（配合 `lower-threshold-item-count`）请求下一页。原生回收保证内存平稳。
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListInfinite/App.vue"
+  entry="src/ListInfinite"
+  defaultEntryName="ListInfinite"
+/>
+
+```ts
+// shared/useInfiniteFeed.ts
+export function useInfiniteFeed(pageSize = 20) {
+  const items = ref(makeCards(pageSize))
+  const loading = ref(false)
+  // loadMore() 追加下一页…
+  return { items, loading, loadMore }
+}
+```
+
+```vue
+<list
+  :lower-threshold-item-count="3"
+  @scrolltolower="loadMore"
+>
+  <list-item
+    v-for="item in items"
+    :key="item.id"
+    :item-key="item.id"
+  >
+    …
+  </list-item>
+</list>
+```
+
+这与 Elk 的 `TimelinePaginator` 同构：分页逻辑在 composable，视口交给 `<list>`。
+
+### 4. 优先用 `list`，而不是第三方虚拟滚动库
+
+依赖测量 DOM（`getBoundingClientRect`、绝对定位窗口）的库，很难直接映射到 Lynx 的双线程 + 原生元件模型。除非布局是 `<list>` 表达不了的特例，否则用内建回收器。
+
+### 5. 单元格继续用 Vue 组件
+
+回收是**原生**职责；组合仍是 **Vue** 职责。把展示型 SFC 放进 `list-item`——不要因为父级是 list 就把一切摊平成巨型模板。
+
+```vue
+<list-item :key="pic.id" :item-key="pic.id">
+  <LikeImageCard :picture="pic" />
+</list-item>
+```
+
+## 决策清单
+
+1. 页面基本是一份线性文档、大约三屏以内？→ **`<scroll-view>`**
+2. 要渲染几十 / 上百条相似行？→ **`<list>`**
+3. 需要瀑布流或多列 flow？→ **`<list list-type="…">`**
+4. 数据集会无限增长？→ **`<list>` + composable + `@scrolltolower`**
+5. `:key` / `:item-key` 是否一致？→ 正确回收所必需
+
+## 延伸阅读
+
+- [管理滚动（Lynx）](https://lynxjs.org/zh/guide/ui/scrolling)
+- [`<scroll-view>` API](https://lynxjs.org/zh/api/elements/built-in/scroll-view)
+- [`<list>` API](https://lynxjs.org/zh/api/elements/built-in/list)
+- [教程：商品画廊](/zh/guide/tutorial-gallery) —— 完整应用中的瀑布流 `<list>`
+- [Elk（Mastodon 客户端）](/zh/guide/elk) —— 用原生 `<list>` 替换 Virtua
+- [主线程脚本](/zh/guide/main-thread-script) —— `<scroll-view>` / `<list>` 上的滚动联动 worklet

--- a/website/docs/zh/guide/scroll-view-vs-list.mdx
+++ b/website/docs/zh/guide/scroll-view-vs-list.mdx
@@ -210,8 +210,8 @@ export function useInfiniteFeed(pageSize = 20) {
 
 这与 Elk 的 `TimelinePaginator` 同构：分页逻辑在 composable，视口交给 `<list>`。
 
-:::warning 当前只保证追加更新
-Vue Lynx 主线程 list 适配层目前只上报**新增 insert**（`removeAction` / `updateAction` 为空）。`@scrolltolower` 无限追加正好落在这条路径上。删除、头部插入、重排、过滤请先看下面的压测示例，等完整的 `ListUpdateInfoRecording` 式 diff 落地后再依赖它们。
+:::warning 已确认缺口：头部插入（prepend）
+Vue Lynx 主线程 list 适配层往 `listItems` **只会 `push`**，忽略 INSERT 的 anchor。**头部插入**（unshift / insert-before）会被报成**尾部** insert——见 `ListPrepend`。`@scrolltolower` 追加仍是支持路径。删除 / 过滤在真机上看起来正常（尽管 `removeAction` 为空）；重排需要仔细目视对照（`ListReorder`）。
 :::
 
 ### 4. 优先用 `list`，而不是第三方虚拟滚动库
@@ -228,16 +228,40 @@ Vue Lynx 主线程 list 适配层目前只上报**新增 insert**（`removeActio
 </list-item>
 ```
 
-## 已知缺口 — 变更压测
+## 变更压测 / 冒烟
 
-下面四个入口是刻意的**踩坑演示**，用来暴露不完整的 list diff。点工具栏，对照橙色 Vue banner 和原生 `<list>` 实际画出的内容。等 MT 适配层补齐完整的 `insertAction` / `removeAction` / `updateAction`（对齐 ReactLynx 的 `ListUpdateInfoRecording`）后，它们应恢复正确。
-
-| 入口 | 变更 | 今天常见症状 |
+| 入口 | 变更 | 状态 |
 |---|---|---|
-| `ListRemove` | 删中间 / 删末尾 | 无 `removeAction` → 幽灵行 / 数量不对 |
-| `ListPrepend` | 头部插入 vs 尾部追加 | INSERT 忽略 anchor → 头部插入被当成尾部 |
-| `ListReorder` | 反转 / 轮转 | move = 删+插却没有 remove → 顺序错乱 |
-| `ListFilter` | 切换「仅偶数」 | 过滤再恢复 → 幽灵行 / 重复 `item-key` |
+| `ListPrepend` | unshift vs append | **已确认缺口** — 新 cell 出现在尾部 |
+| `ListReorder` | Yellow→top / reverse | 仔细对照 — Vue truth 色条 vs `<list>` |
+| `ListRemove` | 删中间 / 删末尾 | 冒烟 — 真机上 OK |
+| `ListFilter` | 偶数过滤切换 | 冒烟 — 真机上 OK |
+
+### 已确认：prepend
+
+点一次 **Prepend**。列表**最顶部**必须变成红色 `NEW …`。若红卡出现在底部，说明适配层忽略了 insert-before。**Append** 是对照，应当正常。
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListPrepend/App.vue"
+  entry="src/ListPrepend"
+  defaultEntryName="ListPrepend"
+/>
+
+### 仔细对照：reorder
+
+四个满宽色块。上方色条是普通 `<view>`（Vue truth）。下方 `<list>` 在 **Yellow → top** 或 **Reverse** 之后必须与色条**同序**。不一致就是 list move 问题。
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListReorder/App.vue"
+  entry="src/ListReorder"
+  defaultEntryName="ListReorder"
+/>
+
+### 冒烟：remove + filter
+
+真机上表现正常；保留作回归点击。
 
 <Go
   example="scrolling"
@@ -248,26 +272,12 @@ Vue Lynx 主线程 list 适配层目前只上报**新增 insert**（`removeActio
 
 <Go
   example="scrolling"
-  defaultFile="src/ListPrepend/App.vue"
-  entry="src/ListPrepend"
-  defaultEntryName="ListPrepend"
-/>
-
-<Go
-  example="scrolling"
-  defaultFile="src/ListReorder/App.vue"
-  entry="src/ListReorder"
-  defaultEntryName="ListReorder"
-/>
-
-<Go
-  example="scrolling"
   defaultFile="src/ListFilter/App.vue"
   entry="src/ListFilter"
   defaultEntryName="ListFilter"
 />
 
-对应的自动化覆盖在 `packages/testing-library` 的 **native list element · mutation gaps** 下，以 `it.fails` 断言*正确*的 `update-list-info` 载荷；适配层修好后这些用例会翻成通过。
+自动化：`packages/testing-library` → **native list element · mutation gaps**。Prepend 对正确的 `position: 0` 保持 `it.fails`；remove/filter 只做 Vue length 冒烟断言。
 
 ## 决策清单
 
@@ -276,7 +286,7 @@ Vue Lynx 主线程 list 适配层目前只上报**新增 insert**（`removeActio
 3. 需要瀑布流或多列 flow？→ **`<list list-type="…">`**
 4. 数据集会无限增长？→ **`<list>` + composable + `@scrolltolower`**
 5. `:key` / `:item-key` 是否一致？→ 正确回收所必需
-6. 需要删除 / 头部插入 / 重排 / 过滤？→ 先跑压测；在 list diff 完整前优先用追加式 Feed
+6. 需要 **prepend**？→ 今天是坏的——在适配层尊重 INSERT anchor 之前，优先追加 / 重建
 
 ## 延伸阅读
 

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -96,6 +96,7 @@ export default defineConfig({
         { text: 'Instant First-Frame Rendering (IFR)', link: '/guide/ifr', tag: 'v0.5' },
         { text: 'Tutorial: Product Gallery', link: '/guide/tutorial-gallery' },
         { text: 'Tutorial: Product Swiper', link: '/guide/tutorial-swiper' },
+        { text: 'scroll-view vs list', link: '/guide/scroll-view-vs-list' },
         {
           dividerType: 'solid',
         },
@@ -141,6 +142,7 @@ export default defineConfig({
         { text: '首屏直出（IFR）', link: '/zh/guide/ifr', tag: 'v0.5' },
         { text: '教程：商品画廊', link: '/zh/guide/tutorial-gallery' },
         { text: '教程：商品轮播', link: '/zh/guide/tutorial-swiper' },
+        { text: 'scroll-view 与 list', link: '/zh/guide/scroll-view-vs-list' },
         {
           dividerType: 'solid',
         },


### PR DESCRIPTION
## Summary

- Wire Explore, Account, and Search feeds to recycling `<list>` pagination in both `elk` and `elk-viewpager`.
- Include the anchor-aware native list update path needed for appended pages.
- Restore native Mastodon pagination compatibility without replacing a working native Response.
- Document the native feed architecture and compatibility constraints.

## Native pagination root cause

The iOS Lynx runtime exposes response headers through iteration using mixed-case names, while `Headers.get()` behaves case-sensitively. masto.js asks for lowercase `link`, so it treated the first page as the end of the feed. Once Link became visible, the runtime URL implementation exposed no valid `.search` and corrupted `searchParams` mutations.

This PR now:

- adds a case-insensitive `.get()` fallback on the existing native Headers object, preserving the unread native response body;
- replaces incomplete URL implementations, not only missing ones;
- keeps `searchParams` mutations synchronized with URL.search;
- synthesizes fallback pagination links without depending on the host URL implementation;
- mirrors the compatibility path in Elk ViewPager.

## Validation

- [x] `node --test examples/elk/scripts/native-compat.test.mjs` — 40/40 passing
- [x] Clean iOS LynxExplorer restart and bundle reload
- [x] WDA-driven native scrolling beyond the initial page
- [x] Lynx DevTool observed 51 `status-card` nodes with a 30-item page size, confirming page 2+ appended
- [x] No `End of the timeline` or `Failed to load timeline` after crossing the first-page boundary
- [x] Native probes confirm lowercase `headers.get("link")` / `headers.get("content-type")` and valid URL pathname/search behavior
