### PR TITLE
feat(slides): Straightforward IFR slide

### DIFF
--- a/slides/index.html
+++ b/slides/index.html
@@ -2100,51 +2100,53 @@ app.<span class="code-fn">use</span>(router)</pre>
     </aside>
   </section>
 
-  <!-- IFR3 — Straightforward IFR: record + reconcile (same visual language as IFR1–2) -->
+  <!-- IFR3 — Straightforward IFR: dual-thread ops + hydrate join -->
   <section class="slide stage">
     <h2 class="h-section" style="text-align:center;max-width:20ch">
       <span class="brand-text">Straightforward</span> IFR
     </h2>
-    <div class="recon">
-      <div class="recon__row">
-        <span class="recon__pair">
-          <code class="op">SET_TEXT 3 "Hi"</code>
-          <span class="recon__eq">=</span>
-          <code class="op">SET_TEXT 3 "Hi"</code>
-        </span>
-        <span class="recon__out is-skip">identical &rarr; skip</span>
+    <div class="ifrjoin">
+      <div class="ifrjoin__cols">
+        <div class="ifrjoin__col" style="--c:#56b8f0">
+          <span class="ifrjoin__label"><i></i>Main (UI) thread</span>
+          <span class="ifrjoin__role">records</span>
+          <code class="ifrjoin__op">SET_TEXT 3 "Hi"</code>
+          <code class="ifrjoin__op">SET_TEXT 3 "Hi"</code>
+          <code class="ifrjoin__op">CREATE 4 view</code>
+        </div>
+        <div class="ifrjoin__rail" aria-hidden="true"></div>
+        <div class="ifrjoin__col" style="--c:#5dd5a8">
+          <span class="ifrjoin__label"><i></i>Background thread</span>
+          <span class="ifrjoin__role">first batches</span>
+          <code class="ifrjoin__op">SET_TEXT 3 "Hi"</code>
+          <code class="ifrjoin__op is-diff">SET_TEXT 3 "你好"</code>
+          <code class="ifrjoin__op is-diff">CREATE 4 text</code>
+        </div>
       </div>
-      <div class="recon__row">
-        <span class="recon__pair">
-          <code class="op">SET_TEXT 3 "Hi"</code>
-          <span class="recon__eq recon__eq--ne">&ne;</span>
-          <code class="op op--hot">SET_TEXT 3 "你好"</code>
-        </span>
-        <span class="recon__out is-patch">value differs &rarr; patch in place</span>
+      <div class="ifrjoin__join">
+        <span class="ifrjoin__elbow ifrjoin__elbow--l" aria-hidden="true"></span>
+        <span class="ifrjoin__pill">hydrate · thread join</span>
+        <span class="ifrjoin__elbow ifrjoin__elbow--r" aria-hidden="true"></span>
       </div>
-      <div class="recon__row">
-        <span class="recon__pair">
-          <code class="op">CREATE 4 view</code>
-          <span class="recon__eq recon__eq--ne">&ne;</span>
-          <code class="op op--bad">CREATE 4 text</code>
-        </span>
-        <span class="recon__out is-tear">structural &rarr; tear down &amp; rebuild</span>
+      <div class="ifrjoin__outcomes">
+        <span class="ifrjoin__out is-skip">identical &rarr; skip</span>
+        <span class="ifrjoin__out is-patch">value differs &rarr; patch</span>
+        <span class="ifrjoin__out is-tear">structural &rarr; rebuild</span>
       </div>
     </div>
     <p class="lead arch-cap" data-mm-fade>
       Both threads render. The ops stream <span class="brand-text">is</span> the recording —
-      the MT records its ops; the BG's first batches hydrate against them.
-      Correctness never depends on the two matching.
+      hydrate joins them. Correctness never depends on the two matching.
     </p>
     <aside class="notes">
-      <p><strong>Straightforward IFR — hydration by ops reconciliation.</strong>
+      <p><strong>Straightforward IFR — hydration as a thread join.</strong>
       No special first-frame format: the same Vue runtime + app (same
       <code>nodeOps</code>) runs on the main thread during
-      <code>loadTemplate</code>. The flat ops stream doubles as the recorded
-      PAPI calls. The BG's initial <code>vuePatchUpdate</code> batches walk the
-      recording frame-by-frame: identical → skipped (already on screen), value
-      diff → patched, structural divergence → tear the first-screen tree down
-      and re-apply. A mismatch only loses the perf win, never correctness (logs
+      <code>loadTemplate</code> and <em>records</em> its flat ops stream. The
+      background boots in parallel, then its first <code>vuePatchUpdate</code>
+      batches walk that recording — a join, not a rewrite: identical → skip,
+      value diff → patch, structural divergence → tear down &amp; rebuild.
+      A mismatch only loses the perf win, never correctness (logs
       <code>IFR hydration mismatch</code> in dev). Deterministic ids &amp;
       <code>vue:N</code> signs route taps to Vue with no rebinding.</p>
     </aside>

--- a/slides/index.html
+++ b/slides/index.html
@@ -24,7 +24,7 @@
     </button>
   </div>
   <div class="chrome chrome--bottom">
-    <span data-counter>01 / 125</span>
+    <span data-counter>01 / 126</span>
   </div>
   <div class="chrome chrome--bottom-right">
     <a href="https://vue.lynxjs.org" target="_blank" rel="noreferrer">vue.lynxjs.org</a>
@@ -2097,6 +2097,58 @@ app.<span class="code-fn">use</span>(router)</pre>
       inside <code>loadTemplate</code> — watch the <strong>paint</strong> flag
       jump left. The background thread still runs the same code, just in
       parallel and off the critical path.</p>
+    </aside>
+  </section>
+
+  <!-- IFR3 — Straightforward IFR: same renderer, ops stream is the recording -->
+  <section class="slide stage">
+    <h2 class="h-section" style="text-align:center;max-width:16ch">
+      <span class="brand-text">Straightforward</span> IFR
+    </h2>
+    <p class="lead" style="text-align:center;max-width:36ch;margin:0 auto 14px">
+      Both threads render. The ops stream <span class="brand-text">is</span> the recording.
+    </p>
+    <div class="recon">
+      <div class="recon__row">
+        <span class="recon__pair">
+          <code class="op">SET_TEXT 3 "Hi"</code>
+          <span class="recon__eq">=</span>
+          <code class="op">SET_TEXT 3 "Hi"</code>
+        </span>
+        <span class="recon__out is-skip">identical &rarr; skip</span>
+      </div>
+      <div class="recon__row">
+        <span class="recon__pair">
+          <code class="op">SET_TEXT 3 "Hi"</code>
+          <span class="recon__eq recon__eq--ne">&ne;</span>
+          <code class="op op--hot">SET_TEXT 3 "你好"</code>
+        </span>
+        <span class="recon__out is-patch">value differs &rarr; patch in place</span>
+      </div>
+      <div class="recon__row">
+        <span class="recon__pair">
+          <code class="op">CREATE 4 view</code>
+          <span class="recon__eq recon__eq--ne">&ne;</span>
+          <code class="op op--bad">CREATE 4 text</code>
+        </span>
+        <span class="recon__out is-tear">structural &rarr; tear down &amp; rebuild</span>
+      </div>
+    </div>
+    <p class="lead arch-cap" data-mm-fade>
+      The MT render records its ops; the BG's first batches hydrate against them.
+      Correctness never depends on the two matching — deterministic ids &amp;
+      <code>vue:N</code> signs route taps to Vue with no rebinding.
+    </p>
+    <aside class="notes">
+      <p><strong>Straightforward IFR — hydration by ops reconciliation.</strong>
+      No special first-frame format: the same Vue runtime + app (same
+      <code>nodeOps</code>) runs on the main thread during
+      <code>loadTemplate</code>. The flat ops stream doubles as the recorded
+      PAPI calls. The BG's initial <code>vuePatchUpdate</code> batches walk the
+      recording frame-by-frame: identical → skipped (already on screen), value
+      diff → patched, structural divergence → tear the first-screen tree down
+      and re-apply. A mismatch only loses the perf win, never correctness (logs
+      <code>IFR hydration mismatch</code> in dev).</p>
     </aside>
   </section>
 

--- a/slides/index.html
+++ b/slides/index.html
@@ -2100,14 +2100,11 @@ app.<span class="code-fn">use</span>(router)</pre>
     </aside>
   </section>
 
-  <!-- IFR3 — Straightforward IFR: same renderer, ops stream is the recording -->
+  <!-- IFR3 — Straightforward IFR: record + reconcile (same visual language as IFR1–2) -->
   <section class="slide stage">
-    <h2 class="h-section" style="text-align:center;max-width:16ch">
+    <h2 class="h-section" style="text-align:center;max-width:20ch">
       <span class="brand-text">Straightforward</span> IFR
     </h2>
-    <p class="lead" style="text-align:center;max-width:36ch;margin:0 auto 14px">
-      Both threads render. The ops stream <span class="brand-text">is</span> the recording.
-    </p>
     <div class="recon">
       <div class="recon__row">
         <span class="recon__pair">
@@ -2135,9 +2132,9 @@ app.<span class="code-fn">use</span>(router)</pre>
       </div>
     </div>
     <p class="lead arch-cap" data-mm-fade>
-      The MT render records its ops; the BG's first batches hydrate against them.
-      Correctness never depends on the two matching — deterministic ids &amp;
-      <code>vue:N</code> signs route taps to Vue with no rebinding.
+      Both threads render. The ops stream <span class="brand-text">is</span> the recording —
+      the MT records its ops; the BG's first batches hydrate against them.
+      Correctness never depends on the two matching.
     </p>
     <aside class="notes">
       <p><strong>Straightforward IFR — hydration by ops reconciliation.</strong>
@@ -2148,7 +2145,8 @@ app.<span class="code-fn">use</span>(router)</pre>
       recording frame-by-frame: identical → skipped (already on screen), value
       diff → patched, structural divergence → tear the first-screen tree down
       and re-apply. A mismatch only loses the perf win, never correctness (logs
-      <code>IFR hydration mismatch</code> in dev).</p>
+      <code>IFR hydration mismatch</code> in dev). Deterministic ids &amp;
+      <code>vue:N</code> signs route taps to Vue with no rebinding.</p>
     </aside>
   </section>
 

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -202,6 +202,12 @@ export const ZH = {
     'IFR 把整个运行时放进<b style="color:#56b8f0">主线程</b>产物 —— 它在 <code>loadTemplate</code> 期间渲染,于是<b>先出画面</b>,后台在一旁并行启动。',
   "The MT render records its ops; the BG's first batches hydrate against them. Correctness never depends on the two matching — deterministic ids & vue:N signs route taps to Vue with no rebinding.":
     '主线程渲染时录下自己的 ops;后台最初的几批拿去和它水合对账。正确性从不依赖两者一致 —— 确定性 id 与 <code>vue:N</code> 签名让点击无需重绑就路由回 Vue。',
+  'Both threads render. The ops stream is the recording — the MT records its ops; the BG\'s first batches hydrate against them. Correctness never depends on the two matching.':
+    '两条线程都渲染。那条 ops 流<span class="brand-text">就是</span>录制 —— 主线程录下 ops,后台最初几批拿去水合对账。正确性从不依赖两者一致。',
+  // recon pills
+  'identical → skip': '相同 → 跳过',
+  'value differs → patch in place': '值不同 → 原地打补丁',
+  'structural → tear down & rebuild': '结构分歧 → 拆掉重建',
   'Normally every static element pays the whole chain — a vnode, a shadow node, ops frames, a thread crossing, an interpreter dispatch.':
     '常规下每个静态元素都要付整条链 —— 一个 vnode、一个影子节点、若干 ops 帧、一次跨线程、一次解释器分发。',
   'The compiler lowers the static subtree to one create() function. Vue sends one op; only the dynamic holes travel after.':

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -204,10 +204,18 @@ export const ZH = {
     '主线程渲染时录下自己的 ops;后台最初的几批拿去和它水合对账。正确性从不依赖两者一致 —— 确定性 id 与 <code>vue:N</code> 签名让点击无需重绑就路由回 Vue。',
   'Both threads render. The ops stream is the recording — the MT records its ops; the BG\'s first batches hydrate against them. Correctness never depends on the two matching.':
     '两条线程都渲染。那条 ops 流<span class="brand-text">就是</span>录制 —— 主线程录下 ops,后台最初几批拿去水合对账。正确性从不依赖两者一致。',
-  // recon pills
+  'Both threads render. The ops stream is the recording — hydrate joins them. Correctness never depends on the two matching.':
+    '两条线程都渲染。那条 ops 流<span class="brand-text">就是</span>录制 —— hydrate 把它们 join 起来。正确性从不依赖两者一致。',
+  // dual-thread join labels (thread names reuse existing Main/Background keys)
+  'records': '录制',
+  'first batches': '最初几批',
+  'hydrate · thread join': 'hydrate · thread join',
+  // recon / join outcome pills
   'identical → skip': '相同 → 跳过',
   'value differs → patch in place': '值不同 → 原地打补丁',
+  'value differs → patch': '值不同 → 打补丁',
   'structural → tear down & rebuild': '结构分歧 → 拆掉重建',
+  'structural → rebuild': '结构分歧 → 重建',
   'Normally every static element pays the whole chain — a vnode, a shadow node, ops frames, a thread crossing, an interpreter dispatch.':
     '常规下每个静态元素都要付整条链 —— 一个 vnode、一个影子节点、若干 ops 帧、一次跨线程、一次解释器分发。',
   'The compiler lowers the static subtree to one create() function. Vue sends one op; only the dynamic holes travel after.':
@@ -575,7 +583,7 @@ export const ZH_NOTES = [
   // IFR2 · IFR:先出画面
   `<p><strong>首屏直出 —— 从 ReactLynx 移植。</strong>开了 <code>enableIFR</code>,主线程产物就带上完整 Vue 运行时 + 应用(不只是 worklet)。<code>renderPage</code> 在 <code>loadTemplate</code> 里同步挂载 —— 看 <strong>paint</strong> 旗标跳到左边。后台线程照样跑同一份代码,只是并行、离开关键路径。</p>`,
   // IFR3 · Straightforward IFR
-  `<p><strong>Straightforward IFR —— 用 ops 对账做水合。</strong>没有特殊的首帧格式:同一份 Vue 运行时 + 应用(同一套 <code>nodeOps</code>)在 <code>loadTemplate</code> 期间跑在主线程上。那条扁平 ops 流本身就是"录下来的 PAPI 调用"。后台最初的 <code>vuePatchUpdate</code> 批次逐帧走这份录制:相同 → 跳过(已在屏上),值不同 → 打补丁,结构分歧 → 拆掉首屏树重建。不一致只损失性能收益,绝不损失正确性(开发期打印 <code>IFR hydration mismatch</code>)。</p>`,
+  `<p><strong>Straightforward IFR —— hydration 当作 thread join。</strong>没有特殊的首帧格式:同一份 Vue 运行时 + 应用(同一套 <code>nodeOps</code>)在 <code>loadTemplate</code> 期间跑在主线程上并<em>录下</em>扁平 ops 流。后台并行启动,随后最初的 <code>vuePatchUpdate</code> 批次逐帧走这份录制 —— 是一次 join,不是重写:相同 → 跳过,值不同 → 打补丁,结构分歧 → 拆掉重建。不一致只损失性能收益,绝不损失正确性(开发期打印 <code>IFR hydration mismatch</code>)。确定性 id 与 <code>vue:N</code> 签名让点击无需重绑就路由回 Vue。</p>`,
   // IFR5 · 逐节点的管线
   `<p>还是 Runtime 那章的同一条管线 —— 但注意它是<em>逐节点</em>跑的,哪怕这些结构永远不变。</p>`,
   // IFR6 · ET 折叠管线

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -189,6 +189,8 @@ export const ZH = {
 
   // ---- IV · Instant First-Frame Rendering + Element Templates ----
   // headlines
+  'Straightforward IFR':
+    '<span class="brand-text">Straightforward</span> IFR',
   'Both threads render. The ops stream is the recording.':
     '两条线程都渲染。那条 ops 流<span class="brand-text">就是</span>录制。',
   'IFR changes when the frame renders. Element Templates change how much work it does.':
@@ -566,6 +568,8 @@ export const ZH_NOTES = [
   `<p><strong>往返的代价。</strong>前六页讲的 VDOM → ShadowElement → ops → PAPI,在第一帧之前必须先整整跑一圈。设备上,这一圈再加后台线程启动与 bundle 求值,就是几十毫秒的白屏。</p>`,
   // IFR2 · IFR:先出画面
   `<p><strong>首屏直出 —— 从 ReactLynx 移植。</strong>开了 <code>enableIFR</code>,主线程产物就带上完整 Vue 运行时 + 应用(不只是 worklet)。<code>renderPage</code> 在 <code>loadTemplate</code> 里同步挂载 —— 看 <strong>paint</strong> 旗标跳到左边。后台线程照样跑同一份代码,只是并行、离开关键路径。</p>`,
+  // IFR3 · Straightforward IFR
+  `<p><strong>Straightforward IFR —— 用 ops 对账做水合。</strong>没有特殊的首帧格式:同一份 Vue 运行时 + 应用(同一套 <code>nodeOps</code>)在 <code>loadTemplate</code> 期间跑在主线程上。那条扁平 ops 流本身就是"录下来的 PAPI 调用"。后台最初的 <code>vuePatchUpdate</code> 批次逐帧走这份录制:相同 → 跳过(已在屏上),值不同 → 打补丁,结构分歧 → 拆掉首屏树重建。不一致只损失性能收益,绝不损失正确性(开发期打印 <code>IFR hydration mismatch</code>)。</p>`,
   // IFR5 · 逐节点的管线
   `<p>还是 Runtime 那章的同一条管线 —— 但注意它是<em>逐节点</em>跑的,哪怕这些结构永远不变。</p>`,
   // IFR6 · ET 折叠管线

--- a/slides/src/main.js
+++ b/slides/src/main.js
@@ -839,6 +839,7 @@ const I18N_SELECTOR = [
   '.flane__label', '.ifrlane__label', '.fcenter', '.lgtag',
   '.demo__caption', '.videopair figcaption',
   '.tile', '.wlab', '.wattr', '.wg b',
+  '.recon__out',
 ].map((s) => `.slide ${s}`).join(', ') + ', .gate-legend span';
 
 let i18nEls = [];

--- a/slides/src/main.js
+++ b/slides/src/main.js
@@ -839,7 +839,7 @@ const I18N_SELECTOR = [
   '.flane__label', '.ifrlane__label', '.fcenter', '.lgtag',
   '.demo__caption', '.videopair figcaption',
   '.tile', '.wlab', '.wattr', '.wg b',
-  '.recon__out',
+  '.ifrjoin__label', '.ifrjoin__role', '.ifrjoin__pill', '.ifrjoin__out',
 ].map((s) => `.slide ${s}`).join(', ') + ', .gate-legend span';
 
 let i18nEls = [];

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -3562,13 +3562,15 @@ vl-media.snap.is-missing .vl-ph__kind { color: rgba(15, 18, 22, 0.65); }
 .ifrjoin__col:first-child { margin-right: clamp(12px, 1.6cqw, 22px); }
 .ifrjoin__col:last-child { margin-left: clamp(12px, 1.6cqw, 22px); }
 .ifrjoin__rail {
-  width: 1px;
+  width: 1.5px;
   justify-self: center;
+  align-self: stretch;
+  margin: 18px 0 8px;
   background: linear-gradient(
     to bottom,
     transparent 0%,
-    var(--line) 12%,
-    var(--line) 88%,
+    color-mix(in srgb, var(--ink-mute) 55%, transparent) 10%,
+    color-mix(in srgb, var(--ink-mute) 55%, transparent) 90%,
     transparent 100%
   );
 }
@@ -3613,24 +3615,25 @@ vl-media.snap.is-missing .vl-ph__kind { color: rgba(15, 18, 22, 0.65); }
 .ifrjoin__join {
   display: grid;
   grid-template-columns: 1fr auto 1fr;
-  align-items: center;
+  align-items: end;
   gap: clamp(10px, 1.4cqw, 18px);
   padding: 0 clamp(8px, 1cqw, 16px);
+  margin-top: 2px;
 }
 .ifrjoin__elbow {
-  height: 18px;
-  border-bottom: 1.5px solid var(--line);
+  height: 22px;
+  border-bottom: 1.5px solid color-mix(in srgb, var(--ink-mute) 55%, transparent);
   position: relative;
 }
 .ifrjoin__elbow--l {
-  border-left: 1.5px solid var(--line);
-  border-bottom-left-radius: 12px;
-  margin-left: 28%;
+  border-left: 1.5px solid color-mix(in srgb, var(--ink-mute) 55%, transparent);
+  border-bottom-left-radius: 14px;
+  margin-left: 22%;
 }
 .ifrjoin__elbow--r {
-  border-right: 1.5px solid var(--line);
-  border-bottom-right-radius: 12px;
-  margin-right: 28%;
+  border-right: 1.5px solid color-mix(in srgb, var(--ink-mute) 55%, transparent);
+  border-bottom-right-radius: 14px;
+  margin-right: 22%;
 }
 .ifrjoin__pill {
   font-family: var(--mono);

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -3533,47 +3533,135 @@ vl-media.snap.is-missing .vl-ph__kind { color: rgba(15, 18, 22, 0.65); }
   color: var(--ink-faint);
 }
 
-/* ---- hydration reconcile (3-way) ---- */
-.recon {
-  width: 100%;
-  max-width: 860px;
+/* ---- Straightforward IFR: dual-thread ops + hydrate join ---- */
+.ifrjoin {
+  width: min(100%, 920px);
   display: flex;
   flex-direction: column;
-  gap: 11px;
+  align-items: stretch;
+  gap: clamp(6px, 1.2cqh, 12px);
 }
-.recon__row {
+.ifrjoin__cols {
+  display: grid;
+  grid-template-columns: 1fr 1px 1fr;
+  align-items: stretch;
+  gap: 0;
+  min-height: clamp(200px, 32cqh, 260px);
+}
+.ifrjoin__col {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+  padding: clamp(14px, 2cqh, 20px) clamp(16px, 2cqw, 24px);
+  border-radius: 14px;
+  border: 1px solid color-mix(in srgb, var(--c, #5dd5a8) 26%, transparent);
+  background: color-mix(in srgb, var(--c, #5dd5a8) 6%, transparent);
+  text-align: left;
+}
+.ifrjoin__col:first-child { margin-right: clamp(12px, 1.6cqw, 22px); }
+.ifrjoin__col:last-child { margin-left: clamp(12px, 1.6cqw, 22px); }
+.ifrjoin__rail {
+  width: 1px;
+  justify-self: center;
+  background: linear-gradient(
+    to bottom,
+    transparent 0%,
+    var(--line) 12%,
+    var(--line) 88%,
+    transparent 100%
+  );
+}
+.ifrjoin__label {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--c, #5dd5a8) 72%, var(--ink));
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 18px;
-  padding: 12px 20px;
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  background: var(--paper-elev);
+  gap: 7px;
 }
-.recon__pair { display: flex; align-items: center; gap: 13px; }
-.recon__pair .op {
-  font-family: var(--mono);
-  font-size: 13.5px;
-  color: var(--ink-soft);
-  padding: 4px 10px;
-  border-radius: 7px;
-  background: rgba(255, 255, 255, 0.04);
+.ifrjoin__label i {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--c, #5dd5a8);
+  box-shadow: 0 0 9px var(--c, #5dd5a8);
 }
-.recon__pair .op--hot,
-.recon__pair .op--bad { color: #f4a6ba; }
-.recon__eq { font-family: var(--mono); color: var(--vue-green); font-size: 15px; }
-.recon__eq--ne { color: var(--ink-mute); }
-.recon__out {
+.ifrjoin__role {
   font-family: var(--mono);
-  font-size: 12.5px;
-  padding: 6px 14px;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+  margin-bottom: 2px;
+}
+.ifrjoin__op {
+  font-family: var(--mono);
+  font-size: clamp(12px, 1.15cqw, 14px);
+  color: color-mix(in srgb, var(--c, #5dd5a8) 78%, var(--ink));
+  padding: 7px 12px;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--c, #5dd5a8) 10%, var(--paper));
+  border: 1px solid color-mix(in srgb, var(--c, #5dd5a8) 22%, transparent);
+  white-space: nowrap;
+}
+.ifrjoin__op.is-diff {
+  color: #f4a6ba;
+  border-color: color-mix(in srgb, #F27A9E 40%, transparent);
+  background: color-mix(in srgb, #F27A9E 9%, var(--paper));
+}
+.ifrjoin__join {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: clamp(10px, 1.4cqw, 18px);
+  padding: 0 clamp(8px, 1cqw, 16px);
+}
+.ifrjoin__elbow {
+  height: 18px;
+  border-bottom: 1.5px solid var(--line);
+  position: relative;
+}
+.ifrjoin__elbow--l {
+  border-left: 1.5px solid var(--line);
+  border-bottom-left-radius: 12px;
+  margin-left: 28%;
+}
+.ifrjoin__elbow--r {
+  border-right: 1.5px solid var(--line);
+  border-bottom-right-radius: 12px;
+  margin-right: 28%;
+}
+.ifrjoin__pill {
+  font-family: var(--mono);
+  font-size: clamp(12px, 1.2cqw, 14px);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding: 8px 18px;
+  border-radius: 999px;
+  color: var(--paper);
+  background: var(--brand-gradient);
+  background-size: 200% 100%;
+  animation: gradientMove 6s linear infinite;
+  box-shadow: 0 0 22px -4px var(--brand-emerald);
+  white-space: nowrap;
+}
+.ifrjoin__outcomes {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+}
+.ifrjoin__out {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  padding: 5px 12px;
   border-radius: 999px;
   white-space: nowrap;
 }
-.recon__out.is-skip { color: var(--vue-green); background: color-mix(in srgb, var(--vue-green) 14%, transparent); }
-.recon__out.is-patch { color: #E8B44A; background: color-mix(in srgb, #E8B44A 14%, transparent); }
-.recon__out.is-tear { color: #f4a6ba; background: color-mix(in srgb, #F27A9E 14%, transparent); }
+.ifrjoin__out.is-skip { color: var(--vue-green); background: color-mix(in srgb, var(--vue-green) 14%, transparent); }
+.ifrjoin__out.is-patch { color: #E8B44A; background: color-mix(in srgb, #E8B44A 14%, transparent); }
+.ifrjoin__out.is-tear { color: #f4a6ba; background: color-mix(in srgb, #F27A9E 14%, transparent); }
 
 /* ---- when vs how-much emphasis ---- */
 .ifr-em { font-family: var(--serif); font-style: italic; font-weight: 400; color: var(--ink); }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds one slide to the Instant First-Frame section on `vueconf-2026`, titled **Straightforward IFR**.

After the paint-first timeline (IFR2), this beat explains the mechanism without inventing a special first-frame format:

- Same Vue runtime + app (same `nodeOps`) on the main thread during `loadTemplate`
- The flat ops stream **is** the recording
- BG's first `vuePatchUpdate` batches hydrate by skip / patch-in-place / tear-down

Restores the reconcile UI that was previously dropped as IFR3, reframed under this name. Deck counter and ZH notes updated (125 → 126).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4289e08f-64f0-478d-b82e-c8106e499243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4289e08f-64f0-478d-b82e-c8106e499243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

