### PR TITLE
feat(element-templates): element slots for dynamic subtrees (#296)

### DIFF
--- a/packages/testing-library/src/__tests__/element-template-transform.test.ts
+++ b/packages/testing-library/src/__tests__/element-template-transform.test.ts
@@ -60,7 +60,11 @@ function compileToComponent(
 }
 
 function normalized(container: Element): string {
-  return container.innerHTML.replace(/ vue-ref-\d+="[^"]*"/g, '');
+  // Element slots use layout-transparent <wrapper> placeholders; strip the
+  // tags (keep children) so lowered and unlowered documents compare equal.
+  return container.innerHTML
+    .replace(/<\/?wrapper[^>]*>/g, '')
+    .replace(/ vue-ref-\d+="[^"]*"/g, '');
 }
 
 /** Render both variants and assert identical documents. */
@@ -199,6 +203,86 @@ describe('element-template transform', () => {
       (lowered.container.querySelector('.shown') as HTMLElement | null)?.style
         .display,
     ).toBe('none');
+  });
+
+  it('lowers a static shell with v-if as an element slot', async () => {
+    const template = `
+<view class="card">
+  <image class="icon" src="a.png" />
+  <view v-if="show" class="cond"><text>visible</text></view>
+  <text class="title">{{ title }}</text>
+</view>`.trim();
+
+    const { lowered, code } = renderBoth(template, () =>
+      reactive({ show: true, title: 'Hello' }));
+    expect(code).toContain('__CreateWrapperElement');
+    expect(code).toContain('"#slot"');
+    expect(lowered.container.querySelector('.cond')?.textContent).toBe(
+      'visible',
+    );
+    expect(lowered.container.querySelector('.title')?.textContent).toBe(
+      'Hello',
+    );
+
+    const state = lowered.state as { show: boolean; title: string };
+    state.show = false;
+    state.title = 'Bye';
+    await nextTick();
+    expect(lowered.container.querySelector('.cond')).toBeNull();
+    expect(lowered.container.querySelector('.title')?.textContent).toBe('Bye');
+
+    state.show = true;
+    await nextTick();
+    expect(lowered.container.querySelector('.cond')?.textContent).toBe(
+      'visible',
+    );
+  });
+
+  it('lowers a static shell with v-for as an element slot', async () => {
+    const template = `
+<view class="card">
+  <text class="head">items</text>
+  <view v-for="item in items" :key="item" class="row">
+    <text class="label">{{ item }}</text>
+  </view>
+</view>`.trim();
+
+    const { lowered, code } = renderBoth(template, () => ({
+      items: reactive(['a', 'b']),
+    }));
+    expect(code).toContain('"#slot"');
+    const labels = () =>
+      [...lowered.container.querySelectorAll('.label')].map((n) =>
+        n.textContent
+      );
+    expect(labels()).toEqual(['a', 'b']);
+
+    const items = lowered.state['items'] as string[];
+    items.push('c');
+    await nextTick();
+    expect(labels()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('lowers a static shell with a component child as an element slot', () => {
+    const template = `
+<view class="card">
+  <image class="icon" src="a.png" />
+  <Child />
+  <text class="tail">end</text>
+</view>`.trim();
+
+    const low = compile(template, {
+      mode: 'module',
+      hoistStatic: false,
+      cacheHandlers: false,
+      whitespace: 'condense',
+      isNativeTag: (t) => t !== 'Child',
+      nodeTransforms: [elementTemplateTransform],
+    });
+    expect(low.code).toContain('__vlx-tpl:');
+    expect(low.code).toContain('"#slot"');
+    expect(low.code).toContain('__CreateWrapperElement');
+    expect(low.code).toContain('__vueLynxRegisterElementTemplate');
   });
 
   it('bakes mixed static text children as text nodes', () => {

--- a/packages/testing-library/src/__tests__/element-template.test.ts
+++ b/packages/testing-library/src/__tests__/element-template.test.ts
@@ -205,4 +205,95 @@ describe('element templates (route b protocol)', () => {
     expect(container.querySelector('.card')).toBeNull();
     expect(container.textContent).toContain('gone');
   });
+
+  it('mounts element-slot content into a wrapper via slot-index ops', async () => {
+    // Skeleton: card > image, slot-wrapper, title-text
+    // holes: ['#slot', '#text']
+    const tpl = registerElementTemplate(
+      't-slot',
+      ['#slot', '#text'],
+      (P: number) => {
+        const e0 = __CreateView(P);
+        __SetCSSId([e0], 0);
+        const e1 = __CreateImage(P);
+        __SetCSSId([e1], 0);
+        __SetClasses(e1, 'icon');
+        __SetAttribute(e1, 'src', 'a.png');
+        __AppendElement(e0, e1);
+        const e2 = __CreateWrapperElement(P);
+        __AppendElement(e0, e2);
+        const e3 = __CreateText(P);
+        __SetCSSId([e3], 0);
+        __SetClasses(e3, 'title');
+        __AppendElement(e0, e3);
+        return [e0, e2, e3];
+      },
+    );
+
+    const show = ref(true);
+    const title = ref('Hello');
+    const Comp = defineComponent({
+      render() {
+        return h(`__vlx-tpl:${tpl}`, {
+          class: 'card',
+          __h0: show.value
+            ? h('view', { class: 'cond' }, [h('text', null, 'visible')])
+            : null,
+          __h1: title.value,
+        });
+      },
+    });
+
+    const { container } = render(Comp);
+    expect(container.querySelector('.icon')).not.toBeNull();
+    expect(container.querySelector('.cond')?.textContent).toBe('visible');
+    expect(container.querySelector('.title')?.textContent).toBe('Hello');
+    // Slot content lives under the wrapper placeholder.
+    expect(container.querySelector('wrapper .cond')).not.toBeNull();
+
+    show.value = false;
+    title.value = 'Bye';
+    await nextTick();
+    expect(container.querySelector('.cond')).toBeNull();
+    expect(container.querySelector('.title')?.textContent).toBe('Bye');
+
+    show.value = true;
+    await nextTick();
+    expect(container.querySelector('.cond')?.textContent).toBe('visible');
+  });
+
+  it('mounts multiple children into an element slot (v-for-like fragment)', async () => {
+    const tpl = registerElementTemplate('t-list-slot', ['#slot'], (P: number) => {
+      const e0 = __CreateView(P);
+      __SetCSSId([e0], 0);
+      __SetClasses(e0, 'list');
+      const e1 = __CreateWrapperElement(P);
+      __AppendElement(e0, e1);
+      return [e0, e1];
+    });
+
+    const items = ref(['a', 'b']);
+    const Comp = defineComponent({
+      render() {
+        return h(`__vlx-tpl:${tpl}`, {
+          __h0: items.value.map((label) =>
+            h('view', { class: 'row', key: label }, [
+              h('text', { class: 'label' }, label),
+            ])
+          ),
+        });
+      },
+    });
+
+    const { container } = render(Comp);
+    let labels = [...container.querySelectorAll('.label')].map((n) =>
+      n.textContent
+    );
+    expect(labels).toEqual(['a', 'b']);
+
+    items.value = ['b', 'c', 'a'];
+    await nextTick();
+    labels = [...container.querySelectorAll('.label')].map((n) => n.textContent);
+    expect(labels).toEqual(['b', 'c', 'a']);
+  });
 });

--- a/packages/vue-lynx/internal/src/ops.ts
+++ b/packages/vue-lynx/internal/src/ops.ts
@@ -29,6 +29,9 @@
  *     function; the root maps to rootId and the template's holes (interior
  *     nodes with dynamic parts) map to rootId+1 … rootId+holeCount, so all
  *     later SET_* ops target them like ordinary elements.
+ *     Holes are either attr/text bindings or element slots (`TPL_SLOT_KEY`).
+ *     Element-slot count is not a separate op argument — it is the count of
+ *     `TPL_SLOT_KEY` entries in the template's registered hole-key list.
  *   REGISTER_TREE:     [16, treeId, structure]
  *     structure: recursive node tuples [tag, props|0, children[]] where
  *     props = { c?: class, s?: styleObj, a?: [[key, value]…], i?: id,
@@ -40,6 +43,12 @@
  *     deterministically: pre-order traversal of the structure starting at
  *     baseUid — the BG thread allocates the identical contiguous block, so
  *     both sides agree on ids without transmitting them.
+ *   INSERT_TEMPLATE_SLOT: [18, rootId, slotIndex, childId, anchorId]
+ *     Insert a dynamic child into the slotIndex-th element slot of the
+ *     template instance rooted at rootId (slot-index addressing — the slot
+ *     parent may be anonymous once sparse ET lands). anchorId=-1 → append.
+ *   REMOVE_TEMPLATE_SLOT: [19, rootId, slotIndex, childId]
+ *     Remove a dynamic child from the slotIndex-th element slot.
  *
  * Naming: INSTANTIATE_TEMPLATE (15) and REGISTER_TREE/CLONE_TREE (16/17) are
  * genuinely different mechanisms, named by mechanism rather than renderer.
@@ -49,7 +58,8 @@
  * hence TEMPLATE. The vapor object is a named tree prototype — serialized
  * structure over the wire plus dense pre-order naming, required because Vapor
  * codegen's addressing knowledge lives in navigation code the protocol cannot
- * see — hence TREE, not TEMPLATE.
+ * see — hence TREE, not TEMPLATE. Element-slot ops (18/19) extend the ET
+ * path so dynamic subtrees can graft into a template by slot-index.
  */
 export const PAGE_ROOT_ID = 1;
 
@@ -73,6 +83,8 @@ export const OP = {
   INSTANTIATE_TEMPLATE: 15,
   REGISTER_TREE: 16,
   CLONE_TREE: 17,
+  INSERT_TEMPLATE_SLOT: 18,
+  REMOVE_TEMPLATE_SLOT: 19,
 } as const;
 
 export type OpCode = (typeof OP)[keyof typeof OP];
@@ -96,6 +108,8 @@ export const OP_ARITY: Readonly<Record<number, number>> = Object.freeze({
   [OP.INSTANTIATE_TEMPLATE]: 3,
   [OP.REGISTER_TREE]: 2,
   [OP.CLONE_TREE]: 2,
+  [OP.INSERT_TEMPLATE_SLOT]: 4,
+  [OP.REMOVE_TEMPLATE_SLOT]: 3,
 });
 
 // ---------------------------------------------------------------------------
@@ -106,6 +120,13 @@ export const OP_ARITY: Readonly<Record<number, number>> = Object.freeze({
 export const TPL_TYPE_PREFIX = '__vlx-tpl:';
 /** Prop-key prefix for hole bindings on lowered vnodes. */
 export const TPL_HOLE_PREFIX = '__h';
+/**
+ * Hole-key marking an element slot (dynamic subtree insertion point).
+ * Attr/text holes use the original prop key or `'#text'`; element slots use
+ * this sentinel. Slot-index `k` is the k-th `TPL_SLOT_KEY` in the holes list
+ * (0-based) and addresses INSERT/REMOVE_TEMPLATE_SLOT ops.
+ */
+export const TPL_SLOT_KEY = '#slot';
 /**
  * Name of the global through which compiler-generated code registers
  * element templates: `globalThis.<TPL_REGISTER_GLOBAL>(id, holes, create)`.

--- a/packages/vue-lynx/main-thread/src/element-templates.ts
+++ b/packages/vue-lynx/main-thread/src/element-templates.ts
@@ -20,18 +20,89 @@
  * The registry is intentionally NOT cleared by resetMainThreadState():
  * registration happens once per bundle evaluation while renderPage may run
  * multiple times (reload, tests).
+ *
+ * Hole keys distinguish attr/text bindings from element slots (`'#slot'`).
+ * Element-slot handles are also indexed by slot-index (order among `'#slot'`
+ * keys) so INSERT/REMOVE_TEMPLATE_SLOT can address them without a stable
+ * parent FiberElement id (needed once sparse ET makes parents anonymous).
  */
+
+import { TPL_SLOT_KEY } from 'vue-lynx/internal/ops';
 
 type CreateFn = (pageUniqueId: number) => LynxElement[];
 
-const templates = new Map<string, CreateFn>();
+interface TemplateEntry {
+  create: CreateFn;
+  holes: string[];
+  /** Indices into create()'s return array (skipping root at 0) for `#slot`. */
+  slotHoleOffsets: number[];
+}
 
-export function registerTemplate(id: string, create: CreateFn): void {
+const templates = new Map<string, TemplateEntry>();
+
+/** template rootId → element-slot handles in slot-index order */
+const instanceSlots = new Map<number, LynxElement[]>();
+
+function slotOffsetsFor(holes: string[]): number[] {
+  const offsets: number[] = [];
+  for (let i = 0; i < holes.length; i++) {
+    if (holes[i] === TPL_SLOT_KEY) offsets.push(i);
+  }
+  return offsets;
+}
+
+export function registerTemplate(
+  id: string,
+  create: CreateFn,
+  holes: string[] = [],
+): void {
   if (!templates.has(id)) {
-    templates.set(id, create);
+    templates.set(id, {
+      create,
+      holes,
+      slotHoleOffsets: slotOffsetsFor(holes),
+    });
   }
 }
 
-export function getTemplate(id: string): CreateFn | undefined {
+export function getTemplate(id: string): TemplateEntry | undefined {
   return templates.get(id);
+}
+
+/**
+ * Record the element-slot handles for a freshly instantiated template so
+ * INSERT/REMOVE_TEMPLATE_SLOT can resolve slotIndex → parent FiberElement.
+ */
+export function bindTemplateInstanceSlots(
+  rootId: number,
+  handles: LynxElement[],
+  entry: TemplateEntry | undefined,
+): void {
+  if (!entry || entry.slotHoleOffsets.length === 0) {
+    instanceSlots.delete(rootId);
+    return;
+  }
+  const slots: LynxElement[] = [];
+  for (const offset of entry.slotHoleOffsets) {
+    // handles = [root, hole0, hole1, …]; hole at holes[offset] → handles[offset+1]
+    slots.push(handles[offset + 1] ?? handles[0]!);
+  }
+  instanceSlots.set(rootId, slots);
+}
+
+export function getTemplateSlotParent(
+  rootId: number,
+  slotIndex: number,
+): LynxElement | undefined {
+  return instanceSlots.get(rootId)?.[slotIndex];
+}
+
+/** Drop slot bindings for removed template instances (best-effort GC). */
+export function unbindTemplateInstanceSlots(rootId: number): void {
+  instanceSlots.delete(rootId);
+}
+
+/** Test helper — clear per-instance slot bindings (not the create registry). */
+export function resetTemplateInstanceSlots(): void {
+  instanceSlots.clear();
 }

--- a/packages/vue-lynx/main-thread/src/entry-main.ts
+++ b/packages/vue-lynx/main-thread/src/entry-main.ts
@@ -53,10 +53,14 @@ g['runOnBackground'] = runOnBackground;
 g[TPL_EXECUTOR_REGISTRY_GLOBAL] = registerTemplate;
 g[TPL_REGISTER_GLOBAL] = (
   id: string,
-  _holes: unknown,
+  holes: unknown,
   create: Parameters<typeof registerTemplate>[1],
 ): string => {
-  registerTemplate(id, create);
+  registerTemplate(
+    id,
+    create,
+    Array.isArray(holes) ? holes as string[] : [],
+  );
   return id;
 };
 

--- a/packages/vue-lynx/main-thread/src/ops-apply.ts
+++ b/packages/vue-lynx/main-thread/src/ops-apply.ts
@@ -21,7 +21,7 @@ import {
   setPageUniqueId,
   trackInsert,
 } from './element-registry.js';
-import { getTemplate } from './element-templates.js';
+import { getTemplate, bindTemplateInstanceSlots, getTemplateSlotParent, resetTemplateInstanceSlots, unbindTemplateInstanceSlots } from './element-templates.js';
 import {
   createListElement,
   flushListUpdates,
@@ -279,10 +279,52 @@ export function applyOps(ops: unknown[], flush = true): void {
         break;
       }
 
+      case OP.INSERT_TEMPLATE_SLOT: {
+        // Slot-index addressing: parent is the slotIndex-th element slot of
+        // the template rooted at rootId (see bindTemplateInstanceSlots).
+        const rootId = ops[i++] as number;
+        const slotIndex = ops[i++] as number;
+        const childId = ops[i++] as number;
+        const anchorId = ops[i++] as number;
+        const parent = getTemplateSlotParent(rootId, slotIndex);
+        const child = elements.get(childId);
+        if (parent && child) {
+          removedRoots.delete(childId);
+          // Parent uid for trackInsert is the slot FiberElement's registry
+          // id (rootId + holeOffset); use child tracking only — the slot
+          // parent is already part of the template instance.
+          if (anchorId === -1) {
+            __AppendElement(parent, child);
+          } else {
+            const anchor = elements.get(anchorId);
+            if (anchor) __InsertElementBefore(parent, child, anchor);
+            else __AppendElement(parent, child);
+          }
+        }
+        break;
+      }
+
       case OP.REMOVE: {
         const parentId = ops[i++] as number;
         const childId = ops[i++] as number;
         const parent = elements.get(parentId);
+        const child = elements.get(childId);
+        if (parent && child) {
+          __RemoveElement(parent, child);
+          removedRoots.add(childId);
+        }
+        // Best-effort: if this REMOVE tears down a template root, drop its
+        // slot-index table (holes share the contiguous id range and are not
+        // individually removed).
+        unbindTemplateInstanceSlots(childId);
+        break;
+      }
+
+      case OP.REMOVE_TEMPLATE_SLOT: {
+        const rootId = ops[i++] as number;
+        const slotIndex = ops[i++] as number;
+        const childId = ops[i++] as number;
+        const parent = getTemplateSlotParent(rootId, slotIndex);
         const child = elements.get(childId);
         if (parent && child) {
           __RemoveElement(parent, child);
@@ -403,10 +445,12 @@ export function applyOps(ops: unknown[], flush = true): void {
         const rootId = ops[i++] as number;
         const tplId = ops[i++] as string;
         const holeCount = ops[i++] as number;
-        const create = getTemplate(tplId);
+        const entry = getTemplate(tplId);
         let handles: LynxElement[];
-        if (create) {
-          handles = create(pageUniqueId);
+        if (entry) {
+          // The create() function builds the whole lowered subtree with
+          // straight-line PAPI calls and returns [root, hole0, hole1, …].
+          handles = entry.create(pageUniqueId);
         } else {
           console.error(
             `[vue-lynx] Unknown element template "${tplId}" on the main thread — rendering a placeholder.`,
@@ -421,6 +465,8 @@ export function applyOps(ops: unknown[], flush = true): void {
         for (let k = 1; k <= holeCount; k++) {
           elements.set(rootId + k, handles[k] ?? root);
         }
+        // Bind element-slot handles for slot-index INSERT/REMOVE.
+        bindTemplateInstanceSlots(rootId, handles, entry);
         break;
       }
 
@@ -470,4 +516,5 @@ export function resetMainThreadState(): void {
   setPageUniqueId(1);
   resetListState();
   resetWorkletState();
+  resetTemplateInstanceSlots();
 }

--- a/packages/vue-lynx/plugin/src/compiler/element-template-transform.ts
+++ b/packages/vue-lynx/plugin/src/compiler/element-template-transform.ts
@@ -24,17 +24,17 @@
  * the root id, and all updates flow through ordinary SET_* ops.
  *
  * Eligibility (per node):
- *  - plain element (no component / slot / <template> / structural directive
- *    on interiors); `list`/`list-item`/`page` excluded (main-thread special
- *    handling)
+ *  - plain element (no slot outlet / <template> on interiors); `list` /
+ *    `list-item` / `page` excluded (main-thread special handling)
  *  - interior nodes: only v-bind/v-on props; no `ref`/`key`/`id`/`onVnode*`;
  *    no runtime directives (v-show, v-model, custom)
  *  - the subtree ROOT keeps all of its own props/directives on the vnode
  *    (they behave exactly like a normal element: Transition classes, v-show,
  *    ref, key, … all still work), so roots are only constrained structurally
- *  - children: elements (recursively eligible), fully-static text, or a
- *    single dynamic-text child (becomes a '#text' hole); anything else
- *    (comments, mixed dynamic text, v-if/v-for/components) breaks the
+ *  - children: elements (recursively eligible), fully-static text, a single
+ *    dynamic-text child (`'#text'` hole), or structural hosts (`v-if` /
+ *    `v-for` / components) registered as element-slot holes (`'#slot'`);
+ *    anything else (comments, slot outlets, mixed dynamic text) breaks the
  *    subtree — descendants are then considered independently
  *
  * Anything ineligible simply stays on the normal vdom/ops path; correctness
@@ -62,6 +62,7 @@ import {
 import {
   TPL_HOLE_PREFIX,
   TPL_REGISTER_GLOBAL,
+  TPL_SLOT_KEY,
   TPL_TYPE_PREFIX,
 } from 'vue-lynx/internal/ops';
 
@@ -126,7 +127,10 @@ function templateId(content: string): string {
 // ---------------------------------------------------------------------------
 
 interface Hole {
-  /** original prop key, or '#text' for a text-content binding */
+  /**
+   * Original prop key, `'#text'` for a text-content binding, or
+   * `TPL_SLOT_KEY` (`'#slot'`) for an element-slot (dynamic subtree).
+   */
   key: string;
   /** compiled value expression (moved onto the lowered vnode as __hN) */
   value: unknown;
@@ -185,6 +189,25 @@ function printBakedValue(
     : (value.content ?? 'undefined');
 }
 
+/** Emit a wrapper placeholder for an element-slot and register the hole. */
+function emitElementSlot(
+  lines: string[],
+  holes: Hole[],
+  holeVars: string[],
+  parentVar: string,
+  nextVar: { n: number },
+  codegen: unknown,
+): void {
+  if (codegen == null) throw INELIGIBLE;
+  const slotVar = `e${nextVar.n++}`;
+  // Wrapper is layout-transparent on Lynx; dynamic content is mounted into
+  // it at runtime via INSERT_TEMPLATE_SLOT (slot-index addressing).
+  lines.push(`const ${slotVar} = __CreateWrapperElement(P);`);
+  lines.push(`__AppendElement(${parentVar}, ${slotVar});`);
+  holes.push({ key: TPL_SLOT_KEY, value: codegen });
+  holeVars.push(slotVar);
+}
+
 function analyzeSubtree(
   rootEl: ElementNode,
   context: TransformContext,
@@ -194,7 +217,7 @@ function analyzeSubtree(
   const holes: Hole[] = [];
   const holeVars: string[] = [];
   let elementCount = 0;
-  let nextVar = 0;
+  const nextVar = { n: 0 };
 
   const scopeId = context.scopeId ?? null;
 
@@ -207,7 +230,7 @@ function analyzeSubtree(
     const vnodeCall = cg as VNodeCall;
 
     elementCount++;
-    const v = `e${nextVar++}`;
+    const v = `e${nextVar.n++}`;
     const createFn = TYPED_CREATE[el.tag];
     lines.push(
       createFn !== undefined
@@ -297,10 +320,36 @@ function analyzeSubtree(
     } else {
       for (const child of kids) {
         if (child.type === NodeTypes.ELEMENT) {
-          const cv = emitElement(child as ElementNode, false);
-          lines.push(`__AppendElement(${v}, ${cv});`);
+          if (child.tagType === ElementTypes.COMPONENT) {
+            // Component child → element slot (static shell stays templated).
+            elementCount++; // wrapper placeholder
+            emitElementSlot(
+              lines,
+              holes,
+              holeVars,
+              v,
+              nextVar,
+              child.codegenNode,
+            );
+          } else {
+            const cv = emitElement(child as ElementNode, false);
+            lines.push(`__AppendElement(${v}, ${cv});`);
+          }
+        } else if (
+          child.type === NodeTypes.IF || child.type === NodeTypes.FOR
+        ) {
+          // Structural directive hosts → element slots.
+          elementCount++; // wrapper placeholder
+          emitElementSlot(
+            lines,
+            holes,
+            holeVars,
+            v,
+            nextVar,
+            child.codegenNode,
+          );
         } else if (child.type === NodeTypes.TEXT) {
-          const tv = `e${nextVar++}`;
+          const tv = `e${nextVar.n++}`;
           lines.push(`const ${tv} = __CreateText(P);`);
           lines.push(...scope.elementScopeStatements(tv, scopeId));
           lines.push(
@@ -311,7 +360,7 @@ function analyzeSubtree(
           // Mixed-children text: bake only when fully static.
           const content = child.content;
           if (content.type !== NodeTypes.TEXT) throw INELIGIBLE;
-          const tv = `e${nextVar++}`;
+          const tv = `e${nextVar.n++}`;
           lines.push(`const ${tv} = __CreateText(P);`);
           lines.push(...scope.elementScopeStatements(tv, scopeId));
           lines.push(
@@ -321,7 +370,7 @@ function analyzeSubtree(
           );
           lines.push(`__AppendElement(${v}, ${tv});`);
         } else {
-          // comments, v-if/v-for, components, dynamic mixed text …
+          // comments, slot outlets, <template>, dynamic mixed text …
           throw INELIGIBLE;
         }
       }

--- a/packages/vue-lynx/plugin/src/compiler/element-template-transform.ts
+++ b/packages/vue-lynx/plugin/src/compiler/element-template-transform.ts
@@ -54,6 +54,7 @@ import {
   ConstantTypes,
   ElementTypes,
   NodeTypes,
+  createFunctionExpression,
   createObjectExpression,
   createObjectProperty,
   createSimpleExpression,
@@ -204,7 +205,18 @@ function emitElementSlot(
   // it at runtime via INSERT_TEMPLATE_SLOT (slot-index addressing).
   lines.push(`const ${slotVar} = __CreateWrapperElement(P);`);
   lines.push(`__AppendElement(${parentVar}, ${slotVar});`);
-  holes.push({ key: TPL_SLOT_KEY, value: codegen });
+  // Wrap in a thunk so openBlock()/createBlock() inside v-if / v-for /
+  // component codegen does NOT register as a dynamicChild of the template
+  // root block (that would double-mount alongside our slot renderer).
+  // The thunk is invoked from patchProp after the parent render completes.
+  const thunk = createFunctionExpression(
+    undefined,
+    // biome-ignore lint/suspicious/noExplicitAny: CodegenNode → FunctionExpression returns
+    codegen as any,
+    false,
+    false,
+  );
+  holes.push({ key: TPL_SLOT_KEY, value: thunk });
   holeVars.push(slotVar);
 }
 

--- a/packages/vue-lynx/runtime/src/element-template.ts
+++ b/packages/vue-lynx/runtime/src/element-template.ts
@@ -8,16 +8,18 @@
  * The vue-lynx compiler transform lowers eligible template subtrees — plain
  * elements with static structure — into "element templates": a `create()`
  * function of straight-line PAPI calls plus a list of *holes* (interior
- * nodes carrying a dynamic prop, event, or text binding). The compiled
- * render function then produces a single vnode of type
+ * nodes carrying a dynamic prop, event, text binding, or element slot).
+ * The compiled render function then produces a single vnode of type
  * `__vlx-tpl:<id>` with props `__h0…__hN` instead of one vnode per node.
  *
  * At runtime:
  *  - mounting the vnode emits ONE `INSTANTIATE_TEMPLATE` op; the main thread
  *    builds the whole subtree natively via the registered create() function
  *  - hole ids are allocated deterministically right after the root id, so
- *    every later update flows through the ordinary SET_* ops with zero new
- *    protocol
+ *    every later attr/text update flows through the ordinary SET_* ops
+ *  - element-slot holes (`'#slot'`) are wrapper placeholders; their content
+ *    (v-if / v-for / component VNodes carried as `__hN` props) is mounted
+ *    into the wrapper via INSERT/REMOVE_TEMPLATE_SLOT (slot-index addressing)
  *
  * This module is the background-thread (and IFR main-thread) side of the
  * registry. The generated code registers through the
@@ -39,10 +41,11 @@ import {
   TPL_EXECUTOR_REGISTRY_GLOBAL,
   TPL_HOLE_PREFIX,
   TPL_REGISTER_GLOBAL,
+  TPL_SLOT_KEY,
   TPL_TYPE_PREFIX,
 } from 'vue-lynx/internal/ops';
 
-export { TPL_HOLE_PREFIX, TPL_TYPE_PREFIX };
+export { TPL_HOLE_PREFIX, TPL_SLOT_KEY, TPL_TYPE_PREFIX };
 
 /** create(pageUniqueId) → [root, hole0, hole1, …] native handles */
 export type ElementTemplateCreate = (
@@ -50,10 +53,17 @@ export type ElementTemplateCreate = (
 ) => unknown[];
 
 /**
- * Template id → hole keys: the original prop key on each interior node, or
- * the special key `'#text'` for a text-content binding.
+ * Template id → hole keys: the original prop key on each interior node,
+ * `'#text'` for a text-content binding, or `TPL_SLOT_KEY` (`'#slot'`) for
+ * an element-slot (dynamic subtree insertion point).
  */
 const templateHoles = new Map<string, string[]>();
+
+type ExecutorRegister = (
+  id: string,
+  create: ElementTemplateCreate,
+  holes?: string[],
+) => void;
 
 /**
  * Register an element template. Called from compiler-generated code (hoisted
@@ -77,8 +87,8 @@ export function registerElementTemplate(
   // IFR and interpreter-only bundles; absent on the background thread).
   const register = (globalThis as Record<string, unknown>)[
     TPL_EXECUTOR_REGISTRY_GLOBAL
-  ] as ((id: string, create: ElementTemplateCreate) => void) | undefined;
-  register?.(id, create);
+  ] as ExecutorRegister | undefined;
+  register?.(id, create, holes);
   return id;
 }
 

--- a/packages/vue-lynx/runtime/src/index.ts
+++ b/packages/vue-lynx/runtime/src/index.ts
@@ -89,6 +89,7 @@ import {
   runOnBackground,
 } from './run-on-background.js';
 import { ShadowElement, createPageRoot, resetTemplateState } from './shadow-element.js';
+import { setTemplateSlotRenderer } from './slot-host.js';
 import { transformToWorklet } from './transform-to-worklet.js';
 import { Transition } from './Transition.js';
 import { TransitionGroup } from './TransitionGroup.js';
@@ -145,6 +146,13 @@ export const _render: (
 ) => void = (vnode, container) => {
   ensureRenderer().render(vnode, container);
 };
+
+// Wire element-template slot mounting through the same renderer (avoids a
+// circular import between node-ops and this module). Lazy: first slot mount
+// ensures the vdom renderer exists.
+setTemplateSlotRenderer((vnode, container) => {
+  ensureRenderer().render(vnode, container);
+});
 
 // ===========================================================================
 // Vue Lynx APIs

--- a/packages/vue-lynx/runtime/src/node-ops.ts
+++ b/packages/vue-lynx/runtime/src/node-ops.ts
@@ -2,11 +2,13 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
-import type { RendererOptions } from '@vue/runtime-core';
+import type { RendererOptions, VNode } from '@vue/runtime-core';
+import { Fragment, Text, createVNode, isVNode } from '@vue/runtime-core';
 
 import { patchEventProp, resetEventPropState } from './event-props.js';
 import {
   TPL_HOLE_PREFIX,
+  TPL_SLOT_KEY,
   TPL_TYPE_PREFIX,
   getElementTemplateHoles,
 } from './element-template.js';
@@ -14,6 +16,7 @@ import { scheduleFlush } from './flush.js';
 import { applyMainThreadProp } from './main-thread-props.js';
 import { OP, pushOp } from './ops.js';
 import { ShadowElement } from './shadow-element.js';
+import { renderTemplateSlot } from './slot-host.js';
 import { normalizeStyleObject } from './style-normalization.js';
 import {
   idRegistry,
@@ -22,6 +25,7 @@ import {
   resolveClass,
   setElementTextContent,
   setIdAttr,
+  setTeardownTemplateSlotsHook,
   setTextNode,
 } from './tree-ops.js';
 
@@ -33,7 +37,7 @@ export { resolveClass } from './tree-ops.js';
 export { patchEventProp } from './event-props.js';
 
 // ---------------------------------------------------------------------------
-// RendererOptions implementation
+// Element-template helpers
 // ---------------------------------------------------------------------------
 
 /**
@@ -41,7 +45,10 @@ export { patchEventProp } from './event-props.js';
  *
  * The root ShadowElement represents the whole subtree. Hole shadows allocate
  * the contiguous uid range following the root; the main thread maps those ids
- * to the create() function's returned hole handles.
+ * to the create() function's returned hole handles. Attr/text updates flow
+ * through patchProp's hole delegation using ordinary SET_* ops; element-slot
+ * content is mounted into wrapper holes via the Vue renderer and
+ * INSERT/REMOVE_TEMPLATE_SLOT.
  */
 function createTemplateInstance(type: string): ShadowElement {
   const tplId = type.slice(TPL_TYPE_PREFIX.length);
@@ -58,13 +65,54 @@ function createTemplateInstance(type: string): ShadowElement {
     return el;
   }
 
-  const holes = holeKeys.map(() => new ShadowElement('#tpl-hole'));
+  const holes: ShadowElement[] = [];
+  const slots: ShadowElement[] = [];
+  for (const key of holeKeys) {
+    const hole = new ShadowElement(
+      key === TPL_SLOT_KEY ? '#tpl-slot' : '#tpl-hole',
+    );
+    holes.push(hole);
+    if (key === TPL_SLOT_KEY) {
+      hole._tplRoot = el;
+      hole._tplSlotIndex = slots.length;
+      slots.push(hole);
+    }
+  }
   el._tplHoleKeys = holeKeys;
   el._tplHoles = holes;
+  el._tplSlots = slots.length > 0 ? slots : undefined;
   pushOp(OP.INSTANTIATE_TEMPLATE, el.uid, tplId, holeKeys.length);
   scheduleFlush();
   return el;
 }
+
+/** Normalize a `__hN` slot prop value into a mountable VNode (or null). */
+function normalizeSlotContent(value: unknown): VNode | null {
+  // Compiler wraps slot expressions in thunks so block tracking does not
+  // leak into the template root; invoke here during patchProp.
+  let resolved = value;
+  if (typeof resolved === 'function') {
+    resolved = (resolved as () => unknown)();
+  }
+  if (resolved == null || resolved === false) return null;
+  if (isVNode(resolved)) return resolved;
+  if (Array.isArray(resolved)) return createVNode(Fragment, null, resolved);
+  return createVNode(Text, null, String(resolved));
+}
+
+/** Unmount any element-slot trees rooted on a template instance. */
+function teardownTemplateSlots(el: ShadowElement): void {
+  if (!el._tplSlots) return;
+  for (const slot of el._tplSlots) {
+    renderTemplateSlot(null, slot);
+  }
+}
+
+setTeardownTemplateSlotsHook(teardownTemplateSlots);
+
+// ---------------------------------------------------------------------------
+// RendererOptions implementation
+// ---------------------------------------------------------------------------
 
 export const nodeOps: RendererOptions<ShadowElement, ShadowElement> = {
   createElement(type: string): ShadowElement {
@@ -151,7 +199,13 @@ export const nodeOps: RendererOptions<ShadowElement, ShadowElement> = {
       const holeKey = el._tplHoleKeys?.[idx];
       const holeEl = el._tplHoles[idx];
       if (holeKey !== undefined && holeEl !== undefined) {
-        if (holeKey === '#text') {
+        if (holeKey === TPL_SLOT_KEY) {
+          // Element slot: `__hN` carries a VNode (v-if / v-for / component),
+          // often as a thunk so openBlock() does not leak into the template
+          // root's dynamicChildren. Mount into the wrapper via the Vue
+          // renderer; inserts inside emit INSERT_TEMPLATE_SLOT.
+          renderTemplateSlot(normalizeSlotContent(nextValue), holeEl);
+        } else if (holeKey === '#text') {
           pushOp(
             OP.SET_TEXT,
             holeEl.uid,

--- a/packages/vue-lynx/runtime/src/shadow-element.ts
+++ b/packages/vue-lynx/runtime/src/shadow-element.ts
@@ -239,6 +239,18 @@ export class ShadowElement {
   // ids without shipping a per-hole mapping.
   _tplHoleKeys: string[] | undefined = undefined;
   _tplHoles: ShadowElement[] | undefined = undefined;
+  /**
+   * Element-slot hole shadows in slot-index order (subset of `_tplHoles`
+   * whose keys are `'#slot'`). Used to emit INSERT/REMOVE_TEMPLATE_SLOT.
+   */
+  _tplSlots: ShadowElement[] | undefined = undefined;
+
+  /**
+   * When set, this ShadowElement is an element-slot wrapper belonging to
+   * the template rooted at `_tplRoot`. Inserts/removes use slot-index ops.
+   */
+  _tplRoot: ShadowElement | undefined = undefined;
+  _tplSlotIndex: number | undefined = undefined;
 
   // --- Vapor / DOM-compat state --------------------------------------------
 

--- a/packages/vue-lynx/runtime/src/slot-host.ts
+++ b/packages/vue-lynx/runtime/src/slot-host.ts
@@ -1,0 +1,38 @@
+// Copyright 2026 Xuan Huang (huxpro). All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * Late-bound renderer for element-template slot content.
+ *
+ * Slot children are carried as `__hN` hole props (VNodes) on the lowered
+ * template vnode. Mounting them through the Vue renderer into the slot
+ * wrapper ShadowElement reuses the full patch/unmount pipeline without
+ * making them children of the template vnode (which would fight the baked
+ * skeleton). The renderer is installed from index.ts after createRenderer
+ * to avoid a circular import with node-ops.
+ */
+
+import type { VNode } from '@vue/runtime-core';
+
+import type { ShadowElement } from './shadow-element.js';
+
+type SlotRenderFn = (
+  vnode: VNode | null,
+  container: ShadowElement,
+) => void;
+
+let renderFn: SlotRenderFn | null = null;
+
+/** @internal — called once from the runtime entry after createRenderer. */
+export function setTemplateSlotRenderer(fn: SlotRenderFn): void {
+  renderFn = fn;
+}
+
+/** Mount / patch / unmount a vnode tree into an element-slot wrapper. */
+export function renderTemplateSlot(
+  vnode: VNode | null,
+  container: ShadowElement,
+): void {
+  renderFn?.(vnode, container);
+}

--- a/packages/vue-lynx/runtime/src/tree-ops.ts
+++ b/packages/vue-lynx/runtime/src/tree-ops.ts
@@ -148,6 +148,60 @@ function ensureTextCreated(node: ShadowElement): void {
   node._mtCreated = true;
 }
 
+/** Emit INSERT or INSERT_TEMPLATE_SLOT depending on the parent. */
+function pushInsertOp(
+  parent: ShadowElement,
+  child: ShadowElement,
+  anchorUid: number,
+): void {
+  if (
+    parent._tplSlotIndex !== undefined && parent._tplRoot !== undefined
+  ) {
+    // Element-slot wrapper: address by (templateRoot, slotIndex) so sparse
+    // ET can keep the slot parent anonymous.
+    pushOp(
+      OP.INSERT_TEMPLATE_SLOT,
+      parent._tplRoot.uid,
+      parent._tplSlotIndex,
+      child.uid,
+      anchorUid,
+    );
+  } else {
+    pushOp(OP.INSERT, parent.uid, child.uid, anchorUid);
+  }
+}
+
+/** Emit REMOVE or REMOVE_TEMPLATE_SLOT depending on the parent. */
+function pushRemoveOp(parent: ShadowElement, child: ShadowElement): void {
+  if (
+    parent._tplSlotIndex !== undefined && parent._tplRoot !== undefined
+  ) {
+    pushOp(
+      OP.REMOVE_TEMPLATE_SLOT,
+      parent._tplRoot.uid,
+      parent._tplSlotIndex,
+      child.uid,
+    );
+  } else {
+    pushOp(OP.REMOVE, parent.uid, child.uid);
+  }
+}
+
+/**
+ * Optional hook: tear down element-slot Vue trees before a template root is
+ * removed. Installed from node-ops to avoid a tree-ops ↔ slot-host cycle.
+ */
+let teardownTemplateSlotsHook:
+  | ((el: ShadowElement) => void)
+  | null = null;
+
+/** @internal */
+export function setTeardownTemplateSlotsHook(
+  fn: ((el: ShadowElement) => void) | null,
+): void {
+  teardownTemplateSlotsHook = fn;
+}
+
 /**
  * Set a #text node's character data, materialising or dematerialising its
  * Main Thread element as the content appears / disappears. Shared by the
@@ -158,7 +212,7 @@ export function setTextNode(node: ShadowElement, text: string): void {
 
   if (!text) {
     if (node._mtInserted && node.parent) {
-      pushOp(OP.REMOVE, node.parent.uid, node.uid);
+      pushRemoveOp(node.parent, node);
       node._mtInserted = false;
       scheduleFlush();
     }
@@ -173,7 +227,7 @@ export function setTextNode(node: ShadowElement, text: string): void {
   const parent = node.parent;
   if (!node._mtInserted && parent && parent.tag !== 'list') {
     const anchor = resolveMainThreadAnchor(node.next);
-    pushOp(OP.INSERT, parent.uid, node.uid, anchor ? anchor.uid : -1);
+    pushInsertOp(parent, node, anchor ? anchor.uid : -1);
     node._mtInserted = true;
   }
   scheduleFlush();
@@ -201,7 +255,7 @@ export function insertNode(
   // Reparent: if child is moving to a different parent (e.g. KeepAlive move),
   // emit REMOVE from old parent so MT correctly detaches first.
   if (child.parent && child.parent !== parent && isMaterialized(child)) {
-    pushOp(OP.REMOVE, child.parent.uid, child.uid);
+    pushRemoveOp(child.parent, child);
     if (child.tag === '#text') child._mtInserted = false;
     scheduleFlush();
   }
@@ -218,7 +272,11 @@ export function insertNode(
   if (child.tag === '#text') ensureTextCreated(child);
 
   const resolvedAnchor = resolveMainThreadAnchor(anchor);
-  pushOp(OP.INSERT, parent.uid, child.uid, resolvedAnchor ? resolvedAnchor.uid : -1);
+  pushInsertOp(
+    parent,
+    child,
+    resolvedAnchor ? resolvedAnchor.uid : -1,
+  );
   if (child.tag === '#text') child._mtInserted = true;
   scheduleFlush();
 }
@@ -242,12 +300,15 @@ export function removeNode(child: ShadowElement): void {
   // Those children were never mounted, so `vnode.el` is undefined — null
   // guard is required here, not just for the `!parent` case.
   if (child?.parent) {
-    const parentUid = child.parent.uid;
+    const parent = child.parent;
     const materialized = isMaterialized(child);
-    child.parent._unlink(child);
+    // Tear down element-slot Vue trees before removing a template root so
+    // component instances inside slots get proper unmount lifecycles.
+    if (child._tplSlots) teardownTemplateSlotsHook?.(child);
+    parent._unlink(child);
     releaseSubtree(child);
     if (materialized) {
-      pushOp(OP.REMOVE, parentUid, child.uid);
+      pushRemoveOp(parent, child);
       scheduleFlush();
     }
     if (child.tag === '#text') child._mtInserted = false;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [#296](https://github.com/Huxpro/vue-lynx/issues/296): extend the element-template hole model with **element slots** so a static shell that contains `v-if` / `v-for` / component children can still be lowered.

**Base: `vapor`.** Replaces the earlier main-targeted [#305](https://github.com/Huxpro/vue-lynx/pull/305) (token cannot retarget that PR’s base).

## Approach (pure JS, Snapshot-style)

- **Compiler** (`element-template-transform.ts`): `v-if` / `v-for` / component children become `#slot` holes. `create()` places a `__CreateWrapperElement` placeholder; slot codegen is an `__hN` prop **thunk** (avoids double-mount via parent `dynamicChildren`).
- **BG runtime**: `#slot` props mount via the Vue renderer into the wrapper (`slot-host.ts`). Inserts/removes go through shared `tree-ops` and emit `INSERT_TEMPLATE_SLOT` / `REMOVE_TEMPLATE_SLOT` by `(templateRootId, slotIndex)`.
- **MT**: template registry keeps hole keys; instantiating binds slot handles for slot-index lookup.

## Protocol (vapor numbering)

| Op | Code | Frame |
|----|------|-------|
| `INSTANTIATE_TEMPLATE` | 15 | `[15, rootId, tplId, holeCount]` |
| `REGISTER_TREE` / `CLONE_TREE` | 16 / 17 | unchanged (vapor) |
| `INSERT_TEMPLATE_SLOT` | **18** | `[18, rootId, slotIndex, childId, anchorId]` |
| `REMOVE_TEMPLATE_SLOT` | **19** | `[19, rootId, slotIndex, childId]` |

Slot ops are **18/19** so they do not collide with vapor’s tree ops.

## Tests

All 225 testing-library tests pass on this vapor-rebased branch.

## Follow-ups

- [#306](https://github.com/Huxpro/vue-lynx/issues/306) — recursive lower inside slots (v-for item bodies)
- #298 / #299 / #300 — sparse + native ET consume the same `#slot` / slot-index abstract

## Note on #305

[#305](https://github.com/Huxpro/vue-lynx/pull/305) still points at `main` with the same commits force-pushed onto `cursor/element-slots-296-9243`. Prefer this PR (`vapor` base). Close #305 when convenient.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4289e08f-64f0-478d-b82e-c8106e499243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4289e08f-64f0-478d-b82e-c8106e499243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

