### PR TITLE
feat(vapor): compile-time addressing analysis (#297)

### DIFF
--- a/.changeset/vapor-addressing-analysis.md
+++ b/.changeset/vapor-addressing-analysis.md
@@ -1,0 +1,5 @@
+---
+"vue-lynx": patch
+---
+
+Add compile-time Vapor addressing analysis: each vapor `template()` factory is annotated with `__vlxAddressing` `{ holes, addressed, slotCount }` (REGISTER_TREE preorder slots). Metadata only — runtime behavior unchanged until sparse A1→A2 consumes it.

--- a/packages/testing-library/src/__tests__/vapor-addressing.test.ts
+++ b/packages/testing-library/src/__tests__/vapor-addressing.test.ts
@@ -1,8 +1,9 @@
 /**
- * Compile-time Vapor addressing analysis (#297).
+ * Compile-time Vapor addressing analysis (#297 / #298).
  *
  * Locks the hole set + addressed-node set (REGISTER_TREE preorder slots)
- * derived from vapor IR — the metadata #298 will consume for sparse naming.
+ * derived from compiler HTML structure (runtime fold rules) + IR holes.
+ * Tag fingerprints guard sparse A2 against same-count preorder skew.
  */
 
 import { describe, expect, it } from 'vitest';
@@ -12,6 +13,7 @@ import {
   analyzeVaporAddressing,
   annotateVaporAddressing,
 } from '../../../vue-lynx/plugin/src/compiler/vapor-addressing.js';
+import { structureSlotsFromHtml } from '../../../vue-lynx/plugin/src/compiler/vapor-structure-from-html.js';
 
 function analyze(
   source: string,
@@ -22,6 +24,25 @@ function analyze(
     isNativeTag: () => true,
   });
 }
+
+describe('structureSlotsFromHtml (runtime fold parity)', () => {
+  it('folds only-child #text but keeps only-child #comment as a slot', () => {
+    expect(structureSlotsFromHtml('<view><text>hi').tags).toEqual([
+      'view',
+      'text',
+    ]);
+    expect(structureSlotsFromHtml('<view><!--only-->').tags).toEqual([
+      'view',
+      '#comment',
+    ]);
+  });
+
+  it('keeps sibling comments in preorder', () => {
+    expect(
+      structureSlotsFromHtml('<view><text> </text><!--c--><image>').tags,
+    ).toEqual(['view', 'text', '#comment', 'image']);
+  });
+});
 
 describe('analyzeVaporAddressing', () => {
   it('names dynamic text + attr holes and keeps the static middle sibling for nthChild', () => {
@@ -37,12 +58,10 @@ describe('analyzeVaporAddressing', () => {
     expect(templates[0]).toMatchObject({
       templateIndex: 0,
       slotCount: 4,
-      // slots: 0=view, 1=text hole, 2=static text, 3=image hole
       holes: [1, 3],
-      // prefix sibling 2 kept so _nthChild(root, 2) reaches the image
       addressed: [0, 1, 2, 3],
+      tags: ['view', 'text', 'text', 'image'],
     });
-    expect(templates[0]!.content).toContain('class=card');
   });
 
   it('includes ancestor wrappers on the child/child path (p* cursors)', () => {
@@ -56,8 +75,8 @@ describe('analyzeVaporAddressing', () => {
     expect(templates[0]).toMatchObject({
       slotCount: 4,
       holes: [2],
-      // 0=root, 1=wrap ancestor, 2=text hole — static sibling 3 not needed
       addressed: [0, 1, 2],
+      tags: ['view', 'view', 'text'],
     });
   });
 
@@ -69,6 +88,7 @@ describe('analyzeVaporAddressing', () => {
     expect(templates[0]).toMatchObject({
       holes: [3],
       addressed: [0, 1, 2, 3],
+      tags: ['view', 'view', 'view', 'text'],
     });
   });
 
@@ -92,6 +112,7 @@ describe('analyzeVaporAddressing', () => {
       holes: [0],
       addressed: [0],
       slotCount: 2,
+      tags: ['view'],
     });
   });
 
@@ -103,6 +124,7 @@ describe('analyzeVaporAddressing', () => {
       holes: [],
       addressed: [0],
       slotCount: 3,
+      tags: ['view'],
     });
   });
 
@@ -128,12 +150,10 @@ describe('analyzeVaporAddressing', () => {
     expect(templates).toHaveLength(2);
     const outer = templates.find((t) => t.templateIndex === 1)!;
     const inner = templates.find((t) => t.templateIndex === 0)!;
-    // Outer shell: parent of the v-if insert is a hole
     expect(outer).toMatchObject({
       holes: [0],
       addressed: [0],
     });
-    // Positive branch: text + image holes
     expect(inner).toMatchObject({
       holes: [1, 2],
       addressed: [0, 1, 2],
@@ -158,10 +178,64 @@ describe('analyzeVaporAddressing', () => {
       { t: 'setup-ref' },
     );
     expect(templates[0]).toMatchObject({
-      // 0 = view (component insert host), 1 = text hole
       holes: [0, 1],
       addressed: [0, 1],
     });
+  });
+
+  // --- Offset / fold-skew cases (review ①) ---------------------------------
+
+  it('comment siblings keep their own slots (not folded as text-like)', () => {
+    const { templates } = analyze(
+      `<view><text>{{ t }}</text><!--c--><image :src="url" /></view>`,
+      { t: 'setup-ref', url: 'setup-ref' },
+    );
+    expect(templates[0]).toMatchObject({
+      // 0=view, 1=text hole, 2=comment, 3=image hole
+      slotCount: 4,
+      holes: [1, 3],
+      addressed: [0, 1, 2, 3],
+      tags: ['view', 'text', '#comment', 'image'],
+    });
+  });
+
+  it('only-child comment consumes a slot (runtime fold is #text-only)', () => {
+    const { templates } = analyze(`<view><!--only--></view>`);
+    expect(templates[0]).toMatchObject({
+      slotCount: 2,
+      holes: [],
+      addressed: [0],
+      tags: ['view'],
+    });
+  });
+
+  it('mixed {{x}} + element siblings: text host + image in preorder', () => {
+    const { templates } = analyze(
+      `<view><text>{{ t }}</text><image :src="url" /></view>`,
+      { t: 'setup-ref', url: 'setup-ref' },
+    );
+    expect(templates[0]).toMatchObject({
+      slotCount: 3,
+      holes: [1, 2],
+      addressed: [0, 1, 2],
+      tags: ['view', 'text', 'image'],
+    });
+  });
+
+  it('nested v-if: outer insert host + inner branch holes', () => {
+    const { templates } = analyze(
+      `<view>
+        <view v-if="a">
+          <text v-if="b">{{ t }}</text>
+        </view>
+      </view>`,
+      { a: 'setup-ref', b: 'setup-ref', t: 'setup-ref' },
+    );
+    // templates: innermost positive, middle positive, outer shell
+    expect(templates.length).toBeGreaterThanOrEqual(2);
+    const outer = templates[templates.length - 1]!;
+    expect(outer.holes).toContain(0);
+    expect(outer.tags[0]).toBe('view');
   });
 });
 
@@ -185,8 +259,8 @@ describe('annotateVaporAddressing', () => {
     const annotated = annotateVaporAddressing(code, result);
     expect(annotated).toContain(`t0.${VAPOR_ADDRESSING_KEY} = `);
     expect(annotated).toContain('"holes":[1,2]');
+    expect(annotated).toContain('"tags":');
     expect(annotated).toContain('const t0 = _template(');
-    // Call site unchanged
     expect(annotated).toContain('const n0 = t0()');
   });
 

--- a/packages/testing-library/src/__tests__/vapor-addressing.test.ts
+++ b/packages/testing-library/src/__tests__/vapor-addressing.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Compile-time Vapor addressing analysis (#297).
+ *
+ * Locks the hole set + addressed-node set (REGISTER_TREE preorder slots)
+ * derived from vapor IR — the metadata #298 will consume for sparse naming.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  VAPOR_ADDRESSING_KEY,
+  analyzeVaporAddressing,
+  annotateVaporAddressing,
+} from '../../../vue-lynx/plugin/src/compiler/vapor-addressing.js';
+
+function analyze(
+  source: string,
+  bindingMetadata: Record<string, string> = {},
+) {
+  return analyzeVaporAddressing(source, {
+    bindingMetadata,
+    isNativeTag: () => true,
+  });
+}
+
+describe('analyzeVaporAddressing', () => {
+  it('names dynamic text + attr holes and keeps the static middle sibling for nthChild', () => {
+    const { templates } = analyze(
+      `<view class="card">
+        <text>{{ title }}</text>
+        <text class="sub">hi</text>
+        <image :src="url" />
+      </view>`,
+      { title: 'setup-ref', url: 'setup-ref' },
+    );
+    expect(templates).toHaveLength(1);
+    expect(templates[0]).toMatchObject({
+      templateIndex: 0,
+      slotCount: 4,
+      // slots: 0=view, 1=text hole, 2=static text, 3=image hole
+      holes: [1, 3],
+      // prefix sibling 2 kept so _nthChild(root, 2) reaches the image
+      addressed: [0, 1, 2, 3],
+    });
+    expect(templates[0]!.content).toContain('class=card');
+  });
+
+  it('includes ancestor wrappers on the child/child path (p* cursors)', () => {
+    const { templates } = analyze(
+      `<view>
+        <view class="wrap"><text>{{ t }}</text></view>
+        <text class="s">static</text>
+      </view>`,
+      { t: 'setup-ref' },
+    );
+    expect(templates[0]).toMatchObject({
+      slotCount: 4,
+      holes: [2],
+      // 0=root, 1=wrap ancestor, 2=text hole — static sibling 3 not needed
+      addressed: [0, 1, 2],
+    });
+  });
+
+  it('keeps deep ancestor chain for inlined _child(_child(_child(...)))', () => {
+    const { templates } = analyze(
+      `<view><view class="a"><view class="b"><text>{{ t }}</text></view></view></view>`,
+      { t: 'setup-ref' },
+    );
+    expect(templates[0]).toMatchObject({
+      holes: [3],
+      addressed: [0, 1, 2, 3],
+    });
+  });
+
+  it('keeps prefix siblings before a trailing text hole', () => {
+    const { templates } = analyze(
+      `<view><text>a</text><text>b</text><text>{{ t }}</text></view>`,
+      { t: 'setup-ref' },
+    );
+    expect(templates[0]).toMatchObject({
+      holes: [3],
+      addressed: [0, 1, 2, 3],
+    });
+  });
+
+  it('marks an event host as a hole; skips unreferenced static children', () => {
+    const { templates } = analyze(
+      `<view @tap="onTap"><text class="c">hi</text></view>`,
+      { onTap: 'setup-const' },
+    );
+    expect(templates[0]).toMatchObject({
+      holes: [0],
+      addressed: [0],
+      slotCount: 2,
+    });
+  });
+
+  it('fully static templates have no holes — only the root is addressed', () => {
+    const { templates } = analyze(
+      `<view class="only"><text class="s">static</text><text class="s2">also</text></view>`,
+    );
+    expect(templates[0]).toMatchObject({
+      holes: [],
+      addressed: [0],
+      slotCount: 3,
+    });
+  });
+
+  it('treats template ref + dynamic text as holes', () => {
+    const { templates } = analyze(
+      `<view ref="root"><text>{{ title }}</text></view>`,
+      { title: 'setup-ref' },
+    );
+    expect(templates[0]).toMatchObject({
+      holes: [0, 1],
+      addressed: [0, 1],
+    });
+  });
+
+  it('marks v-if hosts as holes and analyzes the positive branch template', () => {
+    const { templates } = analyze(
+      `<view>
+        <view v-if="ok"><text>{{ title }}</text><image :src="url" /></view>
+        <text>static</text>
+      </view>`,
+      { ok: 'setup-ref', title: 'setup-ref', url: 'setup-ref' },
+    );
+    expect(templates).toHaveLength(2);
+    const outer = templates.find((t) => t.templateIndex === 1)!;
+    const inner = templates.find((t) => t.templateIndex === 0)!;
+    // Outer shell: parent of the v-if insert is a hole
+    expect(outer).toMatchObject({
+      holes: [0],
+      addressed: [0],
+    });
+    // Positive branch: text + image holes
+    expect(inner).toMatchObject({
+      holes: [1, 2],
+      addressed: [0, 1, 2],
+    });
+  });
+
+  it('marks v-for hosts as holes and analyzes the list-item template', () => {
+    const { templates } = analyze(
+      `<view><text v-for="i in list" :key="i">{{ i }}</text></view>`,
+      { list: 'setup-ref' },
+    );
+    expect(templates).toHaveLength(2);
+    const outer = templates.find((t) => t.templateIndex === 1)!;
+    const item = templates.find((t) => t.templateIndex === 0)!;
+    expect(outer).toMatchObject({ holes: [0], addressed: [0] });
+    expect(item).toMatchObject({ holes: [0], addressed: [0] });
+  });
+
+  it('marks component insertion parents as holes', () => {
+    const { templates } = analyze(
+      `<view><Comp /><text>{{ t }}</text></view>`,
+      { t: 'setup-ref' },
+    );
+    expect(templates[0]).toMatchObject({
+      // 0 = view (component insert host), 1 = text hole
+      holes: [0, 1],
+      addressed: [0, 1],
+    });
+  });
+});
+
+describe('annotateVaporAddressing', () => {
+  it('stamps __vlxAddressing onto each tN factory without changing call sites', () => {
+    const source =
+      `<view class="card"><text>{{ title }}</text><image :src="url" /></view>`;
+    const result = analyze(source, {
+      title: 'setup-ref',
+      url: 'setup-ref',
+    });
+    const code = [
+      'import { template as _template, child as _child } from "vue"',
+      'const t0 = _template("<view class=card><text> </text><image>", 1, 1)',
+      'export function render() {',
+      '  const n0 = t0()',
+      '  return n0',
+      '}',
+    ].join('\n');
+
+    const annotated = annotateVaporAddressing(code, result);
+    expect(annotated).toContain(`t0.${VAPOR_ADDRESSING_KEY} = `);
+    expect(annotated).toContain('"holes":[1,2]');
+    expect(annotated).toContain('const t0 = _template(');
+    // Call site unchanged
+    expect(annotated).toContain('const n0 = t0()');
+  });
+
+  it('annotates multiple templates by index', () => {
+    const result = analyze(
+      `<view><view v-if="ok"><text>{{ t }}</text></view></view>`,
+      { ok: 'setup-ref', t: 'setup-ref' },
+    );
+    const code = [
+      'const t0 = _template("<view><text> ", 0, 1)',
+      'const t1 = _template("<view>", 1, 1)',
+    ].join('\n');
+    const annotated = annotateVaporAddressing(code, result);
+    expect(annotated).toMatch(/const t0 = _template\([\s\S]*?\)\nt0\.__vlxAddressing/);
+    expect(annotated).toMatch(/const t1 = _template\([\s\S]*?\)\nt1\.__vlxAddressing/);
+  });
+});

--- a/packages/vue-lynx/internal/src/ops.ts
+++ b/packages/vue-lynx/internal/src/ops.ts
@@ -158,6 +158,28 @@ export interface TemplateNodeProps {
 /** [tag, props|0, children] */
 export type TemplateNode = [string, TemplateNodeProps | 0, TemplateNode[]];
 
+/**
+ * Property stamped onto vapor `template()` factories by compile-time
+ * addressing analysis (#297). Runtime sparse A2 (#298) reads this.
+ */
+export const VAPOR_ADDRESSING_KEY = '__vlxAddressing';
+
+/**
+ * Sparse naming metadata for one vapor template (REGISTER_TREE preorder
+ * slots). `addressed` is what receives uids under A2; `holes` ⊆ `addressed`
+ * are write / insert-host targets.
+ *
+ * `tags` fingerprints `addressed.map(slot => structure[slot].tag)` so
+ * runtime can fail-safe to dense A1 on IR↔runtime preorder skew (#298).
+ */
+export interface VaporTreeAddressing {
+  holes: number[];
+  addressed: number[];
+  slotCount: number;
+  /** Tags at each addressed slot, parallel to `addressed`. */
+  tags: string[];
+}
+
 // Global names bridging the vapor build plugin and the runtime DOM shim:
 // the plugin's DefinePlugin rewrites free `document`/`window` identifiers to
 // `globalThis.<name>`, and vapor/dom-shim.ts installs the shims under the

--- a/packages/vue-lynx/package.json
+++ b/packages/vue-lynx/package.json
@@ -81,6 +81,7 @@
     "@lynx-js/template-webpack-plugin": "^0.10.5",
     "@lynx-js/webpack-dev-transport": "^0.2.0",
     "@vue/compiler-core": "3.6.0-beta.17",
+    "@vue/compiler-vapor": "3.6.0-beta.17",
     "@vue/runtime-core": "3.6.0-beta.17",
     "@vue/runtime-dom": "3.6.0-beta.17",
     "@vue/runtime-vapor": "3.6.0-beta.17"

--- a/packages/vue-lynx/plugin/rslib.config.ts
+++ b/packages/vue-lynx/plugin/rslib.config.ts
@@ -30,6 +30,7 @@ export default defineConfig({
       '@lynx-js/react/transform',
       '@lynx-js/runtime-wrapper-webpack-plugin',
       '@lynx-js/template-webpack-plugin',
+      '@vue/compiler-vapor',
       'vue-lynx',
       'vue-lynx/internal/ops',
       'vue-lynx/main-thread',

--- a/packages/vue-lynx/plugin/src/compiler/vapor-addressing.ts
+++ b/packages/vue-lynx/plugin/src/compiler/vapor-addressing.ts
@@ -3,24 +3,19 @@
 // LICENSE file in the root directory of this source tree.
 
 /**
- * Compile-time Vapor addressing analysis (#297).
+ * Compile-time Vapor addressing analysis (#297 / #298).
  *
- * Vapor today is a densely named tree (`REGISTER_TREE` / `CLONE_TREE`) because
- * addressing knowledge lives in codegen navigation (`n0 = t0()`, `_child`,
- * `_next`, `_nthChild`, …) that the ops protocol cannot see. To sparsify
- * naming (A1 → A2, #298) we must extract that set at compile time.
+ * Produces per-`template()` metadata consumed by sparse A2 naming:
+ *  - **holes** — dynamic bind / event / ref / text targets + insert hosts
+ *  - **addressed** — holes ∪ root ∪ ancestors ∪ prefix siblings
+ *  - **tags** — fingerprint of `structure[addressed[i]].tag` for fail-safe
+ *    validation against runtime `buildStructure`
  *
- * For each vapor `template()` this module produces:
- *  - **holes** — nodes with dynamic bind / event / ref / text (or directive)
- *    writes, plus parents of dynamic children (`v-if` / `v-for` / components)
- *  - **addressed** — holes ∪ root ∪ ancestors ∪ prefix siblings on the
- *    `child` / `next` / `nthChild` path (the nav-slot closure)
- *
- * Slots are REGISTER_TREE preorder offsets (folded only-child `#text` does
- * not consume a slot — same contract as `buildStructure`).
- *
- * Pure analysis + optional codegen annotation. Does not change runtime
- * behavior unless a later consumer (#298) reads `__vlxAddressing`.
+ * Slot geometry is derived from the compiler HTML string with the **same**
+ * fold rules as runtime `buildStructure` (only-child `#text` folded;
+ * `#comment` always consumes a slot). IR is used only to discover which
+ * elements are holes — never as the preorder authority — so IR↔runtime
+ * fold skew cannot silently mis-name nodes.
  */
 
 import type { BindingMetadata } from '@vue/compiler-dom';
@@ -54,29 +49,21 @@ import {
   transformVSlot,
   transformVText,
 } from '@vue/compiler-vapor';
+import {
+  VAPOR_ADDRESSING_KEY,
+  type VaporTreeAddressing,
+} from 'vue-lynx/internal/ops';
 
-/** Property stamped onto template factories by {@link annotateVaporAddressing}. */
-export const VAPOR_ADDRESSING_KEY = '__vlxAddressing';
+import { structureSlotsFromHtml } from './vapor-structure-from-html.js';
+
+export { VAPOR_ADDRESSING_KEY };
 
 /** Per-template hole + addressed-node metadata (REGISTER_TREE preorder slots). */
-export interface VaporTemplateAddressing {
+export interface VaporTemplateAddressing extends VaporTreeAddressing {
   /** Index of this template in the vapor IR (`t0`, `t1`, …). */
   templateIndex: number;
   /** Compiler-emitted HTML string passed to `template()`. */
   content: string;
-  /** Dense preorder length of the REGISTER_TREE structure (incl. anchors). */
-  slotCount: number;
-  /**
-   * Preorder slots that are holes: dynamic bind/event/ref/text targets, or
-   * parents of dynamic children (element-slot insertion points).
-   */
-  holes: number[];
-  /**
-   * Preorder slots codegen navigation actually needs: holes, template root,
-   * ancestors of holes, and prefix siblings up to the last hole-bearing child
-   * (so `_child` / `_next` / `_nthChild` walks stay valid on a sparse tree).
-   */
-  addressed: number[];
 }
 
 export interface VaporAddressingResult {
@@ -84,12 +71,7 @@ export interface VaporAddressingResult {
 }
 
 export interface AnalyzeVaporAddressingOptions {
-  /**
-   * Binding metadata from `<script setup>` (affects const vs ref codegen, not
-   * the hole set shape for typical templates).
-   */
   bindingMetadata?: BindingMetadata;
-  /** Override native-tag predicate; defaults to Lynx's "everything is native". */
   isNativeTag?: (tag: string) => boolean;
 }
 
@@ -128,16 +110,11 @@ function isInsertPlaceholder(d: IRDynamicInfo): boolean {
   );
 }
 
-/**
- * Text / comment leaf in the IR dynamic tree (not a real element).
- * Only-child cases are folded out of REGISTER_TREE preorder.
- */
+/** Non-element leaf in the IR dynamic tree (text / comment / interpolation). */
 function isTextLike(d: IRDynamicInfo): boolean {
   if (d.template != null || d.operation != null) return false;
   if ((d.flags & DynamicFlag.INSERT) !== 0) return false;
-  // Dynamic interpolation text (GET_TEXT_CHILD host child).
   if ((d.flags & DynamicFlag.NON_TEMPLATE) !== 0) return true;
-  // Static text / comment leaf.
   return (
     d.id === undefined
     && !d.hasDynamicChild
@@ -171,75 +148,51 @@ function collectHoleElementIds(block: BlockIRNode, into: Set<number>): void {
   }
 }
 
-interface SlotInfo {
-  slot: number;
-  parent: number | null;
-  children: number[];
-}
-
 /**
- * Walk one template's IRDynamicInfo root and assign REGISTER_TREE preorder
- * slots (with only-child text folding). Marks insert-host slots as holes.
+ * Map IR element ids → HTML structure slots by walking IR elements in
+ * preorder alongside HTML element slots (skipping `#text` / `#comment`).
+ * Insert-placeholder children mark the current HTML element slot as a hole.
  */
-function assignSlots(
+function mapIrHolesOntoHtmlSlots(
   tplRoot: IRDynamicInfo,
   holeIds: Set<number>,
-  holeSlots: Set<number>,
-): { slotCount: number; idToSlot: Map<number, number>; nodes: SlotInfo[] } {
-  let next = 0;
-  const idToSlot = new Map<number, number>();
-  const nodes: SlotInfo[] = [];
-
-  const walkEl = (d: IRDynamicInfo, parentSlot: number | null): number => {
-    const slot = next++;
-    const info: SlotInfo = { slot, parent: parentSlot, children: [] };
-    nodes[slot] = info;
-    if (d.id !== undefined) idToSlot.set(d.id, slot);
-    if (parentSlot != null) nodes[parentSlot]!.children.push(slot);
-
-    const structKids: IRDynamicInfo[] = [];
-    for (const child of d.children) {
-      if (isInsertPlaceholder(child)) {
-        // Dynamic child (v-if / v-for / component / slot) — host is a hole.
-        holeSlots.add(slot);
-        continue;
-      }
-      structKids.push(child);
-    }
-
-    if (structKids.length === 1 && isTextLike(structKids[0]!)) {
-      // Folded only-child #text — no separate structure slot.
-      return slot;
-    }
-
-    for (const child of structKids) {
-      if (isTextLike(child)) {
-        const textSlot = next++;
-        nodes[textSlot] = { slot: textSlot, parent: slot, children: [] };
-        info.children.push(textSlot);
-      } else {
-        walkEl(child, slot);
-      }
-    }
-    return slot;
-  };
-
-  walkEl(tplRoot, null);
-
-  for (const id of holeIds) {
-    const slot = idToSlot.get(id);
-    if (slot !== undefined) holeSlots.add(slot);
+  htmlTags: readonly string[],
+): number[] {
+  const elementSlots: number[] = [];
+  for (let i = 0; i < htmlTags.length; i++) {
+    const tag = htmlTags[i]!;
+    if (tag !== '#text' && tag !== '#comment') elementSlots.push(i);
   }
 
-  return { slotCount: next, idToSlot, nodes };
+  const holeSlots = new Set<number>();
+  let elIdx = 0;
+
+  const walkEl = (d: IRDynamicInfo): void => {
+    if (isInsertPlaceholder(d) || isTextLike(d)) return;
+
+    const htmlSlot = elementSlots[elIdx++];
+    if (htmlSlot === undefined) return;
+
+    if (d.id !== undefined && holeIds.has(d.id)) {
+      holeSlots.add(htmlSlot);
+    }
+
+    for (const child of d.children) {
+      if (isInsertPlaceholder(child)) {
+        holeSlots.add(htmlSlot);
+        continue;
+      }
+      if (isTextLike(child)) continue;
+      walkEl(child);
+    }
+  };
+
+  walkEl(tplRoot);
+  return [...holeSlots].sort((a, b) => a - b);
 }
 
-/**
- * Nav-slot closure: root + holes + ancestors + prefix siblings (same shape as
- * IFR sparse facades — keeps `_child` / `_next` / `_nthChild` valid).
- */
 function computeAddressed(
-  nodes: SlotInfo[],
+  nodes: { parent: number | null; children: number[] }[],
   holes: readonly number[],
 ): number[] {
   const needed = new Set<number>([0, ...holes]);
@@ -285,7 +238,6 @@ function visitNestedBlock(op: OperationNode, visit: (b: BlockIRNode) => void): v
         if (op.negative.type === IRNodeTypes.BLOCK) {
           visit(op.negative);
         } else {
-          // Nested v-else-if chain: IfIRNode
           visitNestedBlock(op.negative, visit);
         }
       }
@@ -329,18 +281,25 @@ export function analyzeVaporAddressing(
   const visitBlock = (block: BlockIRNode): void => {
     const walk = (d: IRDynamicInfo): void => {
       if (d.template != null) {
+        const entry = ir.template.entries[d.template];
+        const content = entry?.content ?? '';
+        const { tags, nodes, slotCount } = structureSlotsFromHtml(content);
+
         const holeIds = new Set<number>();
         collectHoleElementIds(block, holeIds);
-        const holeSlots = new Set<number>();
-        const { slotCount, nodes } = assignSlots(d, holeIds, holeSlots);
-        const holes = [...holeSlots].sort((a, b) => a - b);
-        const entry = ir.template.entries[d.template];
+        const holes = mapIrHolesOntoHtmlSlots(d, holeIds, tags);
+        const addressed = slotCount > 0
+          ? computeAddressed(nodes, holes)
+          : [];
+        const addressedTags = addressed.map((s) => tags[s] ?? '');
+
         templates.push({
           templateIndex: d.template,
-          content: entry?.content ?? '',
+          content,
           slotCount,
           holes,
-          addressed: computeAddressed(nodes, holes),
+          addressed,
+          tags: addressedTags,
         });
       }
 
@@ -349,8 +308,6 @@ export function analyzeVaporAddressing(
     };
 
     walk(block.dynamic);
-
-    // Block-level structural ops (rare — usually hang off dynamic nodes).
     for (const op of block.operation) visitNestedBlock(op, visitBlock);
   };
 
@@ -361,8 +318,7 @@ export function analyzeVaporAddressing(
 }
 
 /**
- * Stamp `__vlxAddressing` onto each `const tN = template(...)` factory in
- * compiler-vapor output. Runtime ignores the property until #298 consumes it.
+ * Stamp `__vlxAddressing` onto each `const tN = template(...)` factory.
  */
 export function annotateVaporAddressing(
   code: string,
@@ -374,7 +330,6 @@ export function annotateVaporAddressing(
     result.templates.map((t) => [t.templateIndex, t]),
   );
 
-  // Match `const t0 = _template(` / `const t0 = template(` and the full call.
   const re =
     /\bconst\s+(t(\d+))\s*=\s*(_template|template)\s*\(/g;
 
@@ -385,11 +340,10 @@ export function annotateVaporAddressing(
     const name = match[1]!;
     const index = Number(match[2]);
     const meta = byIndex.get(index);
-    const callStart = match.index + match[0].length - 1; // at '('
+    const callStart = match.index + match[0].length - 1;
     const callEnd = findMatchingParen(code, callStart);
     if (callEnd < 0 || !meta) continue;
 
-    // Include trailing semicolon / newline if present.
     let stmtEnd = callEnd + 1;
     while (stmtEnd < code.length && /[ \t]/.test(code[stmtEnd]!)) stmtEnd++;
     if (code[stmtEnd] === ';') stmtEnd++;
@@ -406,15 +360,14 @@ export function annotateVaporAddressing(
 }
 
 function stringifyAddressing(meta: VaporTemplateAddressing): string {
-  // Compact JSON — stable key order for snapshots.
   return JSON.stringify({
     holes: meta.holes,
     addressed: meta.addressed,
     slotCount: meta.slotCount,
+    tags: meta.tags,
   });
 }
 
-/** Find the `)` matching `code[openIndex] === '('`. */
 function findMatchingParen(code: string, openIndex: number): number {
   let depth = 0;
   let inStr: '"' | "'" | '`' | null = null;
@@ -446,10 +399,6 @@ function findMatchingParen(code: string, openIndex: number): number {
   return -1;
 }
 
-/**
- * Analyze `source` and annotate compiler-vapor `code` in one step.
- * Used by the vapor template loader.
- */
 export function analyzeAndAnnotateVaporCode(
   source: string,
   code: string,

--- a/packages/vue-lynx/plugin/src/compiler/vapor-addressing.ts
+++ b/packages/vue-lynx/plugin/src/compiler/vapor-addressing.ts
@@ -1,0 +1,460 @@
+// Copyright 2026 Xuan Huang (huxpro). All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * Compile-time Vapor addressing analysis (#297).
+ *
+ * Vapor today is a densely named tree (`REGISTER_TREE` / `CLONE_TREE`) because
+ * addressing knowledge lives in codegen navigation (`n0 = t0()`, `_child`,
+ * `_next`, `_nthChild`, …) that the ops protocol cannot see. To sparsify
+ * naming (A1 → A2, #298) we must extract that set at compile time.
+ *
+ * For each vapor `template()` this module produces:
+ *  - **holes** — nodes with dynamic bind / event / ref / text (or directive)
+ *    writes, plus parents of dynamic children (`v-if` / `v-for` / components)
+ *  - **addressed** — holes ∪ root ∪ ancestors ∪ prefix siblings on the
+ *    `child` / `next` / `nthChild` path (the nav-slot closure)
+ *
+ * Slots are REGISTER_TREE preorder offsets (folded only-child `#text` does
+ * not consume a slot — same contract as `buildStructure`).
+ *
+ * Pure analysis + optional codegen annotation. Does not change runtime
+ * behavior unless a later consumer (#298) reads `__vlxAddressing`.
+ */
+
+import type { BindingMetadata } from '@vue/compiler-dom';
+import type {
+  BlockIRNode,
+  IRDynamicInfo,
+  OperationNode,
+  RootIRNode,
+} from '@vue/compiler-vapor';
+import {
+  DynamicFlag,
+  IRNodeTypes,
+  isBlockOperation,
+  parse,
+  transform,
+  transformChildren,
+  transformComment,
+  transformElement,
+  transformKey,
+  transformSlotOutlet,
+  transformTemplateRef,
+  transformText,
+  transformVBind,
+  transformVFor,
+  transformVHtml,
+  transformVIf,
+  transformVModel,
+  transformVOn,
+  transformVOnce,
+  transformVShow,
+  transformVSlot,
+  transformVText,
+} from '@vue/compiler-vapor';
+
+/** Property stamped onto template factories by {@link annotateVaporAddressing}. */
+export const VAPOR_ADDRESSING_KEY = '__vlxAddressing';
+
+/** Per-template hole + addressed-node metadata (REGISTER_TREE preorder slots). */
+export interface VaporTemplateAddressing {
+  /** Index of this template in the vapor IR (`t0`, `t1`, …). */
+  templateIndex: number;
+  /** Compiler-emitted HTML string passed to `template()`. */
+  content: string;
+  /** Dense preorder length of the REGISTER_TREE structure (incl. anchors). */
+  slotCount: number;
+  /**
+   * Preorder slots that are holes: dynamic bind/event/ref/text targets, or
+   * parents of dynamic children (element-slot insertion points).
+   */
+  holes: number[];
+  /**
+   * Preorder slots codegen navigation actually needs: holes, template root,
+   * ancestors of holes, and prefix siblings up to the last hole-bearing child
+   * (so `_child` / `_next` / `_nthChild` walks stay valid on a sparse tree).
+   */
+  addressed: number[];
+}
+
+export interface VaporAddressingResult {
+  templates: VaporTemplateAddressing[];
+}
+
+export interface AnalyzeVaporAddressingOptions {
+  /**
+   * Binding metadata from `<script setup>` (affects const vs ref codegen, not
+   * the hole set shape for typical templates).
+   */
+  bindingMetadata?: BindingMetadata;
+  /** Override native-tag predicate; defaults to Lynx's "everything is native". */
+  isNativeTag?: (tag: string) => boolean;
+}
+
+function getBaseTransformPreset(): [
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  any[],
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  Record<string, any>,
+] {
+  return [[
+    transformVOnce,
+    transformVIf,
+    transformVFor,
+    transformKey,
+    transformSlotOutlet,
+    transformTemplateRef,
+    transformElement,
+    transformText,
+    transformVSlot,
+    transformComment,
+    transformChildren,
+  ], {
+    bind: transformVBind,
+    on: transformVOn,
+    html: transformVHtml,
+    text: transformVText,
+    show: transformVShow,
+    model: transformVModel,
+  }];
+}
+
+function isInsertPlaceholder(d: IRDynamicInfo): boolean {
+  return (
+    (d.flags & DynamicFlag.NON_TEMPLATE) !== 0
+    && (d.flags & DynamicFlag.INSERT) !== 0
+  );
+}
+
+/**
+ * Text / comment leaf in the IR dynamic tree (not a real element).
+ * Only-child cases are folded out of REGISTER_TREE preorder.
+ */
+function isTextLike(d: IRDynamicInfo): boolean {
+  if (d.template != null || d.operation != null) return false;
+  if ((d.flags & DynamicFlag.INSERT) !== 0) return false;
+  // Dynamic interpolation text (GET_TEXT_CHILD host child).
+  if ((d.flags & DynamicFlag.NON_TEMPLATE) !== 0) return true;
+  // Static text / comment leaf.
+  return (
+    d.id === undefined
+    && !d.hasDynamicChild
+    && (d.children?.length ?? 0) === 0
+  );
+}
+
+function collectHoleElementIds(block: BlockIRNode, into: Set<number>): void {
+  const consider = (op: OperationNode): void => {
+    switch (op.type) {
+      case IRNodeTypes.SET_PROP:
+      case IRNodeTypes.SET_DYNAMIC_PROPS:
+      case IRNodeTypes.SET_EVENT:
+      case IRNodeTypes.SET_DYNAMIC_EVENTS:
+      case IRNodeTypes.SET_HTML:
+      case IRNodeTypes.SET_TEMPLATE_REF:
+      case IRNodeTypes.SET_TEXT:
+      case IRNodeTypes.DIRECTIVE:
+        if (op.element != null) into.add(op.element);
+        break;
+      case IRNodeTypes.GET_TEXT_CHILD:
+        into.add(op.parent);
+        break;
+      default:
+        break;
+    }
+  };
+  for (const op of block.operation) consider(op);
+  for (const effect of block.effect) {
+    for (const op of effect.operations) consider(op);
+  }
+}
+
+interface SlotInfo {
+  slot: number;
+  parent: number | null;
+  children: number[];
+}
+
+/**
+ * Walk one template's IRDynamicInfo root and assign REGISTER_TREE preorder
+ * slots (with only-child text folding). Marks insert-host slots as holes.
+ */
+function assignSlots(
+  tplRoot: IRDynamicInfo,
+  holeIds: Set<number>,
+  holeSlots: Set<number>,
+): { slotCount: number; idToSlot: Map<number, number>; nodes: SlotInfo[] } {
+  let next = 0;
+  const idToSlot = new Map<number, number>();
+  const nodes: SlotInfo[] = [];
+
+  const walkEl = (d: IRDynamicInfo, parentSlot: number | null): number => {
+    const slot = next++;
+    const info: SlotInfo = { slot, parent: parentSlot, children: [] };
+    nodes[slot] = info;
+    if (d.id !== undefined) idToSlot.set(d.id, slot);
+    if (parentSlot != null) nodes[parentSlot]!.children.push(slot);
+
+    const structKids: IRDynamicInfo[] = [];
+    for (const child of d.children) {
+      if (isInsertPlaceholder(child)) {
+        // Dynamic child (v-if / v-for / component / slot) — host is a hole.
+        holeSlots.add(slot);
+        continue;
+      }
+      structKids.push(child);
+    }
+
+    if (structKids.length === 1 && isTextLike(structKids[0]!)) {
+      // Folded only-child #text — no separate structure slot.
+      return slot;
+    }
+
+    for (const child of structKids) {
+      if (isTextLike(child)) {
+        const textSlot = next++;
+        nodes[textSlot] = { slot: textSlot, parent: slot, children: [] };
+        info.children.push(textSlot);
+      } else {
+        walkEl(child, slot);
+      }
+    }
+    return slot;
+  };
+
+  walkEl(tplRoot, null);
+
+  for (const id of holeIds) {
+    const slot = idToSlot.get(id);
+    if (slot !== undefined) holeSlots.add(slot);
+  }
+
+  return { slotCount: next, idToSlot, nodes };
+}
+
+/**
+ * Nav-slot closure: root + holes + ancestors + prefix siblings (same shape as
+ * IFR sparse facades — keeps `_child` / `_next` / `_nthChild` valid).
+ */
+function computeAddressed(
+  nodes: SlotInfo[],
+  holes: readonly number[],
+): number[] {
+  const needed = new Set<number>([0, ...holes]);
+
+  for (const hole of holes) {
+    let parent = nodes[hole]?.parent ?? null;
+    while (parent != null) {
+      needed.add(parent);
+      parent = nodes[parent]?.parent ?? null;
+    }
+  }
+
+  const subtreeHasNeeded = (slot: number): boolean => {
+    if (needed.has(slot)) return true;
+    const info = nodes[slot];
+    if (!info) return false;
+    for (const child of info.children) {
+      if (subtreeHasNeeded(child)) return true;
+    }
+    return false;
+  };
+
+  for (const info of nodes) {
+    if (!info || info.children.length === 0) continue;
+    let last = -1;
+    for (let i = 0; i < info.children.length; i++) {
+      if (subtreeHasNeeded(info.children[i]!)) last = i;
+    }
+    if (last >= 0) {
+      for (let i = 0; i <= last; i++) needed.add(info.children[i]!);
+    }
+  }
+
+  return [...needed].sort((a, b) => a - b);
+}
+
+function visitNestedBlock(op: OperationNode, visit: (b: BlockIRNode) => void): void {
+  if (!isBlockOperation(op)) return;
+  switch (op.type) {
+    case IRNodeTypes.IF: {
+      visit(op.positive);
+      if (op.negative) {
+        if (op.negative.type === IRNodeTypes.BLOCK) {
+          visit(op.negative);
+        } else {
+          // Nested v-else-if chain: IfIRNode
+          visitNestedBlock(op.negative, visit);
+        }
+      }
+      break;
+    }
+    case IRNodeTypes.FOR:
+      visit(op.render);
+      break;
+    case IRNodeTypes.KEY:
+      visit(op.block);
+      break;
+    default:
+      break;
+  }
+}
+
+function transformToIR(
+  source: string,
+  options: AnalyzeVaporAddressingOptions,
+): RootIRNode {
+  const isNativeTag = options.isNativeTag ?? (() => true);
+  const ast = parse(source, { isNativeTag, whitespace: 'condense' });
+  const [nodeTransforms, directiveTransforms] = getBaseTransformPreset();
+  return transform(ast, {
+    bindingMetadata: options.bindingMetadata,
+    nodeTransforms,
+    directiveTransforms,
+  });
+}
+
+/**
+ * Analyze a Vapor template source string and return per-`template()` metadata.
+ */
+export function analyzeVaporAddressing(
+  source: string,
+  options: AnalyzeVaporAddressingOptions = {},
+): VaporAddressingResult {
+  const ir = transformToIR(source, options);
+  const templates: VaporTemplateAddressing[] = [];
+
+  const visitBlock = (block: BlockIRNode): void => {
+    const walk = (d: IRDynamicInfo): void => {
+      if (d.template != null) {
+        const holeIds = new Set<number>();
+        collectHoleElementIds(block, holeIds);
+        const holeSlots = new Set<number>();
+        const { slotCount, nodes } = assignSlots(d, holeIds, holeSlots);
+        const holes = [...holeSlots].sort((a, b) => a - b);
+        const entry = ir.template.entries[d.template];
+        templates.push({
+          templateIndex: d.template,
+          content: entry?.content ?? '',
+          slotCount,
+          holes,
+          addressed: computeAddressed(nodes, holes),
+        });
+      }
+
+      if (d.operation) visitNestedBlock(d.operation, visitBlock);
+      for (const child of d.children) walk(child);
+    };
+
+    walk(block.dynamic);
+
+    // Block-level structural ops (rare — usually hang off dynamic nodes).
+    for (const op of block.operation) visitNestedBlock(op, visitBlock);
+  };
+
+  visitBlock(ir.block);
+
+  templates.sort((a, b) => a.templateIndex - b.templateIndex);
+  return { templates };
+}
+
+/**
+ * Stamp `__vlxAddressing` onto each `const tN = template(...)` factory in
+ * compiler-vapor output. Runtime ignores the property until #298 consumes it.
+ */
+export function annotateVaporAddressing(
+  code: string,
+  result: VaporAddressingResult,
+): string {
+  if (result.templates.length === 0) return code;
+
+  const byIndex = new Map(
+    result.templates.map((t) => [t.templateIndex, t]),
+  );
+
+  // Match `const t0 = _template(` / `const t0 = template(` and the full call.
+  const re =
+    /\bconst\s+(t(\d+))\s*=\s*(_template|template)\s*\(/g;
+
+  let out = '';
+  let last = 0;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(code)) !== null) {
+    const name = match[1]!;
+    const index = Number(match[2]);
+    const meta = byIndex.get(index);
+    const callStart = match.index + match[0].length - 1; // at '('
+    const callEnd = findMatchingParen(code, callStart);
+    if (callEnd < 0 || !meta) continue;
+
+    // Include trailing semicolon / newline if present.
+    let stmtEnd = callEnd + 1;
+    while (stmtEnd < code.length && /[ \t]/.test(code[stmtEnd]!)) stmtEnd++;
+    if (code[stmtEnd] === ';') stmtEnd++;
+
+    out += code.slice(last, stmtEnd);
+    out += `\n${name}.${VAPOR_ADDRESSING_KEY} = ${
+      stringifyAddressing(meta)
+    }`;
+    last = stmtEnd;
+    re.lastIndex = stmtEnd;
+  }
+  out += code.slice(last);
+  return out;
+}
+
+function stringifyAddressing(meta: VaporTemplateAddressing): string {
+  // Compact JSON — stable key order for snapshots.
+  return JSON.stringify({
+    holes: meta.holes,
+    addressed: meta.addressed,
+    slotCount: meta.slotCount,
+  });
+}
+
+/** Find the `)` matching `code[openIndex] === '('`. */
+function findMatchingParen(code: string, openIndex: number): number {
+  let depth = 0;
+  let inStr: '"' | "'" | '`' | null = null;
+  let escaped = false;
+  for (let i = openIndex; i < code.length; i++) {
+    const ch = code[i]!;
+    if (inStr) {
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (ch === '\\') {
+        escaped = true;
+        continue;
+      }
+      if (ch === inStr) inStr = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === '`') {
+      inStr = ch;
+      continue;
+    }
+    if (ch === '(') depth++;
+    else if (ch === ')') {
+      depth--;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Analyze `source` and annotate compiler-vapor `code` in one step.
+ * Used by the vapor template loader.
+ */
+export function analyzeAndAnnotateVaporCode(
+  source: string,
+  code: string,
+  options: AnalyzeVaporAddressingOptions = {},
+): { code: string; result: VaporAddressingResult } {
+  const result = analyzeVaporAddressing(source, options);
+  return { code: annotateVaporAddressing(code, result), result };
+}

--- a/packages/vue-lynx/plugin/src/compiler/vapor-structure-from-html.ts
+++ b/packages/vue-lynx/plugin/src/compiler/vapor-structure-from-html.ts
@@ -1,0 +1,162 @@
+/**
+ * Extract REGISTER_TREE preorder tags from a vapor template HTML string.
+ *
+ * Mirrors runtime `html-parser` + `buildStructure` fold rules:
+ * only-child `#text` is folded into the parent (no separate slot);
+ * `#comment` always consumes a slot (including only-child comments).
+ *
+ * Kept local to the addressing analyzer so the plugin does not depend on the
+ * runtime package. Must stay in lockstep with shadow-element.ts buildStructure.
+ */
+
+const VOID_ELEMENTS = new Set([
+  'area',
+  'base',
+  'br',
+  'col',
+  'embed',
+  'hr',
+  'img',
+  'input',
+  'link',
+  'meta',
+  'param',
+  'source',
+  'track',
+  'wbr',
+]);
+
+interface HtmlNode {
+  tag: string;
+  children: HtmlNode[];
+}
+
+function isWhitespace(ch: string): boolean {
+  return ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r' || ch === '\f';
+}
+
+/** Minimal vapor-dialect HTML → tree (same dialect as runtime html-parser). */
+function parseHtmlTree(html: string): HtmlNode | null {
+  const fragment: HtmlNode = { tag: '#fragment', children: [] };
+  const stack: HtmlNode[] = [fragment];
+  const top = (): HtmlNode => stack[stack.length - 1]!;
+
+  let i = 0;
+  const len = html.length;
+
+  while (i < len) {
+    if (html[i] === '<') {
+      if (html[i + 1] === '!') {
+        if (html.startsWith('<!--', i)) {
+          const end = html.indexOf('-->', i + 4);
+          top().children.push({ tag: '#comment', children: [] });
+          i = end === -1 ? len : end + 3;
+          continue;
+        }
+        // `<!>` empty comment anchor
+        if (html[i + 2] === '>') {
+          top().children.push({ tag: '#comment', children: [] });
+          i += 3;
+          continue;
+        }
+      }
+      if (html[i + 1] === '/') {
+        const gt = html.indexOf('>', i + 2);
+        if (stack.length > 1) stack.pop();
+        i = gt === -1 ? len : gt + 1;
+        continue;
+      }
+      // open tag
+      let j = i + 1;
+      while (j < len && !isWhitespace(html[j]!) && html[j] !== '>' && html[j] !== '/') {
+        j++;
+      }
+      const tag = html.slice(i + 1, j).toLowerCase();
+      // skip attrs
+      let selfClosing = false;
+      while (j < len && html[j] !== '>') {
+        if (html[j] === '/' && html[j + 1] === '>') {
+          selfClosing = true;
+          j += 2;
+          break;
+        }
+        // quoted attr value
+        if (html[j] === '"' || html[j] === "'") {
+          const q = html[j]!;
+          j++;
+          while (j < len && html[j] !== q) j++;
+          j++;
+          continue;
+        }
+        j++;
+      }
+      if (j < len && html[j] === '>') j++;
+      const node: HtmlNode = { tag, children: [] };
+      top().children.push(node);
+      i = j;
+      if (!selfClosing && !VOID_ELEMENTS.has(tag)) {
+        stack.push(node);
+      }
+      continue;
+    }
+    // text
+    let j = i;
+    while (j < len && html[j] !== '<') j++;
+    const text = html.slice(i, j);
+    if (text.length > 0) {
+      top().children.push({ tag: '#text', children: [] });
+    }
+    i = j;
+  }
+
+  return fragment.children[0] ?? null;
+}
+
+interface StructSlot {
+  tag: string;
+  parent: number | null;
+  children: number[];
+}
+
+/**
+ * Preorder slots matching runtime `buildStructure` (only-child `#text` folded).
+ */
+export function structureSlotsFromHtml(html: string): {
+  tags: string[];
+  nodes: StructSlot[];
+  slotCount: number;
+} {
+  const root = parseHtmlTree(html);
+  const tags: string[] = [];
+  const nodes: StructSlot[] = [];
+
+  if (!root) {
+    return { tags, nodes, slotCount: 0 };
+  }
+
+  const walk = (node: HtmlNode, parent: number | null): number => {
+    const slot = tags.length;
+    tags.push(node.tag);
+    const info: StructSlot = { tag: node.tag, parent, children: [] };
+    nodes[slot] = info;
+    if (parent != null) nodes[parent]!.children.push(slot);
+
+    if (node.tag === '#text' || node.tag === '#comment') {
+      return slot;
+    }
+
+    const kids = node.children;
+    // Runtime fold: only-child #text → no child slot.
+    if (kids.length === 1 && kids[0]!.tag === '#text') {
+      return slot;
+    }
+
+    for (const kid of kids) {
+      walk(kid, slot);
+    }
+    return slot;
+  };
+
+  walk(root, null);
+  return { tags, nodes, slotCount: tags.length };
+}

--- a/packages/vue-lynx/plugin/src/loaders/vapor-template-loader.ts
+++ b/packages/vue-lynx/plugin/src/loaders/vapor-template-loader.ts
@@ -24,6 +24,8 @@
 import { createRequire } from 'node:module';
 import path from 'node:path';
 
+import { analyzeAndAnnotateVaporCode } from '../compiler/vapor-addressing.js';
+
 const require = createRequire(import.meta.url);
 
 // ---------------------------------------------------------------------------
@@ -204,5 +206,26 @@ export default function vaporTemplateLoader(
     }
   }
 
-  loaderContext.callback(null, compiled.code, compiled.map);
+  let code = compiled.code;
+  // Compile-time addressing metadata for Vapor templates (#297): stamp
+  // `__vlxAddressing` onto each `tN` factory. Runtime ignores it until the
+  // sparse A1→A2 path (#298) consumes the hole / addressed sets.
+  if (descriptor.vapor && code) {
+    try {
+      code = analyzeAndAnnotateVaporCode(src, code, {
+        // script.bindings is BindingMetadata from compiler-sfc; cast through
+        // unknown so the loader stays decoupled from which compiler copy
+        // rspack-vue-loader resolved.
+        bindingMetadata: script?.bindings as
+          | import('@vue/compiler-dom').BindingMetadata
+          | undefined,
+        isNativeTag: () => true,
+      }).code;
+    } catch {
+      // Analysis must never break the compile — sparse naming can fall back
+      // to dense CLONE_TREE when metadata is absent.
+    }
+  }
+
+  loaderContext.callback(null, code, compiled.map);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,7 +70,7 @@ importers:
         version: 0.4.6
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.8))
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@lynx-js/tailwind-preset':
         specifier: ^0.4.0
         version: 0.4.0(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))
@@ -101,7 +101,7 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
         version: 1.2.7(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))
@@ -117,7 +117,7 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
         version: 1.2.7(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))
@@ -148,7 +148,7 @@ importers:
         version: 0.4.6
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@lynx-js/tailwind-preset':
         specifier: ^0.4.0
         version: 0.4.0(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))
@@ -188,7 +188,7 @@ importers:
         version: 0.4.6
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@lynx-js/tailwind-preset':
         specifier: ^0.4.0
         version: 0.4.0(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))
@@ -213,7 +213,7 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
         version: 1.2.7(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))
@@ -229,7 +229,7 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
         version: 1.2.7(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))
@@ -257,7 +257,7 @@ importers:
         version: 0.4.6
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@rsbuild/plugin-sass':
         specifier: ^1.5.1
         version: 1.5.1(@rsbuild/core@2.0.11(core-js@3.47.0))
@@ -291,7 +291,7 @@ importers:
         version: 0.4.6
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@lynx-js/tailwind-preset':
         specifier: ^0.4.0
         version: 0.4.0(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))
@@ -319,7 +319,7 @@ importers:
         version: 0.4.6
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
         version: 1.2.7(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))
@@ -335,7 +335,7 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
         version: 1.2.7(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))
@@ -351,7 +351,7 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
         version: 1.2.7(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))
@@ -370,7 +370,7 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
         version: 1.2.7(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))(vue@3.6.0-beta.17(typescript@5.9.3))
@@ -386,7 +386,7 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
         version: 1.2.7(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))
@@ -405,7 +405,7 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
         version: 1.2.7(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))(vue@3.6.0-beta.17(typescript@5.9.3))
@@ -421,7 +421,7 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
         version: 1.2.7(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))
@@ -437,7 +437,7 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
         version: 1.2.7(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))
@@ -453,7 +453,7 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
         version: 1.2.7(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))
@@ -469,7 +469,7 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
         version: 1.2.7(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))
@@ -485,7 +485,7 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
         version: 1.2.7(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))
@@ -504,7 +504,7 @@ importers:
         version: 0.4.6
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@lynx-js/tailwind-preset':
         specifier: ^0.4.0
         version: 0.4.0(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))
@@ -529,7 +529,7 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
         version: 1.2.7(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))
@@ -545,7 +545,7 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
         version: 1.2.7(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))
@@ -564,7 +564,7 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
         version: 1.2.7(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))(vue@3.6.0-beta.17(typescript@5.9.3))
@@ -580,7 +580,7 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
         version: 1.2.7(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))
@@ -596,7 +596,7 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
         version: 1.2.7(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))
@@ -612,7 +612,7 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
         version: 1.2.7(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))
@@ -628,7 +628,7 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
         version: 1.2.7(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))
@@ -644,7 +644,7 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
         version: 1.2.7(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))
@@ -663,7 +663,7 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
         version: 1.2.7(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))(vue@3.6.0-beta.17(typescript@5.9.3))
@@ -679,7 +679,7 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@lynx-js/web-core':
         specifier: ^0.22.1
         version: 0.22.1(patch_hash=e55082865178c10630667e6486a617cf53a0e881e787d2823c4d093c614600ad)(@lynx-js/css-serializer@0.1.6)(tslib@2.8.1)
@@ -713,13 +713,13 @@ importers:
         version: 0.17.2(@lynx-js/react@0.122.1(@lynx-js/types@3.7.0)(@types/react@18.3.31))(tslib@2.8.1)
       '@lynx-js/rspeedy':
         specifier: ^0.15.2
-        version: 0.15.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(core-js@3.47.0)(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
+        version: 0.15.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(core-js@3.47.0)(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.8))
       '@lynx-js/types':
         specifier: ^3.4.0
         version: 3.7.0
       '@rsbuild/plugin-babel':
         specifier: ^2.0.1
-        version: 2.0.1(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.19))
+        version: 2.0.1(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
       '@types/react':
         specifier: ^18.3.0
         version: 18.3.31
@@ -757,7 +757,7 @@ importers:
         version: 0.4.6
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
         version: 1.2.7(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))(vue@3.6.0-beta.17(typescript@5.9.3))
@@ -822,7 +822,7 @@ importers:
         version: 0.17.2(@lynx-js/react@0.122.1(@lynx-js/types@3.7.0)(@types/react@18.3.31))(tslib@2.8.1)
       '@lynx-js/rspeedy':
         specifier: ^0.15.2
-        version: 0.15.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(core-js@3.47.0)(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
+        version: 0.15.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(core-js@3.47.0)(typescript@5.9.3)(webpack@5.105.4)
       '@types/react':
         specifier: ^18.3.0
         version: 18.3.31
@@ -838,7 +838,7 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
         version: 1.2.7(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))
@@ -942,6 +942,9 @@ importers:
         specifier: ^1.0.0
         version: 1.3.19
       '@vue/compiler-core':
+        specifier: 3.6.0-beta.17
+        version: 3.6.0-beta.17
+      '@vue/compiler-vapor':
         specifier: 3.6.0-beta.17
         version: 3.6.0-beta.17
       '@vue/runtime-core':
@@ -8209,59 +8212,7 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@lynx-js/rspeedy@0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.8))':
-    dependencies:
-      '@lynx-js/cache-events-webpack-plugin': 0.0.2
-      '@lynx-js/chunk-loading-webpack-plugin': 0.3.3
-      '@lynx-js/web-rsbuild-server-middleware': 0.19.8
-      '@lynx-js/webpack-dev-transport': 0.2.0
-      '@lynx-js/websocket': 0.0.4
-      '@rsbuild/core': 1.7.3
-      '@rsbuild/plugin-css-minimizer': 1.1.1(@rsbuild/core@1.7.3)(webpack@5.105.4(postcss@8.5.8))
-      '@rsdoctor/rspack-plugin': 1.2.3(@rsbuild/core@1.7.3)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@parcel/css'
-      - '@rspack/core'
-      - '@swc/css'
-      - bufferutil
-      - clean-css
-      - csso
-      - debug
-      - esbuild
-      - lightningcss
-      - supports-color
-      - utf-8-validate
-      - webpack
-
-  '@lynx-js/rspeedy@0.13.5(@rspack/core@2.0.8(@swc/helpers@0.5.23))(typescript@5.9.3)(webpack@5.105.4)':
-    dependencies:
-      '@lynx-js/cache-events-webpack-plugin': 0.0.2
-      '@lynx-js/chunk-loading-webpack-plugin': 0.3.3
-      '@lynx-js/web-rsbuild-server-middleware': 0.19.8
-      '@lynx-js/webpack-dev-transport': 0.2.0
-      '@lynx-js/websocket': 0.0.4
-      '@rsbuild/core': 1.7.3
-      '@rsbuild/plugin-css-minimizer': 1.1.1(@rsbuild/core@1.7.3)(webpack@5.105.4)
-      '@rsdoctor/rspack-plugin': 1.2.3(@rsbuild/core@1.7.3)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@parcel/css'
-      - '@rspack/core'
-      - '@swc/css'
-      - bufferutil
-      - clean-css
-      - csso
-      - debug
-      - esbuild
-      - lightningcss
-      - supports-color
-      - utf-8-validate
-      - webpack
-
-  '@lynx-js/rspeedy@0.15.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(core-js@3.47.0)(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.19))':
+  '@lynx-js/rspeedy@0.15.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(core-js@3.47.0)(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.8))':
     dependencies:
       '@lynx-js/cache-events-webpack-plugin': 0.1.0
       '@lynx-js/chunk-loading-webpack-plugin': 0.4.1
@@ -8270,8 +8221,38 @@ snapshots:
       '@lynx-js/webpack-dev-transport': 0.3.0
       '@lynx-js/websocket': 0.0.4
       '@rsbuild/core': 2.0.11(core-js@3.47.0)
-      '@rsbuild/plugin-css-minimizer': 2.0.0(@rsbuild/core@2.0.11(core-js@3.47.0))(webpack@5.105.4(postcss@8.5.19))
-      '@rsdoctor/rspack-plugin': 1.5.18(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.19))
+      '@rsbuild/plugin-css-minimizer': 2.0.0(@rsbuild/core@2.0.11(core-js@3.47.0))(webpack@5.105.4(postcss@8.5.8))
+      '@rsdoctor/rspack-plugin': 1.5.18(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@module-federation/runtime-tools'
+      - '@parcel/css'
+      - '@rspack/core'
+      - '@swc/css'
+      - bufferutil
+      - clean-css
+      - core-js
+      - csso
+      - esbuild
+      - lightningcss
+      - supports-color
+      - utf-8-validate
+      - webpack
+
+  '@lynx-js/rspeedy@0.15.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(core-js@3.47.0)(typescript@5.9.3)(webpack@5.105.4)':
+    dependencies:
+      '@lynx-js/cache-events-webpack-plugin': 0.1.0
+      '@lynx-js/chunk-loading-webpack-plugin': 0.4.1
+      '@lynx-js/debug-metadata-rsbuild-plugin': 0.1.2
+      '@lynx-js/web-rsbuild-server-middleware': 0.22.1
+      '@lynx-js/webpack-dev-transport': 0.3.0
+      '@lynx-js/websocket': 0.0.4
+      '@rsbuild/core': 2.0.11(core-js@3.47.0)
+      '@rsbuild/plugin-css-minimizer': 2.0.0(@rsbuild/core@2.0.11(core-js@3.47.0))(webpack@5.105.4)
+      '@rsdoctor/rspack-plugin': 1.5.18(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -8746,14 +8727,14 @@ snapshots:
     transitivePeerDependencies:
       - '@module-federation/runtime-tools'
 
-  '@rsbuild/plugin-babel@2.0.1(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.19))':
+  '@rsbuild/plugin-babel@2.0.1(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)
       '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7)
       '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7)
       '@types/babel__core': 7.20.5
-      babel-loader: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.19))
+      babel-loader: 10.1.1(@babel/core@7.29.7)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
       reduce-configs: 1.1.2
     optionalDependencies:
       '@rsbuild/core': 2.0.11(core-js@3.47.0)
@@ -8797,12 +8778,12 @@ snapshots:
       - lightningcss
       - webpack
 
-  '@rsbuild/plugin-css-minimizer@1.1.1(@rsbuild/core@1.7.3)(webpack@5.105.4(postcss@8.5.8))':
+  '@rsbuild/plugin-css-minimizer@2.0.0(@rsbuild/core@2.0.11(core-js@3.47.0))(webpack@5.105.4(postcss@8.5.8))':
     dependencies:
-      css-minimizer-webpack-plugin: 7.0.2(webpack@5.105.4(postcss@8.5.8))
+      css-minimizer-webpack-plugin: 8.0.0(webpack@5.105.4(postcss@8.5.8))
       reduce-configs: 1.1.2
     optionalDependencies:
-      '@rsbuild/core': 1.7.3
+      '@rsbuild/core': 2.0.11(core-js@3.47.0)
     transitivePeerDependencies:
       - '@parcel/css'
       - '@swc/css'
@@ -8812,24 +8793,9 @@ snapshots:
       - lightningcss
       - webpack
 
-  '@rsbuild/plugin-css-minimizer@1.1.1(@rsbuild/core@1.7.3)(webpack@5.105.4)':
+  '@rsbuild/plugin-css-minimizer@2.0.0(@rsbuild/core@2.0.11(core-js@3.47.0))(webpack@5.105.4)':
     dependencies:
-      css-minimizer-webpack-plugin: 7.0.2(webpack@5.105.4)
-      reduce-configs: 1.1.2
-    optionalDependencies:
-      '@rsbuild/core': 1.7.3
-    transitivePeerDependencies:
-      - '@parcel/css'
-      - '@swc/css'
-      - clean-css
-      - csso
-      - esbuild
-      - lightningcss
-      - webpack
-
-  '@rsbuild/plugin-css-minimizer@2.0.0(@rsbuild/core@2.0.11(core-js@3.47.0))(webpack@5.105.4(postcss@8.5.19))':
-    dependencies:
-      css-minimizer-webpack-plugin: 8.0.0(webpack@5.105.4(postcss@8.5.19))
+      css-minimizer-webpack-plugin: 8.0.0(webpack@5.105.4)
       reduce-configs: 1.1.2
     optionalDependencies:
       '@rsbuild/core': 2.0.11(core-js@3.47.0)
@@ -8940,63 +8906,37 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/core@1.2.3(@rsbuild/core@1.7.3)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))':
-    dependencies:
-      '@rsbuild/plugin-check-syntax': 1.3.0(@rsbuild/core@1.7.3)
-      '@rsdoctor/graph': 1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
-      '@rsdoctor/sdk': 1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
-      '@rsdoctor/types': 1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
-      '@rsdoctor/utils': 1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
-      axios: 1.13.6
-      browserslist-load-config: 1.0.3
-      enhanced-resolve: 5.12.0
-      filesize: 10.1.6
-      fs-extra: 11.3.6
-      lodash: 4.17.23
-      path-browserify: 1.0.1
-      semver: 7.8.5
-      source-map: 0.7.6
-    transitivePeerDependencies:
-      - '@rsbuild/core'
-      - '@rspack/core'
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-      - webpack
-
-  '@rsdoctor/core@1.2.3(@rsbuild/core@1.7.3)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)':
-    dependencies:
-      '@rsbuild/plugin-check-syntax': 1.3.0(@rsbuild/core@1.7.3)
-      '@rsdoctor/graph': 1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
-      '@rsdoctor/sdk': 1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
-      '@rsdoctor/types': 1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
-      '@rsdoctor/utils': 1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
-      axios: 1.13.6
-      browserslist-load-config: 1.0.3
-      enhanced-resolve: 5.12.0
-      filesize: 10.1.6
-      fs-extra: 11.3.6
-      lodash: 4.17.23
-      path-browserify: 1.0.1
-      semver: 7.8.5
-      source-map: 0.7.6
-    transitivePeerDependencies:
-      - '@rsbuild/core'
-      - '@rspack/core'
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-      - webpack
-
-  '@rsdoctor/core@1.5.18(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.19))':
+  '@rsdoctor/core@1.5.18(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))':
     dependencies:
       '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.0.11(core-js@3.47.0))
-      '@rsdoctor/graph': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.19))
-      '@rsdoctor/sdk': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.19))
-      '@rsdoctor/types': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.19))
-      '@rsdoctor/utils': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.19))
+      '@rsdoctor/graph': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
+      '@rsdoctor/sdk': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
+      '@rsdoctor/types': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
+      '@rsdoctor/utils': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
+      '@rspack/resolver': 0.2.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      browserslist-load-config: 1.0.3
+      es-toolkit: 1.49.0
+      filesize: 11.0.22
+      fs-extra: 11.3.6
+      semver: 7.8.5
+      source-map: 0.7.6
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@rsbuild/core'
+      - '@rspack/core'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - webpack
+
+  '@rsdoctor/core@1.5.18(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)':
+    dependencies:
+      '@rsbuild/plugin-check-syntax': 1.6.1(@rsbuild/core@2.0.11(core-js@3.47.0))
+      '@rsdoctor/graph': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
+      '@rsdoctor/sdk': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
+      '@rsdoctor/types': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
+      '@rsdoctor/utils': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
       '@rspack/resolver': 0.2.8(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       browserslist-load-config: 1.0.3
       es-toolkit: 1.49.0
@@ -9025,32 +8965,21 @@ snapshots:
       - supports-color
       - webpack
 
-  '@rsdoctor/graph@1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))':
+  '@rsdoctor/graph@1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))':
     dependencies:
-      '@rsdoctor/types': 1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
-      '@rsdoctor/utils': 1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
-      lodash.unionby: 4.8.0
+      '@rsdoctor/types': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
+      '@rsdoctor/utils': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
+      es-toolkit: 1.49.0
+      path-browserify: 1.0.1
       source-map: 0.7.6
     transitivePeerDependencies:
       - '@rspack/core'
-      - supports-color
       - webpack
 
-  '@rsdoctor/graph@1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)':
+  '@rsdoctor/graph@1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)':
     dependencies:
-      '@rsdoctor/types': 1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
-      '@rsdoctor/utils': 1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
-      lodash.unionby: 4.8.0
-      source-map: 0.7.6
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - supports-color
-      - webpack
-
-  '@rsdoctor/graph@1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.19))':
-    dependencies:
-      '@rsdoctor/types': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.19))
-      '@rsdoctor/utils': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.19))
+      '@rsdoctor/types': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
+      '@rsdoctor/utils': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
       es-toolkit: 1.49.0
       path-browserify: 1.0.1
       source-map: 0.7.6
@@ -9076,49 +9005,31 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/rspack-plugin@1.2.3(@rsbuild/core@1.7.3)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))':
+  '@rsdoctor/rspack-plugin@1.5.18(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))':
     dependencies:
-      '@rsdoctor/core': 1.2.3(@rsbuild/core@1.7.3)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
-      '@rsdoctor/graph': 1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
-      '@rsdoctor/sdk': 1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
-      '@rsdoctor/types': 1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
-      '@rsdoctor/utils': 1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
-      lodash: 4.17.23
+      '@rsdoctor/core': 1.5.18(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
+      '@rsdoctor/graph': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
+      '@rsdoctor/sdk': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
+      '@rsdoctor/types': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
+      '@rsdoctor/utils': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
     optionalDependencies:
       '@rspack/core': 2.0.8(@swc/helpers@0.5.23)
     transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
       - '@rsbuild/core'
       - bufferutil
-      - debug
       - supports-color
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/rspack-plugin@1.2.3(@rsbuild/core@1.7.3)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)':
+  '@rsdoctor/rspack-plugin@1.5.18(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)':
     dependencies:
-      '@rsdoctor/core': 1.2.3(@rsbuild/core@1.7.3)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
-      '@rsdoctor/graph': 1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
-      '@rsdoctor/sdk': 1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
-      '@rsdoctor/types': 1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
-      '@rsdoctor/utils': 1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
-      lodash: 4.17.23
-    optionalDependencies:
-      '@rspack/core': 2.0.8(@swc/helpers@0.5.23)
-    transitivePeerDependencies:
-      - '@rsbuild/core'
-      - bufferutil
-      - debug
-      - supports-color
-      - utf-8-validate
-      - webpack
-
-  '@rsdoctor/rspack-plugin@1.5.18(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.19))':
-    dependencies:
-      '@rsdoctor/core': 1.5.18(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.19))
-      '@rsdoctor/graph': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.19))
-      '@rsdoctor/sdk': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.19))
-      '@rsdoctor/types': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.19))
-      '@rsdoctor/utils': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.19))
+      '@rsdoctor/core': 1.5.18(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@rsbuild/core@2.0.11(core-js@3.47.0))(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
+      '@rsdoctor/graph': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
+      '@rsdoctor/sdk': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
+      '@rsdoctor/types': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
+      '@rsdoctor/utils': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
     optionalDependencies:
       '@rspack/core': 2.0.8(@swc/helpers@0.5.23)
     transitivePeerDependencies:
@@ -9154,60 +9065,29 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@rsdoctor/sdk@1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))':
-    dependencies:
-      '@rsdoctor/client': 1.2.3
-      '@rsdoctor/graph': 1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
-      '@rsdoctor/types': 1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
-      '@rsdoctor/utils': 1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
-      '@types/fs-extra': 11.0.4
-      body-parser: 1.20.3
-      cors: 2.8.5
-      dayjs: 1.11.13
-      fs-extra: 11.3.6
-      json-cycle: 1.5.0
-      open: 8.4.2
-      sirv: 2.0.4
-      socket.io: 4.8.1
-      source-map: 0.7.6
-      tapable: 2.2.2
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - webpack
-
-  '@rsdoctor/sdk@1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)':
-    dependencies:
-      '@rsdoctor/client': 1.2.3
-      '@rsdoctor/graph': 1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
-      '@rsdoctor/types': 1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
-      '@rsdoctor/utils': 1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
-      '@types/fs-extra': 11.0.4
-      body-parser: 1.20.3
-      cors: 2.8.5
-      dayjs: 1.11.13
-      fs-extra: 11.3.6
-      json-cycle: 1.5.0
-      open: 8.4.2
-      sirv: 2.0.4
-      socket.io: 4.8.1
-      source-map: 0.7.6
-      tapable: 2.2.2
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - webpack
-
-  '@rsdoctor/sdk@1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.19))':
+  '@rsdoctor/sdk@1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))':
     dependencies:
       '@rsdoctor/client': 1.5.18
-      '@rsdoctor/graph': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.19))
-      '@rsdoctor/types': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.19))
-      '@rsdoctor/utils': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.19))
+      '@rsdoctor/graph': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
+      '@rsdoctor/types': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
+      '@rsdoctor/utils': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
+      launch-editor: 2.14.1
+      safer-buffer: 2.1.2
+      socket.io: 4.8.1
+      tapable: 2.3.3
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - webpack
+
+  '@rsdoctor/sdk@1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)':
+    dependencies:
+      '@rsdoctor/client': 1.5.18
+      '@rsdoctor/graph': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
+      '@rsdoctor/types': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
+      '@rsdoctor/utils': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
       launch-editor: 2.14.1
       safer-buffer: 2.1.2
       socket.io: 4.8.1
@@ -9229,27 +9109,7 @@ snapshots:
       '@rspack/core': 2.0.8(@swc/helpers@0.5.23)
       webpack: 5.105.4(postcss@8.5.19)
 
-  '@rsdoctor/types@1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))':
-    dependencies:
-      '@types/connect': 3.4.38
-      '@types/estree': 1.0.5
-      '@types/tapable': 2.2.7
-      source-map: 0.7.6
-    optionalDependencies:
-      '@rspack/core': 2.0.8(@swc/helpers@0.5.23)
-      webpack: 5.105.4(postcss@8.5.8)
-
-  '@rsdoctor/types@1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)':
-    dependencies:
-      '@types/connect': 3.4.38
-      '@types/estree': 1.0.5
-      '@types/tapable': 2.2.7
-      source-map: 0.7.6
-    optionalDependencies:
-      '@rspack/core': 2.0.8(@swc/helpers@0.5.23)
-      webpack: 5.105.4
-
-  '@rsdoctor/types@1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.19))':
+  '@rsdoctor/types@1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))':
     dependencies:
       '@types/connect': 3.4.38
       '@types/estree': 1.0.5
@@ -9257,7 +9117,17 @@ snapshots:
       source-map: 0.7.6
     optionalDependencies:
       '@rspack/core': 2.0.8(@swc/helpers@0.5.23)
-      webpack: 5.105.4(postcss@8.5.19)
+      webpack: 5.105.4(postcss@8.5.8)
+
+  '@rsdoctor/types@1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/estree': 1.0.5
+      '@types/tapable': 2.3.0
+      source-map: 0.7.6
+    optionalDependencies:
+      '@rspack/core': 2.0.8(@swc/helpers@0.5.23)
+      webpack: 5.105.4
 
   '@rsdoctor/utils@1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.19))':
     dependencies:
@@ -9283,58 +9153,31 @@ snapshots:
       - supports-color
       - webpack
 
-  '@rsdoctor/utils@1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))':
+  '@rsdoctor/utils@1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@rsdoctor/types': 1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
+      '@rsdoctor/types': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8))
       '@types/estree': 1.0.5
       acorn: 8.17.0
       acorn-import-attributes: 1.9.5(acorn@8.17.0)
-      acorn-walk: 8.3.4
-      connect: 3.7.0
+      acorn-walk: 8.3.5
       deep-eql: 4.1.4
-      envinfo: 7.14.0
-      filesize: 10.1.6
+      envinfo: 7.21.0
       fs-extra: 11.3.6
       get-port: 5.1.1
       json-stream-stringify: 3.0.1
       lines-and-columns: 2.0.4
       picocolors: 1.1.1
-      rslog: 1.3.2
-      strip-ansi: 6.0.1
+      rslog: 2.3.0
+      strip-ansi: 7.2.0
     transitivePeerDependencies:
       - '@rspack/core'
-      - supports-color
       - webpack
 
-  '@rsdoctor/utils@1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)':
+  '@rsdoctor/utils@1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)':
     dependencies:
       '@babel/code-frame': 7.26.2
-      '@rsdoctor/types': 1.2.3(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
-      '@types/estree': 1.0.5
-      acorn: 8.17.0
-      acorn-import-attributes: 1.9.5(acorn@8.17.0)
-      acorn-walk: 8.3.4
-      connect: 3.7.0
-      deep-eql: 4.1.4
-      envinfo: 7.14.0
-      filesize: 10.1.6
-      fs-extra: 11.3.6
-      get-port: 5.1.1
-      json-stream-stringify: 3.0.1
-      lines-and-columns: 2.0.4
-      picocolors: 1.1.1
-      rslog: 1.3.2
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - supports-color
-      - webpack
-
-  '@rsdoctor/utils@1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.19))':
-    dependencies:
-      '@babel/code-frame': 7.26.2
-      '@rsdoctor/types': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.19))
+      '@rsdoctor/types': 1.5.18(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4)
       '@types/estree': 1.0.5
       acorn: 8.17.0
       acorn-import-attributes: 1.9.5(acorn@8.17.0)
@@ -10634,13 +10477,13 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  babel-loader@10.1.1(@babel/core@7.29.7)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.19)):
+  babel-loader@10.1.1(@babel/core@7.29.7)(@rspack/core@2.0.8(@swc/helpers@0.5.23))(webpack@5.105.4(postcss@8.5.8)):
     dependencies:
       '@babel/core': 7.29.7
       find-up: 5.0.0
     optionalDependencies:
       '@rspack/core': 2.0.8(@swc/helpers@0.5.23)
-      webpack: 5.105.4(postcss@8.5.19)
+      webpack: 5.105.4(postcss@8.5.8)
 
   babel-plugin-react-compiler@1.0.0:
     dependencies:
@@ -10904,27 +10747,7 @@ snapshots:
       serialize-javascript: 6.0.2
       webpack: 5.105.4(postcss@8.5.19)
 
-  css-minimizer-webpack-plugin@7.0.2(webpack@5.105.4(postcss@8.5.8)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      cssnano: 7.1.3(postcss@8.5.19)
-      jest-worker: 29.7.0
-      postcss: 8.5.19
-      schema-utils: 4.3.3
-      serialize-javascript: 6.0.2
-      webpack: 5.105.4(postcss@8.5.8)
-
-  css-minimizer-webpack-plugin@7.0.2(webpack@5.105.4):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      cssnano: 7.1.3(postcss@8.5.19)
-      jest-worker: 29.7.0
-      postcss: 8.5.19
-      schema-utils: 4.3.3
-      serialize-javascript: 6.0.2
-      webpack: 5.105.4
-
-  css-minimizer-webpack-plugin@8.0.0(webpack@5.105.4(postcss@8.5.19)):
+  css-minimizer-webpack-plugin@8.0.0(webpack@5.105.4(postcss@8.5.8)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       cssnano: 7.1.3(postcss@8.5.8)
@@ -10932,7 +10755,17 @@ snapshots:
       postcss: 8.5.8
       schema-utils: 4.3.3
       serialize-javascript: 7.0.7
-      webpack: 5.105.4(postcss@8.5.19)
+      webpack: 5.105.4(postcss@8.5.8)
+
+  css-minimizer-webpack-plugin@8.0.0(webpack@5.105.4):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      cssnano: 7.1.3(postcss@8.5.8)
+      jest-worker: 30.4.1
+      postcss: 8.5.8
+      schema-utils: 4.3.3
+      serialize-javascript: 7.0.7
+      webpack: 5.105.4
 
   css-select@5.2.2:
     dependencies:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [#297](https://github.com/Huxpro/vue-lynx/issues/297) — compile-time extraction of Vapor’s **hole set + addressed node set** so #298 can move from dense `CLONE_TREE` naming (A1) to sparse naming (A2).

Vapor codegen addresses nodes via navigation (`n0 = t0()`, `_child`, `_next`, `_nthChild`) that the ops protocol cannot see. This PR analyzes `@vue/compiler-vapor` IR and stamps metadata onto each `template()` factory:

```js
const t0 = _template("<view…>", 1, 1)
t0.__vlxAddressing = {"holes":[1,3],"addressed":[0,1,2,3],"slotCount":4}
```

**Slots** are `REGISTER_TREE` preorder offsets (folded only-child `#text` does not consume a slot — same contract as `buildStructure`).

| Field | Meaning |
| --- | --- |
| `holes` | Dynamic bind / event / ref / text targets + parents of dynamic children (`v-if` / `v-for` / components) |
| `addressed` | Nav-slot closure: holes ∪ root ∪ ancestors ∪ prefix siblings (keeps `_child` / `_next` / `_nthChild` valid on a sparse tree) |
| `slotCount` | Dense preorder length |

Runtime ignores `__vlxAddressing` until #298 consumes it — **no behavior change**.

## Changes

- `plugin/src/compiler/vapor-addressing.ts` — `analyzeVaporAddressing` / `annotateVaporAddressing`
- `vapor-template-loader` annotates vapor template compiles (failures are swallowed so analysis never breaks the build)
- 12 unit tests locking representative shapes (attr/text holes, ancestors, prefix siblings, events, refs, v-if/v-for/component hosts, fully static)

## Test plan

- [x] `pnpm --filter vue-lynx-testing-library test` (232 tests, including new addressing suite)
- [x] `pnpm --filter vue-lynx run build`

## Follow-ups

- **#298** — consume `__vlxAddressing` for sparse A1→A2
- Inline `<script setup vapor>` path (prod `inlineTemplate`) can reuse the same annotate helper in a later pass; this PR covers the vapor template-loader path + the pure analysis API

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-09e3db05-2e0d-43c3-9de3-91afbcac9da2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-09e3db05-2e0d-43c3-9de3-91afbcac9da2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

