### PR TITLE
fix(examples/elk): stabilize Sheet enter animation

### DIFF
--- a/examples/elk-viewpager/scripts/native-compat.test.mjs
+++ b/examples/elk-viewpager/scripts/native-compat.test.mjs
@@ -90,7 +90,11 @@ test('Vue Lynx Sheet keeps hybrid drag and settle work on the main thread', asyn
   assert.match(source, /modelValue/);
   assert.match(source, /v-show="modelValue"/);
   assert.doesNotMatch(source, /v-if="modelValue"/);
-  assert.match(source, /<Transition name="sheet" @after-leave="handleAfterLeave">/);
+  assert.match(
+    source,
+    /<Transition[\s\S]*?name="sheet"[\s\S]*?persisted[\s\S]*?:duration="\{ enter: 250, leave: 188 \}"[\s\S]*?@before-enter="handleBeforeEnter"[\s\S]*?@after-leave="handleAfterLeave"/,
+    'v-show sheet enter must be persisted with explicit durations and a before-enter snap',
+  );
   assert.match(source, /class="sheet-backdrop"[^>]*:main-thread-ref="backdropRef"[^>]*@tap="requestClose"/s);
   assert.match(source, /class="sheet-surface"/);
   assert.match(
@@ -146,6 +150,7 @@ test('Vue Lynx Sheet keeps hybrid drag and settle work on the main thread', asyn
   assert.match(source, /animationGenerationRef/);
   assert.doesNotMatch(source, /watch\(\(\) => props\.modelValue/);
   assert.doesNotMatch(source, /prepareSheetForOpen/);
+  assert.match(source, /function handleBeforeEnter\(\)[\s\S]*?runOnMainThread\(resetSheetMotion\)/);
   assert.match(
     source,
     /class="sheet-surface-transition"[^>]*:style="surfaceStyle"/,
@@ -164,9 +169,46 @@ test('Vue Lynx Sheet keeps hybrid drag and settle work on the main thread', asyn
   );
   assert.doesNotMatch(source, /\.sheet-enter-from \.sheet-surface,/);
   assert.match(source, /function resetSheetMotion\(\)[\s\S]*?applySheetMotion\(0\)/);
+  assert.match(
+    source,
+    /function resetSheetMotion\(\)[\s\S]*?setMotionTransition\('none', 'none'\)[\s\S]*?applySheetMotion\(0\)/,
+    'reset must leave gesture nodes with transition none, not revive stylesheet transitions',
+  );
+  assert.doesNotMatch(
+    source,
+    /function resetSheetMotion\(\)[\s\S]*?setMotionTransition\('', ''\)/,
+  );
   assert.match(source, /runOnBackground\(requestClose\)/);
-  assert.match(source, /transition:\s*opacity/);
-  assert.match(source, /transition:\s*transform/);
+  assert.match(
+    source,
+    /\.sheet-enter-active,[\s\S]*?\.sheet-leave-active\s*\{[^}]*transition:\s*opacity/s,
+    'opacity interpolation must live on enter/leave-active only',
+  );
+  assert.match(
+    source,
+    /\.sheet-enter-active \.sheet-surface-transition,[\s\S]*?\.sheet-leave-active \.sheet-surface-transition\s*\{[^}]*transition:\s*transform/s,
+    'transform interpolation must live on enter/leave-active only',
+  );
+  assert.match(
+    source,
+    /\.sheet-enter-from,[\s\S]*?\.sheet-enter-from \.sheet-surface-transition\s*\{[^}]*transition:\s*none/s,
+    'enter-from must snap closed instead of reverse-animating into the closed pose',
+  );
+  for (const [selector, label] of [
+    ['.sheet-layer', 'layer'],
+    ['.sheet-backdrop', 'backdrop'],
+    ['.sheet-surface-transition', 'wrapper'],
+    ['.sheet-surface', 'gesture surface'],
+  ]) {
+    const escaped = selector.replace(/\./g, '\\.');
+    const block = source.match(new RegExp(`(?:^|\\n)${escaped}\\s*\\{([^}]*)\\}`));
+    assert.ok(block, `missing base ${label} rule`);
+    assert.doesNotMatch(
+      block[1],
+      /\btransition\s*:/,
+      `always-on ${label} transitions reverse-animate into enter-from on leave interrupt`,
+    );
+  }
   assert.doesNotMatch(source, /transition:\s*all/);
 });
 

--- a/examples/elk-viewpager/scripts/native-compat.test.mjs
+++ b/examples/elk-viewpager/scripts/native-compat.test.mjs
@@ -62,7 +62,9 @@ test('sheet filters noisy velocity samples and integrates a stable spring step',
 });
 
 test('sheet worklets keep primitive defaults when detached from module scope', () => {
-  const claim = isolateWorklet(sheetGesture.shouldClaimSheetGesture);
+  const claim = isolateWorklet(sheetGesture.shouldClaimSheetGesture, {
+    SHEET_GESTURE_LOCK_DISTANCE: sheetGesture.SHEET_GESTURE_LOCK_DISTANCE,
+  });
   const resolveDrag = isolateWorklet(sheetGesture.resolveSheetDrag, {
     rubberEffect: sheetGesture.rubberEffect,
   });
@@ -124,6 +126,16 @@ test('Vue Lynx Sheet keeps hybrid drag and settle work on the main thread', asyn
   assert.match(source, /setAttribute\?\.\('enable-scroll', enabled\)/);
   assert.match(source, /setPanelScrollEnabled\(false\)/);
   assert.match(source, /setPanelScrollEnabled\(true\)/);
+  assert.match(
+    source,
+    /panelScrollEnabledRef\.current === enabled/,
+    'avoid redundant enable-scroll attribute writes on every gesture reset',
+  );
+  assert.match(
+    source,
+    /backdropOpacityRef/,
+    'quantize backdrop opacity writes during drag',
+  );
   assert.match(
     source,
     /\.sheet-rubber-fill\s*\{[^}]*background-color:\s*var\(--c-sheet-fill-bg\)/s,

--- a/examples/elk-viewpager/src/components/sheet/Sheet.vue
+++ b/examples/elk-viewpager/src/components/sheet/Sheet.vue
@@ -150,7 +150,7 @@ function finishSettle(target: number, dismiss: boolean, generation: number) {
     runOnBackground(requestClose)();
   }
   else {
-    setMotionTransition('', '');
+    setMotionTransition('none', 'none');
   }
 }
 
@@ -306,10 +306,17 @@ function handleTouchCancel() {
 function resetSheetMotion() {
   'main thread';
   cancelSettle();
+  // Keep transition disabled on gesture-owned nodes. Clearing to '' would
+  // revive any stylesheet transition and let later patches animate unexpectedly.
   setMotionTransition('none', 'none');
   applySheetMotion(0);
   resetGestureState();
-  setMotionTransition('', '');
+}
+
+function handleBeforeEnter() {
+  // Snap residual main-thread gesture transforms before CSS enter classes
+  // paint, so the wrapper transition is the only enter motion.
+  runOnMainThread(resetSheetMotion)();
 }
 
 function handleAfterLeave() {
@@ -318,7 +325,13 @@ function handleAfterLeave() {
 </script>
 
 <template>
-  <Transition name="sheet" @after-leave="handleAfterLeave">
+  <Transition
+    name="sheet"
+    persisted
+    :duration="{ enter: 250, leave: 188 }"
+    @before-enter="handleBeforeEnter"
+    @after-leave="handleAfterLeave"
+  >
     <view v-show="modelValue" class="sheet-layer" :style="layerStyle">
       <view
         class="sheet-backdrop"
@@ -372,7 +385,6 @@ function handleAfterLeave() {
   justify-content: flex-end;
   overflow: hidden;
   opacity: 1;
-  transition: opacity 250ms cubic-bezier(0.25, 1, 0.5, 1);
 }
 
 .sheet-backdrop {
@@ -383,7 +395,6 @@ function handleAfterLeave() {
   left: 0;
   background-color: rgba(0, 0, 0, 0.5);
   opacity: 1;
-  transition: opacity 250ms cubic-bezier(0.25, 1, 0.5, 1);
 }
 
 .sheet-surface-transition {
@@ -393,7 +404,6 @@ function handleAfterLeave() {
   flex-direction: column;
   width: 100%;
   transform: translateY(0);
-  transition: transform 250ms cubic-bezier(0.25, 1, 0.5, 1);
 }
 
 .sheet-surface {
@@ -407,7 +417,6 @@ function handleAfterLeave() {
   border-top-right-radius: 8px;
   background-color: var(--c-sheet-bg);
   transform: translateY(0);
-  transition: transform 250ms cubic-bezier(0.25, 1, 0.5, 1);
 }
 
 .sheet-rubber-fill {
@@ -448,6 +457,27 @@ function handleAfterLeave() {
   background-color: var(--c-sheet-bg);
 }
 
+/*
+ * Vue-canonical transitions: only -enter-active / -leave-active enable
+ * interpolation. Always-on base transitions reverse-animate into enter-from
+ * when a leave is interrupted (sheet slides down, then pops open).
+ */
+.sheet-enter-active,
+.sheet-leave-active {
+  transition: opacity 250ms cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+.sheet-enter-active .sheet-surface-transition,
+.sheet-leave-active .sheet-surface-transition {
+  transition: transform 250ms cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+/* Snap closed while enter-from is present; animate only after it is removed. */
+.sheet-enter-from,
+.sheet-enter-from .sheet-surface-transition {
+  transition: none;
+}
+
 .sheet-enter-from,
 .sheet-leave-to {
   opacity: 0;
@@ -459,11 +489,6 @@ function handleAfterLeave() {
 }
 
 .sheet-leave-active {
-  transition-duration: 188ms;
-  transition-timing-function: ease-in;
-}
-
-.sheet-leave-active .sheet-backdrop {
   transition-duration: 188ms;
   transition-timing-function: ease-in;
 }

--- a/examples/elk-viewpager/src/components/sheet/Sheet.vue
+++ b/examples/elk-viewpager/src/components/sheet/Sheet.vue
@@ -73,6 +73,8 @@ const gestureLockedRef = useMainThreadRef(false);
 const gestureRejectedRef = useMainThreadRef(false);
 const settleTimerRef = useMainThreadRef(0);
 const animationGenerationRef = useMainThreadRef(0);
+const panelScrollEnabledRef = useMainThreadRef(true);
+const backdropOpacityRef = useMainThreadRef(-1);
 
 const layerStyle = computed(() => ({ bottom: `${props.bottomInset}px` }));
 const surfaceStyle = computed(() => ({
@@ -101,6 +103,9 @@ function setMotionTransition(surfaceValue: string, backdropValue: string) {
 
 function setPanelScrollEnabled(enabled: boolean) {
   'main thread';
+  if (panelScrollEnabledRef.current === enabled)
+    return;
+  panelScrollEnabledRef.current = enabled;
   panelRef.current?.setAttribute?.('enable-scroll', enabled);
 }
 
@@ -110,13 +115,18 @@ function applySheetMotion(translation: number) {
     ? surfaceHeightRef.current
     : 640;
   const progress = sheetOpenProgress(translation, sheetSize);
+  // Quantize opacity writes; transform stays full-precision for drag feel.
+  const opacity = Math.round(progress * 100) / 100;
 
   translationRef.current = translation;
   surfaceRef.current?.setStyleProperty?.(
     'transform',
     `translateY(${translation}px)`,
   );
-  backdropRef.current?.setStyleProperty?.('opacity', String(progress));
+  if (opacity !== backdropOpacityRef.current) {
+    backdropOpacityRef.current = opacity;
+    backdropRef.current?.setStyleProperty?.('opacity', String(opacity));
+  }
 }
 
 function cancelSettle() {
@@ -239,10 +249,7 @@ function handleTouchMove(event: SheetTouchEvent) {
       setPanelScrollEnabled(false);
       gestureLockedRef.current = true;
     }
-    else if (
-      Math.sqrt(deltaX * deltaX + deltaY * deltaY)
-      >= 8
-    ) {
+    else if (deltaX * deltaX + deltaY * deltaY >= 64) {
       gestureRejectedRef.current = true;
       return;
     }
@@ -305,9 +312,19 @@ function handleTouchCancel() {
 
 function resetSheetMotion() {
   'main thread';
-  cancelSettle();
   // Keep transition disabled on gesture-owned nodes. Clearing to '' would
   // revive any stylesheet transition and let later patches animate unexpectedly.
+  if (
+    settleTimerRef.current === 0
+    && Math.abs(translationRef.current) < 0.5
+    && !gestureLockedRef.current
+  ) {
+    setMotionTransition('none', 'none');
+    setPanelScrollEnabled(true);
+    return;
+  }
+
+  cancelSettle();
   setMotionTransition('none', 'none');
   applySheetMotion(0);
   resetGestureState();

--- a/examples/elk-viewpager/src/components/sheet/gesture.ts
+++ b/examples/elk-viewpager/src/components/sheet/gesture.ts
@@ -23,8 +23,8 @@ export function shouldClaimSheetGesture(
   scrollTop: number,
 ): boolean {
   'main thread';
-  const displacement = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
-  if (displacement < 8)
+  // Compare squared distance to avoid Math.sqrt on every touchmove sample.
+  if (deltaX * deltaX + deltaY * deltaY < SHEET_GESTURE_LOCK_DISTANCE * SHEET_GESTURE_LOCK_DISTANCE)
     return false;
 
   if (Math.abs(deltaY) <= Math.abs(deltaX))

--- a/examples/elk/scripts/native-compat.test.mjs
+++ b/examples/elk/scripts/native-compat.test.mjs
@@ -90,7 +90,11 @@ test('Vue Lynx Sheet keeps hybrid drag and settle work on the main thread', asyn
   assert.match(source, /modelValue/);
   assert.match(source, /v-show="modelValue"/);
   assert.doesNotMatch(source, /v-if="modelValue"/);
-  assert.match(source, /<Transition name="sheet" @after-leave="handleAfterLeave">/);
+  assert.match(
+    source,
+    /<Transition[\s\S]*?name="sheet"[\s\S]*?persisted[\s\S]*?:duration="\{ enter: 250, leave: 188 \}"[\s\S]*?@before-enter="handleBeforeEnter"[\s\S]*?@after-leave="handleAfterLeave"/,
+    'v-show sheet enter must be persisted with explicit durations and a before-enter snap',
+  );
   assert.match(source, /class="sheet-backdrop"[^>]*:main-thread-ref="backdropRef"[^>]*@tap="requestClose"/s);
   assert.match(source, /class="sheet-surface"/);
   assert.match(
@@ -146,6 +150,7 @@ test('Vue Lynx Sheet keeps hybrid drag and settle work on the main thread', asyn
   assert.match(source, /animationGenerationRef/);
   assert.doesNotMatch(source, /watch\(\(\) => props\.modelValue/);
   assert.doesNotMatch(source, /prepareSheetForOpen/);
+  assert.match(source, /function handleBeforeEnter\(\)[\s\S]*?runOnMainThread\(resetSheetMotion\)/);
   assert.match(
     source,
     /class="sheet-surface-transition"[^>]*:style="surfaceStyle"/,
@@ -164,9 +169,46 @@ test('Vue Lynx Sheet keeps hybrid drag and settle work on the main thread', asyn
   );
   assert.doesNotMatch(source, /\.sheet-enter-from \.sheet-surface,/);
   assert.match(source, /function resetSheetMotion\(\)[\s\S]*?applySheetMotion\(0\)/);
+  assert.match(
+    source,
+    /function resetSheetMotion\(\)[\s\S]*?setMotionTransition\('none', 'none'\)[\s\S]*?applySheetMotion\(0\)/,
+    'reset must leave gesture nodes with transition none, not revive stylesheet transitions',
+  );
+  assert.doesNotMatch(
+    source,
+    /function resetSheetMotion\(\)[\s\S]*?setMotionTransition\('', ''\)/,
+  );
   assert.match(source, /runOnBackground\(requestClose\)/);
-  assert.match(source, /transition:\s*opacity/);
-  assert.match(source, /transition:\s*transform/);
+  assert.match(
+    source,
+    /\.sheet-enter-active,[\s\S]*?\.sheet-leave-active\s*\{[^}]*transition:\s*opacity/s,
+    'opacity interpolation must live on enter/leave-active only',
+  );
+  assert.match(
+    source,
+    /\.sheet-enter-active \.sheet-surface-transition,[\s\S]*?\.sheet-leave-active \.sheet-surface-transition\s*\{[^}]*transition:\s*transform/s,
+    'transform interpolation must live on enter/leave-active only',
+  );
+  assert.match(
+    source,
+    /\.sheet-enter-from,[\s\S]*?\.sheet-enter-from \.sheet-surface-transition\s*\{[^}]*transition:\s*none/s,
+    'enter-from must snap closed instead of reverse-animating into the closed pose',
+  );
+  for (const [selector, label] of [
+    ['.sheet-layer', 'layer'],
+    ['.sheet-backdrop', 'backdrop'],
+    ['.sheet-surface-transition', 'wrapper'],
+    ['.sheet-surface', 'gesture surface'],
+  ]) {
+    const escaped = selector.replace(/\./g, '\\.');
+    const block = source.match(new RegExp(`(?:^|\\n)${escaped}\\s*\\{([^}]*)\\}`));
+    assert.ok(block, `missing base ${label} rule`);
+    assert.doesNotMatch(
+      block[1],
+      /\btransition\s*:/,
+      `always-on ${label} transitions reverse-animate into enter-from on leave interrupt`,
+    );
+  }
   assert.doesNotMatch(source, /transition:\s*all/);
 });
 

--- a/examples/elk/scripts/native-compat.test.mjs
+++ b/examples/elk/scripts/native-compat.test.mjs
@@ -62,7 +62,9 @@ test('sheet filters noisy velocity samples and integrates a stable spring step',
 });
 
 test('sheet worklets keep primitive defaults when detached from module scope', () => {
-  const claim = isolateWorklet(sheetGesture.shouldClaimSheetGesture);
+  const claim = isolateWorklet(sheetGesture.shouldClaimSheetGesture, {
+    SHEET_GESTURE_LOCK_DISTANCE: sheetGesture.SHEET_GESTURE_LOCK_DISTANCE,
+  });
   const resolveDrag = isolateWorklet(sheetGesture.resolveSheetDrag, {
     rubberEffect: sheetGesture.rubberEffect,
   });
@@ -124,6 +126,16 @@ test('Vue Lynx Sheet keeps hybrid drag and settle work on the main thread', asyn
   assert.match(source, /setAttribute\?\.\('enable-scroll', enabled\)/);
   assert.match(source, /setPanelScrollEnabled\(false\)/);
   assert.match(source, /setPanelScrollEnabled\(true\)/);
+  assert.match(
+    source,
+    /panelScrollEnabledRef\.current === enabled/,
+    'avoid redundant enable-scroll attribute writes on every gesture reset',
+  );
+  assert.match(
+    source,
+    /backdropOpacityRef/,
+    'quantize backdrop opacity writes during drag',
+  );
   assert.match(
     source,
     /\.sheet-rubber-fill\s*\{[^}]*background-color:\s*var\(--c-sheet-fill-bg\)/s,

--- a/examples/elk/src/components/sheet/Sheet.vue
+++ b/examples/elk/src/components/sheet/Sheet.vue
@@ -150,7 +150,7 @@ function finishSettle(target: number, dismiss: boolean, generation: number) {
     runOnBackground(requestClose)();
   }
   else {
-    setMotionTransition('', '');
+    setMotionTransition('none', 'none');
   }
 }
 
@@ -306,10 +306,17 @@ function handleTouchCancel() {
 function resetSheetMotion() {
   'main thread';
   cancelSettle();
+  // Keep transition disabled on gesture-owned nodes. Clearing to '' would
+  // revive any stylesheet transition and let later patches animate unexpectedly.
   setMotionTransition('none', 'none');
   applySheetMotion(0);
   resetGestureState();
-  setMotionTransition('', '');
+}
+
+function handleBeforeEnter() {
+  // Snap residual main-thread gesture transforms before CSS enter classes
+  // paint, so the wrapper transition is the only enter motion.
+  runOnMainThread(resetSheetMotion)();
 }
 
 function handleAfterLeave() {
@@ -318,7 +325,13 @@ function handleAfterLeave() {
 </script>
 
 <template>
-  <Transition name="sheet" @after-leave="handleAfterLeave">
+  <Transition
+    name="sheet"
+    persisted
+    :duration="{ enter: 250, leave: 188 }"
+    @before-enter="handleBeforeEnter"
+    @after-leave="handleAfterLeave"
+  >
     <view v-show="modelValue" class="sheet-layer" :style="layerStyle">
       <view
         class="sheet-backdrop"
@@ -372,7 +385,6 @@ function handleAfterLeave() {
   justify-content: flex-end;
   overflow: hidden;
   opacity: 1;
-  transition: opacity 250ms cubic-bezier(0.25, 1, 0.5, 1);
 }
 
 .sheet-backdrop {
@@ -383,7 +395,6 @@ function handleAfterLeave() {
   left: 0;
   background-color: rgba(0, 0, 0, 0.5);
   opacity: 1;
-  transition: opacity 250ms cubic-bezier(0.25, 1, 0.5, 1);
 }
 
 .sheet-surface-transition {
@@ -393,7 +404,6 @@ function handleAfterLeave() {
   flex-direction: column;
   width: 100%;
   transform: translateY(0);
-  transition: transform 250ms cubic-bezier(0.25, 1, 0.5, 1);
 }
 
 .sheet-surface {
@@ -407,7 +417,6 @@ function handleAfterLeave() {
   border-top-right-radius: 8px;
   background-color: var(--c-sheet-bg);
   transform: translateY(0);
-  transition: transform 250ms cubic-bezier(0.25, 1, 0.5, 1);
 }
 
 .sheet-rubber-fill {
@@ -448,6 +457,27 @@ function handleAfterLeave() {
   background-color: var(--c-sheet-bg);
 }
 
+/*
+ * Vue-canonical transitions: only -enter-active / -leave-active enable
+ * interpolation. Always-on base transitions reverse-animate into enter-from
+ * when a leave is interrupted (sheet slides down, then pops open).
+ */
+.sheet-enter-active,
+.sheet-leave-active {
+  transition: opacity 250ms cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+.sheet-enter-active .sheet-surface-transition,
+.sheet-leave-active .sheet-surface-transition {
+  transition: transform 250ms cubic-bezier(0.25, 1, 0.5, 1);
+}
+
+/* Snap closed while enter-from is present; animate only after it is removed. */
+.sheet-enter-from,
+.sheet-enter-from .sheet-surface-transition {
+  transition: none;
+}
+
 .sheet-enter-from,
 .sheet-leave-to {
   opacity: 0;
@@ -459,11 +489,6 @@ function handleAfterLeave() {
 }
 
 .sheet-leave-active {
-  transition-duration: 188ms;
-  transition-timing-function: ease-in;
-}
-
-.sheet-leave-active .sheet-backdrop {
   transition-duration: 188ms;
   transition-timing-function: ease-in;
 }

--- a/examples/elk/src/components/sheet/Sheet.vue
+++ b/examples/elk/src/components/sheet/Sheet.vue
@@ -73,6 +73,8 @@ const gestureLockedRef = useMainThreadRef(false);
 const gestureRejectedRef = useMainThreadRef(false);
 const settleTimerRef = useMainThreadRef(0);
 const animationGenerationRef = useMainThreadRef(0);
+const panelScrollEnabledRef = useMainThreadRef(true);
+const backdropOpacityRef = useMainThreadRef(-1);
 
 const layerStyle = computed(() => ({ bottom: `${props.bottomInset}px` }));
 const surfaceStyle = computed(() => ({
@@ -101,6 +103,9 @@ function setMotionTransition(surfaceValue: string, backdropValue: string) {
 
 function setPanelScrollEnabled(enabled: boolean) {
   'main thread';
+  if (panelScrollEnabledRef.current === enabled)
+    return;
+  panelScrollEnabledRef.current = enabled;
   panelRef.current?.setAttribute?.('enable-scroll', enabled);
 }
 
@@ -110,13 +115,18 @@ function applySheetMotion(translation: number) {
     ? surfaceHeightRef.current
     : 640;
   const progress = sheetOpenProgress(translation, sheetSize);
+  // Quantize opacity writes; transform stays full-precision for drag feel.
+  const opacity = Math.round(progress * 100) / 100;
 
   translationRef.current = translation;
   surfaceRef.current?.setStyleProperty?.(
     'transform',
     `translateY(${translation}px)`,
   );
-  backdropRef.current?.setStyleProperty?.('opacity', String(progress));
+  if (opacity !== backdropOpacityRef.current) {
+    backdropOpacityRef.current = opacity;
+    backdropRef.current?.setStyleProperty?.('opacity', String(opacity));
+  }
 }
 
 function cancelSettle() {
@@ -239,10 +249,7 @@ function handleTouchMove(event: SheetTouchEvent) {
       setPanelScrollEnabled(false);
       gestureLockedRef.current = true;
     }
-    else if (
-      Math.sqrt(deltaX * deltaX + deltaY * deltaY)
-      >= 8
-    ) {
+    else if (deltaX * deltaX + deltaY * deltaY >= 64) {
       gestureRejectedRef.current = true;
       return;
     }
@@ -305,9 +312,19 @@ function handleTouchCancel() {
 
 function resetSheetMotion() {
   'main thread';
-  cancelSettle();
   // Keep transition disabled on gesture-owned nodes. Clearing to '' would
   // revive any stylesheet transition and let later patches animate unexpectedly.
+  if (
+    settleTimerRef.current === 0
+    && Math.abs(translationRef.current) < 0.5
+    && !gestureLockedRef.current
+  ) {
+    setMotionTransition('none', 'none');
+    setPanelScrollEnabled(true);
+    return;
+  }
+
+  cancelSettle();
   setMotionTransition('none', 'none');
   applySheetMotion(0);
   resetGestureState();

--- a/examples/elk/src/components/sheet/gesture.ts
+++ b/examples/elk/src/components/sheet/gesture.ts
@@ -23,8 +23,8 @@ export function shouldClaimSheetGesture(
   scrollTop: number,
 ): boolean {
   'main thread';
-  const displacement = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
-  if (displacement < 8)
+  // Compare squared distance to avoid Math.sqrt on every touchmove sample.
+  if (deltaX * deltaX + deltaY * deltaY < SHEET_GESTURE_LOCK_DISTANCE * SHEET_GESTURE_LOCK_DISTANCE)
     return false;
 
   if (Math.abs(deltaY) <= Math.abs(deltaX))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Elk's bottom Sheet enter animation could intermittently flicker (especially when reopening during leave). Headless rAF sampling showed always-on base `transition` rules reverse-animating into `enter-from` before the real open motion.

### Root cause
`.sheet-layer` / `.sheet-surface-transition` / `.sheet-surface` always had CSS transitions. On leave interrupt, applying `sheet-enter-from` animated *toward* the closed pose, then `enter-to` snapped/animates open — visible as a flash.

### Fix
- Move opacity/transform interpolation to `.sheet-enter-active` / `.sheet-leave-active` only (Vue-canonical)
- Force `transition: none` while `enter-from` is present so the closed pose snaps
- `persisted` + explicit `{ enter: 250, leave: 188 }` durations
- `@before-enter` snaps residual MT gesture transforms
- Keep gesture-owned `setStyleProperty` transitions at `none` after settle/reset (do not clear to `''`)

Same change applied to `examples/elk` and `examples/elk-viewpager`.

### Verification
- `node --import tsx --test scripts/native-compat.test.mjs` — pass (elk + elk-viewpager)
- Headless Chromium rAF sampling of quiet opens + reopen-during-leave (follow-up in this PR after CI)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b4aba896-ff9d-411e-9aa1-09e33c4c289a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b4aba896-ff9d-411e-9aa1-09e33c4c289a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

