### PR TITLE
fix(ai-chat): stabilize mobile Sheet enter animation

### DIFF
--- a/examples/ai-chat/src/App.vue
+++ b/examples/ai-chat/src/App.vue
@@ -27,6 +27,11 @@ const { sidebarOpen, close: closeSidebar } = useSidebarDrawer();
 const reducedMotion = useReducedMotion();
 const drawerRef = useTemplateRef<ShadowElement>('drawerRef');
 const DRAWER_EASING = 'cubic-bezier(0.25, 1, 0.5, 1)';
+const DRAWER_CLOSED = 'translateX(-288px)';
+const DRAWER_OPEN = 'translateX(0px)';
+
+/** Drops stale open/close animations when the user toggles quickly. */
+let drawerMotionGeneration = 0;
 
 const themeClass = computed(() => `theme-${colorMode.value}`);
 const rootClass = computed(() => [
@@ -43,17 +48,67 @@ function handleSidebarShowChange(show: boolean) {
   if (!show) closeSidebar();
 }
 
+function nextPaint(): Promise<void> {
+  // Match Vue Transition / Elk Sheet: one committed frame at the current
+  // pose before flipping the transform under an armed CSS transition.
+  return new Promise((resolve) => {
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => resolve());
+      });
+    }
+    else {
+      setTimeout(resolve, 16);
+    }
+  });
+}
+
 async function syncDrawerSurface(open: boolean) {
   // Lynx UI's Sheet keeps horizontal movement on the main thread. Vue's
   // background style diff does not reliably update a previously translated
-  // native surface, so use the native UI method for the same direct mutation.
+  // native surface — and worse, a reactive style binding that always writes the closed transform
+  // re-applies the closed pose on unrelated re-renders (theme, fetches),
+  // fighting setNativeProps mid-enter and while open. Own transform only
+  // through setNativeProps; CSS holds the initial closed pose.
+  const generation = ++drawerMotionGeneration;
   await nextTick();
-  drawerRef.value
-    ?.setNativeProps({
-      transform: open ? 'translateX(0px)' : 'translateX(-288px)',
-      transition: reducedMotion.value ? 'none' : `transform 240ms ${DRAWER_EASING}`,
-    })
-    .exec();
+  if (generation !== drawerMotionGeneration) return;
+
+  const el = drawerRef.value;
+  if (!el) return;
+
+  const target = open ? DRAWER_OPEN : DRAWER_CLOSED;
+  if (reducedMotion.value) {
+    el.setNativeProps({
+      transform: target,
+      transition: 'none',
+    }).exec();
+    return;
+  }
+
+  // Two-phase: arm transition at the current pose, then set the target.
+  el.setNativeProps({
+    transition: `transform 240ms ${DRAWER_EASING}`,
+  }).exec();
+
+  await nextPaint();
+  if (generation !== drawerMotionGeneration) return;
+
+  el.setNativeProps({
+    transform: target,
+  }).exec();
+
+  // Drop the transition after settle so a later style patch cannot
+  // animate the sheet (Elk Sheet clears motion transitions the same way).
+  setTimeout(() => {
+    if (generation !== drawerMotionGeneration) return;
+    drawerRef.value
+      ?.setNativeProps({
+        transition: 'none',
+        transform: target,
+      })
+      .exec();
+  }, 240);
 }
 
 watch(sidebarOpen, (open) => void syncDrawerSurface(open));
@@ -86,18 +141,16 @@ onMounted(async () => {
       v-if="isMobile && sidebarOpen"
       class="absolute inset-0 drawer-backdrop"
       :event-through="false"
-      :style="{ opacity: sidebarOpen ? '1' : '0' }"
       @tap="handleSidebarShowChange(false)"
     />
-    <!-- Keep only the moving surface mounted so its transform can animate. -->
+    <!-- Keep only the moving surface mounted so its transform can animate.
+         Do not bind transform via :style — Vue style patches overwrite
+         setNativeProps and cause enter flicker / open-state snaps. -->
     <view
       v-if="isMobile"
       ref="drawerRef"
       class="absolute top-0 bottom-0 left-0 drawer-panel shadow-lg"
       :event-through="false"
-      :style="{
-        transform: 'translateX(-288px)',
-      }"
     >
       <Sidebar drawer />
     </view>
@@ -119,9 +172,11 @@ onMounted(async () => {
   z-index: 40;
   width: 288px;
   background-color: var(--ui-bg-sidebar);
+  transform: translateX(-288px);
 }
 .drawer-backdrop {
   z-index: 30;
-  transition: opacity 240ms cubic-bezier(0.25, 1, 0.5, 1);
+  /* Hit-test only — content dimming supplies the visible enter fade. */
+  opacity: 1;
 }
 </style>

--- a/examples/ai-chat/tests/native-interactions.test.ts
+++ b/examples/ai-chat/tests/native-interactions.test.ts
@@ -158,19 +158,20 @@ describe('native drawer motion', () => {
     expect(source).toContain(':style="navbarStyle"');
   });
 
-  it('animates the persistent backdrop and panel with direct native style updates', async () => {
+  it('animates the persistent panel with two-phase native style updates', async () => {
     const source = await readFile(path.resolve(import.meta.dirname, '../src/App.vue'), 'utf8');
 
     expect(source).toContain("const drawerRef = useTemplateRef<ShadowElement>('drawerRef')");
-    expect(source).toMatch(/drawerRef\.value\s*\?\.setNativeProps\(\{/);
-    expect(source).toContain("transform: open ? 'translateX(0px)' : 'translateX(-288px)'");
-    expect(source).toContain("transition: reducedMotion.value ? 'none' : `transform 240ms ${DRAWER_EASING}`");
+    expect(source).toContain('function nextPaint()');
+    expect(source).toMatch(/el\.setNativeProps\(\{\s*transition:/);
+    expect(source).toMatch(/el\.setNativeProps\(\{\s*transform:\s*target/);
+    expect(source).toContain('const target = open ? DRAWER_OPEN : DRAWER_CLOSED');
+    expect(source).toContain("transition: 'none'");
     expect(source).toContain('ref="drawerRef"');
-    expect(source).toMatch(/\.drawer-backdrop\s*{[^}]*transition:\s*opacity 240ms/);
-    expect(source).toContain("opacity: sidebarOpen ? '1' : '0'");
+    expect(source).toMatch(/\.drawer-panel\s*{[^}]*transform:\s*translateX\(-288px\)/s);
   });
 
-  it('mounts the native backdrop only while open and keeps the moving surface stable', async () => {
+  it('mounts the native backdrop only while open and keeps transform off Vue :style', async () => {
     const source = await readFile(path.resolve(import.meta.dirname, '../src/App.vue'), 'utf8');
 
     expect(source).toContain('v-if="isMobile && sidebarOpen"');
@@ -180,7 +181,12 @@ describe('native drawer motion', () => {
     expect(source).toMatch(
       /v-if="isMobile"[\s\S]*?ref="drawerRef"[\s\S]*?class="absolute top-0 bottom-0 left-0/,
     );
-    expect(source).toContain("transform: 'translateX(-288px)'");
+    // Transform must not live in a reactive style binding — Vue style
+    // patches overwrite setNativeProps and flash the sheet closed.
+    expect(source).not.toMatch(
+      /class="absolute top-0 bottom-0 left-0 drawer-panel[\s\S]*?:style="/,
+    );
+    expect(source).not.toContain("transform: 'translateX(-288px)'");
     expect(source).not.toContain("transform: sidebarOpen ? 'translateX(0px)' : 'translateX(-288px)'");
     expect(source).not.toContain('drawer-layer');
     expect(source).not.toContain('<Transition name="drawer-panel"');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The AI Chat mobile side Sheet (drawer) sometimes flickered on open because Vue’s reactive `:style="{ transform: 'translateX(-288px)' }"` kept re-applying the **closed** pose on unrelated re-renders (theme, fetches, etc.), fighting `setNativeProps` mid-enter and while open.

## Root cause (headless Chrome)

1. Open path correctly moved the panel with `setNativeProps({ transform: 0, transition })`.
2. Any later App re-render re-patched the static closed transform into the style attribute.
3. With the transition still armed, the sheet animated/snapped back toward `-288px` → visible flicker.

Reproduced by opening the sheet, then toggling theme while keeping the backdrop from stealing hits: before the fix the panel drifted closed; after the fix `translateX` stays at `0` across re-renders.

## Fix

- Keep the initial closed pose in CSS only (`transform: translateX(-288px)`).
- Drive open/close **only** through `setNativeProps` (no reactive transform style binding).
- Two-phase motion: arm `transition`, wait a paint (double rAF / 16ms), then set the target transform.
- Clear `transition` after settle so leftover timing cannot animate accidental patches.
- Generation guard so rapid toggles don’t apply stale async frames.

## Verification

- `pnpm test` in `examples/ai-chat` — 73/73 passed
- Headless Lynx-for-Web harness: continuous enter path (`-288 → … → 0`), open state survives theme re-renders

[Sheet mid-enter](https://cursor.com/agents/bc-20070008-b469-47e9-981b-248c04bd69fb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsheet-enter-080.png)
[Sheet open after theme re-render](https://cursor.com/agents/bc-20070008-b469-47e9-981b-248c04bd69fb/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsheet-open-after-theme.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20070008-b469-47e9-981b-248c04bd69fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20070008-b469-47e9-981b-248c04bd69fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

