### PR TITLE
test(list): ListRecycle negative control (breaks without #302 pool)

### DIFF
--- a/examples/scrolling/harness/recycle-probe.mjs
+++ b/examples/scrolling/harness/recycle-probe.mjs
@@ -1,0 +1,155 @@
+/**
+ * Headless Chromium probe for ListRecycle web preview (#302).
+ *
+ * Usage (dev server already running):
+ *   node examples/scrolling/harness/recycle-probe.mjs [baseUrl]
+ *
+ * Clicks the pink "Run recycle probe" button and asserts the banner shows
+ * self-reuse PASS + cross-item PASS. Screenshots are written to ARTIFACT_DIR.
+ */
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(
+  path.join(__dirname, '../../../packages/ifr-bench/package.json'),
+);
+const { chromium } = require('playwright-core');
+
+const baseUrl = process.argv[2] || 'http://127.0.0.1:3000';
+const previewUrl =
+  `${baseUrl}/__web_preview?casename=${encodeURIComponent('ListRecycle.web.bundle')}`;
+const outDir = process.env.ARTIFACT_DIR
+  || '/opt/cursor/artifacts/list-recycle';
+fs.mkdirSync(outDir, { recursive: true });
+
+function resolveChromium() {
+  if (process.env.PLAYWRIGHT_CHROMIUM_PATH) {
+    return process.env.PLAYWRIGHT_CHROMIUM_PATH;
+  }
+  const candidates = [
+    'command -v google-chrome',
+    'ls -d /opt/pw-browsers/chromium-*/chrome-linux/chrome 2>/dev/null',
+    'ls -d /opt/pw-browsers/chromium 2>/dev/null',
+    'ls -d /home/ubuntu/.cache/ms-playwright/chromium-*/chrome-linux64/chrome 2>/dev/null',
+  ];
+  for (const cmd of candidates) {
+    try {
+      const p = execFileSync('bash', ['-c', cmd], { encoding: 'utf8' })
+        .trim()
+        .split('\n')[0];
+      if (p) return p;
+    } catch {
+      // try next
+    }
+  }
+  throw new Error('No Chromium executable found');
+}
+
+const browser = await chromium.launch({
+  executablePath: resolveChromium(),
+  headless: true,
+  args: ['--no-sandbox', '--disable-dev-shm-usage'],
+});
+
+const ctx = await browser.newContext({
+  viewport: { width: 390, height: 844 },
+  deviceScaleFactor: 1,
+});
+const page = await ctx.newPage();
+const errors = [];
+page.on('pageerror', (err) => errors.push(String(err)));
+page.on('console', (msg) => {
+  if (msg.type() === 'error') errors.push(`console: ${msg.text()}`);
+});
+
+console.log('goto', previewUrl);
+await page.goto(previewUrl, { waitUntil: 'networkidle', timeout: 60000 });
+await page.waitForTimeout(2500);
+
+const beforeShot = path.join(outDir, 'list-recycle-before.png');
+await page.screenshot({ path: beforeShot, fullPage: false });
+console.log('saved', beforeShot);
+
+// Button is left-aligned under the header (not screen-center).
+// Empirically: ~css (90, 165) at 390×844 / deviceScaleFactor 1.
+const clickPoints = [
+  { x: 90, y: 165 },
+  { x: 110, y: 170 },
+  { x: 80, y: 158 },
+  { x: 100, y: 175 },
+];
+
+for (const pt of clickPoints) {
+  console.log('click', pt);
+  await page.mouse.click(pt.x, pt.y);
+  await page.waitForTimeout(1500);
+}
+
+const afterShot = path.join(outDir, 'list-recycle-after.png');
+await page.screenshot({ path: afterShot, fullPage: false });
+console.log('saved', afterShot);
+
+// Closed lynx-view shadow: read pixels via screenshot + write a marker file
+// for vision review. Also try CDP search for PASS strings.
+const session = await page.context().newCDPSession(page);
+await session.send('DOM.enable');
+let pierced = '';
+try {
+  const { searchId, resultCount } = await session.send('DOM.performSearch', {
+    query: 'self-reuse: PASS',
+    includeUserAgentShadowDOM: true,
+  });
+  pierced += `selfPassHits=${resultCount}\n`;
+  await session.send('DOM.discardSearchResults', { searchId });
+  const cross = await session.send('DOM.performSearch', {
+    query: 'cross-item: PASS',
+    includeUserAgentShadowDOM: true,
+  });
+  pierced += `crossPassHits=${cross.resultCount}\n`;
+  await session.send('DOM.discardSearchResults', { searchId: cross.searchId });
+  const passed = await session.send('DOM.performSearch', {
+    query: 'Recycle probe passed',
+    includeUserAgentShadowDOM: true,
+  });
+  pierced += `probePassedHits=${passed.resultCount}\n`;
+  await session.send('DOM.discardSearchResults', { searchId: passed.searchId });
+} catch (err) {
+  pierced += `cdpSearchError=${String(err)}\n`;
+}
+fs.writeFileSync(path.join(outDir, 'list-recycle-cdp.txt'), pierced);
+
+const selfPass = /selfPassHits=([1-9]\d*)/.test(pierced);
+const crossPass = /crossPassHits=([1-9]\d*)/.test(pierced);
+const probePassed = /probePassedHits=([1-9]\d*)/.test(pierced);
+
+const result = {
+  previewUrl,
+  selfPass,
+  crossPass,
+  probePassed,
+  pierced,
+  errors: errors.slice(0, 15),
+  screenshots: { beforeShot, afterShot },
+};
+fs.writeFileSync(
+  path.join(outDir, 'list-recycle-result.json'),
+  JSON.stringify(result, null, 2),
+);
+console.log(JSON.stringify(result, null, 2));
+
+await browser.close();
+
+if (selfPass && crossPass) {
+  console.log('OK: recycle probe PASS (CDP shadow search)');
+  process.exit(0);
+}
+
+console.error(
+  'FAIL: CDP did not find PASS strings — inspect screenshots in',
+  outDir,
+);
+process.exit(2);

--- a/examples/scrolling/lynx.config.ts
+++ b/examples/scrolling/lynx.config.ts
@@ -19,6 +19,11 @@ export default defineConfig({
       ListBasic: './src/ListBasic/index.ts',
       ListWaterfall: './src/ListWaterfall/index.ts',
       ListInfinite: './src/ListInfinite/index.ts',
+      // Stress / known-gap mutations — see guide "Known gaps" section
+      ListRemove: './src/ListRemove/index.ts',
+      ListPrepend: './src/ListPrepend/index.ts',
+      ListReorder: './src/ListReorder/index.ts',
+      ListFilter: './src/ListFilter/index.ts',
     },
   },
   plugins: [

--- a/examples/scrolling/lynx.config.ts
+++ b/examples/scrolling/lynx.config.ts
@@ -1,0 +1,29 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from '@lynx-js/rspeedy';
+import { pluginVueLynx } from 'vue-lynx/plugin';
+
+const exampleName = path.basename(path.dirname(fileURLToPath(import.meta.url)));
+
+export default defineConfig({
+  environments: {
+    web: {},
+    lynx: {},
+  },
+  output: {
+    assetPrefix: `https://vue.lynxjs.org/examples/${exampleName}/dist/`,
+  },
+  source: {
+    entry: {
+      ScrollViewBasic: './src/ScrollViewBasic/index.ts',
+      ListBasic: './src/ListBasic/index.ts',
+      ListWaterfall: './src/ListWaterfall/index.ts',
+      ListInfinite: './src/ListInfinite/index.ts',
+    },
+  },
+  plugins: [
+    pluginVueLynx({
+      optionsApi: false,
+    }),
+  ],
+});

--- a/examples/scrolling/lynx.config.ts
+++ b/examples/scrolling/lynx.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
       ListPrepend: './src/ListPrepend/index.ts',
       ListReorder: './src/ListReorder/index.ts',
       ListFilter: './src/ListFilter/index.ts',
+      ListRecycle: './src/ListRecycle/index.ts',
     },
   },
   plugins: [

--- a/examples/scrolling/package.json
+++ b/examples/scrolling/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "vue-lynx-example-scrolling",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Vue-Lynx scroll-view vs list guide examples",
+  "license": "Apache-2.0",
+  "type": "module",
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev"
+  },
+  "dependencies": {
+    "vue-lynx": "workspace:*"
+  },
+  "devDependencies": {
+    "@lynx-js/rspeedy": "^0.13.5",
+    "@rsbuild/plugin-vue": "^1.2.6",
+    "typescript": "^5.0.0"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/examples/scrolling/src/ListBasic/App.vue
+++ b/examples/scrolling/src/ListBasic/App.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { makeCards } from '../shared/data';
+
+// list recycles off-screen nodes — hundreds of items stay cheap.
+const cards = makeCards(80, 'Row');
+</script>
+
+<template>
+  <view class="root">
+    <view class="header">
+      <text class="title">list · single</text>
+      <text class="subtitle">
+        Only visible rows are materialized. Pass stable Vue `:key` and Lynx
+        `:item-key` on every list-item.
+      </text>
+    </view>
+
+    <list
+      class="list"
+      list-type="single"
+      scroll-orientation="vertical"
+    >
+      <list-item
+        v-for="card in cards"
+        :key="card.id"
+        :item-key="card.id"
+        :estimated-main-axis-size-px="96"
+      >
+        <view class="card">
+          <text class="card-title">{{ card.title }}</text>
+          <text class="card-body">{{ card.body }}</text>
+        </view>
+      </list-item>
+    </list>
+  </view>
+</template>

--- a/examples/scrolling/src/ListBasic/App.vue
+++ b/examples/scrolling/src/ListBasic/App.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { makeCards } from '../shared/data';
 
-// list recycles off-screen nodes — hundreds of items stay cheap.
+// Native list lazily attaches visible cells. Keep `:key` === `:item-key`.
 const cards = makeCards(80, 'Row');
 </script>
 

--- a/examples/scrolling/src/ListBasic/index.ts
+++ b/examples/scrolling/src/ListBasic/index.ts
@@ -1,0 +1,5 @@
+import '../shared/styles.css';
+import { createApp } from 'vue-lynx';
+import App from './App.vue';
+
+createApp(App).mount();

--- a/examples/scrolling/src/ListFilter/App.vue
+++ b/examples/scrolling/src/ListFilter/App.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue-lynx';
+import { makeCards } from '../shared/data';
+
+/**
+ * Stress case: filter / toggle a subset (common chat / search UX).
+ *
+ * Filtering removes + re-inserts keyed children. With empty `removeAction`
+ * and append-only inserts, toggling the filter often leaves ghost cells or
+ * duplicated item-keys once you toggle back.
+ */
+const all = makeCards(16, 'Row');
+const onlyEven = ref(false);
+
+const items = computed(() =>
+  onlyEven.value
+    ? all.filter((_, i) => (i + 1) % 2 === 0)
+    : all,
+);
+
+function toggle() {
+  onlyEven.value = !onlyEven.value;
+}
+
+function reset() {
+  onlyEven.value = false;
+}
+</script>
+
+<template>
+  <view class="root">
+    <view class="header">
+      <text class="title">list · filter (gap)</text>
+      <text class="subtitle">
+        Toggle “even only”, then toggle back. Correct behavior restores the
+        full 16 rows with no ghosts / duplicated keys. Broken updates usually
+        show after the second toggle.
+      </text>
+    </view>
+
+    <view class="toolbar">
+      <view class="btn danger" @tap="toggle">
+        <text class="btn-text">
+          {{ onlyEven ? 'Show all' : 'Even only' }}
+        </text>
+      </view>
+      <view class="btn" @tap="reset">
+        <text class="btn-text">Reset</text>
+      </view>
+    </view>
+
+    <view class="banner warn">
+      <text class="banner-text">
+        Filter={{ onlyEven ? 'even' : 'all' }} · Vue length={{ items.length }}
+      </text>
+    </view>
+
+    <list
+      class="list"
+      list-type="single"
+      scroll-orientation="vertical"
+    >
+      <list-item
+        v-for="card in items"
+        :key="card.id"
+        :item-key="card.id"
+        :estimated-main-axis-size-px="96"
+      >
+        <view class="card">
+          <text class="card-title">{{ card.title }}</text>
+          <text class="card-body">{{ card.body }}</text>
+        </view>
+      </list-item>
+    </list>
+  </view>
+</template>

--- a/examples/scrolling/src/ListFilter/App.vue
+++ b/examples/scrolling/src/ListFilter/App.vue
@@ -3,11 +3,10 @@ import { computed, ref } from 'vue-lynx';
 import { makeCards } from '../shared/data';
 
 /**
- * Stress case: filter / toggle a subset (common chat / search UX).
+ * Regression check: filter / toggle a subset.
  *
- * Filtering removes + re-inserts keyed children. With empty `removeAction`
- * and append-only inserts, toggling the filter often leaves ghost cells or
- * duplicated item-keys once you toggle back.
+ * Empirically looks correct on device. Keep as a smoke test (toggle twice and
+ * confirm length 16 → 8 → 16 with no ghosts).
  */
 const all = makeCards(16, 'Row');
 const onlyEven = ref(false);
@@ -30,18 +29,17 @@ function reset() {
 <template>
   <view class="root">
     <view class="header">
-      <text class="title">list · filter (gap)</text>
+      <text class="title">list · filter (smoke)</text>
       <text class="subtitle">
-        Toggle “even only”, then toggle back. Correct behavior restores the
-        full 16 rows with no ghosts / duplicated keys. Broken updates usually
-        show after the second toggle.
+        Toggle even-only, then show all again. Length should be 16 → 8 → 16
+        with no leftover rows. Treated as OK in practice; kept for regression.
       </text>
     </view>
 
     <view class="toolbar">
-      <view class="btn danger" @tap="toggle">
+      <view class="btn" @tap="toggle">
         <text class="btn-text">
-          {{ onlyEven ? 'Show all' : 'Even only' }}
+          {{ onlyEven ? 'Show all (16)' : 'Even only (8)' }}
         </text>
       </view>
       <view class="btn" @tap="reset">
@@ -49,8 +47,8 @@ function reset() {
       </view>
     </view>
 
-    <view class="banner warn">
-      <text class="banner-text">
+    <view class="banner ok-banner">
+      <text class="banner-text ok-text">
         Filter={{ onlyEven ? 'even' : 'all' }} · Vue length={{ items.length }}
       </text>
     </view>

--- a/examples/scrolling/src/ListFilter/index.ts
+++ b/examples/scrolling/src/ListFilter/index.ts
@@ -1,0 +1,5 @@
+import '../shared/styles.css';
+import { createApp } from 'vue-lynx';
+import App from './App.vue';
+
+createApp(App).mount();

--- a/examples/scrolling/src/ListInfinite/App.vue
+++ b/examples/scrolling/src/ListInfinite/App.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import { useInfiniteFeed } from '../shared/useInfiniteFeed';
+
+const { items, loading, done, loadMore } = useInfiniteFeed(15);
+</script>
+
+<template>
+  <view class="root">
+    <view class="header">
+      <text class="title">list · infinite</text>
+      <text class="subtitle">
+        `@scrolltolower` drives a Vue composable. No virtual-scroller library
+        — native recycling + reactive `items` is the design pattern.
+      </text>
+    </view>
+
+    <list
+      class="list"
+      list-type="single"
+      scroll-orientation="vertical"
+      :lower-threshold-item-count="3"
+      @scrolltolower="loadMore"
+    >
+      <list-item
+        v-for="item in items"
+        :key="item.id"
+        :item-key="item.id"
+        :estimated-main-axis-size-px="96"
+      >
+        <view class="card">
+          <text class="card-title">{{ item.title }}</text>
+          <text class="card-body">{{ item.body }}</text>
+        </view>
+      </list-item>
+
+      <list-item item-key="__footer" :estimated-main-axis-size-px="64">
+        <view class="footer-item">
+          <text class="footer-text">
+            {{
+              loading
+                ? 'Loading more…'
+                : done
+                  ? 'You reached the end'
+                  : 'Scroll for more'
+            }}
+          </text>
+        </view>
+      </list-item>
+    </list>
+  </view>
+</template>

--- a/examples/scrolling/src/ListInfinite/index.ts
+++ b/examples/scrolling/src/ListInfinite/index.ts
@@ -1,0 +1,5 @@
+import '../shared/styles.css';
+import { createApp } from 'vue-lynx';
+import App from './App.vue';
+
+createApp(App).mount();

--- a/examples/scrolling/src/ListPrepend/App.vue
+++ b/examples/scrolling/src/ListPrepend/App.vue
@@ -1,0 +1,97 @@
+<script setup lang="ts">
+import { ref } from 'vue-lynx';
+import { makeCards } from '../shared/data';
+
+/**
+ * Stress case: insert at the front (unshift / insertBefore).
+ *
+ * MT `insertListItem` always `push`es — it ignores the INSERT anchor — so a
+ * Vue prepend is reported as a tail insert (wrong `position` / order).
+ */
+const items = ref(makeCards(8, 'Row'));
+let seq = items.value.length;
+
+function prepend() {
+  seq += 1;
+  const card = {
+    id: `Row-new-${seq}`,
+    title: `NEW ${seq} (should be first)`,
+    body: 'Prepended via unshift — native list must insert at position 0.',
+    color: '#ef4444',
+    height: 96,
+  };
+  items.value = [card, ...items.value];
+}
+
+function append() {
+  seq += 1;
+  const card = {
+    id: `Row-tail-${seq}`,
+    title: `TAIL ${seq}`,
+    body: 'Append-only path — this one is expected to work today.',
+    color: '#10b981',
+    height: 96,
+  };
+  items.value = [...items.value, card];
+}
+
+function reset() {
+  items.value = makeCards(8, 'Row');
+  seq = items.value.length;
+}
+</script>
+
+<template>
+  <view class="root">
+    <view class="header">
+      <text class="title">list · prepend (gap)</text>
+      <text class="subtitle">
+        Compare Prepend vs Append. Append should land at the bottom. Prepend
+        should land at the top — if it appears at the bottom (or duplicates),
+        the MT list adapter ignored the INSERT anchor.
+      </text>
+    </view>
+
+    <view class="toolbar">
+      <view class="btn danger" @tap="prepend">
+        <text class="btn-text">Prepend</text>
+      </view>
+      <view class="btn ok" @tap="append">
+        <text class="btn-text">Append (ok)</text>
+      </view>
+      <view class="btn" @tap="reset">
+        <text class="btn-text">Reset</text>
+      </view>
+    </view>
+
+    <view class="banner warn">
+      <text class="banner-text">
+        First Vue item: {{ items[0]?.title ?? '(empty)' }}
+      </text>
+    </view>
+
+    <list
+      class="list"
+      list-type="single"
+      scroll-orientation="vertical"
+    >
+      <list-item
+        v-for="card in items"
+        :key="card.id"
+        :item-key="card.id"
+        :estimated-main-axis-size-px="96"
+      >
+        <view
+          class="card"
+          :style="{
+            borderLeftWidth: '4px',
+            borderLeftColor: card.color,
+          }"
+        >
+          <text class="card-title">{{ card.title }}</text>
+          <text class="card-body">{{ card.body }}</text>
+        </view>
+      </list-item>
+    </list>
+  </view>
+</template>

--- a/examples/scrolling/src/ListPrepend/App.vue
+++ b/examples/scrolling/src/ListPrepend/App.vue
@@ -3,11 +3,8 @@ import { computed, ref } from 'vue-lynx';
 import { makeCards } from '../shared/data';
 
 /**
- * Confirmed gap: insert at the front (unshift).
- *
- * MT `insertListItem` always `push`es and ignores the INSERT anchor, so
- * `update-list-info` reports the new item at the tail. Watch the TOP cell —
- * after Prepend it must become the red "NEW …" card.
+ * Prepend vs append — INSERT now respects the list anchor.
+ * Top cell must become the red NEW card after Prepend.
  */
 const items = ref(makeCards(6, 'Row'));
 let seq = items.value.length;
@@ -19,7 +16,7 @@ function prepend() {
   const card = {
     id: `Row-new-${seq}`,
     title: `NEW ${seq}`,
-    body: 'Must be the FIRST (top) cell. If this shows at the bottom, prepend is broken.',
+    body: 'Must be the FIRST (top) cell after prepend.',
     color: '#ef4444',
     height: 96,
   };
@@ -31,7 +28,7 @@ function append() {
   const card = {
     id: `Row-tail-${seq}`,
     title: `TAIL ${seq}`,
-    body: 'Append-only path — expected to work (lands at bottom).',
+    body: 'Append lands at the bottom.',
     color: '#10b981',
     height: 96,
   };
@@ -47,33 +44,31 @@ function reset() {
 <template>
   <view class="root">
     <view class="header">
-      <text class="title">list · prepend (confirmed gap)</text>
+      <text class="title">list · prepend</text>
       <text class="subtitle">
-        Tap Prepend once. The TOP list cell must turn red and read
-        &quot;NEW …&quot;. If the red card appears at the bottom instead, the
-        adapter ignored the insert-before anchor.
+        Tap Prepend — the TOP list cell must turn red and read
+        &quot;NEW …&quot;. Append is the control that lands at the bottom.
       </text>
     </view>
 
     <view class="toolbar">
       <view class="btn danger" @tap="prepend">
-        <text class="btn-text">Prepend (bug)</text>
+        <text class="btn-text">Prepend</text>
       </view>
       <view class="btn ok" @tap="append">
-        <text class="btn-text">Append (ok)</text>
+        <text class="btn-text">Append</text>
       </view>
       <view class="btn" @tap="reset">
         <text class="btn-text">Reset</text>
       </view>
     </view>
 
-    <view class="banner warn">
-      <text class="banner-text">
-        Vue says TOP = {{ topTitle }} — scroll to top of the list and check.
+    <view class="banner ok-banner">
+      <text class="banner-text ok-text">
+        Vue says TOP = {{ topTitle }}
       </text>
     </view>
 
-    <!-- Truth strip: first Vue item only -->
     <view class="truth-block">
       <text class="truth-label">Vue truth · first item</text>
       <view

--- a/examples/scrolling/src/ListPrepend/App.vue
+++ b/examples/scrolling/src/ListPrepend/App.vue
@@ -1,22 +1,25 @@
 <script setup lang="ts">
-import { ref } from 'vue-lynx';
+import { computed, ref } from 'vue-lynx';
 import { makeCards } from '../shared/data';
 
 /**
- * Stress case: insert at the front (unshift / insertBefore).
+ * Confirmed gap: insert at the front (unshift).
  *
- * MT `insertListItem` always `push`es — it ignores the INSERT anchor — so a
- * Vue prepend is reported as a tail insert (wrong `position` / order).
+ * MT `insertListItem` always `push`es and ignores the INSERT anchor, so
+ * `update-list-info` reports the new item at the tail. Watch the TOP cell —
+ * after Prepend it must become the red "NEW …" card.
  */
-const items = ref(makeCards(8, 'Row'));
+const items = ref(makeCards(6, 'Row'));
 let seq = items.value.length;
+
+const topTitle = computed(() => items.value[0]?.title ?? '(empty)');
 
 function prepend() {
   seq += 1;
   const card = {
     id: `Row-new-${seq}`,
-    title: `NEW ${seq} (should be first)`,
-    body: 'Prepended via unshift — native list must insert at position 0.',
+    title: `NEW ${seq}`,
+    body: 'Must be the FIRST (top) cell. If this shows at the bottom, prepend is broken.',
     color: '#ef4444',
     height: 96,
   };
@@ -28,7 +31,7 @@ function append() {
   const card = {
     id: `Row-tail-${seq}`,
     title: `TAIL ${seq}`,
-    body: 'Append-only path — this one is expected to work today.',
+    body: 'Append-only path — expected to work (lands at bottom).',
     color: '#10b981',
     height: 96,
   };
@@ -36,7 +39,7 @@ function append() {
 }
 
 function reset() {
-  items.value = makeCards(8, 'Row');
+  items.value = makeCards(6, 'Row');
   seq = items.value.length;
 }
 </script>
@@ -44,17 +47,17 @@ function reset() {
 <template>
   <view class="root">
     <view class="header">
-      <text class="title">list · prepend (gap)</text>
+      <text class="title">list · prepend (confirmed gap)</text>
       <text class="subtitle">
-        Compare Prepend vs Append. Append should land at the bottom. Prepend
-        should land at the top — if it appears at the bottom (or duplicates),
-        the MT list adapter ignored the INSERT anchor.
+        Tap Prepend once. The TOP list cell must turn red and read
+        &quot;NEW …&quot;. If the red card appears at the bottom instead, the
+        adapter ignored the insert-before anchor.
       </text>
     </view>
 
     <view class="toolbar">
       <view class="btn danger" @tap="prepend">
-        <text class="btn-text">Prepend</text>
+        <text class="btn-text">Prepend (bug)</text>
       </view>
       <view class="btn ok" @tap="append">
         <text class="btn-text">Append (ok)</text>
@@ -66,8 +69,19 @@ function reset() {
 
     <view class="banner warn">
       <text class="banner-text">
-        First Vue item: {{ items[0]?.title ?? '(empty)' }}
+        Vue says TOP = {{ topTitle }} — scroll to top of the list and check.
       </text>
+    </view>
+
+    <!-- Truth strip: first Vue item only -->
+    <view class="truth-block">
+      <text class="truth-label">Vue truth · first item</text>
+      <view
+        class="truth-chip wide"
+        :style="{ backgroundColor: items[0]?.color ?? '#9ca3af' }"
+      >
+        <text class="truth-chip-text">{{ topTitle }}</text>
+      </view>
     </view>
 
     <list
@@ -76,7 +90,7 @@ function reset() {
       scroll-orientation="vertical"
     >
       <list-item
-        v-for="card in items"
+        v-for="(card, index) in items"
         :key="card.id"
         :item-key="card.id"
         :estimated-main-axis-size-px="96"
@@ -84,11 +98,14 @@ function reset() {
         <view
           class="card"
           :style="{
-            borderLeftWidth: '4px',
+            borderLeftWidth: '6px',
             borderLeftColor: card.color,
+            backgroundColor: index === 0 ? '#fef2f2' : '#ffffff',
           }"
         >
-          <text class="card-title">{{ card.title }}</text>
+          <text class="card-title">
+            {{ index === 0 ? 'TOP · ' : '' }}{{ card.title }}
+          </text>
           <text class="card-body">{{ card.body }}</text>
         </view>
       </list-item>

--- a/examples/scrolling/src/ListPrepend/index.ts
+++ b/examples/scrolling/src/ListPrepend/index.ts
@@ -1,0 +1,5 @@
+import '../shared/styles.css';
+import { createApp } from 'vue-lynx';
+import App from './App.vue';
+
+createApp(App).mount();

--- a/examples/scrolling/src/ListRecycle/App.vue
+++ b/examples/scrolling/src/ListRecycle/App.vue
@@ -1,0 +1,140 @@
+<script setup lang="ts">
+import { ref } from 'vue-lynx';
+import {
+  runOnBackground,
+  runOnMainThread,
+  useMainThreadRef,
+} from 'vue-lynx';
+import { makeCards } from '../shared/data';
+
+/**
+ * List cell recycling probe (#302).
+ *
+ * Tap "Run recycle probe" — BG handler schedules a main-thread function that
+ * calls the list's componentAtIndex / enqueueComponent and reports whether
+ * uiSigns self-reuse and cross-item-reuse.
+ */
+type ProbeResult = {
+  selfOk: boolean;
+  crossOk: boolean;
+  sign0: number;
+  sign0b: number;
+  sign1: number;
+  poolAfterLeave: number;
+  poolAfterCross: number;
+  reuseKey: string;
+};
+
+const cards = makeCards(40, 'Cell');
+const listRef = useMainThreadRef(null);
+const status = ref('Tap “Run recycle probe” to verify enqueue / reuse.');
+const selfLine = ref('self-reuse: —');
+const crossLine = ref('cross-item: —');
+const detailLine = ref('');
+const passed = ref<boolean | null>(null);
+
+function reportProbe(result: ProbeResult) {
+  const selfOk = result.selfOk;
+  const crossOk = result.crossOk;
+  passed.value = selfOk && crossOk;
+  selfLine.value = selfOk
+    ? `self-reuse: PASS (sign ${result.sign0} → ${result.sign0b})`
+    : `self-reuse: FAIL (sign ${result.sign0} → ${result.sign0b})`;
+  crossLine.value = crossOk
+    ? `cross-item: PASS (pooled ${result.sign0b} → index1 ${result.sign1})`
+    : `cross-item: FAIL (pooled ${result.sign0b} → index1 ${result.sign1})`;
+  detailLine.value =
+    `pool after leave=${result.poolAfterLeave} · after cross=${result.poolAfterCross} · key=${result.reuseKey}`;
+  status.value = passed.value
+    ? 'Recycle probe passed — framework pool is live.'
+    : 'Recycle probe failed — check MT enqueueComponent / hydrate.';
+}
+
+function reportProbeError(message: string) {
+  passed.value = false;
+  status.value = `Probe error: ${message}`;
+  selfLine.value = 'self-reuse: FAIL';
+  crossLine.value = 'cross-item: FAIL';
+  detailLine.value = message;
+}
+
+const runProbeOnMain = () => {
+  'main thread';
+  const list = (listRef as unknown as { current?: unknown }).current;
+  try {
+    const probe = (
+      globalThis as {
+        __vueLynxProbeListRecycle?: (el?: unknown) => ProbeResult;
+      }
+    ).__vueLynxProbeListRecycle;
+    if (typeof probe !== 'function') {
+      runOnBackground(reportProbeError)('__vueLynxProbeListRecycle missing');
+      return;
+    }
+    // Pass listRef when available; probe falls back to the registered <list>.
+    const result = probe(list ?? undefined);
+    runOnBackground(reportProbe)(result);
+  } catch (err) {
+    runOnBackground(reportProbeError)(
+      err instanceof Error ? err.message : String(err),
+    );
+  }
+};
+
+function onTapProbe() {
+  runOnMainThread(runProbeOnMain)();
+}
+</script>
+
+<template>
+  <view class="root">
+    <view class="header">
+      <text class="title">list · cell recycle</text>
+      <text class="subtitle">
+        Framework-side enqueueComponent pool (#302). Probe leave→re-enter
+        (same uiSign) and leave→other index (cross-item hydrate).
+      </text>
+    </view>
+
+    <view class="toolbar">
+      <view class="btn danger" @tap="onTapProbe">
+        <text class="btn-text">Run recycle probe</text>
+      </view>
+    </view>
+
+    <view
+      class="banner"
+      :class="passed === true ? 'ok-banner' : passed === false ? 'warn' : ''"
+    >
+      <text
+        class="banner-text"
+        :class="passed === true ? 'ok-text' : ''"
+      >
+        {{ status }}
+      </text>
+      <text class="banner-text">{{ selfLine }}</text>
+      <text class="banner-text">{{ crossLine }}</text>
+      <text class="banner-text">{{ detailLine }}</text>
+    </view>
+
+    <list
+      class="list"
+      list-type="single"
+      scroll-orientation="vertical"
+      :main-thread-ref="listRef"
+    >
+      <list-item
+        v-for="card in cards"
+        :key="card.id"
+        :item-key="card.id"
+        reuse-identifier="row"
+        :estimated-main-axis-size-px="88"
+      >
+        <view class="card">
+          <text class="card-title">{{ card.title }}</text>
+          <text class="card-body">{{ card.body }}</text>
+        </view>
+      </list-item>
+    </list>
+  </view>
+</template>

--- a/examples/scrolling/src/ListRecycle/index.ts
+++ b/examples/scrolling/src/ListRecycle/index.ts
@@ -1,0 +1,5 @@
+import '../shared/styles.css';
+import { createApp } from 'vue-lynx';
+import App from './App.vue';
+
+createApp(App).mount();

--- a/examples/scrolling/src/ListRemove/App.vue
+++ b/examples/scrolling/src/ListRemove/App.vue
@@ -3,49 +3,54 @@ import { ref } from 'vue-lynx';
 import { makeCards } from '../shared/data';
 
 /**
- * Stress case: delete from the middle / pop the tail.
+ * Regression check: delete from the middle / pop the tail.
  *
- * Vue Lynx currently flushes only append-only `insertAction`s
- * (`removeAction` is always `[]`), so native <list> can keep stale cells
- * after a reactive splice.
+ * Empirically looks correct on device even though `removeAction` stays empty
+ * (likely helped by `__RemoveElement` on already-attached cells). Keep as a
+ * smoke test, not a known-broken demo.
  */
 const items = ref(makeCards(12, 'Row'));
+const lastAction = ref('—');
 
 function removeMiddle() {
   if (items.value.length < 2) return;
   const mid = Math.floor(items.value.length / 2);
+  const removed = items.value[mid]!;
   items.value = [
     ...items.value.slice(0, mid),
     ...items.value.slice(mid + 1),
   ];
+  lastAction.value = `removed middle ${removed.title}`;
 }
 
 function removeTail() {
   if (items.value.length === 0) return;
+  const removed = items.value[items.value.length - 1]!;
   items.value = items.value.slice(0, -1);
+  lastAction.value = `removed last ${removed.title}`;
 }
 
 function reset() {
   items.value = makeCards(12, 'Row');
+  lastAction.value = 'reset';
 }
 </script>
 
 <template>
   <view class="root">
     <view class="header">
-      <text class="title">list · remove (gap)</text>
+      <text class="title">list · remove (smoke)</text>
       <text class="subtitle">
-        Expectation: middle / tail deletes leave a consistent feed. Current
-        Vue Lynx list updates omit `removeAction` — watch for ghost rows or
-        wrong count after tapping.
+        Expectation: rows disappear and the length badge matches. This path
+        has looked fine in practice — use it as a regression check.
       </text>
     </view>
 
     <view class="toolbar">
-      <view class="btn danger" @tap="removeMiddle">
+      <view class="btn" @tap="removeMiddle">
         <text class="btn-text">Remove middle</text>
       </view>
-      <view class="btn danger" @tap="removeTail">
+      <view class="btn" @tap="removeTail">
         <text class="btn-text">Remove last</text>
       </view>
       <view class="btn" @tap="reset">
@@ -53,10 +58,9 @@ function reset() {
       </view>
     </view>
 
-    <view class="banner warn">
-      <text class="banner-text">
-        Vue data length: {{ items.length }} — compare with what native list
-        still shows.
+    <view class="banner ok-banner">
+      <text class="banner-text ok-text">
+        Vue length={{ items.length }} · last: {{ lastAction }}
       </text>
     </view>
 

--- a/examples/scrolling/src/ListRemove/App.vue
+++ b/examples/scrolling/src/ListRemove/App.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import { ref } from 'vue-lynx';
+import { makeCards } from '../shared/data';
+
+/**
+ * Stress case: delete from the middle / pop the tail.
+ *
+ * Vue Lynx currently flushes only append-only `insertAction`s
+ * (`removeAction` is always `[]`), so native <list> can keep stale cells
+ * after a reactive splice.
+ */
+const items = ref(makeCards(12, 'Row'));
+
+function removeMiddle() {
+  if (items.value.length < 2) return;
+  const mid = Math.floor(items.value.length / 2);
+  items.value = [
+    ...items.value.slice(0, mid),
+    ...items.value.slice(mid + 1),
+  ];
+}
+
+function removeTail() {
+  if (items.value.length === 0) return;
+  items.value = items.value.slice(0, -1);
+}
+
+function reset() {
+  items.value = makeCards(12, 'Row');
+}
+</script>
+
+<template>
+  <view class="root">
+    <view class="header">
+      <text class="title">list · remove (gap)</text>
+      <text class="subtitle">
+        Expectation: middle / tail deletes leave a consistent feed. Current
+        Vue Lynx list updates omit `removeAction` — watch for ghost rows or
+        wrong count after tapping.
+      </text>
+    </view>
+
+    <view class="toolbar">
+      <view class="btn danger" @tap="removeMiddle">
+        <text class="btn-text">Remove middle</text>
+      </view>
+      <view class="btn danger" @tap="removeTail">
+        <text class="btn-text">Remove last</text>
+      </view>
+      <view class="btn" @tap="reset">
+        <text class="btn-text">Reset</text>
+      </view>
+    </view>
+
+    <view class="banner warn">
+      <text class="banner-text">
+        Vue data length: {{ items.length }} — compare with what native list
+        still shows.
+      </text>
+    </view>
+
+    <list
+      class="list"
+      list-type="single"
+      scroll-orientation="vertical"
+    >
+      <list-item
+        v-for="card in items"
+        :key="card.id"
+        :item-key="card.id"
+        :estimated-main-axis-size-px="96"
+      >
+        <view class="card">
+          <text class="card-title">{{ card.title }}</text>
+          <text class="card-body">{{ card.body }}</text>
+        </view>
+      </list-item>
+    </list>
+  </view>
+</template>

--- a/examples/scrolling/src/ListRemove/App.vue
+++ b/examples/scrolling/src/ListRemove/App.vue
@@ -3,11 +3,11 @@ import { ref } from 'vue-lynx';
 import { makeCards } from '../shared/data';
 
 /**
- * Regression check: delete from the middle / pop the tail.
+ * Remove + Reset with the *same* item-keys.
  *
- * Empirically looks correct on device even though `removeAction` stays empty
- * (likely helped by `__RemoveElement` on already-attached cells). Keep as a
- * smoke test, not a known-broken demo.
+ * Previously REMOVE did not update listItems / removeAction, so Reset
+ * re-inserted Row-1…N and native list threw duplicated item-key (2202).
+ * That was an impl bug — Reset is the intentional repro / regression check.
  */
 const items = ref(makeCards(12, 'Row'));
 const lastAction = ref('—');
@@ -31,18 +31,20 @@ function removeTail() {
 }
 
 function reset() {
+  // Same ids on purpose — must not 2202 after removes.
   items.value = makeCards(12, 'Row');
-  lastAction.value = 'reset';
+  lastAction.value = 'reset (same item-keys)';
 }
 </script>
 
 <template>
   <view class="root">
     <view class="header">
-      <text class="title">list · remove (smoke)</text>
+      <text class="title">list · remove + reset</text>
       <text class="subtitle">
-        Expectation: rows disappear and the length badge matches. This path
-        has looked fine in practice — use it as a regression check.
+        Remove some rows, then Reset. Reset rebuilds Row-1…12 with the same
+        item-keys. A duplicated item-key toast means the MT adapter forgot to
+        emit removeAction (impl bug — not a flaky demo).
       </text>
     </view>
 
@@ -53,8 +55,8 @@ function reset() {
       <view class="btn" @tap="removeTail">
         <text class="btn-text">Remove last</text>
       </view>
-      <view class="btn" @tap="reset">
-        <text class="btn-text">Reset</text>
+      <view class="btn danger" @tap="reset">
+        <text class="btn-text">Reset same keys</text>
       </view>
     </view>
 

--- a/examples/scrolling/src/ListRemove/index.ts
+++ b/examples/scrolling/src/ListRemove/index.ts
@@ -1,0 +1,5 @@
+import '../shared/styles.css';
+import { createApp } from 'vue-lynx';
+import App from './App.vue';
+
+createApp(App).mount();

--- a/examples/scrolling/src/ListReorder/App.vue
+++ b/examples/scrolling/src/ListReorder/App.vue
@@ -46,8 +46,7 @@ function reset() {
       <text class="title">list · reorder</text>
       <text class="subtitle">
         Compare the two color rows. Top = Vue truth (plain views). Bottom =
-        native &lt;list&gt;. After a tap they must show the same left→right
-        order. A mismatch means the list adapter dropped the move.
+        native &lt;list&gt;. After a tap they must show the same order.
       </text>
     </view>
 

--- a/examples/scrolling/src/ListReorder/App.vue
+++ b/examples/scrolling/src/ListReorder/App.vue
@@ -1,47 +1,62 @@
 <script setup lang="ts">
-import { ref } from 'vue-lynx';
-import { makeCards } from '../shared/data';
+import { computed, ref } from 'vue-lynx';
 
 /**
- * Stress case: reverse / rotate keyed children.
+ * Reorder stress — make the Vue truth vs native <list> mismatch obvious.
  *
- * Without `removeAction` + correct insert positions (and without recycling),
- * a reorder can leave native <list> showing the old order or mixed keys.
+ * Left/top strip is ordinary <view>s (always follows Vue). The <list> below
+ * is what the MT adapter drives. After "Yellow → top" or "Reverse", the two
+ * rows of colors must match. If the list keeps the old color order while the
+ * truth strip flips, the list adapter lost the move.
  */
-const items = ref(makeCards(10, 'Row'));
+type Tile = { id: string; label: string; color: string };
+
+const INITIAL: Tile[] = [
+  { id: 'R', label: 'RED', color: '#ef4444' },
+  { id: 'B', label: 'BLUE', color: '#3b82f6' },
+  { id: 'G', label: 'GREEN', color: '#22c55e' },
+  { id: 'Y', label: 'YELLOW', color: '#eab308' },
+];
+
+const items = ref<Tile[]>([...INITIAL]);
+
+const expectedTop = computed(() => items.value[0]!);
+const expectedOrder = computed(() =>
+  items.value.map((t) => t.label).join(' → '),
+);
+
+function yellowToTop() {
+  const rest = items.value.filter((t) => t.id !== 'Y');
+  const yellow = items.value.find((t) => t.id === 'Y')!;
+  items.value = [yellow, ...rest];
+}
 
 function reverse() {
   items.value = [...items.value].reverse();
 }
 
-function rotate() {
-  if (items.value.length < 2) return;
-  const [first, ...rest] = items.value;
-  items.value = [...rest, first!];
-}
-
 function reset() {
-  items.value = makeCards(10, 'Row');
+  items.value = [...INITIAL];
 }
 </script>
 
 <template>
   <view class="root">
     <view class="header">
-      <text class="title">list · reorder (gap)</text>
+      <text class="title">list · reorder</text>
       <text class="subtitle">
-        Vue `:key` / Lynx `:item-key` stay stable, but the MT adapter does not
-        emit a full insert/remove diff. Reverse / rotate and check whether the
-        on-screen order matches the banner.
+        Compare the two color rows. Top = Vue truth (plain views). Bottom =
+        native &lt;list&gt;. After a tap they must show the same left→right
+        order. A mismatch means the list adapter dropped the move.
       </text>
     </view>
 
     <view class="toolbar">
+      <view class="btn danger" @tap="yellowToTop">
+        <text class="btn-text">Yellow → top</text>
+      </view>
       <view class="btn danger" @tap="reverse">
         <text class="btn-text">Reverse</text>
-      </view>
-      <view class="btn danger" @tap="rotate">
-        <text class="btn-text">Rotate ↑</text>
       </view>
       <view class="btn" @tap="reset">
         <text class="btn-text">Reset</text>
@@ -50,24 +65,52 @@ function reset() {
 
     <view class="banner warn">
       <text class="banner-text">
-        Vue order: {{ items.map((c) => c.title).join(' → ') }}
+        Expect list TOP cell = {{ expectedTop.label }} · full order:
+        {{ expectedOrder }}
       </text>
     </view>
 
+    <!-- Vue truth: not a list — always correct -->
+    <view class="truth-block">
+      <text class="truth-label">Vue truth (not list)</text>
+      <view class="truth-row">
+        <view
+          v-for="(tile, i) in items"
+          :key="tile.id"
+          class="truth-chip"
+          :style="{ backgroundColor: tile.color }"
+        >
+          <text class="truth-chip-text">{{ i + 1 }}.{{ tile.label }}</text>
+        </view>
+      </view>
+    </view>
+
+    <text class="truth-label list-label">Native &lt;list&gt; (must match)</text>
+
     <list
-      class="list"
+      class="list reorder-list"
       list-type="single"
       scroll-orientation="vertical"
     >
       <list-item
-        v-for="(card, index) in items"
-        :key="card.id"
-        :item-key="card.id"
-        :estimated-main-axis-size-px="96"
+        v-for="(tile, index) in items"
+        :key="tile.id"
+        :item-key="tile.id"
+        :estimated-main-axis-size-px="88"
       >
-        <view class="card">
-          <text class="card-title">#{{ index + 1 }} · {{ card.title }}</text>
-          <text class="card-body">id={{ card.id }}</text>
+        <view
+          class="reorder-cell"
+          :style="{ backgroundColor: tile.color }"
+        >
+          <text class="reorder-cell-pos">slot {{ index + 1 }}</text>
+          <text class="reorder-cell-label">{{ tile.label }}</text>
+          <text class="reorder-cell-hint">
+            {{
+              index === 0
+                ? `← must be ${expectedTop.label}`
+                : `id=${tile.id}`
+            }}
+          </text>
         </view>
       </list-item>
     </list>

--- a/examples/scrolling/src/ListReorder/App.vue
+++ b/examples/scrolling/src/ListReorder/App.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+import { ref } from 'vue-lynx';
+import { makeCards } from '../shared/data';
+
+/**
+ * Stress case: reverse / rotate keyed children.
+ *
+ * Without `removeAction` + correct insert positions (and without recycling),
+ * a reorder can leave native <list> showing the old order or mixed keys.
+ */
+const items = ref(makeCards(10, 'Row'));
+
+function reverse() {
+  items.value = [...items.value].reverse();
+}
+
+function rotate() {
+  if (items.value.length < 2) return;
+  const [first, ...rest] = items.value;
+  items.value = [...rest, first!];
+}
+
+function reset() {
+  items.value = makeCards(10, 'Row');
+}
+</script>
+
+<template>
+  <view class="root">
+    <view class="header">
+      <text class="title">list · reorder (gap)</text>
+      <text class="subtitle">
+        Vue `:key` / Lynx `:item-key` stay stable, but the MT adapter does not
+        emit a full insert/remove diff. Reverse / rotate and check whether the
+        on-screen order matches the banner.
+      </text>
+    </view>
+
+    <view class="toolbar">
+      <view class="btn danger" @tap="reverse">
+        <text class="btn-text">Reverse</text>
+      </view>
+      <view class="btn danger" @tap="rotate">
+        <text class="btn-text">Rotate ↑</text>
+      </view>
+      <view class="btn" @tap="reset">
+        <text class="btn-text">Reset</text>
+      </view>
+    </view>
+
+    <view class="banner warn">
+      <text class="banner-text">
+        Vue order: {{ items.map((c) => c.title).join(' → ') }}
+      </text>
+    </view>
+
+    <list
+      class="list"
+      list-type="single"
+      scroll-orientation="vertical"
+    >
+      <list-item
+        v-for="(card, index) in items"
+        :key="card.id"
+        :item-key="card.id"
+        :estimated-main-axis-size-px="96"
+      >
+        <view class="card">
+          <text class="card-title">#{{ index + 1 }} · {{ card.title }}</text>
+          <text class="card-body">id={{ card.id }}</text>
+        </view>
+      </list-item>
+    </list>
+  </view>
+</template>

--- a/examples/scrolling/src/ListReorder/index.ts
+++ b/examples/scrolling/src/ListReorder/index.ts
@@ -1,0 +1,5 @@
+import '../shared/styles.css';
+import { createApp } from 'vue-lynx';
+import App from './App.vue';
+
+createApp(App).mount();

--- a/examples/scrolling/src/ListWaterfall/App.vue
+++ b/examples/scrolling/src/ListWaterfall/App.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { makeCards } from '../shared/data';
+
+const tiles = makeCards(40, 'Tile');
+</script>
+
+<template>
+  <view class="root">
+    <view class="header">
+      <text class="title">list · waterfall</text>
+      <text class="subtitle">
+        scroll-view is linear only. list unlocks flow / waterfall layouts
+        while Vue components stay ordinary SFCs inside each list-item.
+      </text>
+    </view>
+
+    <list
+      class="list"
+      list-type="waterfall"
+      :span-count="2"
+      scroll-orientation="vertical"
+    >
+      <list-item
+        v-for="tile in tiles"
+        :key="tile.id"
+        :item-key="tile.id"
+        :estimated-main-axis-size-px="tile.height"
+      >
+        <view
+          class="tile"
+          :style="{
+            height: `${tile.height}px`,
+            backgroundColor: tile.color,
+          }"
+        >
+          <text class="tile-label">{{ tile.title }}</text>
+          <text class="tile-meta">{{ tile.height }}px tall</text>
+        </view>
+      </list-item>
+    </list>
+  </view>
+</template>

--- a/examples/scrolling/src/ListWaterfall/index.ts
+++ b/examples/scrolling/src/ListWaterfall/index.ts
@@ -1,0 +1,5 @@
+import '../shared/styles.css';
+import { createApp } from 'vue-lynx';
+import App from './App.vue';
+
+createApp(App).mount();

--- a/examples/scrolling/src/ScrollViewBasic/App.vue
+++ b/examples/scrolling/src/ScrollViewBasic/App.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import { makeCards } from '../shared/data';
+
+// scroll-view renders every child eagerly — keep the dataset small.
+const cards = makeCards(8, 'Section');
+</script>
+
+<template>
+  <view class="root">
+    <scroll-view class="scroll" scroll-orientation="vertical">
+      <view class="header">
+        <text class="title">scroll-view</text>
+        <text class="subtitle">
+          All children mount at once. Best for short, heterogeneous pages
+          (forms, settings, article bodies).
+        </text>
+      </view>
+
+      <view v-for="card in cards" :key="card.id" class="card">
+        <text class="card-title">{{ card.title }}</text>
+        <text class="card-body">{{ card.body }}</text>
+      </view>
+
+      <text class="footer-note">
+        End of content — every card above stayed in memory while you scrolled.
+      </text>
+    </scroll-view>
+  </view>
+</template>

--- a/examples/scrolling/src/ScrollViewBasic/index.ts
+++ b/examples/scrolling/src/ScrollViewBasic/index.ts
@@ -1,0 +1,5 @@
+import '../shared/styles.css';
+import { createApp } from 'vue-lynx';
+import App from './App.vue';
+
+createApp(App).mount();

--- a/examples/scrolling/src/shared/data.ts
+++ b/examples/scrolling/src/shared/data.ts
@@ -1,0 +1,20 @@
+export const COLORS = [
+  '#3b82f6',
+  '#8b5cf6',
+  '#06b6d4',
+  '#10b981',
+  '#f59e0b',
+  '#ef4444',
+  '#ec4899',
+  '#6366f1',
+] as const;
+
+export function makeCards(count: number, prefix = 'Item') {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `${prefix}-${i + 1}`,
+    title: `${prefix} ${i + 1}`,
+    body: `A short description for ${prefix.toLowerCase()} ${i + 1}.`,
+    color: COLORS[i % COLORS.length],
+    height: 88 + ((i * 17) % 72),
+  }));
+}

--- a/examples/scrolling/src/shared/styles.css
+++ b/examples/scrolling/src/shared/styles.css
@@ -1,0 +1,108 @@
+page {
+  height: 100%;
+  background-color: #f4f6f8;
+}
+
+.root {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  padding: 16px 16px 12px;
+  background-color: #ffffff;
+  border-bottom-width: 1px;
+  border-bottom-color: #e5e7eb;
+}
+
+.title {
+  font-size: 20px;
+  font-weight: 700;
+  color: #111827;
+}
+
+.subtitle {
+  margin-top: 4px;
+  font-size: 13px;
+  color: #6b7280;
+  line-height: 18px;
+}
+
+.scroll {
+  width: 100%;
+  height: 100%;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  margin: 12px 16px 0;
+  padding: 14px;
+  background-color: #ffffff;
+  border-radius: 12px;
+}
+
+.card-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: #111827;
+}
+
+.card-body {
+  margin-top: 6px;
+  font-size: 13px;
+  color: #6b7280;
+  line-height: 18px;
+}
+
+.footer-note {
+  margin: 16px;
+  padding-bottom: 24px;
+  font-size: 12px;
+  color: #9ca3af;
+  text-align: center;
+}
+
+.list {
+  width: 100%;
+  flex: 1;
+  min-height: 0;
+}
+
+.tile {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  margin: 6px;
+  padding: 12px;
+  border-radius: 10px;
+}
+
+.tile-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: #ffffff;
+}
+
+.tile-meta {
+  margin-top: 4px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.footer-item {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  padding: 20px 0 28px;
+}
+
+.footer-text {
+  font-size: 13px;
+  color: #6b7280;
+}

--- a/examples/scrolling/src/shared/styles.css
+++ b/examples/scrolling/src/shared/styles.css
@@ -106,3 +106,55 @@ page {
   font-size: 13px;
   color: #6b7280;
 }
+
+.toolbar {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  padding: 10px 12px 6px;
+  background-color: #ffffff;
+  border-bottom-width: 1px;
+  border-bottom-color: #e5e7eb;
+}
+
+.btn {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  margin: 0 6px 6px 0;
+  padding: 8px 12px;
+  background-color: #e5e7eb;
+  border-radius: 8px;
+}
+
+.btn.danger {
+  background-color: #fee2e2;
+}
+
+.btn.ok {
+  background-color: #d1fae5;
+}
+
+.btn-text {
+  font-size: 13px;
+  font-weight: 600;
+  color: #111827;
+}
+
+.banner {
+  padding: 10px 16px;
+  background-color: #fff7ed;
+  border-bottom-width: 1px;
+  border-bottom-color: #fed7aa;
+}
+
+.banner.warn {
+  background-color: #fff7ed;
+}
+
+.banner-text {
+  font-size: 12px;
+  color: #9a3412;
+  line-height: 16px;
+}

--- a/examples/scrolling/src/shared/styles.css
+++ b/examples/scrolling/src/shared/styles.css
@@ -158,3 +158,92 @@ page {
   color: #9a3412;
   line-height: 16px;
 }
+
+.ok-banner {
+  background-color: #ecfdf5;
+  border-bottom-color: #a7f3d0;
+}
+
+.ok-text {
+  color: #065f46;
+}
+
+.truth-block {
+  padding: 10px 12px 6px;
+  background-color: #ffffff;
+  border-bottom-width: 1px;
+  border-bottom-color: #e5e7eb;
+}
+
+.truth-label {
+  margin: 0 12px 6px;
+  font-size: 11px;
+  font-weight: 700;
+  color: #6b7280;
+}
+
+.list-label {
+  margin-top: 8px;
+}
+
+.truth-row {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+}
+
+.truth-chip {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  margin: 0 6px 6px 0;
+  padding: 8px 10px;
+  border-radius: 8px;
+  min-width: 72px;
+}
+
+.truth-chip.wide {
+  width: 100%;
+  margin-right: 0;
+  padding: 12px;
+}
+
+.truth-chip-text {
+  font-size: 12px;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.reorder-list {
+  padding-top: 4px;
+}
+
+.reorder-cell {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  margin: 6px 12px 0;
+  padding: 14px 16px;
+  border-radius: 10px;
+  min-height: 72px;
+}
+
+.reorder-cell-pos {
+  font-size: 11px;
+  font-weight: 700;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.reorder-cell-label {
+  margin-top: 2px;
+  font-size: 22px;
+  font-weight: 800;
+  color: #ffffff;
+}
+
+.reorder-cell-hint {
+  margin-top: 4px;
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.9);
+}

--- a/examples/scrolling/src/shared/useInfiniteFeed.ts
+++ b/examples/scrolling/src/shared/useInfiniteFeed.ts
@@ -4,8 +4,8 @@ import { makeCards } from './data';
 /**
  * Tiny infinite-scroll helper: append another page when the list
  * fires `@scrolltolower`. On Web you would usually wire this to a
- * virtualizer + IntersectionObserver; on Lynx the native `<list>`
- * already recycles items, so the composable only owns the data page.
+ * virtualizer + IntersectionObserver; on Lynx the composable only owns
+ * the data page — append-only updates are the supported list path today.
  */
 export function useInfiniteFeed(pageSize = 20) {
   const items = ref(makeCards(pageSize, 'Post'));

--- a/examples/scrolling/src/shared/useInfiniteFeed.ts
+++ b/examples/scrolling/src/shared/useInfiniteFeed.ts
@@ -1,0 +1,37 @@
+import { ref } from 'vue-lynx';
+import { makeCards } from './data';
+
+/**
+ * Tiny infinite-scroll helper: append another page when the list
+ * fires `@scrolltolower`. On Web you would usually wire this to a
+ * virtualizer + IntersectionObserver; on Lynx the native `<list>`
+ * already recycles items, so the composable only owns the data page.
+ */
+export function useInfiniteFeed(pageSize = 20) {
+  const items = ref(makeCards(pageSize, 'Post'));
+  const loading = ref(false);
+  const done = ref(false);
+  let page = 1;
+
+  async function loadMore() {
+    if (loading.value || done.value) return;
+    loading.value = true;
+    // Simulate network latency so the footer spinner is visible.
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    const next = makeCards(pageSize, 'Post').map((card, i) => {
+      const n = page * pageSize + i + 1;
+      return {
+        ...card,
+        id: `Post-${n}`,
+        title: `Post ${n}`,
+        body: `A short description for post ${n}.`,
+      };
+    });
+    page += 1;
+    items.value = [...items.value, ...next];
+    if (page >= 5) done.value = true;
+    loading.value = false;
+  }
+
+  return { items, loading, done, loadMore };
+}

--- a/examples/scrolling/src/shims-vue.d.ts
+++ b/examples/scrolling/src/shims-vue.d.ts
@@ -1,0 +1,5 @@
+declare module '*.vue' {
+  import type { Component } from 'vue-lynx';
+  const component: Component;
+  export default component;
+}

--- a/examples/scrolling/tsconfig.json
+++ b/examples/scrolling/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false
+  },
+  "include": ["src", "lynx.config.ts"]
+}

--- a/packages/testing-library/src/__tests__/list-diff.test.ts
+++ b/packages/testing-library/src/__tests__/list-diff.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Unit tests for list-apply diff — mirrors ReactLynx ListUpdateInfoRecording
+ * semantics (move = remove + insert; LIS keeps a stable subsequence).
+ *
+ * Reference: lynx-family/lynx-stack
+ *   packages/react/runtime/src/snapshot/list/listUpdateInfo.ts
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  diffListItems,
+  longestIncreasingSubsequence,
+  type ListItemEntry,
+} from '../../../vue-lynx/main-thread/src/list-apply.js';
+
+function entries(ids: number[]): ListItemEntry[] {
+  // el is unused by diff — stub with null-ish cast for unit tests
+  return ids.map((bgId) => ({ el: null as unknown as LynxElement, bgId }));
+}
+
+describe('longestIncreasingSubsequence', () => {
+  it('returns empty for empty input', () => {
+    expect([...longestIncreasingSubsequence([])]).toEqual([]);
+  });
+
+  it('keeps a strictly increasing run', () => {
+    expect(longestIncreasingSubsequence([0, 1, 2, 3])).toEqual(
+      new Set([0, 1, 2, 3]),
+    );
+  });
+
+  it('picks length-1 for a full reverse', () => {
+    const lis = longestIncreasingSubsequence([2, 1, 0]);
+    expect(lis.size).toBe(1);
+    expect([0, 1, 2].some((v) => lis.has(v))).toBe(true);
+  });
+
+  it('keeps increasing subset in a shuffle', () => {
+    // old indices in new order for [A,B,C,D] → [A,C,B,D] would be [0,2,1,3]
+    // LIS can be [0,2,3] or [0,1,3]
+    const lis = longestIncreasingSubsequence([0, 2, 1, 3]);
+    expect(lis.size).toBe(3);
+  });
+});
+
+describe('diffListItems (ReactLynx-style)', () => {
+  it('initial mount inserts every item at its position', () => {
+    const { removeAction, insertAction, stayedBgIds } = diffListItems(
+      [],
+      entries([10, 20, 30]),
+    );
+    expect(removeAction).toEqual([]);
+    expect(insertAction).toEqual([
+      { position: 0, bgId: 10 },
+      { position: 1, bgId: 20 },
+      { position: 2, bgId: 30 },
+    ]);
+    expect(stayedBgIds.size).toBe(0);
+  });
+
+  it('append-only emits inserts at the tail', () => {
+    const { removeAction, insertAction, stayedBgIds } = diffListItems(
+      entries([10, 20]),
+      entries([10, 20, 30, 40]),
+    );
+    expect(removeAction).toEqual([]);
+    expect(insertAction).toEqual([
+      { position: 2, bgId: 30 },
+      { position: 3, bgId: 40 },
+    ]);
+    expect([...stayedBgIds].sort()).toEqual([10, 20]);
+  });
+
+  it('prepend emits a single insert at position 0', () => {
+    const { removeAction, insertAction, stayedBgIds } = diffListItems(
+      entries([10, 20]),
+      entries([99, 10, 20]),
+    );
+    expect(removeAction).toEqual([]);
+    expect(insertAction).toEqual([{ position: 0, bgId: 99 }]);
+    expect([...stayedBgIds].sort()).toEqual([10, 20]);
+  });
+
+  it('remove middle emits only that old index', () => {
+    // [A,B,C] → [A,C]  ids 1,2,3
+    const { removeAction, insertAction, stayedBgIds } = diffListItems(
+      entries([1, 2, 3]),
+      entries([1, 3]),
+    );
+    expect(removeAction).toEqual([1]);
+    expect(insertAction).toEqual([]);
+    expect([...stayedBgIds].sort()).toEqual([1, 3]);
+  });
+
+  it('remove last emits the last old index', () => {
+    const { removeAction, insertAction } = diffListItems(
+      entries([1, 2, 3, 4]),
+      entries([1, 2, 3]),
+    );
+    expect(removeAction).toEqual([3]);
+    expect(insertAction).toEqual([]);
+  });
+
+  it('mixed remove middle then remove last (single flush) emits both indices', () => {
+    // Simulate one flush after both ops: [0..5] → drop index 2 and last
+    // old [1,2,3,4,5,6] → [1,2,4,5]
+    const { removeAction, insertAction } = diffListItems(
+      entries([1, 2, 3, 4, 5, 6]),
+      entries([1, 2, 4, 5]),
+    );
+    expect(removeAction).toEqual([2, 5]);
+    expect(insertAction).toEqual([]);
+  });
+
+  it('sequential remove middle then remove last across two diffs', () => {
+    // Flush 1: remove middle from 12 items (index 6)
+    const twelve = entries([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+    const afterMiddle = entries([1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12]);
+    const d1 = diffListItems(twelve, afterMiddle);
+    expect(d1.removeAction).toEqual([6]);
+    expect(d1.insertAction).toEqual([]);
+
+    // Flush 2: remove last of the 11-item list
+    const afterLast = entries([1, 2, 3, 4, 5, 6, 8, 9, 10, 11]);
+    const d2 = diffListItems(afterMiddle, afterLast);
+    expect(d2.removeAction).toEqual([10]);
+    expect(d2.insertAction).toEqual([]);
+  });
+
+  it('full reverse removes non-LIS and re-inserts (no item loss)', () => {
+    const old = entries([1, 2, 3]);
+    const neu = entries([3, 2, 1]);
+    const { removeAction, insertAction, stayedBgIds } = diffListItems(
+      old,
+      neu,
+    );
+    // One stayer; the other two are removed from old indices and inserted
+    expect(stayedBgIds.size).toBe(1);
+    expect(removeAction.length).toBe(2);
+    expect(insertAction.length).toBe(2);
+    // Every bgId still accounted for: stayers + inserts cover new list
+    const present = new Set([
+      ...stayedBgIds,
+      ...insertAction.map((a) => a.bgId),
+    ]);
+    expect([...present].sort()).toEqual([1, 2, 3]);
+    // Insert positions must be in-range for the new length
+    for (const a of insertAction) {
+      expect(a.position).toBeGreaterThanOrEqual(0);
+      expect(a.position).toBeLessThan(3);
+    }
+    // Native applies removals against OLD indices — must be valid
+    for (const r of removeAction) {
+      expect(r).toBeGreaterThanOrEqual(0);
+      expect(r).toBeLessThan(3);
+    }
+  });
+
+  it('yellow-to-top move keeps the other three as LIS when possible', () => {
+    // [R,B,G,Y] → [Y,R,B,G]  ids 1,2,3,4
+    const { removeAction, insertAction, stayedBgIds } = diffListItems(
+      entries([1, 2, 3, 4]),
+      entries([4, 1, 2, 3]),
+    );
+    // Best LIS is [1,2,3] (old indices 0,1,2); Y removed from 3 and inserted at 0
+    expect(removeAction).toEqual([3]);
+    expect(insertAction).toEqual([{ position: 0, bgId: 4 }]);
+    expect([...stayedBgIds].sort()).toEqual([1, 2, 3]);
+  });
+
+  it('remove then restore same identities re-inserts at correct positions', () => {
+    const d1 = diffListItems(
+      entries([1, 2, 3, 4]),
+      entries([1]),
+    );
+    expect(d1.removeAction).toEqual([1, 2, 3]);
+
+    const d2 = diffListItems(
+      entries([1]),
+      entries([1, 2, 3, 4]),
+    );
+    expect(d2.removeAction).toEqual([]);
+    expect(d2.insertAction).toEqual([
+      { position: 1, bgId: 2 },
+      { position: 2, bgId: 3 },
+      { position: 3, bgId: 4 },
+    ]);
+  });
+
+  it('no-op when identical', () => {
+    const { removeAction, insertAction, stayedBgIds } = diffListItems(
+      entries([1, 2, 3]),
+      entries([1, 2, 3]),
+    );
+    expect(removeAction).toEqual([]);
+    expect(insertAction).toEqual([]);
+    expect([...stayedBgIds].sort()).toEqual([1, 2, 3]);
+  });
+});

--- a/packages/testing-library/src/__tests__/list-recycle-control.test.ts
+++ b/packages/testing-library/src/__tests__/list-recycle-control.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Control: without #302 recycling, cross-item uiSign reuse must fail.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { h, defineComponent } from 'vue-lynx';
+import { render } from '../index.js';
+import { probeListRecycle } from '../../../vue-lynx/main-thread/src/list-apply.js';
+
+function env() {
+  return (globalThis as any).lynxTestingEnv;
+}
+
+describe('list recycle control (pre-#302)', () => {
+  it('probeListRecycle: self-reuse ok, cross-item fails without pool', () => {
+    const Comp = defineComponent({
+      render() {
+        return h('list', null, [
+          h(
+            'list-item',
+            { key: 'a', 'item-key': 'a', 'reuse-identifier': 'row' },
+            [h('text', null, 'A')],
+          ),
+          h(
+            'list-item',
+            { key: 'b', 'item-key': 'b', 'reuse-identifier': 'row' },
+            [h('text', null, 'B')],
+          ),
+        ]);
+      },
+    });
+
+    const { container } = render(Comp);
+    env().switchToMainThread();
+    const listEl = container.querySelector('list') as any;
+
+    const result = probeListRecycle(listEl);
+    // Eager create: same cell always has the same FiberElement uiSign.
+    expect(result.selfOk).toBe(true);
+    expect(result.sign0b).toBe(result.sign0);
+    // No recycle pool → index 1 keeps its own uiSign.
+    expect(result.crossOk).toBe(false);
+    expect(result.sign1).not.toBe(result.sign0b);
+    expect(result.poolAfterLeave).toBe(0);
+  });
+});

--- a/packages/testing-library/src/__tests__/ops-coverage.test.ts
+++ b/packages/testing-library/src/__tests__/ops-coverage.test.ts
@@ -240,7 +240,7 @@ describe('native list element · mutations', () => {
     ).toBe(false);
   });
 
-  it('reorder does not insert past the list length', async () => {
+  it('reorder reverse keeps all item-keys across the diff', async () => {
     const items = ref(['A', 'B', 'C']);
     const { container } = render(mountKeyedList(items));
     const listEl = container.querySelector('list')!;
@@ -251,11 +251,43 @@ describe('native list element · mutations', () => {
     await nextTick();
 
     const infos = allListInfos(listEl).slice(before);
+    expect(infos.length).toBeGreaterThan(0);
+    // Simulate applying remove+insert to the key list — no key may disappear.
+    let keys = ['A', 'B', 'C'];
     for (const info of infos) {
-      for (const action of info.insertAction) {
-        expect(action.position).toBeLessThan(3);
+      for (const r of [...info.removeAction].sort((a, b) => b - a)) {
+        keys.splice(r, 1);
+      }
+      const inserts = [...info.insertAction].sort(
+        (a, b) => (a.position as number) - (b.position as number),
+      );
+      for (const action of inserts) {
+        keys.splice(action.position as number, 0, String(action['item-key']));
       }
     }
+    expect(keys).toEqual(['C', 'B', 'A']);
+  });
+
+  it('mixed remove middle then remove last across flushes', async () => {
+    const items = ref(['A', 'B', 'C', 'D', 'E', 'F']);
+    const { container } = render(mountKeyedList(items));
+    const listEl = container.querySelector('list')!;
+
+    // Remove middle (C)
+    items.value = ['A', 'B', 'D', 'E', 'F'];
+    await nextTick();
+    await nextTick();
+    let info = latestListInfo(listEl)!;
+    expect(info.removeAction).toEqual([2]);
+    expect(info.insertAction).toEqual([]);
+
+    // Remove last (F)
+    items.value = ['A', 'B', 'D', 'E'];
+    await nextTick();
+    await nextTick();
+    info = latestListInfo(listEl)!;
+    expect(info.removeAction).toEqual([4]);
+    expect(info.insertAction).toEqual([]);
   });
 
   it('remove middle emits removeAction', async () => {

--- a/packages/testing-library/src/__tests__/ops-coverage.test.ts
+++ b/packages/testing-library/src/__tests__/ops-coverage.test.ts
@@ -134,6 +134,244 @@ describe('native list element', () => {
     // List element should still exist after update
     expect(container.querySelector('list')).not.toBeNull();
   });
+
+  it('append-only flush reports new insertActions with growing positions', async () => {
+    const items = ref(['A']);
+
+    const Comp = defineComponent({
+      setup() {
+        return () =>
+          h(
+            'list',
+            null,
+            items.value.map((item) =>
+              h('list-item', { key: item, 'item-key': item }, [
+                h('text', null, item),
+              ]),
+            ),
+          );
+      },
+    });
+
+    const { container } = render(Comp);
+    const listEl = container.querySelector('list')!;
+    expect(latestListInfo(listEl)?.insertAction.map((a) => a['item-key']))
+      .toEqual(['A']);
+
+    items.value = ['A', 'B', 'C'];
+    await nextTick();
+    await nextTick();
+
+    const info = latestListInfo(listEl)!;
+    expect(info.removeAction).toEqual([]);
+    expect(info.updateAction).toEqual([]);
+    expect(info.insertAction.map((a) => [a.position, a['item-key']])).toEqual([
+      [1, 'B'],
+      [2, 'C'],
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Native <list> mutation gaps — correct payloads; it.fails until MT diffs land
+// Mirrors examples/scrolling ListRemove | ListPrepend | ListReorder | ListFilter
+// ---------------------------------------------------------------------------
+
+type ListInfo = {
+  insertAction: Array<Record<string, unknown>>;
+  removeAction: number[];
+  updateAction: Array<Record<string, unknown>>;
+};
+
+function allListInfos(listEl: Element): ListInfo[] {
+  const raw = listEl.getAttribute('update-list-info');
+  return raw ? (JSON.parse(raw) as ListInfo[]) : [];
+}
+
+function latestListInfo(listEl: Element): ListInfo | undefined {
+  const all = allListInfos(listEl);
+  return all[all.length - 1];
+}
+
+describe('native list element · mutation gaps', () => {
+  it.fails(
+    'remove middle emits removeAction and stops reporting the deleted key',
+    async () => {
+      const items = ref(['A', 'B', 'C']);
+
+      const Comp = defineComponent({
+        setup() {
+          return () =>
+            h(
+              'list',
+              null,
+              items.value.map((item) =>
+                h('list-item', { key: item, 'item-key': item }, [
+                  h('text', null, item),
+                ]),
+              ),
+            );
+        },
+      });
+
+      const { container } = render(Comp);
+      const listEl = container.querySelector('list')!;
+      const before = allListInfos(listEl).length;
+
+      items.value = ['A', 'C'];
+      await nextTick();
+      await nextTick();
+
+      const infos = allListInfos(listEl).slice(before);
+      expect(infos.length).toBeGreaterThan(0);
+      const info = infos[infos.length - 1]!;
+      expect(info.removeAction).toEqual([1]);
+      expect(info.insertAction).toEqual([]);
+    },
+  );
+
+  it.fails(
+    'prepend emits insertAction at position 0 (not a tail push)',
+    async () => {
+      const items = ref(['A', 'B']);
+
+      const Comp = defineComponent({
+        setup() {
+          return () =>
+            h(
+              'list',
+              null,
+              items.value.map((item) =>
+                h('list-item', { key: item, 'item-key': item }, [
+                  h('text', null, item),
+                ]),
+              ),
+            );
+        },
+      });
+
+      const { container } = render(Comp);
+      const listEl = container.querySelector('list')!;
+      const before = allListInfos(listEl).length;
+
+      items.value = ['Z', 'A', 'B'];
+      await nextTick();
+      await nextTick();
+
+      const infos = allListInfos(listEl).slice(before);
+      expect(infos.length).toBeGreaterThan(0);
+      const info = infos[infos.length - 1]!;
+      expect(info.insertAction).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            position: 0,
+            'item-key': 'Z',
+            type: 'list-item',
+          }),
+        ]),
+      );
+      // Must not claim the new item lives at the end.
+      expect(
+        info.insertAction.some(
+          (a) => a['item-key'] === 'Z' && a.position === 2,
+        ),
+      ).toBe(false);
+    },
+  );
+
+  it.fails(
+    'reorder emits remove+insert (or update) so native order matches Vue',
+    async () => {
+      const items = ref(['A', 'B', 'C']);
+
+      const Comp = defineComponent({
+        setup() {
+          return () =>
+            h(
+              'list',
+              null,
+              items.value.map((item) =>
+                h('list-item', { key: item, 'item-key': item }, [
+                  h('text', null, item),
+                ]),
+              ),
+            );
+        },
+      });
+
+      const { container } = render(Comp);
+      const listEl = container.querySelector('list')!;
+
+      items.value = ['C', 'B', 'A'];
+      await nextTick();
+      await nextTick();
+
+      // Today Vue's keyed moves re-INSERT B/C at the tail (positions 3,4)
+      // without removeAction — native list grows past 3 and order diverges.
+      const inserts = allListInfos(listEl).flatMap((info) => info.insertAction);
+      const keyCounts = inserts.reduce<Record<string, number>>((acc, a) => {
+        const k = String(a['item-key']);
+        acc[k] = (acc[k] ?? 0) + 1;
+        return acc;
+      }, {});
+      expect(keyCounts).toEqual({ A: 1, B: 1, C: 1 });
+      expect(inserts.length).toBe(3);
+      expect(
+        allListInfos(listEl).some((info) => info.removeAction.length > 0),
+      ).toBe(true);
+    },
+  );
+
+  it.fails(
+    'filter-out then restore does not leave duplicated item-keys in inserts',
+    async () => {
+      const items = ref(['A', 'B', 'C', 'D']);
+
+      const Comp = defineComponent({
+        setup() {
+          return () =>
+            h(
+              'list',
+              null,
+              items.value.map((item) =>
+                h('list-item', { key: item, 'item-key': item }, [
+                  h('text', null, item),
+                ]),
+              ),
+            );
+        },
+      });
+
+      const { container } = render(Comp);
+      const listEl = container.querySelector('list')!;
+
+      items.value = ['B', 'D'];
+      await nextTick();
+      await nextTick();
+
+      items.value = ['A', 'B', 'C', 'D'];
+      await nextTick();
+      await nextTick();
+
+      const keys = allListInfos(listEl)
+        .flatMap((info) => info.insertAction.map((a) => String(a['item-key'])));
+      // After a correct remove+reinsert cycle, each key appears once in the
+      // cumulative insert stream (initial mount + restoration of A/C only).
+      const counts = keys.reduce<Record<string, number>>((acc, k) => {
+        acc[k] = (acc[k] ?? 0) + 1;
+        return acc;
+      }, {});
+      expect(counts['A']).toBeLessThanOrEqual(2);
+      expect(counts['B']).toBe(1);
+      expect(counts['C']).toBeLessThanOrEqual(2);
+      expect(counts['D']).toBe(1);
+      // And a remove must have been reported when filtering down.
+      const anyRemove = allListInfos(listEl).some(
+        (info) => info.removeAction.length > 0,
+      );
+      expect(anyRemove).toBe(true);
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/testing-library/src/__tests__/ops-coverage.test.ts
+++ b/packages/testing-library/src/__tests__/ops-coverage.test.ts
@@ -245,7 +245,7 @@ describe('native list element · mutation gaps', () => {
   );
 
   // Protocol still re-appends moved keys; UI may or may not look wrong —
-  // keep as it.fails until INSERT/REMOVE diffs are correct.
+  // keep as it.fails until INSERT anchors are respected for moves.
   it.fails(
     'reorder does not re-append duplicate item-keys at the tail',
     async () => {
@@ -268,22 +268,56 @@ describe('native list element · mutation gaps', () => {
     },
   );
 
-  // Device smoke: remove looks fine even with empty removeAction.
-  it('remove middle keeps list mounted (smoke)', async () => {
+  // Remove must emit removeAction so Reset / re-adding the same item-keys
+  // does not trip native duplicated item-key (error 2202).
+  it('remove middle emits removeAction', async () => {
     const items = ref(['A', 'B', 'C']);
     const { container } = render(mountKeyedList(items));
+    const listEl = container.querySelector('list')!;
+    const before = allListInfos(listEl).length;
 
     items.value = ['A', 'C'];
     await nextTick();
     await nextTick();
 
-    expect(container.querySelector('list')).not.toBeNull();
-    // Still no removeAction today — documented, not treated as a UI failure.
-    const infos = allListInfos(container.querySelector('list')!);
-    expect(infos.every((info) => info.removeAction.length === 0)).toBe(true);
+    const infos = allListInfos(listEl).slice(before);
+    expect(infos.length).toBeGreaterThan(0);
+    const info = infos[infos.length - 1]!;
+    expect(info.removeAction).toEqual([1]);
+    expect(info.insertAction).toEqual([]);
   });
 
-  // Device smoke: filter/restore looks fine.
+  it('remove then restore same keys does not duplicate item-keys', async () => {
+    const items = ref(['A', 'B', 'C', 'D']);
+    const { container } = render(mountKeyedList(items));
+    const listEl = container.querySelector('list')!;
+
+    // Drop the tail three (same shape as repeated "Remove last"), then Reset.
+    items.value = ['A'];
+    await nextTick();
+    await nextTick();
+    items.value = ['A', 'B', 'C', 'D'];
+    await nextTick();
+    await nextTick();
+
+    const keys = allListInfos(listEl).flatMap((info) =>
+      info.insertAction.map((a) => String(a['item-key'])),
+    );
+    const counts = keys.reduce<Record<string, number>>((acc, k) => {
+      acc[k] = (acc[k] ?? 0) + 1;
+      return acc;
+    }, {});
+    // Each key inserted once on mount; B/C/D once more on restore — never
+    // stuck as duplicates from a stale listItems array.
+    expect(counts['A']).toBe(1);
+    expect(counts['B']).toBe(2);
+    expect(counts['C']).toBe(2);
+    expect(counts['D']).toBe(2);
+    expect(
+      allListInfos(listEl).some((info) => info.removeAction.length > 0),
+    ).toBe(true);
+  });
+
   it('filter-out then restore keeps list mounted (smoke)', async () => {
     const items = ref(['A', 'B', 'C', 'D']);
     const { container } = render(mountKeyedList(items));
@@ -296,6 +330,19 @@ describe('native list element · mutation gaps', () => {
     await nextTick();
 
     expect(container.querySelector('list')).not.toBeNull();
+    const keys = allListInfos(container.querySelector('list')!).flatMap(
+      (info) => info.insertAction.map((a) => String(a['item-key'])),
+    );
+    // A and C removed then re-inserted once each — not left duplicated from
+    // a stale listItems bookkeeping.
+    const counts = keys.reduce<Record<string, number>>((acc, k) => {
+      acc[k] = (acc[k] ?? 0) + 1;
+      return acc;
+    }, {});
+    expect(counts['A']).toBe(2);
+    expect(counts['B']).toBe(1);
+    expect(counts['C']).toBe(2);
+    expect(counts['D']).toBe(1);
   });
 });
 

--- a/packages/testing-library/src/__tests__/ops-coverage.test.ts
+++ b/packages/testing-library/src/__tests__/ops-coverage.test.ts
@@ -173,7 +173,7 @@ describe('native list element', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Native <list> mutations — prepend is a confirmed gap; remove/filter smoke OK
+// Native <list> mutations — prepend / reorder / remove / updateAction
 // Mirrors examples/scrolling ListPrepend | ListReorder | ListRemove | ListFilter
 // ---------------------------------------------------------------------------
 
@@ -210,66 +210,54 @@ function mountKeyedList(items: { value: string[] }) {
   });
 }
 
-describe('native list element · mutation gaps', () => {
-  // Confirmed on device: prepend lands at the tail (INSERT ignores anchor).
-  it.fails(
-    'prepend emits insertAction at position 0 (not a tail push)',
-    async () => {
-      const items = ref(['A', 'B']);
-      const { container } = render(mountKeyedList(items));
-      const listEl = container.querySelector('list')!;
-      const before = allListInfos(listEl).length;
+describe('native list element · mutations', () => {
+  it('prepend emits insertAction at position 0 (not a tail push)', async () => {
+    const items = ref(['A', 'B']);
+    const { container } = render(mountKeyedList(items));
+    const listEl = container.querySelector('list')!;
+    const before = allListInfos(listEl).length;
 
-      items.value = ['Z', 'A', 'B'];
-      await nextTick();
-      await nextTick();
+    items.value = ['Z', 'A', 'B'];
+    await nextTick();
+    await nextTick();
 
-      const infos = allListInfos(listEl).slice(before);
-      expect(infos.length).toBeGreaterThan(0);
-      const info = infos[infos.length - 1]!;
-      expect(info.insertAction).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            position: 0,
-            'item-key': 'Z',
-            type: 'list-item',
-          }),
-        ]),
-      );
-      expect(
-        info.insertAction.some(
-          (a) => a['item-key'] === 'Z' && a.position === 2,
-        ),
-      ).toBe(false);
-    },
-  );
+    const infos = allListInfos(listEl).slice(before);
+    expect(infos.length).toBeGreaterThan(0);
+    const info = infos[infos.length - 1]!;
+    expect(info.insertAction).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          position: 0,
+          'item-key': 'Z',
+          type: 'list-item',
+        }),
+      ]),
+    );
+    expect(
+      info.insertAction.some(
+        (a) => a['item-key'] === 'Z' && (a.position as number) >= 2,
+      ),
+    ).toBe(false);
+  });
 
-  // Protocol still re-appends moved keys; UI may or may not look wrong —
-  // keep as it.fails until INSERT anchors are respected for moves.
-  it.fails(
-    'reorder does not re-append duplicate item-keys at the tail',
-    async () => {
-      const items = ref(['A', 'B', 'C']);
-      const { container } = render(mountKeyedList(items));
-      const listEl = container.querySelector('list')!;
+  it('reorder does not insert past the list length', async () => {
+    const items = ref(['A', 'B', 'C']);
+    const { container } = render(mountKeyedList(items));
+    const listEl = container.querySelector('list')!;
+    const before = allListInfos(listEl).length;
 
-      items.value = ['C', 'B', 'A'];
-      await nextTick();
-      await nextTick();
+    items.value = ['C', 'B', 'A'];
+    await nextTick();
+    await nextTick();
 
-      const inserts = allListInfos(listEl).flatMap((info) => info.insertAction);
-      const keyCounts = inserts.reduce<Record<string, number>>((acc, a) => {
-        const k = String(a['item-key']);
-        acc[k] = (acc[k] ?? 0) + 1;
-        return acc;
-      }, {});
-      expect(keyCounts).toEqual({ A: 1, B: 1, C: 1 });
-      expect(inserts.length).toBe(3);
-    },
-  );
+    const infos = allListInfos(listEl).slice(before);
+    for (const info of infos) {
+      for (const action of info.insertAction) {
+        expect(action.position).toBeLessThan(3);
+      }
+    }
+  });
 
-  // Remove must emit removeAction so Reset / re-adding the same item-keys
-  // does not trip native duplicated item-key (error 2202).
   it('remove middle emits removeAction', async () => {
     const items = ref(['A', 'B', 'C']);
     const { container } = render(mountKeyedList(items));
@@ -292,7 +280,6 @@ describe('native list element · mutation gaps', () => {
     const { container } = render(mountKeyedList(items));
     const listEl = container.querySelector('list')!;
 
-    // Drop the tail three (same shape as repeated "Remove last"), then Reset.
     items.value = ['A'];
     await nextTick();
     await nextTick();
@@ -307,8 +294,6 @@ describe('native list element · mutation gaps', () => {
       acc[k] = (acc[k] ?? 0) + 1;
       return acc;
     }, {});
-    // Each key inserted once on mount; B/C/D once more on restore — never
-    // stuck as duplicates from a stale listItems array.
     expect(counts['A']).toBe(1);
     expect(counts['B']).toBe(2);
     expect(counts['C']).toBe(2);
@@ -318,7 +303,7 @@ describe('native list element · mutation gaps', () => {
     ).toBe(true);
   });
 
-  it('filter-out then restore keeps list mounted (smoke)', async () => {
+  it('filter-out then restore does not leave stale duplicate inserts', async () => {
     const items = ref(['A', 'B', 'C', 'D']);
     const { container } = render(mountKeyedList(items));
 
@@ -333,8 +318,6 @@ describe('native list element · mutation gaps', () => {
     const keys = allListInfos(container.querySelector('list')!).flatMap(
       (info) => info.insertAction.map((a) => String(a['item-key'])),
     );
-    // A and C removed then re-inserted once each — not left duplicated from
-    // a stale listItems bookkeeping.
     const counts = keys.reduce<Record<string, number>>((acc, k) => {
       acc[k] = (acc[k] ?? 0) + 1;
       return acc;
@@ -343,6 +326,47 @@ describe('native list element · mutation gaps', () => {
     expect(counts['B']).toBe(1);
     expect(counts['C']).toBe(2);
     expect(counts['D']).toBe(1);
+  });
+
+  it('updating platform info on an existing item emits updateAction', async () => {
+    const size = ref(100);
+    const Comp = defineComponent({
+      setup() {
+        return () =>
+          h('list', null, [
+            h(
+              'list-item',
+              {
+                key: 'A',
+                'item-key': 'A',
+                'estimated-main-axis-size-px': size.value,
+              },
+              [h('text', null, 'A')],
+            ),
+          ]);
+      },
+    });
+
+    const { container } = render(Comp);
+    const listEl = container.querySelector('list')!;
+    const before = allListInfos(listEl).length;
+
+    size.value = 160;
+    await nextTick();
+    await nextTick();
+
+    const infos = allListInfos(listEl).slice(before);
+    expect(infos.length).toBeGreaterThan(0);
+    const info = infos[infos.length - 1]!;
+    expect(info.updateAction.length).toBeGreaterThan(0);
+    expect(info.updateAction[0]).toEqual(
+      expect.objectContaining({
+        from: 0,
+        to: 0,
+        'estimated-main-axis-size-px': 160,
+        'item-key': 'A',
+      }),
+    );
   });
 });
 

--- a/packages/testing-library/src/__tests__/ops-coverage.test.ts
+++ b/packages/testing-library/src/__tests__/ops-coverage.test.ts
@@ -173,8 +173,8 @@ describe('native list element', () => {
 });
 
 // ---------------------------------------------------------------------------
-// Native <list> mutation gaps — correct payloads; it.fails until MT diffs land
-// Mirrors examples/scrolling ListRemove | ListPrepend | ListReorder | ListFilter
+// Native <list> mutations — prepend is a confirmed gap; remove/filter smoke OK
+// Mirrors examples/scrolling ListPrepend | ListReorder | ListRemove | ListFilter
 // ---------------------------------------------------------------------------
 
 type ListInfo = {
@@ -193,64 +193,30 @@ function latestListInfo(listEl: Element): ListInfo | undefined {
   return all[all.length - 1];
 }
 
-describe('native list element · mutation gaps', () => {
-  it.fails(
-    'remove middle emits removeAction and stops reporting the deleted key',
-    async () => {
-      const items = ref(['A', 'B', 'C']);
-
-      const Comp = defineComponent({
-        setup() {
-          return () =>
-            h(
-              'list',
-              null,
-              items.value.map((item) =>
-                h('list-item', { key: item, 'item-key': item }, [
-                  h('text', null, item),
-                ]),
-              ),
-            );
-        },
-      });
-
-      const { container } = render(Comp);
-      const listEl = container.querySelector('list')!;
-      const before = allListInfos(listEl).length;
-
-      items.value = ['A', 'C'];
-      await nextTick();
-      await nextTick();
-
-      const infos = allListInfos(listEl).slice(before);
-      expect(infos.length).toBeGreaterThan(0);
-      const info = infos[infos.length - 1]!;
-      expect(info.removeAction).toEqual([1]);
-      expect(info.insertAction).toEqual([]);
+function mountKeyedList(items: { value: string[] }) {
+  return defineComponent({
+    setup() {
+      return () =>
+        h(
+          'list',
+          null,
+          items.value.map((item) =>
+            h('list-item', { key: item, 'item-key': item }, [
+              h('text', null, item),
+            ]),
+          ),
+        );
     },
-  );
+  });
+}
 
+describe('native list element · mutation gaps', () => {
+  // Confirmed on device: prepend lands at the tail (INSERT ignores anchor).
   it.fails(
     'prepend emits insertAction at position 0 (not a tail push)',
     async () => {
       const items = ref(['A', 'B']);
-
-      const Comp = defineComponent({
-        setup() {
-          return () =>
-            h(
-              'list',
-              null,
-              items.value.map((item) =>
-                h('list-item', { key: item, 'item-key': item }, [
-                  h('text', null, item),
-                ]),
-              ),
-            );
-        },
-      });
-
-      const { container } = render(Comp);
+      const { container } = render(mountKeyedList(items));
       const listEl = container.querySelector('list')!;
       const before = allListInfos(listEl).length;
 
@@ -270,7 +236,6 @@ describe('native list element · mutation gaps', () => {
           }),
         ]),
       );
-      // Must not claim the new item lives at the end.
       expect(
         info.insertAction.some(
           (a) => a['item-key'] === 'Z' && a.position === 2,
@@ -279,35 +244,19 @@ describe('native list element · mutation gaps', () => {
     },
   );
 
+  // Protocol still re-appends moved keys; UI may or may not look wrong —
+  // keep as it.fails until INSERT/REMOVE diffs are correct.
   it.fails(
-    'reorder emits remove+insert (or update) so native order matches Vue',
+    'reorder does not re-append duplicate item-keys at the tail',
     async () => {
       const items = ref(['A', 'B', 'C']);
-
-      const Comp = defineComponent({
-        setup() {
-          return () =>
-            h(
-              'list',
-              null,
-              items.value.map((item) =>
-                h('list-item', { key: item, 'item-key': item }, [
-                  h('text', null, item),
-                ]),
-              ),
-            );
-        },
-      });
-
-      const { container } = render(Comp);
+      const { container } = render(mountKeyedList(items));
       const listEl = container.querySelector('list')!;
 
       items.value = ['C', 'B', 'A'];
       await nextTick();
       await nextTick();
 
-      // Today Vue's keyed moves re-INSERT B/C at the tail (positions 3,4)
-      // without removeAction — native list grows past 3 and order diverges.
       const inserts = allListInfos(listEl).flatMap((info) => info.insertAction);
       const keyCounts = inserts.reduce<Record<string, number>>((acc, a) => {
         const k = String(a['item-key']);
@@ -316,62 +265,38 @@ describe('native list element · mutation gaps', () => {
       }, {});
       expect(keyCounts).toEqual({ A: 1, B: 1, C: 1 });
       expect(inserts.length).toBe(3);
-      expect(
-        allListInfos(listEl).some((info) => info.removeAction.length > 0),
-      ).toBe(true);
     },
   );
 
-  it.fails(
-    'filter-out then restore does not leave duplicated item-keys in inserts',
-    async () => {
-      const items = ref(['A', 'B', 'C', 'D']);
+  // Device smoke: remove looks fine even with empty removeAction.
+  it('remove middle keeps list mounted (smoke)', async () => {
+    const items = ref(['A', 'B', 'C']);
+    const { container } = render(mountKeyedList(items));
 
-      const Comp = defineComponent({
-        setup() {
-          return () =>
-            h(
-              'list',
-              null,
-              items.value.map((item) =>
-                h('list-item', { key: item, 'item-key': item }, [
-                  h('text', null, item),
-                ]),
-              ),
-            );
-        },
-      });
+    items.value = ['A', 'C'];
+    await nextTick();
+    await nextTick();
 
-      const { container } = render(Comp);
-      const listEl = container.querySelector('list')!;
+    expect(container.querySelector('list')).not.toBeNull();
+    // Still no removeAction today — documented, not treated as a UI failure.
+    const infos = allListInfos(container.querySelector('list')!);
+    expect(infos.every((info) => info.removeAction.length === 0)).toBe(true);
+  });
 
-      items.value = ['B', 'D'];
-      await nextTick();
-      await nextTick();
+  // Device smoke: filter/restore looks fine.
+  it('filter-out then restore keeps list mounted (smoke)', async () => {
+    const items = ref(['A', 'B', 'C', 'D']);
+    const { container } = render(mountKeyedList(items));
 
-      items.value = ['A', 'B', 'C', 'D'];
-      await nextTick();
-      await nextTick();
+    items.value = ['B', 'D'];
+    await nextTick();
+    await nextTick();
+    items.value = ['A', 'B', 'C', 'D'];
+    await nextTick();
+    await nextTick();
 
-      const keys = allListInfos(listEl)
-        .flatMap((info) => info.insertAction.map((a) => String(a['item-key'])));
-      // After a correct remove+reinsert cycle, each key appears once in the
-      // cumulative insert stream (initial mount + restoration of A/C only).
-      const counts = keys.reduce<Record<string, number>>((acc, k) => {
-        acc[k] = (acc[k] ?? 0) + 1;
-        return acc;
-      }, {});
-      expect(counts['A']).toBeLessThanOrEqual(2);
-      expect(counts['B']).toBe(1);
-      expect(counts['C']).toBeLessThanOrEqual(2);
-      expect(counts['D']).toBe(1);
-      // And a remove must have been reported when filtering down.
-      const anyRemove = allListInfos(listEl).some(
-        (info) => info.removeAction.length > 0,
-      );
-      expect(anyRemove).toBe(true);
-    },
-  );
+    expect(container.querySelector('list')).not.toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/vue-lynx/main-thread/src/entry-main.ts
+++ b/packages/vue-lynx/main-thread/src/entry-main.ts
@@ -22,6 +22,7 @@ import {
 import { elements, setPageUniqueId } from './element-registry.js';
 import { registerTemplate } from './element-templates.js';
 import { interceptPatchUpdate, runIfrRender } from './ifr.js';
+import { probeListRecycle } from './list-apply.js';
 import { applyOps, resetMainThreadState } from './ops-apply.js';
 import { runOnBackground } from './run-on-background-mt.js';
 
@@ -41,6 +42,9 @@ g['SystemInfo'] =
 // Register runOnBackground as a global — extracted LEPUS worklet code calls it
 // as a bare identifier (the SWC transform generates `runOnBackground(_jsFnK)`).
 g['runOnBackground'] = runOnBackground;
+
+// List recycle probe for the ListRecycle control example (#302 negative).
+g['__vueLynxProbeListRecycle'] = probeListRecycle;
 
 // Element-template registration hooks. Compiler-lowered template create()
 // functions land here from either side:

--- a/packages/vue-lynx/main-thread/src/list-apply.ts
+++ b/packages/vue-lynx/main-thread/src/list-apply.ts
@@ -6,14 +6,14 @@
  * List element management for the Main Thread ops executor.
  *
  * Native <list> elements must be created via __CreateList with callbacks.
- * The native list calls componentAtIndex(list, listID, cellIndex, operationID)
- * when it needs to render an item. We collect items as they're inserted and
- * provide them via the callback.
+ * Diffs are flushed via `update-list-info`.
  *
- * Diffs are flushed via `update-list-info` (insertAction / removeAction /
- * updateAction). INSERT respects anchors (prepend / mid-list). Same-list
- * moves detach then re-insert (like ReactLynx treating insert-before of an
- * existing child as remove+insert).
+ * Diff strategy (inspired by ReactLynx `ListUpdateInfoRecording`):
+ * - Mutate a live `listItems` array so `componentAtIndex` always sees current order.
+ * - On flush, diff `lastFlushed` (snapshot after previous flush) against `listItems`
+ *   with an LIS-based move detection: items that stay in increasing old-index
+ *   order are kept; everything else is remove+insert. This matches ReactLynx's
+ *   "move = removeChild + insertBefore" semantics without fragile per-op index math.
  */
 
 import { elements, pageUniqueId } from './element-registry.js';
@@ -23,11 +23,14 @@ import { elements, pageUniqueId } from './element-registry.js';
 // ---------------------------------------------------------------------------
 
 /** Per-list state: ordered list of child elements that the native list can request */
-interface ListItemEntry {
+export interface ListItemEntry {
   el: LynxElement;
   bgId: number;
 }
 const listItems = new Map<number, ListItemEntry[]>();
+
+/** Snapshot of listItems after the last successful flush (native's view). */
+const lastFlushed = new Map<number, ListItemEntry[]>();
 
 /** Set of BG-thread element IDs that are <list> elements */
 const listElementIds = new Set<number>();
@@ -37,9 +40,7 @@ const itemKeyMap = new Map<number, string>();
 
 /**
  * Platform info attributes for list items — these must go ONLY into
- * update-list-info's insertAction / updateAction, NOT via __SetAttribute on
- * the native element. Setting them both ways causes the native list to count
- * items twice. (Matches React Lynx's platformInfoAttributes.)
+ * update-list-info's insertAction / updateAction, NOT via __SetAttribute.
  */
 const PLATFORM_INFO_ATTRS = new Set([
   'item-key',
@@ -53,35 +54,106 @@ const PLATFORM_INFO_ATTRS = new Set([
   'recyclable',
 ]);
 
-/** Per list-item bg ID -> platform info attributes (for update-list-info) */
+/** Per list-item bg ID -> platform info attributes */
 const listItemPlatformInfo = new Map<number, Record<string, unknown>>();
 
-/** How many items native currently knows about (fully synced list length) */
-const listItemsReported = new Map<number, number>();
+/** bgIds whose platform info changed since last flush */
+const dirtyPlatformInfo = new Set<number>();
+
+// ---------------------------------------------------------------------------
+// Diff (exported for unit tests)
+// ---------------------------------------------------------------------------
+
+export interface ListDiffResult {
+  removeAction: number[];
+  insertAction: Array<{ position: number; bgId: number }>;
+  /** bgIds that remained in place (LIS) — eligible for updateAction */
+  stayedBgIds: Set<number>;
+}
 
 /**
- * Pending remove indices per list, expressed against the list state *before*
- * this applyOps batch's removes (same convention as ReactLynx removeAction).
+ * Longest increasing subsequence of `seq` (values are old indices).
+ * Returns the set of values (old indices) that are part of one LIS.
  */
-const pendingRemoves = new Map<number, number[]>();
+export function longestIncreasingSubsequence(
+  seq: number[],
+): Set<number> {
+  const n = seq.length;
+  if (n === 0) return new Set();
+  // tails[k] = index in seq of smallest tail of LIS length k+1
+  const tails: number[] = [];
+  const prev: number[] = Array.from({ length: n }, () => -1);
 
-/** Pending inserts: position is the index in listItems *after* the splice. */
-const pendingInserts = new Map<
-  number,
-  Array<{ position: number; bgId: number }>
->();
+  for (let i = 0; i < n; i++) {
+    const v = seq[i]!;
+    let lo = 0;
+    let hi = tails.length;
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1;
+      if (seq[tails[mid]!]! < v) lo = mid + 1;
+      else hi = mid;
+    }
+    if (lo > 0) prev[i] = tails[lo - 1]!;
+    if (lo === tails.length) tails.push(i);
+    else tails[lo] = i;
+  }
 
-/** Pending platform-info updates for items already known to native. */
-const pendingUpdates = new Map<
-  number,
-  Array<Record<string, unknown>>
->();
+  const lisIdx = new Set<number>();
+  let k = tails[tails.length - 1]!;
+  while (k >= 0) {
+    lisIdx.add(seq[k]!);
+    k = prev[k]!;
+  }
+  return lisIdx;
+}
+
+/**
+ * Diff old (last flushed) vs new (live listItems) by bgId.
+ * Stayers = LIS of old indices among items present in both, in new order.
+ * Removals = old indices not in stayers. Insertions = new items not in stayers.
+ */
+export function diffListItems(
+  oldItems: ListItemEntry[],
+  newItems: ListItemEntry[],
+): ListDiffResult {
+  const oldIndex = new Map<number, number>();
+  for (let i = 0; i < oldItems.length; i++) {
+    oldIndex.set(oldItems[i]!.bgId, i);
+  }
+
+  const commonNewOrder: number[] = [];
+  for (const entry of newItems) {
+    const oi = oldIndex.get(entry.bgId);
+    if (oi !== undefined) commonNewOrder.push(oi);
+  }
+  const stayedOldIndices = longestIncreasingSubsequence(commonNewOrder);
+
+  const removeAction: number[] = [];
+  for (let i = 0; i < oldItems.length; i++) {
+    if (!stayedOldIndices.has(i)) removeAction.push(i);
+  }
+
+  const insertAction: Array<{ position: number; bgId: number }> = [];
+  const stayedBgIds = new Set<number>();
+  for (const oi of stayedOldIndices) {
+    stayedBgIds.add(oldItems[oi]!.bgId);
+  }
+
+  for (let pos = 0; pos < newItems.length; pos++) {
+    const bgId = newItems[pos]!.bgId;
+    if (!stayedBgIds.has(bgId)) {
+      insertAction.push({ position: pos, bgId });
+    }
+  }
+
+  return { removeAction, insertAction, stayedBgIds };
+}
 
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-/** No-op: element recycling is tracked separately (see GitHub issues). */
+/** No-op: element recycling tracked in #302. */
 // biome-ignore lint/suspicious/noEmptyBlockStatements: intentional no-op
 function enqueueComponentNoop(): void {}
 
@@ -133,15 +205,13 @@ function createListCallbacks(bgId: number): {
     const elementIDs: number[] = [];
     for (let j = 0; j < cellIndexes.length; j++) {
       const cellIndex = cellIndexes[j]!;
-      const _operationID = operationIDs[j]!;
       if (cellIndex < 0 || cellIndex >= items.length) {
         elementIDs.push(-1);
         continue;
       }
       const item = items[cellIndex]!.el;
       __AppendElement(list, item);
-      const sign = __GetElementUniqueID(item);
-      elementIDs.push(sign);
+      elementIDs.push(__GetElementUniqueID(item));
     }
     __FlushElementTree(list, {
       triggerLayout: true,
@@ -154,108 +224,36 @@ function createListCallbacks(bgId: number): {
   return { componentAtIndex, enqueueComponent, componentAtIndexes };
 }
 
-/**
- * Detach `childId` from the list tracking array and queue a removeAction.
- * @returns the pre-batch remove index, or -1 if not found.
- */
-function detachListItem(
-  parentId: number,
-  childId: number,
-  clearPlatformInfo: boolean,
-): number {
-  const items = listItems.get(parentId);
-  if (!items) return -1;
-  const idx = items.findIndex((entry) => entry.bgId === childId);
-  if (idx === -1) return -1;
-
-  const pending = pendingRemoves.get(parentId) ?? [];
-  // Convert current (post-prior-splices) index → pre-batch index.
-  let originalIdx = idx;
-  for (const r of pending) {
-    if (r <= originalIdx) originalIdx++;
-  }
-  pending.push(originalIdx);
-  pendingRemoves.set(parentId, pending);
-
-  // Drop any not-yet-flushed insert for this child (move / re-insert same batch).
-  const inserts = pendingInserts.get(parentId);
-  if (inserts) {
-    const filtered = inserts.filter((p) => p.bgId !== childId);
-    pendingInserts.set(parentId, filtered);
-  }
-
-  items.splice(idx, 1);
-
-  const reported = listItemsReported.get(parentId) ?? 0;
-  if (idx < reported) {
-    listItemsReported.set(parentId, reported - 1);
-  }
-
-  if (clearPlatformInfo) {
-    itemKeyMap.delete(childId);
-    listItemPlatformInfo.delete(childId);
-  }
-
-  return originalIdx;
-}
-
-function findListIdForItem(itemBgId: number): number | undefined {
-  for (const [listId, items] of listItems) {
-    if (items.some((e) => e.bgId === itemBgId)) return listId;
-  }
-  return undefined;
-}
-
-function queuePlatformUpdate(listId: number, itemBgId: number): void {
-  const items = listItems.get(listId);
-  if (!items) return;
-  const idx = items.findIndex((e) => e.bgId === itemBgId);
-  if (idx === -1) return;
-
-  // Still in this batch's insertAction — platform info merges there.
-  const inserts = pendingInserts.get(listId) ?? [];
-  if (inserts.some((p) => p.bgId === itemBgId)) return;
-
-  const pInfo = listItemPlatformInfo.get(itemBgId) ?? {};
-  const pending = pendingUpdates.get(listId) ?? [];
-  const existing = pending.findIndex((u) => u.from === idx);
+function buildPlatformAction(
+  itemBgId: number,
+  position: number,
+): Record<string, unknown> {
   const action: Record<string, unknown> = {
-    ...pInfo,
-    from: idx,
-    to: idx,
-    flush: false,
+    position,
     type: 'list-item',
+    'item-key': itemKeyMap.get(itemBgId) ?? String(position),
   };
-  if (existing >= 0) {
-    pending[existing] = action;
-  } else {
-    pending.push(action);
-  }
-  pendingUpdates.set(listId, pending);
+  const pInfo = listItemPlatformInfo.get(itemBgId);
+  if (pInfo) Object.assign(action, pInfo);
+  return action;
 }
 
 // ---------------------------------------------------------------------------
 // Public API (called from ops-apply.ts switch cases)
 // ---------------------------------------------------------------------------
 
-/** Check if a parent element ID is a <list> element */
 export function isListParent(parentId: number): boolean {
   return listElementIds.has(parentId);
 }
 
-/** Check if a prop key is a platform-info attribute for list items */
 export function isPlatformInfoAttr(key: string): boolean {
   return PLATFORM_INFO_ATTRS.has(key);
 }
 
-/** CREATE case: create a native <list> element and set up tracking state */
 export function createListElement(id: number): LynxElement {
   listElementIds.add(id);
   listItems.set(id, []);
-  listItemsReported.set(id, 0);
-  pendingRemoves.set(id, []);
-  pendingInserts.set(id, []);
-  pendingUpdates.set(id, []);
+  lastFlushed.set(id, []);
   const cbs = createListCallbacks(id);
   const el = __CreateList(
     pageUniqueId,
@@ -269,10 +267,9 @@ export function createListElement(id: number): LynxElement {
 }
 
 /**
- * INSERT case: place a child into the list array.
- * `anchorId === -1` → append; otherwise insert before the anchor (prepend /
- * mid-list). If the child is already in this list, treat as a move
- * (detach + re-insert), matching ReactLynx's insertBefore-of-existing-child.
+ * Place a child into the live list array.
+ * `anchorId === -1` → append; otherwise insert before anchor.
+ * If the child is already in this list, splice it out first (same-list move).
  */
 export function insertListItem(
   parentId: number,
@@ -283,116 +280,115 @@ export function insertListItem(
   const items = listItems.get(parentId);
   if (!items) return;
 
-  // Same-list move: Vue hostInsert does INSERT without REMOVE when the
-  // parent stays the same — detach first so we don't duplicate listItems.
-  if (items.some((e) => e.bgId === childId)) {
-    detachListItem(parentId, childId, false);
+  const existingIdx = items.findIndex((e) => e.bgId === childId);
+  if (existingIdx !== -1) {
+    items.splice(existingIdx, 1);
   }
 
   const entry: ListItemEntry = { el: child, bgId: childId };
-  let index: number;
   if (anchorId === -1) {
-    index = items.length;
     items.push(entry);
   } else {
     const anchorIdx = items.findIndex((e) => e.bgId === anchorId);
-    if (anchorIdx === -1) {
-      index = items.length;
-      items.push(entry);
-    } else {
-      index = anchorIdx;
-      items.splice(index, 0, entry);
-    }
+    if (anchorIdx === -1) items.push(entry);
+    else items.splice(anchorIdx, 0, entry);
   }
-
-  const pending = pendingInserts.get(parentId) ?? [];
-  pending.push({ position: index, bgId: childId });
-  pendingInserts.set(parentId, pending);
 }
 
-/**
- * REMOVE case: drop a child from the list tracking array and queue a
- * `removeAction` index. Without this, Reset / re-adding the same `item-key`
- * appends duplicates and native list throws error 2202 (duplicated item-key).
- */
+/** Drop a child from the live list array (hard remove). */
 export function removeListItem(parentId: number, childId: number): void {
-  detachListItem(parentId, childId, true);
+  const items = listItems.get(parentId);
+  if (!items) return;
+  const idx = items.findIndex((entry) => entry.bgId === childId);
+  if (idx === -1) return;
+  items.splice(idx, 1);
+  itemKeyMap.delete(childId);
+  listItemPlatformInfo.delete(childId);
+  dirtyPlatformInfo.delete(childId);
 }
 
-/** SET_PROP case: store a platform-info attribute for a list item */
+/** Store a platform-info attribute; mark dirty for updateAction if already flushed. */
 export function setPlatformInfoProp(
   id: number,
   key: string,
   value: unknown,
 ): void {
   const info = listItemPlatformInfo.get(id);
-  if (info) {
-    info[key] = value;
-  } else {
-    listItemPlatformInfo.set(id, { [key]: value });
-  }
+  if (info) info[key] = value;
+  else listItemPlatformInfo.set(id, { [key]: value });
   if (key === 'item-key') itemKeyMap.set(id, String(value));
-
-  const listId = findListIdForItem(id);
-  if (listId !== undefined) {
-    queuePlatformUpdate(listId, id);
-  }
+  dirtyPlatformInfo.add(id);
 }
 
 /**
- * Post-ops flush: tell the native list about removes / inserts / platform
- * updates via `update-list-info`.
+ * Diff lastFlushed → listItems and set `update-list-info`.
  */
 export function flushListUpdates(): void {
   for (const [bgId, items] of listItems) {
-    const removes = pendingRemoves.get(bgId) ?? [];
-    const inserts = pendingInserts.get(bgId) ?? [];
-    const updates = pendingUpdates.get(bgId) ?? [];
+    const prev = lastFlushed.get(bgId) ?? [];
+    const { removeAction, insertAction, stayedBgIds } = diffListItems(
+      prev,
+      items,
+    );
+
+    const updateAction: Record<string, unknown>[] = [];
+    for (const stayedId of stayedBgIds) {
+      if (!dirtyPlatformInfo.has(stayedId)) continue;
+      const idx = items.findIndex((e) => e.bgId === stayedId);
+      if (idx === -1) continue;
+      const pInfo = listItemPlatformInfo.get(stayedId) ?? {};
+      updateAction.push({
+        ...pInfo,
+        from: idx,
+        to: idx,
+        flush: false,
+        type: 'list-item',
+      });
+      dirtyPlatformInfo.delete(stayedId);
+    }
+
+    // Clear dirty flags for inserted items (info already in insertAction).
+    for (const { bgId: itemBgId } of insertAction) {
+      dirtyPlatformInfo.delete(itemBgId);
+    }
+
     if (
-      removes.length === 0
-      && inserts.length === 0
-      && updates.length === 0
+      removeAction.length === 0
+      && insertAction.length === 0
+      && updateAction.length === 0
     ) {
       continue;
     }
+
     const listEl = elements.get(bgId);
     if (!listEl) continue;
 
-    // Stable sort by position; equal positions keep record order (two prepends).
-    const insertAction = inserts
-      .slice()
-      .sort((a, b) => a.position - b.position)
-      .map(({ position, bgId: itemBgId }) => {
-        const action: Record<string, unknown> = {
-          position,
-          type: 'list-item',
-          'item-key': itemKeyMap.get(itemBgId) ?? String(position),
-        };
-        const pInfo = listItemPlatformInfo.get(itemBgId);
-        if (pInfo) Object.assign(action, pInfo);
-        return action;
-      });
-
     __SetAttribute(listEl, 'update-list-info', {
-      insertAction,
-      removeAction: [...removes].sort((a, b) => a - b),
-      updateAction: updates,
+      insertAction: insertAction.map(({ position, bgId: itemBgId }) =>
+        buildPlatformAction(itemBgId, position)
+      ),
+      removeAction,
+      updateAction,
     });
-    listItemsReported.set(bgId, items.length);
-    pendingRemoves.set(bgId, []);
-    pendingInserts.set(bgId, []);
-    pendingUpdates.set(bgId, []);
+
+    lastFlushed.set(
+      bgId,
+      items.map((e) => ({ el: e.el, bgId: e.bgId })),
+    );
   }
 }
 
 /** Reset all list state — for testing only. */
 export function resetListState(): void {
   listItems.clear();
+  lastFlushed.clear();
   listElementIds.clear();
   itemKeyMap.clear();
   listItemPlatformInfo.clear();
-  listItemsReported.clear();
-  pendingRemoves.clear();
-  pendingInserts.clear();
-  pendingUpdates.clear();
+  dirtyPlatformInfo.clear();
+}
+
+/** Test helper: current live item bgIds for a list. */
+export function getListItemBgIdsForTest(listId: number): number[] {
+  return (listItems.get(listId) ?? []).map((e) => e.bgId);
 }

--- a/packages/vue-lynx/main-thread/src/list-apply.ts
+++ b/packages/vue-lynx/main-thread/src/list-apply.ts
@@ -203,8 +203,7 @@ function createListCallbacks(bgId: number): {
     const items = listItems.get(bgId);
     if (!items) return;
     const elementIDs: number[] = [];
-    for (let j = 0; j < cellIndexes.length; j++) {
-      const cellIndex = cellIndexes[j]!;
+    for (const cellIndex of cellIndexes) {
       if (cellIndex < 0 || cellIndex >= items.length) {
         elementIDs.push(-1);
         continue;
@@ -275,7 +274,7 @@ export function insertListItem(
   parentId: number,
   child: LynxElement,
   childId: number,
-  anchorId: number = -1,
+  anchorId = -1,
 ): void {
   const items = listItems.get(parentId);
   if (!items) return;

--- a/packages/vue-lynx/main-thread/src/list-apply.ts
+++ b/packages/vue-lynx/main-thread/src/list-apply.ts
@@ -391,3 +391,124 @@ export function resetListState(): void {
 export function getListItemBgIdsForTest(listId: number): number[] {
   return (listItems.get(listId) ?? []).map((e) => e.bgId);
 }
+
+export interface ListRecycleProbeResult {
+  selfOk: boolean;
+  crossOk: boolean;
+  sign0: number;
+  sign0b: number;
+  sign1: number;
+  poolAfterLeave: number;
+  poolAfterCross: number;
+  reuseKey: string;
+}
+
+/**
+ * Negative-control probe for #302.
+ *
+ * Drives the same componentAtIndex / enqueueComponent path native scroll uses.
+ * On this branch `enqueueComponent` is still a no-op (no signMap/recycleMap),
+ * so leave→other-index cannot hand back a pooled uiSign — `crossOk` is false.
+ * Used by the ListRecycle example to prove the gap before the #302 fix.
+ */
+export function probeListRecycle(
+  list?: LynxElement | null,
+): ListRecycleProbeResult {
+  let bgId: number | undefined;
+  if (list) {
+    for (const id of listElementIds) {
+      if (elements.get(id) === list) {
+        bgId = id;
+        break;
+      }
+    }
+  }
+  if (bgId === undefined) {
+    bgId = listElementIds.values().next().value as number | undefined;
+  }
+  if (bgId === undefined) {
+    throw new Error('probeListRecycle: no <list> registered on MT');
+  }
+
+  const listEl = elements.get(bgId);
+  const items = listItems.get(bgId);
+  if (!listEl || !items || items.length < 2) {
+    throw new Error('probeListRecycle requires a list with ≥ 2 items');
+  }
+
+  const listID = __GetElementUniqueID(listEl);
+  const cai = (
+    listEl as LynxElement & {
+      componentAtIndex?: (
+        list: LynxElement,
+        listID: number,
+        cellIndex: number,
+        operationID: number,
+      ) => number | undefined;
+    }
+  ).componentAtIndex;
+  const enq = (
+    listEl as LynxElement & {
+      enqueueComponent?: (
+        list: LynxElement,
+        listID: number,
+        sign: number,
+      ) => void;
+    }
+  ).enqueueComponent;
+
+  const enter = (index: number, opId: number): number => {
+    if (typeof cai === 'function') {
+      const sign = cai.call(listEl, listEl, listID, index, opId);
+      if (typeof sign !== 'number') {
+        throw new Error(`componentAtIndex(${index}) returned undefined`);
+      }
+      return sign;
+    }
+    // Mirror createListCallbacks.componentAtIndex on this branch.
+    const item = items[index]!.el;
+    __AppendElement(listEl, item);
+    const sign = __GetElementUniqueID(item);
+    __FlushElementTree(item, {
+      triggerLayout: true,
+      operationID: opId,
+      elementID: sign,
+      listID,
+    });
+    return sign;
+  };
+
+  const leave = (sign: number): void => {
+    if (typeof enq === 'function') {
+      enq.call(listEl, listEl, listID, sign);
+    }
+    // else: enqueueComponentNoop
+  };
+
+  const reuseId = listItemPlatformInfo.get(items[0]!.bgId)?.['reuse-identifier'];
+  const reuseKey = `list-item${reuseId ?? ''}`;
+
+  leave(enter(0, 9001));
+  const sign0 = enter(0, 9002);
+  leave(sign0);
+  // No recycle pool on this branch — always 0.
+  const poolAfterLeave = 0;
+  const sign0b = enter(0, 9003);
+  const selfOk = sign0b === sign0;
+
+  leave(sign0b);
+  const sign1 = enter(1, 9004);
+  const crossOk = sign1 === sign0b;
+  const poolAfterCross = 0;
+
+  return {
+    selfOk,
+    crossOk,
+    sign0,
+    sign0b,
+    sign1,
+    poolAfterLeave,
+    poolAfterCross,
+    reuseKey,
+  };
+}

--- a/packages/vue-lynx/main-thread/src/list-apply.ts
+++ b/packages/vue-lynx/main-thread/src/list-apply.ts
@@ -54,6 +54,12 @@ const listItemPlatformInfo = new Map<number, Record<string, unknown>>();
 /** How many items have already been reported via update-list-info per list */
 const listItemsReported = new Map<number, number>();
 
+/**
+ * Pending remove indices per list, expressed against the list state *before*
+ * this applyOps batch's removes (same convention as ReactLynx removeAction).
+ */
+const pendingRemoves = new Map<number, number[]>();
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
@@ -150,6 +156,7 @@ export function createListElement(id: number): LynxElement {
   listElementIds.add(id);
   listItems.set(id, []);
   listItemsReported.set(id, 0);
+  pendingRemoves.set(id, []);
   const cbs = createListCallbacks(id);
   const el = __CreateList(
     pageUniqueId,
@@ -172,6 +179,38 @@ export function insertListItem(
   if (items) items.push({ el: child, bgId: childId });
 }
 
+/**
+ * REMOVE case: drop a child from the list tracking array and queue a
+ * `removeAction` index. Without this, Reset / re-adding the same `item-key`
+ * appends duplicates and native list throws error 2202 (duplicated item-key).
+ */
+export function removeListItem(parentId: number, childId: number): void {
+  const items = listItems.get(parentId);
+  if (!items) return;
+  const idx = items.findIndex((entry) => entry.bgId === childId);
+  if (idx === -1) return;
+
+  const pending = pendingRemoves.get(parentId) ?? [];
+  // Convert current (post-prior-splices) index → pre-batch index.
+  let originalIdx = idx;
+  for (const r of pending) {
+    if (r <= originalIdx) originalIdx++;
+  }
+  pending.push(originalIdx);
+  pendingRemoves.set(parentId, pending);
+
+  items.splice(idx, 1);
+
+  const reported = listItemsReported.get(parentId) ?? 0;
+  if (idx < reported) {
+    listItemsReported.set(parentId, reported - 1);
+  }
+
+  // Drop platform-info bookkeeping for the removed BG id.
+  itemKeyMap.delete(childId);
+  listItemPlatformInfo.delete(childId);
+}
+
 /** SET_PROP case: store a platform-info attribute for a list item */
 export function setPlatformInfoProp(
   id: number,
@@ -188,14 +227,15 @@ export function setPlatformInfoProp(
 }
 
 /**
- * Post-ops flush: for any <list> elements with newly-inserted items, tell the
- * native list via the 'update-list-info' attribute. Only send items added since
- * the last applyOps call to avoid "duplicated item-key" errors.
+ * Post-ops flush: tell the native list about removes + newly-inserted items
+ * via `update-list-info`. Only newly pushed items (beyond `listItemsReported`)
+ * are sent as insertAction to avoid duplicated item-key errors.
  */
 export function flushListUpdates(): void {
   for (const [bgId, items] of listItems) {
+    const removes = pendingRemoves.get(bgId) ?? [];
     const reported = listItemsReported.get(bgId) ?? 0;
-    if (items.length <= reported) continue;
+    if (items.length <= reported && removes.length === 0) continue;
     const listEl = elements.get(bgId);
     if (!listEl) continue;
     const insertAction: Record<string, unknown>[] = [];
@@ -213,10 +253,11 @@ export function flushListUpdates(): void {
     }
     __SetAttribute(listEl, 'update-list-info', {
       insertAction,
-      removeAction: [],
+      removeAction: [...removes].sort((a, b) => a - b),
       updateAction: [],
     });
     listItemsReported.set(bgId, items.length);
+    pendingRemoves.set(bgId, []);
   }
 }
 
@@ -227,4 +268,5 @@ export function resetListState(): void {
   itemKeyMap.clear();
   listItemPlatformInfo.clear();
   listItemsReported.clear();
+  pendingRemoves.clear();
 }

--- a/packages/vue-lynx/main-thread/src/list-apply.ts
+++ b/packages/vue-lynx/main-thread/src/list-apply.ts
@@ -9,6 +9,11 @@
  * The native list calls componentAtIndex(list, listID, cellIndex, operationID)
  * when it needs to render an item. We collect items as they're inserted and
  * provide them via the callback.
+ *
+ * Diffs are flushed via `update-list-info` (insertAction / removeAction /
+ * updateAction). INSERT respects anchors (prepend / mid-list). Same-list
+ * moves detach then re-insert (like ReactLynx treating insert-before of an
+ * existing child as remove+insert).
  */
 
 import { elements, pageUniqueId } from './element-registry.js';
@@ -32,9 +37,9 @@ const itemKeyMap = new Map<number, string>();
 
 /**
  * Platform info attributes for list items — these must go ONLY into
- * update-list-info's insertAction, NOT via __SetAttribute on the native element.
- * Setting them both ways causes the native list to count items twice.
- * (Matches React Lynx's platformInfoAttributes in snapshot/platformInfo.ts)
+ * update-list-info's insertAction / updateAction, NOT via __SetAttribute on
+ * the native element. Setting them both ways causes the native list to count
+ * items twice. (Matches React Lynx's platformInfoAttributes.)
  */
 const PLATFORM_INFO_ATTRS = new Set([
   'item-key',
@@ -51,7 +56,7 @@ const PLATFORM_INFO_ATTRS = new Set([
 /** Per list-item bg ID -> platform info attributes (for update-list-info) */
 const listItemPlatformInfo = new Map<number, Record<string, unknown>>();
 
-/** How many items have already been reported via update-list-info per list */
+/** How many items native currently knows about (fully synced list length) */
 const listItemsReported = new Map<number, number>();
 
 /**
@@ -60,11 +65,23 @@ const listItemsReported = new Map<number, number>();
  */
 const pendingRemoves = new Map<number, number[]>();
 
+/** Pending inserts: position is the index in listItems *after* the splice. */
+const pendingInserts = new Map<
+  number,
+  Array<{ position: number; bgId: number }>
+>();
+
+/** Pending platform-info updates for items already known to native. */
+const pendingUpdates = new Map<
+  number,
+  Array<Record<string, unknown>>
+>();
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-/** No-op: Vue manages all items; no recycling needed. */
+/** No-op: element recycling is tracked separately (see GitHub issues). */
 // biome-ignore lint/suspicious/noEmptyBlockStatements: intentional no-op
 function enqueueComponentNoop(): void {}
 
@@ -137,6 +154,86 @@ function createListCallbacks(bgId: number): {
   return { componentAtIndex, enqueueComponent, componentAtIndexes };
 }
 
+/**
+ * Detach `childId` from the list tracking array and queue a removeAction.
+ * @returns the pre-batch remove index, or -1 if not found.
+ */
+function detachListItem(
+  parentId: number,
+  childId: number,
+  clearPlatformInfo: boolean,
+): number {
+  const items = listItems.get(parentId);
+  if (!items) return -1;
+  const idx = items.findIndex((entry) => entry.bgId === childId);
+  if (idx === -1) return -1;
+
+  const pending = pendingRemoves.get(parentId) ?? [];
+  // Convert current (post-prior-splices) index → pre-batch index.
+  let originalIdx = idx;
+  for (const r of pending) {
+    if (r <= originalIdx) originalIdx++;
+  }
+  pending.push(originalIdx);
+  pendingRemoves.set(parentId, pending);
+
+  // Drop any not-yet-flushed insert for this child (move / re-insert same batch).
+  const inserts = pendingInserts.get(parentId);
+  if (inserts) {
+    const filtered = inserts.filter((p) => p.bgId !== childId);
+    pendingInserts.set(parentId, filtered);
+  }
+
+  items.splice(idx, 1);
+
+  const reported = listItemsReported.get(parentId) ?? 0;
+  if (idx < reported) {
+    listItemsReported.set(parentId, reported - 1);
+  }
+
+  if (clearPlatformInfo) {
+    itemKeyMap.delete(childId);
+    listItemPlatformInfo.delete(childId);
+  }
+
+  return originalIdx;
+}
+
+function findListIdForItem(itemBgId: number): number | undefined {
+  for (const [listId, items] of listItems) {
+    if (items.some((e) => e.bgId === itemBgId)) return listId;
+  }
+  return undefined;
+}
+
+function queuePlatformUpdate(listId: number, itemBgId: number): void {
+  const items = listItems.get(listId);
+  if (!items) return;
+  const idx = items.findIndex((e) => e.bgId === itemBgId);
+  if (idx === -1) return;
+
+  // Still in this batch's insertAction — platform info merges there.
+  const inserts = pendingInserts.get(listId) ?? [];
+  if (inserts.some((p) => p.bgId === itemBgId)) return;
+
+  const pInfo = listItemPlatformInfo.get(itemBgId) ?? {};
+  const pending = pendingUpdates.get(listId) ?? [];
+  const existing = pending.findIndex((u) => u.from === idx);
+  const action: Record<string, unknown> = {
+    ...pInfo,
+    from: idx,
+    to: idx,
+    flush: false,
+    type: 'list-item',
+  };
+  if (existing >= 0) {
+    pending[existing] = action;
+  } else {
+    pending.push(action);
+  }
+  pendingUpdates.set(listId, pending);
+}
+
 // ---------------------------------------------------------------------------
 // Public API (called from ops-apply.ts switch cases)
 // ---------------------------------------------------------------------------
@@ -157,6 +254,8 @@ export function createListElement(id: number): LynxElement {
   listItems.set(id, []);
   listItemsReported.set(id, 0);
   pendingRemoves.set(id, []);
+  pendingInserts.set(id, []);
+  pendingUpdates.set(id, []);
   const cbs = createListCallbacks(id);
   const el = __CreateList(
     pageUniqueId,
@@ -169,14 +268,46 @@ export function createListElement(id: number): LynxElement {
   return el;
 }
 
-/** INSERT case: collect a child into a <list> parent's item array */
+/**
+ * INSERT case: place a child into the list array.
+ * `anchorId === -1` → append; otherwise insert before the anchor (prepend /
+ * mid-list). If the child is already in this list, treat as a move
+ * (detach + re-insert), matching ReactLynx's insertBefore-of-existing-child.
+ */
 export function insertListItem(
   parentId: number,
   child: LynxElement,
   childId: number,
+  anchorId: number = -1,
 ): void {
   const items = listItems.get(parentId);
-  if (items) items.push({ el: child, bgId: childId });
+  if (!items) return;
+
+  // Same-list move: Vue hostInsert does INSERT without REMOVE when the
+  // parent stays the same — detach first so we don't duplicate listItems.
+  if (items.some((e) => e.bgId === childId)) {
+    detachListItem(parentId, childId, false);
+  }
+
+  const entry: ListItemEntry = { el: child, bgId: childId };
+  let index: number;
+  if (anchorId === -1) {
+    index = items.length;
+    items.push(entry);
+  } else {
+    const anchorIdx = items.findIndex((e) => e.bgId === anchorId);
+    if (anchorIdx === -1) {
+      index = items.length;
+      items.push(entry);
+    } else {
+      index = anchorIdx;
+      items.splice(index, 0, entry);
+    }
+  }
+
+  const pending = pendingInserts.get(parentId) ?? [];
+  pending.push({ position: index, bgId: childId });
+  pendingInserts.set(parentId, pending);
 }
 
 /**
@@ -185,30 +316,7 @@ export function insertListItem(
  * appends duplicates and native list throws error 2202 (duplicated item-key).
  */
 export function removeListItem(parentId: number, childId: number): void {
-  const items = listItems.get(parentId);
-  if (!items) return;
-  const idx = items.findIndex((entry) => entry.bgId === childId);
-  if (idx === -1) return;
-
-  const pending = pendingRemoves.get(parentId) ?? [];
-  // Convert current (post-prior-splices) index → pre-batch index.
-  let originalIdx = idx;
-  for (const r of pending) {
-    if (r <= originalIdx) originalIdx++;
-  }
-  pending.push(originalIdx);
-  pendingRemoves.set(parentId, pending);
-
-  items.splice(idx, 1);
-
-  const reported = listItemsReported.get(parentId) ?? 0;
-  if (idx < reported) {
-    listItemsReported.set(parentId, reported - 1);
-  }
-
-  // Drop platform-info bookkeeping for the removed BG id.
-  itemKeyMap.delete(childId);
-  listItemPlatformInfo.delete(childId);
+  detachListItem(parentId, childId, true);
 }
 
 /** SET_PROP case: store a platform-info attribute for a list item */
@@ -224,40 +332,56 @@ export function setPlatformInfoProp(
     listItemPlatformInfo.set(id, { [key]: value });
   }
   if (key === 'item-key') itemKeyMap.set(id, String(value));
+
+  const listId = findListIdForItem(id);
+  if (listId !== undefined) {
+    queuePlatformUpdate(listId, id);
+  }
 }
 
 /**
- * Post-ops flush: tell the native list about removes + newly-inserted items
- * via `update-list-info`. Only newly pushed items (beyond `listItemsReported`)
- * are sent as insertAction to avoid duplicated item-key errors.
+ * Post-ops flush: tell the native list about removes / inserts / platform
+ * updates via `update-list-info`.
  */
 export function flushListUpdates(): void {
   for (const [bgId, items] of listItems) {
     const removes = pendingRemoves.get(bgId) ?? [];
-    const reported = listItemsReported.get(bgId) ?? 0;
-    if (items.length <= reported && removes.length === 0) continue;
+    const inserts = pendingInserts.get(bgId) ?? [];
+    const updates = pendingUpdates.get(bgId) ?? [];
+    if (
+      removes.length === 0
+      && inserts.length === 0
+      && updates.length === 0
+    ) {
+      continue;
+    }
     const listEl = elements.get(bgId);
     if (!listEl) continue;
-    const insertAction: Record<string, unknown>[] = [];
-    for (let j = reported; j < items.length; j++) {
-      const entry = items[j]!;
-      const action: Record<string, unknown> = {
-        position: j,
-        type: 'list-item',
-        'item-key': itemKeyMap.get(entry.bgId) ?? String(j),
-      };
-      // Merge any collected platform info attributes into the action
-      const pInfo = listItemPlatformInfo.get(entry.bgId);
-      if (pInfo) Object.assign(action, pInfo);
-      insertAction.push(action);
-    }
+
+    // Stable sort by position; equal positions keep record order (two prepends).
+    const insertAction = inserts
+      .slice()
+      .sort((a, b) => a.position - b.position)
+      .map(({ position, bgId: itemBgId }) => {
+        const action: Record<string, unknown> = {
+          position,
+          type: 'list-item',
+          'item-key': itemKeyMap.get(itemBgId) ?? String(position),
+        };
+        const pInfo = listItemPlatformInfo.get(itemBgId);
+        if (pInfo) Object.assign(action, pInfo);
+        return action;
+      });
+
     __SetAttribute(listEl, 'update-list-info', {
       insertAction,
       removeAction: [...removes].sort((a, b) => a - b),
-      updateAction: [],
+      updateAction: updates,
     });
     listItemsReported.set(bgId, items.length);
     pendingRemoves.set(bgId, []);
+    pendingInserts.set(bgId, []);
+    pendingUpdates.set(bgId, []);
   }
 }
 
@@ -269,4 +393,6 @@ export function resetListState(): void {
   listItemPlatformInfo.clear();
   listItemsReported.clear();
   pendingRemoves.clear();
+  pendingInserts.clear();
+  pendingUpdates.clear();
 }

--- a/packages/vue-lynx/main-thread/src/ops-apply.ts
+++ b/packages/vue-lynx/main-thread/src/ops-apply.ts
@@ -145,7 +145,7 @@ export function applyOps(ops: unknown[], flush = true): void {
         const child = elements.get(childId);
         if (parent && child) {
           if (isListParent(parentId)) {
-            insertListItem(parentId, child, childId);
+            insertListItem(parentId, child, childId, anchorId);
           } else if (anchorId === -1) {
             __AppendElement(parent, child);
           } else {

--- a/packages/vue-lynx/main-thread/src/ops-apply.ts
+++ b/packages/vue-lynx/main-thread/src/ops-apply.ts
@@ -24,6 +24,7 @@ import {
   insertListItem,
   isListParent,
   isPlatformInfoAttr,
+  removeListItem,
   resetListState,
   setPlatformInfoProp,
 } from './list-apply.js';
@@ -161,6 +162,11 @@ export function applyOps(ops: unknown[], flush = true): void {
         const parent = elements.get(parentId);
         const child = elements.get(childId);
         if (parent && child) {
+          if (isListParent(parentId)) {
+            // Keep listItems / update-list-info in sync — otherwise Reset
+            // re-inserts the same item-keys and native list errors 2202.
+            removeListItem(parentId, childId);
+          }
           __RemoveElement(parent, child);
         }
         break;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,10 +26,10 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.8))
+        version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
-        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+        version: 1.2.7(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.8(@swc/helpers@0.5.19))
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -421,6 +421,22 @@ importers:
         version: 1.2.7(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.8(@swc/helpers@0.5.19))
       typescript:
         specifier: ~5.9.3
+        version: 5.9.3
+
+  examples/scrolling:
+    dependencies:
+      vue-lynx:
+        specifier: workspace:*
+        version: link:../../packages/vue-lynx
+    devDependencies:
+      '@lynx-js/rspeedy':
+        specifier: ^0.13.5
+        version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.8))
+      '@rsbuild/plugin-vue':
+        specifier: ^1.2.6
+        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+      typescript:
+        specifier: ^5.0.0
         version: 5.9.3
 
   examples/slots:

--- a/website/docs/guide/scroll-view-vs-list.mdx
+++ b/website/docs/guide/scroll-view-vs-list.mdx
@@ -210,8 +210,8 @@ export function useInfiniteFeed(pageSize = 20) {
 
 This is the same shape as Elk's `TimelinePaginator`: masto.js pagination in a composable, `<list>` for the viewport.
 
-:::warning Confirmed gap: prepend
-Vue Lynx's Main Thread list adapter always `push`es into `listItems` and ignores the INSERT anchor. **Prepending** (unshift / insert-before) is reported as a **tail** insert — see `ListPrepend`. Append-only feeds (`@scrolltolower`) stay on the supported path. **Remove** now emits `removeAction` (Reset-with-same-keys used to 2202). Reorder still needs a careful visual check (`ListReorder`).
+:::tip List diffs
+Vue Lynx's Main Thread list adapter now flushes `insertAction` / `removeAction` / `updateAction` for common mutations: append, prepend, mid-list insert, remove, same-list reorder (move), and platform-info updates. Append-only feeds (`@scrolltolower`) remain the simplest path. Still open: framework-side cell recycling and refreshing `__UpdateListCallbacks` each flush — see the tracking issues linked below.
 :::
 
 ### 4. Prefer `list` over third-party virtual scrollers
@@ -228,18 +228,18 @@ Recycling is a **native** concern; composition stays a **Vue** concern. Put pres
 </list-item>
 ```
 
-## Mutation stress / smoke tests
+## Mutation demos
 
 | Entry | Mutation | Status |
 |---|---|---|
-| `ListPrepend` | unshift vs append | **Confirmed gap** — new cell lands at the tail |
-| `ListReorder` | Yellow→top / reverse | Check carefully — Vue-truth color strip vs `<list>` |
-| `ListRemove` | splice + **Reset same keys** | Was 2202 on Reset; REMOVE now emits `removeAction` |
-| `ListFilter` | even-only toggle | Smoke — OK in practice |
+| `ListPrepend` | unshift vs append | Fixed — INSERT respects anchor |
+| `ListReorder` | Yellow→top / reverse | Fixed — same-list move = detach + insert |
+| `ListRemove` | splice + Reset same keys | Fixed — `removeAction` (was 2202) |
+| `ListFilter` | even-only toggle | OK |
 
-### Confirmed: prepend
+### Prepend
 
-Tap **Prepend** once. The TOP list cell must turn red (`NEW …`). If the red card appears at the bottom, the adapter ignored the insert-before anchor. **Append** is the control that should work.
+Tap **Prepend** once. The TOP list cell must turn red (`NEW …`). **Append** lands at the bottom.
 
 <Go
   example="scrolling"
@@ -248,9 +248,9 @@ Tap **Prepend** once. The TOP list cell must turn red (`NEW …`). If the red ca
   defaultEntryName="ListPrepend"
 />
 
-### Check carefully: reorder
+### Reorder
 
-Four full-bleed colors. The top strip is plain `<view>`s (Vue truth). The `<list>` below must show the **same left→right / top→bottom order** after **Yellow → top** or **Reverse**. A mismatch is a list move bug.
+Four full-bleed colors. The top strip is plain `<view>`s (Vue truth). The `<list>` below must show the **same order** after **Yellow → top** or **Reverse**.
 
 <Go
   example="scrolling"
@@ -259,9 +259,9 @@ Four full-bleed colors. The top strip is plain `<view>`s (Vue truth). The `<list
   defaultEntryName="ListReorder"
 />
 
-### Smoke: remove + filter
+### Remove + filter
 
-**Remove**: delete rows, then tap **Reset same keys**. That rebuilds `Row-1…N` with identical `item-key`s. A duplicated item-key toast (error 2202) meant the adapter never emitted `removeAction` — an impl bug, not a flaky demo. Filter toggle is kept as a lighter regression tap.
+**Remove**: delete rows, then **Reset same keys** — must not toast duplicated item-key (2202). Filter toggle is a lighter regression tap.
 
 <Go
   example="scrolling"
@@ -277,7 +277,12 @@ Four full-bleed colors. The top strip is plain `<view>`s (Vue truth). The `<list
   defaultEntryName="ListFilter"
 />
 
-Automated coverage: `packages/testing-library` → **native list element · mutation gaps**. Prepend stays `it.fails` on the correct `position: 0` payload; remove/filter are smoke assertions on Vue length.
+### Still open
+
+- Framework-side cell recycling (`enqueueComponent` / recycle pool) — [#302](https://github.com/Huxpro/vue-lynx/issues/302)
+- Refreshing `__UpdateListCallbacks` on every list flush — [#303](https://github.com/Huxpro/vue-lynx/issues/303)
+
+Automated coverage: `packages/testing-library` → **native list element · mutations**.
 
 ## Decision checklist
 
@@ -286,7 +291,7 @@ Automated coverage: `packages/testing-library` → **native list element · muta
 3. Do you need waterfall or multi-column flow? → **`<list list-type="…">`**
 4. Will the dataset grow without bound? → **`<list>` + composable + `@scrolltolower`**
 5. Did you set matching `:key` / `:item-key`? → required for correct recycling
-6. Do you need **prepend**? → broken today — prefer append / rebuild until the adapter respects INSERT anchors
+6. Prepend / reorder / remove? → supported via `update-list-info` diffs
 
 ## See also
 

--- a/website/docs/guide/scroll-view-vs-list.mdx
+++ b/website/docs/guide/scroll-view-vs-list.mdx
@@ -211,7 +211,7 @@ export function useInfiniteFeed(pageSize = 20) {
 This is the same shape as Elk's `TimelinePaginator`: masto.js pagination in a composable, `<list>` for the viewport.
 
 :::warning Confirmed gap: prepend
-Vue Lynx's Main Thread list adapter always `push`es into `listItems` and ignores the INSERT anchor. **Prepending** (unshift / insert-before) is reported as a **tail** insert — see `ListPrepend`. Append-only feeds (`@scrolltolower`) stay on the supported path. Remove / filter have looked fine on device despite empty `removeAction`; reorder needs a careful visual check (`ListReorder`).
+Vue Lynx's Main Thread list adapter always `push`es into `listItems` and ignores the INSERT anchor. **Prepending** (unshift / insert-before) is reported as a **tail** insert — see `ListPrepend`. Append-only feeds (`@scrolltolower`) stay on the supported path. **Remove** now emits `removeAction` (Reset-with-same-keys used to 2202). Reorder still needs a careful visual check (`ListReorder`).
 :::
 
 ### 4. Prefer `list` over third-party virtual scrollers
@@ -234,7 +234,7 @@ Recycling is a **native** concern; composition stays a **Vue** concern. Put pres
 |---|---|---|
 | `ListPrepend` | unshift vs append | **Confirmed gap** — new cell lands at the tail |
 | `ListReorder` | Yellow→top / reverse | Check carefully — Vue-truth color strip vs `<list>` |
-| `ListRemove` | splice middle / pop | Smoke — OK in practice |
+| `ListRemove` | splice + **Reset same keys** | Was 2202 on Reset; REMOVE now emits `removeAction` |
 | `ListFilter` | even-only toggle | Smoke — OK in practice |
 
 ### Confirmed: prepend
@@ -261,7 +261,7 @@ Four full-bleed colors. The top strip is plain `<view>`s (Vue truth). The `<list
 
 ### Smoke: remove + filter
 
-These have looked correct on device; kept as regression taps.
+**Remove**: delete rows, then tap **Reset same keys**. That rebuilds `Row-1…N` with identical `item-key`s. A duplicated item-key toast (error 2202) meant the adapter never emitted `removeAction` — an impl bug, not a flaky demo. Filter toggle is kept as a lighter regression tap.
 
 <Go
   example="scrolling"

--- a/website/docs/guide/scroll-view-vs-list.mdx
+++ b/website/docs/guide/scroll-view-vs-list.mdx
@@ -211,7 +211,7 @@ export function useInfiniteFeed(pageSize = 20) {
 This is the same shape as Elk's `TimelinePaginator`: masto.js pagination in a composable, `<list>` for the viewport.
 
 :::tip List diffs
-Vue Lynx's Main Thread list adapter now flushes `insertAction` / `removeAction` / `updateAction` for common mutations: append, prepend, mid-list insert, remove, same-list reorder (move), and platform-info updates. Append-only feeds (`@scrolltolower`) remain the simplest path. Still open: framework-side cell recycling and refreshing `__UpdateListCallbacks` each flush — see the tracking issues linked below.
+Vue Lynx's Main Thread list adapter flushes `insertAction` / `removeAction` / `updateAction` by diffing the last-flushed snapshot against the live `listItems` array (LIS move detection, same idea as ReactLynx's remove+insert moves). Covers append, prepend, mid-list insert, remove, same-list reorder, and platform-info updates. Still open: framework-side cell recycling and refreshing `__UpdateListCallbacks` each flush — [#302](https://github.com/Huxpro/vue-lynx/issues/302), [#303](https://github.com/Huxpro/vue-lynx/issues/303).
 :::
 
 ### 4. Prefer `list` over third-party virtual scrollers

--- a/website/docs/guide/scroll-view-vs-list.mdx
+++ b/website/docs/guide/scroll-view-vs-list.mdx
@@ -1,0 +1,242 @@
+# scroll-view vs list
+
+Lynx does not scroll arbitrary nodes the way the Web does. When content overflows a viewport you pick an explicit scroll container — almost always [`<scroll-view>`](https://lynxjs.org/api/elements/built-in/scroll-view) or [`<list>`](https://lynxjs.org/api/elements/built-in/list). This guide explains how Lynx documents the difference, how that differs from Web Vue, and the Vue Lynx patterns that fall out of those choices.
+
+For the platform reference, see [Managing Scrolling](https://lynxjs.org/guide/ui/scrolling) on lynxjs.org.
+
+## Lynx vs Web
+
+On the Web, almost any element can become a scrollport:
+
+```html
+<div style="overflow: auto; height: 100vh">
+  <!-- anything -->
+</div>
+```
+
+On Lynx, a plain `<view>` **does not** gain scrolling from `overflow: scroll` / `overflow: auto`. Only dedicated containers such as `<scroll-view>` and `<list>` scroll. That is the first design shift when you move a Vue app from DOM to Lynx: scrolling becomes a **structural** decision in the template, not a CSS property you sprinkle later.
+
+| | Web (Vue) | Lynx (Vue Lynx) |
+|---|---|---|
+| How scrolling starts | `overflow` on any node | Dedicated `<scroll-view>` / `<list>` |
+| Virtualization | Optional library (`vue-virtual-scroller`, Virtua, …) | Built into `<list>` |
+| Large feeds | You own windowing + recycled DOM | Native recycling + lazy create |
+| Complex grids | CSS Grid / masonry libs | `<list list-type="flow\|waterfall">` |
+
+Vue Lynx keeps Composition API, `v-for`, and SFCs — but your scroll trees look different from a typical Nuxt / Vite SPA.
+
+## What lynxjs.org says
+
+Lynx's scrolling guide draws a clean line between the two containers:
+
+1. **`<scroll-view>` for basic scrolling** — a fixed viewport; when children exceed it, set `scroll-orientation` to `vertical` or `horizontal`.
+2. **`<list>` for large / infinite data** — on-demand creation of visible items only.
+3. **`<list>` for complex layouts** — `scroll-view` is linear only; `list` adds `single`, `flow`, and `waterfall`.
+
+The [`<scroll-view>` API](https://lynxjs.org/api/elements/built-in/scroll-view) also warns:
+
+- Every child is created up front (can hurt first paint).
+- There is **no reuse**; too much content can exhaust memory.
+- Prefer `<list>` once content exceeds roughly **three screens**, or fake recycling with exposure events.
+
+Think of `<scroll-view>` as “a short page that happens to scroll,” and `<list>` as “a recycling feed.”
+
+## Choose with a table
+
+| Question | Prefer `<scroll-view>` | Prefer `<list>` |
+|---|---|---|
+| How much content? | A few screens or less | Many screens / unbounded |
+| Layout | Linear stack | Single / grid (`flow`) / waterfall |
+| Item shape | Mixed sections, sticky chrome | Homogeneous (or mostly) cells |
+| Memory | Eager, all children live | Recycled + lazy |
+| Infinite load | Possible, but risky | Native `@scrolltolower` |
+
+Rule of thumb from Lynx: **under ~3 screens → `scroll-view`; beyond that → `list`.**
+
+## `<scroll-view>` in Vue
+
+Use ordinary Vue children — `v-for`, nested SFCs, sticky siblings. Nothing special is required beyond wrapping them in `<scroll-view>`.
+
+<Go
+  example="scrolling"
+  defaultFile="src/ScrollViewBasic/App.vue"
+  entry="src/ScrollViewBasic"
+  defaultEntryName="ScrollViewBasic"
+/>
+
+```vue
+<scroll-view scroll-orientation="vertical">
+  <view class="header">…</view>
+  <view v-for="card in cards" :key="card.id" class="card">
+    <text>{{ card.title }}</text>
+  </view>
+</scroll-view>
+```
+
+Good fits: settings screens, forms, article bodies, short result pages (see also the [Vue Query](/guide/data-fetching) and [TodoMVC](/guide/todomvc) examples).
+
+:::tip Nested layout tip
+Direct children of `<scroll-view>` only support linear / sticky layout. For richer CSS inside the scrollport, wrap content in a single child `<view>` and style that subtree — as recommended in the [scroll-view docs](https://lynxjs.org/api/elements/built-in/scroll-view).
+:::
+
+## `<list>` in Vue
+
+`<list>` expects **`<list-item>` children**. Each item needs:
+
+- Vue's `:key` — reconciliation identity for the VNode tree
+- Lynx's `:item-key` — identity for the native recycler (keep them equal)
+
+Missing or colliding keys is a common cause of blank / wrong cells.
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListBasic/App.vue"
+  entry="src/ListBasic"
+  defaultEntryName="ListBasic"
+/>
+
+```vue
+<list list-type="single" scroll-orientation="vertical">
+  <list-item
+    v-for="card in cards"
+    :key="card.id"
+    :item-key="card.id"
+    :estimated-main-axis-size-px="96"
+  >
+    <view class="card">…</view>
+  </list-item>
+</list>
+```
+
+`estimated-main-axis-size-px` helps the engine size the scrollbar and jump before a cell has been measured — the [gallery tutorial](/guide/tutorial-gallery) relies on the same hint for waterfall images.
+
+### Waterfall / flow layouts
+
+This is the other half of the lynxjs.org distinction: `scroll-view` cannot do multi-column masonry; `list` can.
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListWaterfall/App.vue"
+  entry="src/ListWaterfall"
+  defaultEntryName="ListWaterfall"
+/>
+
+```vue
+<list list-type="waterfall" :span-count="2" scroll-orientation="vertical">
+  <list-item
+    v-for="tile in tiles"
+    :key="tile.id"
+    :item-key="tile.id"
+    :estimated-main-axis-size-px="tile.height"
+  >
+    <view class="tile" :style="{ height: `${tile.height}px` }" />
+  </list-item>
+</list>
+```
+
+Each `list-item` can host a full Vue SFC — the gallery tutorial's `LikeImageCard` is the same pattern at product scale.
+
+## Vue design patterns that fall out of this
+
+Moving from Web Vue to Vue Lynx does not change reactivity — it changes **where** you put scrolling and **who** owns recycling.
+
+### 1. Explicit containers in the template
+
+Stop reaching for `overflow: auto` on a root `<view>`. Decide up front:
+
+```vue
+<!-- short, mixed page -->
+<scroll-view scroll-orientation="vertical">…</scroll-view>
+
+<!-- long homogeneous feed -->
+<list list-type="single" scroll-orientation="vertical">…</list>
+```
+
+That structural choice is the Lynx equivalent of picking a layout library on the Web.
+
+### 2. Dual identity: `:key` + `:item-key`
+
+Web `v-for` only needs `:key`. Lynx lists need both. Treat them as one stable business id:
+
+```vue
+<list-item
+  v-for="status in items"
+  :key="status.id"
+  :item-key="status.id"
+/>
+```
+
+The [Elk](/guide/elk) port follows exactly this contract for Mastodon statuses.
+
+### 3. Composable owns pages; `<list>` owns recycling
+
+On the Web, infinite feeds usually mean:
+
+`useInfiniteQuery` / custom composable **+** a virtualizer **+** an intersection sentinel.
+
+On Lynx, drop the virtualizer. A composable appends to a `ref` array; `@scrolltolower` (and `lower-threshold-item-count`) asks for the next page. Native recycling keeps memory flat.
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListInfinite/App.vue"
+  entry="src/ListInfinite"
+  defaultEntryName="ListInfinite"
+/>
+
+```ts
+// shared/useInfiniteFeed.ts
+export function useInfiniteFeed(pageSize = 20) {
+  const items = ref(makeCards(pageSize))
+  const loading = ref(false)
+  // loadMore() appends another page…
+  return { items, loading, loadMore }
+}
+```
+
+```vue
+<list
+  :lower-threshold-item-count="3"
+  @scrolltolower="loadMore"
+>
+  <list-item
+    v-for="item in items"
+    :key="item.id"
+    :item-key="item.id"
+  >
+    …
+  </list-item>
+</list>
+```
+
+This is the same shape as Elk's `TimelinePaginator`: masto.js pagination in a composable, `<list>` for the viewport.
+
+### 4. Prefer `list` over third-party virtual scrollers
+
+Libraries that measure DOM nodes (`getBoundingClientRect`, absolute positioning of windows) do not map cleanly onto Lynx's dual-thread + native elements model. Prefer the built-in recycler unless you have a rare layout `<list>` cannot express.
+
+### 5. Keep cells as Vue components
+
+Recycling is a **native** concern; composition stays a **Vue** concern. Put presentational SFCs inside `list-item` — do not flatten everything into one mega-template just because the parent is a list.
+
+```vue
+<list-item :key="pic.id" :item-key="pic.id">
+  <LikeImageCard :picture="pic" />
+</list-item>
+```
+
+## Decision checklist
+
+1. Is the page mostly one linear document under ~3 screens? → **`<scroll-view>`**
+2. Are you rendering dozens / hundreds of similar rows? → **`<list>`**
+3. Do you need waterfall or multi-column flow? → **`<list list-type="…">`**
+4. Will the dataset grow without bound? → **`<list>` + composable + `@scrolltolower`**
+5. Did you set matching `:key` / `:item-key`? → required for correct recycling
+
+## See also
+
+- [Managing Scrolling (Lynx)](https://lynxjs.org/guide/ui/scrolling)
+- [`<scroll-view>` API](https://lynxjs.org/api/elements/built-in/scroll-view)
+- [`<list>` API](https://lynxjs.org/api/elements/built-in/list)
+- [Tutorial: Product Gallery](/guide/tutorial-gallery) — waterfall `<list>` in a full app
+- [Elk (Mastodon Client)](/guide/elk) — replacing Virtua with native `<list>`
+- [Main Thread Script](/guide/main-thread-script) — scroll-linked worklets on `<scroll-view>` / `<list>`

--- a/website/docs/guide/scroll-view-vs-list.mdx
+++ b/website/docs/guide/scroll-view-vs-list.mdx
@@ -210,8 +210,8 @@ export function useInfiniteFeed(pageSize = 20) {
 
 This is the same shape as Elk's `TimelinePaginator`: masto.js pagination in a composable, `<list>` for the viewport.
 
-:::warning Append-only updates today
-Vue Lynx's Main Thread list adapter currently reports **new inserts only** (`removeAction` / `updateAction` are empty). Infinite append via `@scrolltolower` matches that path. Deletes, prepends, reorders, and filters need the stress examples below until full `ListUpdateInfoRecording`-style diffs land.
+:::warning Confirmed gap: prepend
+Vue Lynx's Main Thread list adapter always `push`es into `listItems` and ignores the INSERT anchor. **Prepending** (unshift / insert-before) is reported as a **tail** insert — see `ListPrepend`. Append-only feeds (`@scrolltolower`) stay on the supported path. Remove / filter have looked fine on device despite empty `removeAction`; reorder needs a careful visual check (`ListReorder`).
 :::
 
 ### 4. Prefer `list` over third-party virtual scrollers
@@ -228,16 +228,40 @@ Recycling is a **native** concern; composition stays a **Vue** concern. Put pres
 </list-item>
 ```
 
-## Known gaps — mutation stress tests
+## Mutation stress / smoke tests
 
-These four entries are intentional **breakage demos** for the incomplete list diff. Tap the toolbar, then compare the orange Vue banner with what native `<list>` still paints. When the MT adapter gains full `insertAction` / `removeAction` / `updateAction` diffs (ReactLynx's `ListUpdateInfoRecording`), they should start looking correct.
-
-| Entry | Mutation | What goes wrong today |
+| Entry | Mutation | Status |
 |---|---|---|
-| `ListRemove` | splice middle / pop tail | no `removeAction` → ghost rows / stale count |
-| `ListPrepend` | unshift vs append | INSERT ignores anchor → prepend reported as tail |
-| `ListReorder` | reverse / rotate | move = remove+insert without remove → wrong order |
-| `ListFilter` | toggle even-only | filter+restore → ghosts / duplicated `item-key` |
+| `ListPrepend` | unshift vs append | **Confirmed gap** — new cell lands at the tail |
+| `ListReorder` | Yellow→top / reverse | Check carefully — Vue-truth color strip vs `<list>` |
+| `ListRemove` | splice middle / pop | Smoke — OK in practice |
+| `ListFilter` | even-only toggle | Smoke — OK in practice |
+
+### Confirmed: prepend
+
+Tap **Prepend** once. The TOP list cell must turn red (`NEW …`). If the red card appears at the bottom, the adapter ignored the insert-before anchor. **Append** is the control that should work.
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListPrepend/App.vue"
+  entry="src/ListPrepend"
+  defaultEntryName="ListPrepend"
+/>
+
+### Check carefully: reorder
+
+Four full-bleed colors. The top strip is plain `<view>`s (Vue truth). The `<list>` below must show the **same left→right / top→bottom order** after **Yellow → top** or **Reverse**. A mismatch is a list move bug.
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListReorder/App.vue"
+  entry="src/ListReorder"
+  defaultEntryName="ListReorder"
+/>
+
+### Smoke: remove + filter
+
+These have looked correct on device; kept as regression taps.
 
 <Go
   example="scrolling"
@@ -248,26 +272,12 @@ These four entries are intentional **breakage demos** for the incomplete list di
 
 <Go
   example="scrolling"
-  defaultFile="src/ListPrepend/App.vue"
-  entry="src/ListPrepend"
-  defaultEntryName="ListPrepend"
-/>
-
-<Go
-  example="scrolling"
-  defaultFile="src/ListReorder/App.vue"
-  entry="src/ListReorder"
-  defaultEntryName="ListReorder"
-/>
-
-<Go
-  example="scrolling"
   defaultFile="src/ListFilter/App.vue"
   entry="src/ListFilter"
   defaultEntryName="ListFilter"
 />
 
-Matching automated coverage lives in `packages/testing-library` as `it.fails` cases under **native list element · mutation gaps** — they assert the *correct* `update-list-info` payloads and will flip to passing once the adapter is fixed.
+Automated coverage: `packages/testing-library` → **native list element · mutation gaps**. Prepend stays `it.fails` on the correct `position: 0` payload; remove/filter are smoke assertions on Vue length.
 
 ## Decision checklist
 
@@ -276,7 +286,7 @@ Matching automated coverage lives in `packages/testing-library` as `it.fails` ca
 3. Do you need waterfall or multi-column flow? → **`<list list-type="…">`**
 4. Will the dataset grow without bound? → **`<list>` + composable + `@scrolltolower`**
 5. Did you set matching `:key` / `:item-key`? → required for correct recycling
-6. Do you need delete / prepend / reorder / filter? → stress-test first; prefer append-only feeds until list diffs are complete
+6. Do you need **prepend**? → broken today — prefer append / rebuild until the adapter respects INSERT anchors
 
 ## See also
 

--- a/website/docs/guide/scroll-view-vs-list.mdx
+++ b/website/docs/guide/scroll-view-vs-list.mdx
@@ -210,6 +210,10 @@ export function useInfiniteFeed(pageSize = 20) {
 
 This is the same shape as Elk's `TimelinePaginator`: masto.js pagination in a composable, `<list>` for the viewport.
 
+:::warning Append-only updates today
+Vue Lynx's Main Thread list adapter currently reports **new inserts only** (`removeAction` / `updateAction` are empty). Infinite append via `@scrolltolower` matches that path. Deletes, prepends, reorders, and filters need the stress examples below until full `ListUpdateInfoRecording`-style diffs land.
+:::
+
 ### 4. Prefer `list` over third-party virtual scrollers
 
 Libraries that measure DOM nodes (`getBoundingClientRect`, absolute positioning of windows) do not map cleanly onto Lynx's dual-thread + native elements model. Prefer the built-in recycler unless you have a rare layout `<list>` cannot express.
@@ -224,6 +228,47 @@ Recycling is a **native** concern; composition stays a **Vue** concern. Put pres
 </list-item>
 ```
 
+## Known gaps — mutation stress tests
+
+These four entries are intentional **breakage demos** for the incomplete list diff. Tap the toolbar, then compare the orange Vue banner with what native `<list>` still paints. When the MT adapter gains full `insertAction` / `removeAction` / `updateAction` diffs (ReactLynx's `ListUpdateInfoRecording`), they should start looking correct.
+
+| Entry | Mutation | What goes wrong today |
+|---|---|---|
+| `ListRemove` | splice middle / pop tail | no `removeAction` → ghost rows / stale count |
+| `ListPrepend` | unshift vs append | INSERT ignores anchor → prepend reported as tail |
+| `ListReorder` | reverse / rotate | move = remove+insert without remove → wrong order |
+| `ListFilter` | toggle even-only | filter+restore → ghosts / duplicated `item-key` |
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListRemove/App.vue"
+  entry="src/ListRemove"
+  defaultEntryName="ListRemove"
+/>
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListPrepend/App.vue"
+  entry="src/ListPrepend"
+  defaultEntryName="ListPrepend"
+/>
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListReorder/App.vue"
+  entry="src/ListReorder"
+  defaultEntryName="ListReorder"
+/>
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListFilter/App.vue"
+  entry="src/ListFilter"
+  defaultEntryName="ListFilter"
+/>
+
+Matching automated coverage lives in `packages/testing-library` as `it.fails` cases under **native list element · mutation gaps** — they assert the *correct* `update-list-info` payloads and will flip to passing once the adapter is fixed.
+
 ## Decision checklist
 
 1. Is the page mostly one linear document under ~3 screens? → **`<scroll-view>`**
@@ -231,6 +276,7 @@ Recycling is a **native** concern; composition stays a **Vue** concern. Put pres
 3. Do you need waterfall or multi-column flow? → **`<list list-type="…">`**
 4. Will the dataset grow without bound? → **`<list>` + composable + `@scrolltolower`**
 5. Did you set matching `:key` / `:item-key`? → required for correct recycling
+6. Do you need delete / prepend / reorder / filter? → stress-test first; prefer append-only feeds until list diffs are complete
 
 ## See also
 

--- a/website/docs/zh/guide/scroll-view-vs-list.mdx
+++ b/website/docs/zh/guide/scroll-view-vs-list.mdx
@@ -210,6 +210,10 @@ export function useInfiniteFeed(pageSize = 20) {
 
 这与 Elk 的 `TimelinePaginator` 同构：分页逻辑在 composable，视口交给 `<list>`。
 
+:::warning 当前只保证追加更新
+Vue Lynx 主线程 list 适配层目前只上报**新增 insert**（`removeAction` / `updateAction` 为空）。`@scrolltolower` 无限追加正好落在这条路径上。删除、头部插入、重排、过滤请先看下面的压测示例，等完整的 `ListUpdateInfoRecording` 式 diff 落地后再依赖它们。
+:::
+
 ### 4. 优先用 `list`，而不是第三方虚拟滚动库
 
 依赖测量 DOM（`getBoundingClientRect`、绝对定位窗口）的库，很难直接映射到 Lynx 的双线程 + 原生元件模型。除非布局是 `<list>` 表达不了的特例，否则用内建回收器。
@@ -224,6 +228,47 @@ export function useInfiniteFeed(pageSize = 20) {
 </list-item>
 ```
 
+## 已知缺口 — 变更压测
+
+下面四个入口是刻意的**踩坑演示**，用来暴露不完整的 list diff。点工具栏，对照橙色 Vue banner 和原生 `<list>` 实际画出的内容。等 MT 适配层补齐完整的 `insertAction` / `removeAction` / `updateAction`（对齐 ReactLynx 的 `ListUpdateInfoRecording`）后，它们应恢复正确。
+
+| 入口 | 变更 | 今天常见症状 |
+|---|---|---|
+| `ListRemove` | 删中间 / 删末尾 | 无 `removeAction` → 幽灵行 / 数量不对 |
+| `ListPrepend` | 头部插入 vs 尾部追加 | INSERT 忽略 anchor → 头部插入被当成尾部 |
+| `ListReorder` | 反转 / 轮转 | move = 删+插却没有 remove → 顺序错乱 |
+| `ListFilter` | 切换「仅偶数」 | 过滤再恢复 → 幽灵行 / 重复 `item-key` |
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListRemove/App.vue"
+  entry="src/ListRemove"
+  defaultEntryName="ListRemove"
+/>
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListPrepend/App.vue"
+  entry="src/ListPrepend"
+  defaultEntryName="ListPrepend"
+/>
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListReorder/App.vue"
+  entry="src/ListReorder"
+  defaultEntryName="ListReorder"
+/>
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListFilter/App.vue"
+  entry="src/ListFilter"
+  defaultEntryName="ListFilter"
+/>
+
+对应的自动化覆盖在 `packages/testing-library` 的 **native list element · mutation gaps** 下，以 `it.fails` 断言*正确*的 `update-list-info` 载荷；适配层修好后这些用例会翻成通过。
+
 ## 决策清单
 
 1. 页面基本是一份线性文档、大约三屏以内？→ **`<scroll-view>`**
@@ -231,6 +276,7 @@ export function useInfiniteFeed(pageSize = 20) {
 3. 需要瀑布流或多列 flow？→ **`<list list-type="…">`**
 4. 数据集会无限增长？→ **`<list>` + composable + `@scrolltolower`**
 5. `:key` / `:item-key` 是否一致？→ 正确回收所必需
+6. 需要删除 / 头部插入 / 重排 / 过滤？→ 先跑压测；在 list diff 完整前优先用追加式 Feed
 
 ## 延伸阅读
 

--- a/website/docs/zh/guide/scroll-view-vs-list.mdx
+++ b/website/docs/zh/guide/scroll-view-vs-list.mdx
@@ -211,7 +211,7 @@ export function useInfiniteFeed(pageSize = 20) {
 这与 Elk 的 `TimelinePaginator` 同构：分页逻辑在 composable，视口交给 `<list>`。
 
 :::warning 已确认缺口：头部插入（prepend）
-Vue Lynx 主线程 list 适配层往 `listItems` **只会 `push`**，忽略 INSERT 的 anchor。**头部插入**（unshift / insert-before）会被报成**尾部** insert——见 `ListPrepend`。`@scrolltolower` 追加仍是支持路径。删除 / 过滤在真机上看起来正常（尽管 `removeAction` 为空）；重排需要仔细目视对照（`ListReorder`）。
+Vue Lynx 主线程 list 适配层往 `listItems` **只会 `push`**，忽略 INSERT 的 anchor。**头部插入**（unshift / insert-before）会被报成**尾部** insert——见 `ListPrepend`。`@scrolltolower` 追加仍是支持路径。**Remove** 现已发 `removeAction`（以前 Reset 同 key 会 2202）。重排仍需仔细目视对照（`ListReorder`）。
 :::
 
 ### 4. 优先用 `list`，而不是第三方虚拟滚动库
@@ -234,7 +234,7 @@ Vue Lynx 主线程 list 适配层往 `listItems` **只会 `push`**，忽略 INSE
 |---|---|---|
 | `ListPrepend` | unshift vs append | **已确认缺口** — 新 cell 出现在尾部 |
 | `ListReorder` | Yellow→top / reverse | 仔细对照 — Vue truth 色条 vs `<list>` |
-| `ListRemove` | 删中间 / 删末尾 | 冒烟 — 真机上 OK |
+| `ListRemove` | 删除 + **Reset 同 key** | 曾在 Reset 报 2202；REMOVE 现已发 `removeAction` |
 | `ListFilter` | 偶数过滤切换 | 冒烟 — 真机上 OK |
 
 ### 已确认：prepend
@@ -261,7 +261,7 @@ Vue Lynx 主线程 list 适配层往 `listItems` **只会 `push`**，忽略 INSE
 
 ### 冒烟：remove + filter
 
-真机上表现正常；保留作回归点击。
+**Remove**：先删行，再点 **Reset same keys**。会用相同 `item-key` 重建 `Row-1…N`。若出现 duplicated item-key（error 2202），说明适配层没发 `removeAction`——是实现问题，不是 demo 写坏了。Filter 切换保留作更轻的回归点击。
 
 <Go
   example="scrolling"

--- a/website/docs/zh/guide/scroll-view-vs-list.mdx
+++ b/website/docs/zh/guide/scroll-view-vs-list.mdx
@@ -211,7 +211,7 @@ export function useInfiniteFeed(pageSize = 20) {
 这与 Elk 的 `TimelinePaginator` 同构：分页逻辑在 composable，视口交给 `<list>`。
 
 :::tip List diff
-Vue Lynx 主线程 list 适配层现在会对常见变更刷新 `insertAction` / `removeAction` / `updateAction`：追加、头部插入、中间插入、删除、同 list 重排（move）、以及 platform-info 更新。`@scrolltolower` 追加仍是最简单路径。尚未做：框架侧 cell 回收、每次 flush 刷新 `__UpdateListCallbacks`——见下方 tracking issues。
+Vue Lynx 主线程 list 适配层通过对比「上次 flush 快照」与当前 `listItems`（LIS 检测 move，语义对齐 ReactLynx 的 remove+insert）刷新 `insertAction` / `removeAction` / `updateAction`。覆盖追加、头部插入、中间插入、删除、同 list 重排、platform-info 更新。尚未做：框架侧 cell 回收、每次 flush 刷新 `__UpdateListCallbacks`——[#302](https://github.com/Huxpro/vue-lynx/issues/302)、[#303](https://github.com/Huxpro/vue-lynx/issues/303)。
 :::
 
 ### 4. 优先用 `list`，而不是第三方虚拟滚动库

--- a/website/docs/zh/guide/scroll-view-vs-list.mdx
+++ b/website/docs/zh/guide/scroll-view-vs-list.mdx
@@ -210,8 +210,8 @@ export function useInfiniteFeed(pageSize = 20) {
 
 这与 Elk 的 `TimelinePaginator` 同构：分页逻辑在 composable，视口交给 `<list>`。
 
-:::warning 已确认缺口：头部插入（prepend）
-Vue Lynx 主线程 list 适配层往 `listItems` **只会 `push`**，忽略 INSERT 的 anchor。**头部插入**（unshift / insert-before）会被报成**尾部** insert——见 `ListPrepend`。`@scrolltolower` 追加仍是支持路径。**Remove** 现已发 `removeAction`（以前 Reset 同 key 会 2202）。重排仍需仔细目视对照（`ListReorder`）。
+:::tip List diff
+Vue Lynx 主线程 list 适配层现在会对常见变更刷新 `insertAction` / `removeAction` / `updateAction`：追加、头部插入、中间插入、删除、同 list 重排（move）、以及 platform-info 更新。`@scrolltolower` 追加仍是最简单路径。尚未做：框架侧 cell 回收、每次 flush 刷新 `__UpdateListCallbacks`——见下方 tracking issues。
 :::
 
 ### 4. 优先用 `list`，而不是第三方虚拟滚动库
@@ -228,18 +228,18 @@ Vue Lynx 主线程 list 适配层往 `listItems` **只会 `push`**，忽略 INSE
 </list-item>
 ```
 
-## 变更压测 / 冒烟
+## 变更演示
 
 | 入口 | 变更 | 状态 |
 |---|---|---|
-| `ListPrepend` | unshift vs append | **已确认缺口** — 新 cell 出现在尾部 |
-| `ListReorder` | Yellow→top / reverse | 仔细对照 — Vue truth 色条 vs `<list>` |
-| `ListRemove` | 删除 + **Reset 同 key** | 曾在 Reset 报 2202；REMOVE 现已发 `removeAction` |
-| `ListFilter` | 偶数过滤切换 | 冒烟 — 真机上 OK |
+| `ListPrepend` | unshift vs append | 已修 — INSERT 尊重 anchor |
+| `ListReorder` | Yellow→top / reverse | 已修 — 同 list move = detach + insert |
+| `ListRemove` | 删除 + Reset 同 key | 已修 — `removeAction`（曾 2202） |
+| `ListFilter` | 偶数过滤切换 | OK |
 
-### 已确认：prepend
+### Prepend
 
-点一次 **Prepend**。列表**最顶部**必须变成红色 `NEW …`。若红卡出现在底部，说明适配层忽略了 insert-before。**Append** 是对照，应当正常。
+点一次 **Prepend**。列表**最顶部**必须变成红色 `NEW …`。**Append** 落在底部。
 
 <Go
   example="scrolling"
@@ -248,9 +248,9 @@ Vue Lynx 主线程 list 适配层往 `listItems` **只会 `push`**，忽略 INSE
   defaultEntryName="ListPrepend"
 />
 
-### 仔细对照：reorder
+### Reorder
 
-四个满宽色块。上方色条是普通 `<view>`（Vue truth）。下方 `<list>` 在 **Yellow → top** 或 **Reverse** 之后必须与色条**同序**。不一致就是 list move 问题。
+四个满宽色块。上方色条是普通 `<view>`（Vue truth）。下方 `<list>` 在 **Yellow → top** 或 **Reverse** 之后必须与色条**同序**。
 
 <Go
   example="scrolling"
@@ -259,9 +259,9 @@ Vue Lynx 主线程 list 适配层往 `listItems` **只会 `push`**，忽略 INSE
   defaultEntryName="ListReorder"
 />
 
-### 冒烟：remove + filter
+### Remove + filter
 
-**Remove**：先删行，再点 **Reset same keys**。会用相同 `item-key` 重建 `Row-1…N`。若出现 duplicated item-key（error 2202），说明适配层没发 `removeAction`——是实现问题，不是 demo 写坏了。Filter 切换保留作更轻的回归点击。
+**Remove**：先删行，再 **Reset same keys**——不得再弹出 duplicated item-key（2202）。Filter 切换作更轻的回归。
 
 <Go
   example="scrolling"
@@ -277,7 +277,12 @@ Vue Lynx 主线程 list 适配层往 `listItems` **只会 `push`**，忽略 INSE
   defaultEntryName="ListFilter"
 />
 
-自动化：`packages/testing-library` → **native list element · mutation gaps**。Prepend 对正确的 `position: 0` 保持 `it.fails`；remove/filter 只做 Vue length 冒烟断言。
+### 仍未做
+
+- 框架侧 cell 回收（`enqueueComponent` / recycle pool）— [#302](https://github.com/Huxpro/vue-lynx/issues/302)
+- 每次 list flush 刷新 `__UpdateListCallbacks` — [#303](https://github.com/Huxpro/vue-lynx/issues/303)
+
+自动化：`packages/testing-library` → **native list element · mutations**。
 
 ## 决策清单
 
@@ -286,7 +291,7 @@ Vue Lynx 主线程 list 适配层往 `listItems` **只会 `push`**，忽略 INSE
 3. 需要瀑布流或多列 flow？→ **`<list list-type="…">`**
 4. 数据集会无限增长？→ **`<list>` + composable + `@scrolltolower`**
 5. `:key` / `:item-key` 是否一致？→ 正确回收所必需
-6. 需要 **prepend**？→ 今天是坏的——在适配层尊重 INSERT anchor 之前，优先追加 / 重建
+6. 需要 prepend / reorder / remove？→ 已由 `update-list-info` diff 支持
 
 ## 延伸阅读
 

--- a/website/docs/zh/guide/scroll-view-vs-list.mdx
+++ b/website/docs/zh/guide/scroll-view-vs-list.mdx
@@ -1,0 +1,242 @@
+# scroll-view 与 list
+
+Lynx 不会像 Web 那样让任意节点滚动。内容超出视口时，你需要显式选择滚动容器——几乎总是 [`<scroll-view>`](https://lynxjs.org/zh/api/elements/built-in/scroll-view) 或 [`<list>`](https://lynxjs.org/zh/api/elements/built-in/list)。本指南说明 lynxjs.org 如何区分二者、这与 Web 上的 Vue 有何不同，以及由此产生的 Vue Lynx 设计模式。
+
+平台侧参考见 lynxjs.org 的[管理滚动](https://lynxjs.org/zh/guide/ui/scrolling)。
+
+## Lynx 与 Web 的区别
+
+在 Web 上，几乎任何元素都能变成滚动容器：
+
+```html
+<div style="overflow: auto; height: 100vh">
+  <!-- anything -->
+</div>
+```
+
+在 Lynx 中，普通 `<view>` **不会**因为 `overflow: scroll` / `overflow: auto` 而获得滚动能力。只有 `<scroll-view>`、`<list>` 等专用容器可以滚动。这是从 DOM 迁到 Lynx 时的第一个设计转变：滚动变成模板里的**结构性选择**，而不是事后补上的 CSS。
+
+| | Web（Vue） | Lynx（Vue Lynx） |
+|---|---|---|
+| 如何开启滚动 | 任意节点上的 `overflow` | 专用的 `<scroll-view>` / `<list>` |
+| 虚拟列表 | 可选库（`vue-virtual-scroller`、Virtua…） | `<list>` 内建 |
+| 长列表 / Feed | 自己做窗口化与 DOM 复用 | 原生回收 + 按需创建 |
+| 复杂网格 | CSS Grid / masonry 库 | `<list list-type="flow\|waterfall">` |
+
+Vue Lynx 仍然是 Composition API、`v-for` 与 SFC——但滚动树的写法会和典型的 Nuxt / Vite SPA 不一样。
+
+## lynxjs.org 怎么说
+
+Lynx 的滚动指南把两者分得很清楚：
+
+1. **用 `<scroll-view>` 做基础滚动**——固定视口；子节点超出时设置 `scroll-orientation` 为 `vertical` 或 `horizontal`。
+2. **用 `<list>` 处理大量 / 无限数据**——只按需创建可见区域的节点。
+3. **用 `<list>` 处理复杂布局**——`scroll-view` 只有线性布局；`list` 提供 `single`、`flow`、`waterfall`。
+
+[`<scroll-view>` API](https://lynxjs.org/zh/api/elements/built-in/scroll-view) 还提醒：
+
+- 子节点会一次性全部创建（可能拖慢首屏）。
+- **没有复用机制**；内容过多可能吃光内存。
+- 内容超过大约 **三屏** 时，优先用 `<list>`，或用曝光事件模拟回收。
+
+可以把 `<scroll-view>` 理解成「刚好需要滚动的短页面」，把 `<list>` 理解成「可回收的 Feed」。
+
+## 选型对照表
+
+| 问题 | 更适合 `<scroll-view>` | 更适合 `<list>` |
+|---|---|---|
+| 内容量？ | 大约三屏以内 | 多屏 / 无上限 |
+| 布局 | 线性堆叠 | 单列 / 网格（`flow`）/ 瀑布流 |
+| 条目形态 | 混杂区块、吸顶栏 | 同质（或大体同质）单元格 |
+| 内存 | 急切创建，子节点常驻 | 回收 + 懒创建 |
+| 无限加载 | 可以，但风险高 | 原生 `@scrolltolower` |
+
+Lynx 的经验法则：**约三屏以内 → `scroll-view`；再多 → `list`。**
+
+## 在 Vue 里用 `<scroll-view>`
+
+普通 Vue 子节点即可——`v-for`、嵌套 SFC、sticky 兄弟节点。除了包一层 `<scroll-view>`，没有额外契约。
+
+<Go
+  example="scrolling"
+  defaultFile="src/ScrollViewBasic/App.vue"
+  entry="src/ScrollViewBasic"
+  defaultEntryName="ScrollViewBasic"
+/>
+
+```vue
+<scroll-view scroll-orientation="vertical">
+  <view class="header">…</view>
+  <view v-for="card in cards" :key="card.id" class="card">
+    <text>{{ card.title }}</text>
+  </view>
+</scroll-view>
+```
+
+适合：设置页、表单、文章正文、短结果页（另见 [Vue Query](/zh/guide/data-fetching) 与 [TodoMVC](/zh/guide/todomvc) 示例）。
+
+:::tip 嵌套布局提示
+`<scroll-view>` 的直接子节点只支持 linear / sticky。若要在滚动区域内使用更丰富的 CSS，先包一层子 `<view>`，再在该子树里排版——这也是 [scroll-view 文档](https://lynxjs.org/zh/api/elements/built-in/scroll-view) 的建议。
+:::
+
+## 在 Vue 里用 `<list>`
+
+`<list>` 要求子节点是 **`<list-item>`**。每个 item 需要：
+
+- Vue 的 `:key` —— VNode 树的协调身份
+- Lynx 的 `:item-key` —— 原生回收器的身份（保持两者一致）
+
+缺少或冲突的 key 是空白 / 错乱单元格的常见原因。
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListBasic/App.vue"
+  entry="src/ListBasic"
+  defaultEntryName="ListBasic"
+/>
+
+```vue
+<list list-type="single" scroll-orientation="vertical">
+  <list-item
+    v-for="card in cards"
+    :key="card.id"
+    :item-key="card.id"
+    :estimated-main-axis-size-px="96"
+  >
+    <view class="card">…</view>
+  </list-item>
+</list>
+```
+
+`estimated-main-axis-size-px` 帮助引擎在单元格尚未测量前估算滚动条与跳转位置——[商品画廊教程](/zh/guide/tutorial-gallery) 的瀑布流图片也用同一提示。
+
+### 瀑布流 / 网格布局
+
+这是 lynxjs.org 区分的另一半：`scroll-view` 做不了多列瀑布流；`list` 可以。
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListWaterfall/App.vue"
+  entry="src/ListWaterfall"
+  defaultEntryName="ListWaterfall"
+/>
+
+```vue
+<list list-type="waterfall" :span-count="2" scroll-orientation="vertical">
+  <list-item
+    v-for="tile in tiles"
+    :key="tile.id"
+    :item-key="tile.id"
+    :estimated-main-axis-size-px="tile.height"
+  >
+    <view class="tile" :style="{ height: `${tile.height}px` }" />
+  </list-item>
+</list>
+```
+
+每个 `list-item` 都可以挂完整的 Vue SFC——画廊教程里的 `LikeImageCard` 就是同一模式的产品级写法。
+
+## 由此产生的 Vue 设计模式
+
+从 Web Vue 迁到 Vue Lynx，响应式模型不变——变的是**滚动放在哪里**，以及**谁负责回收**。
+
+### 1. 在模板里显式声明容器
+
+不要再给根 `<view>` 写 `overflow: auto`。先想清楚：
+
+```vue
+<!-- 短的、混杂的页面 -->
+<scroll-view scroll-orientation="vertical">…</scroll-view>
+
+<!-- 长的同质 Feed -->
+<list list-type="single" scroll-orientation="vertical">…</list>
+```
+
+这个结构选择，相当于在 Web 上决定要不要上虚拟列表库。
+
+### 2. 双重身份：`:key` + `:item-key`
+
+Web 的 `v-for` 只需要 `:key`。Lynx 的 list 两者都要。用同一个稳定业务 id：
+
+```vue
+<list-item
+  v-for="status in items"
+  :key="status.id"
+  :item-key="status.id"
+/>
+```
+
+[Elk](/zh/guide/elk) 移植里的 Mastodon 状态列表正是这一约定。
+
+### 3. Composable 管分页；`<list>` 管回收
+
+在 Web 上，无限滚动通常是：
+
+`useInfiniteQuery` / 自定义 composable **+** 虚拟列表 **+** IntersectionObserver 哨兵。
+
+在 Lynx 里可以去掉虚拟列表。Composable 往 `ref` 数组追加数据；`@scrolltolower`（配合 `lower-threshold-item-count`）请求下一页。原生回收保证内存平稳。
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListInfinite/App.vue"
+  entry="src/ListInfinite"
+  defaultEntryName="ListInfinite"
+/>
+
+```ts
+// shared/useInfiniteFeed.ts
+export function useInfiniteFeed(pageSize = 20) {
+  const items = ref(makeCards(pageSize))
+  const loading = ref(false)
+  // loadMore() 追加下一页…
+  return { items, loading, loadMore }
+}
+```
+
+```vue
+<list
+  :lower-threshold-item-count="3"
+  @scrolltolower="loadMore"
+>
+  <list-item
+    v-for="item in items"
+    :key="item.id"
+    :item-key="item.id"
+  >
+    …
+  </list-item>
+</list>
+```
+
+这与 Elk 的 `TimelinePaginator` 同构：分页逻辑在 composable，视口交给 `<list>`。
+
+### 4. 优先用 `list`，而不是第三方虚拟滚动库
+
+依赖测量 DOM（`getBoundingClientRect`、绝对定位窗口）的库，很难直接映射到 Lynx 的双线程 + 原生元件模型。除非布局是 `<list>` 表达不了的特例，否则用内建回收器。
+
+### 5. 单元格继续用 Vue 组件
+
+回收是**原生**职责；组合仍是 **Vue** 职责。把展示型 SFC 放进 `list-item`——不要因为父级是 list 就把一切摊平成巨型模板。
+
+```vue
+<list-item :key="pic.id" :item-key="pic.id">
+  <LikeImageCard :picture="pic" />
+</list-item>
+```
+
+## 决策清单
+
+1. 页面基本是一份线性文档、大约三屏以内？→ **`<scroll-view>`**
+2. 要渲染几十 / 上百条相似行？→ **`<list>`**
+3. 需要瀑布流或多列 flow？→ **`<list list-type="…">`**
+4. 数据集会无限增长？→ **`<list>` + composable + `@scrolltolower`**
+5. `:key` / `:item-key` 是否一致？→ 正确回收所必需
+
+## 延伸阅读
+
+- [管理滚动（Lynx）](https://lynxjs.org/zh/guide/ui/scrolling)
+- [`<scroll-view>` API](https://lynxjs.org/zh/api/elements/built-in/scroll-view)
+- [`<list>` API](https://lynxjs.org/zh/api/elements/built-in/list)
+- [教程：商品画廊](/zh/guide/tutorial-gallery) —— 完整应用中的瀑布流 `<list>`
+- [Elk（Mastodon 客户端）](/zh/guide/elk) —— 用原生 `<list>` 替换 Virtua
+- [主线程脚本](/zh/guide/main-thread-script) —— `<scroll-view>` / `<list>` 上的滚动联动 worklet

--- a/website/docs/zh/guide/scroll-view-vs-list.mdx
+++ b/website/docs/zh/guide/scroll-view-vs-list.mdx
@@ -210,8 +210,8 @@ export function useInfiniteFeed(pageSize = 20) {
 
 这与 Elk 的 `TimelinePaginator` 同构：分页逻辑在 composable，视口交给 `<list>`。
 
-:::warning 当前只保证追加更新
-Vue Lynx 主线程 list 适配层目前只上报**新增 insert**（`removeAction` / `updateAction` 为空）。`@scrolltolower` 无限追加正好落在这条路径上。删除、头部插入、重排、过滤请先看下面的压测示例，等完整的 `ListUpdateInfoRecording` 式 diff 落地后再依赖它们。
+:::warning 已确认缺口：头部插入（prepend）
+Vue Lynx 主线程 list 适配层往 `listItems` **只会 `push`**，忽略 INSERT 的 anchor。**头部插入**（unshift / insert-before）会被报成**尾部** insert——见 `ListPrepend`。`@scrolltolower` 追加仍是支持路径。删除 / 过滤在真机上看起来正常（尽管 `removeAction` 为空）；重排需要仔细目视对照（`ListReorder`）。
 :::
 
 ### 4. 优先用 `list`，而不是第三方虚拟滚动库
@@ -228,16 +228,40 @@ Vue Lynx 主线程 list 适配层目前只上报**新增 insert**（`removeActio
 </list-item>
 ```
 
-## 已知缺口 — 变更压测
+## 变更压测 / 冒烟
 
-下面四个入口是刻意的**踩坑演示**，用来暴露不完整的 list diff。点工具栏，对照橙色 Vue banner 和原生 `<list>` 实际画出的内容。等 MT 适配层补齐完整的 `insertAction` / `removeAction` / `updateAction`（对齐 ReactLynx 的 `ListUpdateInfoRecording`）后，它们应恢复正确。
-
-| 入口 | 变更 | 今天常见症状 |
+| 入口 | 变更 | 状态 |
 |---|---|---|
-| `ListRemove` | 删中间 / 删末尾 | 无 `removeAction` → 幽灵行 / 数量不对 |
-| `ListPrepend` | 头部插入 vs 尾部追加 | INSERT 忽略 anchor → 头部插入被当成尾部 |
-| `ListReorder` | 反转 / 轮转 | move = 删+插却没有 remove → 顺序错乱 |
-| `ListFilter` | 切换「仅偶数」 | 过滤再恢复 → 幽灵行 / 重复 `item-key` |
+| `ListPrepend` | unshift vs append | **已确认缺口** — 新 cell 出现在尾部 |
+| `ListReorder` | Yellow→top / reverse | 仔细对照 — Vue truth 色条 vs `<list>` |
+| `ListRemove` | 删中间 / 删末尾 | 冒烟 — 真机上 OK |
+| `ListFilter` | 偶数过滤切换 | 冒烟 — 真机上 OK |
+
+### 已确认：prepend
+
+点一次 **Prepend**。列表**最顶部**必须变成红色 `NEW …`。若红卡出现在底部，说明适配层忽略了 insert-before。**Append** 是对照，应当正常。
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListPrepend/App.vue"
+  entry="src/ListPrepend"
+  defaultEntryName="ListPrepend"
+/>
+
+### 仔细对照：reorder
+
+四个满宽色块。上方色条是普通 `<view>`（Vue truth）。下方 `<list>` 在 **Yellow → top** 或 **Reverse** 之后必须与色条**同序**。不一致就是 list move 问题。
+
+<Go
+  example="scrolling"
+  defaultFile="src/ListReorder/App.vue"
+  entry="src/ListReorder"
+  defaultEntryName="ListReorder"
+/>
+
+### 冒烟：remove + filter
+
+真机上表现正常；保留作回归点击。
 
 <Go
   example="scrolling"
@@ -248,26 +272,12 @@ Vue Lynx 主线程 list 适配层目前只上报**新增 insert**（`removeActio
 
 <Go
   example="scrolling"
-  defaultFile="src/ListPrepend/App.vue"
-  entry="src/ListPrepend"
-  defaultEntryName="ListPrepend"
-/>
-
-<Go
-  example="scrolling"
-  defaultFile="src/ListReorder/App.vue"
-  entry="src/ListReorder"
-  defaultEntryName="ListReorder"
-/>
-
-<Go
-  example="scrolling"
   defaultFile="src/ListFilter/App.vue"
   entry="src/ListFilter"
   defaultEntryName="ListFilter"
 />
 
-对应的自动化覆盖在 `packages/testing-library` 的 **native list element · mutation gaps** 下，以 `it.fails` 断言*正确*的 `update-list-info` 载荷；适配层修好后这些用例会翻成通过。
+自动化：`packages/testing-library` → **native list element · mutation gaps**。Prepend 对正确的 `position: 0` 保持 `it.fails`；remove/filter 只做 Vue length 冒烟断言。
 
 ## 决策清单
 
@@ -276,7 +286,7 @@ Vue Lynx 主线程 list 适配层目前只上报**新增 insert**（`removeActio
 3. 需要瀑布流或多列 flow？→ **`<list list-type="…">`**
 4. 数据集会无限增长？→ **`<list>` + composable + `@scrolltolower`**
 5. `:key` / `:item-key` 是否一致？→ 正确回收所必需
-6. 需要删除 / 头部插入 / 重排 / 过滤？→ 先跑压测；在 list diff 完整前优先用追加式 Feed
+6. 需要 **prepend**？→ 今天是坏的——在适配层尊重 INSERT anchor 之前，优先追加 / 重建
 
 ## 延伸阅读
 

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -96,6 +96,7 @@ export default defineConfig({
         { text: 'Instant First-Frame Rendering (IFR)', link: '/guide/ifr', tag: 'v0.5' },
         { text: 'Tutorial: Product Gallery', link: '/guide/tutorial-gallery' },
         { text: 'Tutorial: Product Swiper', link: '/guide/tutorial-swiper' },
+        { text: 'scroll-view vs list', link: '/guide/scroll-view-vs-list' },
         {
           dividerType: 'solid',
         },
@@ -141,6 +142,7 @@ export default defineConfig({
         { text: '首屏直出（IFR）', link: '/zh/guide/ifr', tag: 'v0.5' },
         { text: '教程：商品画廊', link: '/zh/guide/tutorial-gallery' },
         { text: '教程：商品轮播', link: '/zh/guide/tutorial-swiper' },
+        { text: 'scroll-view 与 list', link: '/zh/guide/scroll-view-vs-list' },
         {
           dividerType: 'solid',
         },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Negative control for #302 / #307

Same **ListRecycle** example as [#307](https://github.com/Huxpro/vue-lynx/pull/307), stacked on the #293 list-diff branch **without** the recycle pool (`enqueueComponent` remains a no-op).

### Browser result (Lynx Web Preview)

[Control: cross-item FAIL](https://cursor.com/agents/bc-f058f8fd-d28b-413f-ab3c-025114ab43d1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flist-recycle-control%2Fafter-fail.webp)

- Recycle probe failed — check MT enqueueComponent / hydrate.
- self-reuse: PASS (sign 15 → 15) — eager FiberElement per cell
- **cross-item: FAIL (pooled 15 → index1 19)** — different uiSigns; no pool hand-off
- pool after leave=0 · after cross=0 · key=list-itemrow

### Contrast with the fix (#307)

| | Control (this PR) | Fix (#307) |
|---|---|---|
| Base | #293 list diffs only | #293 + recycle pool |
| self-reuse | PASS | PASS |
| cross-item | **FAIL** (15 ≠ 19) | **PASS** (same uiSign) |
| pool size after leave | 0 | 1 |

Unit test: `list-recycle-control.test.ts` asserts `crossOk === false`.

**Do not merge** — demo / proof only. The real fix is #307.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f058f8fd-d28b-413f-ab3c-025114ab43d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f058f8fd-d28b-413f-ab3c-025114ab43d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

