### PR TITLE
Add hidden /vapor and /vueconf preview redirects

### DIFF
--- a/website/vercel.json
+++ b/website/vercel.json
@@ -4,6 +4,18 @@
   "outputDirectory": "doc_build",
   "cleanUrls": true,
   "ignoreCommand": "node scripts/vercel-ignore.mjs",
+  "redirects": [
+    {
+      "source": "/vapor",
+      "destination": "https://vue-lynx-git-vapor-huxpros-projects.vercel.app",
+      "permanent": false
+    },
+    {
+      "source": "/vueconf",
+      "destination": "https://vue-lynx-git-vueconf-2026-huxpros-projects.vercel.app",
+      "permanent": false
+    }
+  ],
   "headers": [
     {
       "source": "/examples/(.*)\\.lynx\\.bundle",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Add two unlisted short-path redirects on the docs site:

| Path | Destination |
|------|-------------|
| `/vapor` | Vercel branch preview for `vapor` |
| `/vueconf` | Vercel branch preview for `vueconf-2026` |

Destinations use the stable branch preview hostnames (`…-git-<branch>-…vercel.app`), so they always track the latest deployment on those branches. Redirects are temporary (`permanent: false`) and are not linked from nav/sitemap.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fe84691a-c712-4a98-9fb3-cfc580f9c0ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fe84691a-c712-4a98-9fb3-cfc580f9c0ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

