### PR TITLE
feat(slides): Vapor dense / cross-thread addressable slide before ET

### DIFF
--- a/slides/index.html
+++ b/slides/index.html
@@ -2934,135 +2934,6 @@ app.<span class="code-fn">use</span>(router)</pre>
     </aside>
   </section>
 
-  <!-- V·6a — original pipe layers, split across BG | MT -->
-  <section class="slide stage" data-bg="clean">
-    <div class="pipesplit">
-      <div class="pipesplit__side" data-flip="vr-col-bg">
-        <p class="pipesplit__lab" data-flip="vr-lab-bg"><i></i>Background · Vapor</p>
-        <div class="pipe pipe--side">
-          <div class="pipe__layer" data-flip="vr-l1">
-            <span class="k">compiled</span><span class="t">vapor component — <b>import 'vue'</b></span>
-          </div>
-          <div class="pipe__arr">&#9660;</div>
-          <div class="pipe__layer" data-flip="vr-l2">
-            <span class="k">alias</span><span class="t">'vue' &rarr; vue-lynx/vapor</span>
-          </div>
-          <div class="pipe__arr">&#9660;</div>
-          <div class="pipe__layer" data-flip="vr-l3">
-            <span class="k">runtime</span><span class="t">@vue/runtime-vapor</span>
-          </div>
-          <div class="pipe__arr">&#9660;</div>
-          <div class="pipe__layer" data-flip="vr-l4">
-            <span class="k">shims</span><span class="t">document · Node · Element</span>
-          </div>
-          <div class="pipe__arr">&#9660;</div>
-          <div class="pipe__layer" data-flip="vr-l5">
-            <span class="k">surface</span><span class="t">ShadowElement — DOM-compatible</span>
-          </div>
-        </div>
-      </div>
-      <div class="pipesplit__rail" aria-hidden="true" data-mm-fade>
-        <span class="pipesplit__arrow">&rarr;</span>
-        <span class="pipesplit__cap">ops</span>
-      </div>
-      <div class="pipesplit__side" data-flip="vr-col-mt">
-        <p class="pipesplit__lab" data-flip="vr-lab-mt"><i></i>Main · interpreter</p>
-        <div class="pipe pipe--side">
-          <div class="pipe__layer pipe__layer--main" data-flip="vr-l6">
-            <span class="k">main</span><span class="t">ops stream &rarr; native elements</span>
-          </div>
-        </div>
-      </div>
-    </div>
-    <p class="lead" data-mm-fade>
-      Same layers as before — BG holds the DOM-shaped stack; MT only sees the ops stream.
-    </p>
-    <aside class="notes">
-      <p><strong>Just relocate the pipe.</strong> The six layers didn&rsquo;t change — compiled / alias / runtime / shims / ShadowElement sit on the background thread; <code>ops stream → native</code> sits on Main. Next beat: light up the two reuse layers.</p>
-    </aside>
-  </section>
-
-  <!-- V·6b — same split; highlight unmodified + the trick (magic-move) -->
-  <section class="slide stage" data-bg="clean">
-    <div class="pipesplit">
-      <div class="pipesplit__side" data-flip="vr-col-bg">
-        <p class="pipesplit__lab" data-flip="vr-lab-bg"><i></i>Background · Vapor</p>
-        <div class="pipe pipe--side">
-          <div class="pipe__layer" data-flip="vr-l1">
-            <span class="k">compiled</span><span class="t">vapor component — <b>import 'vue'</b></span>
-          </div>
-          <div class="pipe__arr">&#9660;</div>
-          <div class="pipe__layer" data-flip="vr-l2">
-            <span class="k">alias</span><span class="t">'vue' &rarr; vue-lynx/vapor</span>
-          </div>
-          <div class="pipe__arr">&#9660;</div>
-          <div class="pipe__layer pipe__layer--key" data-flip="vr-l3">
-            <span class="k">runtime</span><span class="t">@vue/runtime-vapor</span>
-            <span class="pipe__reuse" data-mm-fade>unmodified</span>
-          </div>
-          <div class="pipe__arr">&#9660;</div>
-          <div class="pipe__layer" data-flip="vr-l4">
-            <span class="k">shims</span><span class="t">document · Node · Element</span>
-          </div>
-          <div class="pipe__arr">&#9660;</div>
-          <div class="pipe__layer pipe__layer--key" data-flip="vr-l5">
-            <span class="k">surface</span><span class="t">ShadowElement — DOM-compatible</span>
-            <span class="pipe__reuse" data-mm-fade>the trick</span>
-          </div>
-        </div>
-      </div>
-      <div class="pipesplit__rail" aria-hidden="true" data-mm-fade>
-        <span class="pipesplit__arrow">&rarr;</span>
-        <span class="pipesplit__cap">ops</span>
-      </div>
-      <div class="pipesplit__side" data-flip="vr-col-mt">
-        <p class="pipesplit__lab" data-flip="vr-lab-mt"><i></i>Main · interpreter</p>
-        <div class="pipe pipe--side">
-          <div class="pipe__layer pipe__layer--main" data-flip="vr-l6">
-            <span class="k">main</span><span class="t">ops stream &rarr; native elements</span>
-          </div>
-        </div>
-      </div>
-    </div>
-    <p class="lead" data-mm-fade>
-      Make BG <em>look like</em> the DOM — <code>@vue/runtime-vapor</code> ships
-      unmodified; those calls become the same ops vdom already uses.
-    </p>
-    <aside class="notes">
-      <p><strong>The reuse story, still the same layers.</strong> Two green badges light up on the BG stack: <code>@vue/runtime-vapor</code> is <em>unmodified</em> because ShadowElement answers <code>insertBefore</code> / <code>cloneNode</code> / <code>setAttribute</code>. Those calls become the ops stream on Main — the same one vdom mode already uses.</p>
-    </aside>
-  </section>
-
-  <!-- V·10 — Workflow: one source, two renderers, verified -->
-  <section class="slide stage" data-bg="clean">
-    <div class="vsplit">
-      <div class="vsource">
-        <span class="node__label" style="color:var(--ink)">App.vue</span>
-        <span class="vrender__meta">byte-identical source<br/>+ one <code>vapor</code> attr</span>
-      </div>
-      <span class="vflow__arr is-brand" style="font-size:clamp(22px,2.6cqw,34px)">&rarr;</span>
-      <div class="vsplit__fork">
-        <div class="vrender vrender--teal">
-          <span class="vrender__name">VDOM</span>
-          <span class="vrender__meta">48 / 48 examples pass</span>
-        </div>
-        <div class="vrender vrender--vue">
-          <span class="vrender__name">Vapor</span>
-          <span class="vrender__meta">36 supported · <b>0.000%</b> visual diff</span>
-        </div>
-      </div>
-    </div>
-    <p class="lead" data-mm-fade>
-      Every example built &amp; driven in both modes through Lynx for Web.
-      The support matrix is generated from the run — it can't drift from what
-      actually passed.
-    </p>
-    <aside class="notes">
-      <p><strong>How we trust it.</strong> The Vapor app is <em>generated from the vdom source</em> — the only difference is the <code>vapor</code> attribute, so the workload is byte-for-byte identical. 36/36 supported examples hit 0.000% pixel diff against their vdom twin.</p>
-      <p>The matrix (<code>examples/vapor-support.json</code>, with per-entry source hashes) generates the docs table — it can't drift from the verification output.</p>
-    </aside>
-  </section>
-
   <!-- V·10b — Upstream Vapor tests + host-fit (styled like the VDOM proof slide A7) -->
   <section class="slide stage" data-bg="clean">
     <div class="mega" style="font-size:clamp(52px,9cqw,140px)">
@@ -3098,6 +2969,36 @@ app.<span class="code-fn">use</span>(router)</pre>
       <p><strong>The skips aren't a broken list.</strong> SSR/hydration + vdom↔vapor interop are 57% of everything that doesn't run — neither is a Lynx-compatibility signal (no SSR surface exists; interop is deliberately unsupported). Browser-only platform is another 24%. Test-infra is under 1% — vs vdom's dominant 59% — because the raw-bundle re-export trick killed the private-import problem. The port even found a real bug (ShadowElement was reactivity-proxyable; <code>__v_skip</code> fixed it).</p>
       <p><strong>The affinity point.</strong> On the tests that touch the actual element surface, Vapor passes 81% vs vdom's 57% — and needs <em>zero behavioral shims</em>: production <code>@vue/runtime-vapor</code> runs unmodified over ShadowElement, where vdom mode needed 1,074 LOC of simulation in the execution path. Vapor's host contract — clone a template + imperative setters — is just a closer fit to Lynx. (Contract fit, not speed.)</p>
       <p><strong>The mic-drop number — 7× VDOM.</strong> Cross-framework suite (ReactLynx vs Vue VDOM vs Vue Vapor), real clicks to composed-DOM end state. The Vue-vs-Vue headline: Vapor 7.0× VDOM on the 10k select storm, 1.9× on update storm — same app, same bundle, one attribute apart.</p>
+    </aside>
+  </section>
+
+  <!-- V·10 — Workflow: one source, two renderers, verified -->
+  <section class="slide stage" data-bg="clean">
+    <div class="vsplit">
+      <div class="vsource">
+        <span class="node__label" style="color:var(--ink)">App.vue</span>
+        <span class="vrender__meta">byte-identical source<br/>+ one <code>vapor</code> attr</span>
+      </div>
+      <span class="vflow__arr is-brand" style="font-size:clamp(22px,2.6cqw,34px)">&rarr;</span>
+      <div class="vsplit__fork">
+        <div class="vrender vrender--teal">
+          <span class="vrender__name">VDOM</span>
+          <span class="vrender__meta">48 / 48 examples pass</span>
+        </div>
+        <div class="vrender vrender--vue">
+          <span class="vrender__name">Vapor</span>
+          <span class="vrender__meta">36 supported · <b>0.000%</b> visual diff</span>
+        </div>
+      </div>
+    </div>
+    <p class="lead" data-mm-fade>
+      Every example built &amp; driven in both modes through Lynx for Web.
+      The support matrix is generated from the run — it can't drift from what
+      actually passed.
+    </p>
+    <aside class="notes">
+      <p><strong>How we trust it.</strong> The Vapor app is <em>generated from the vdom source</em> — the only difference is the <code>vapor</code> attribute, so the workload is byte-for-byte identical. 36/36 supported examples hit 0.000% pixel diff against their vdom twin.</p>
+      <p>The matrix (<code>examples/vapor-support.json</code>, with per-entry source hashes) generates the docs table — it can't drift from the verification output.</p>
     </aside>
   </section>
 
@@ -3149,7 +3050,96 @@ app.<span class="code-fn">use</span>(router)</pre>
     </p>
     <aside class="notes">
       <p><strong>The payoff of the morph.</strong> The three middle boxes just vanished. State and the target node stay put; a single reactive effect bridges them.</p>
-      <p>That's the whole idea: fine-grained updates instead of tree diffing.</p>
+      <p>That's the whole idea: fine-grained updates instead of tree diffing. Next: how that stack lands on Web vs Lynx.</p>
+    </aside>
+  </section>
+
+  <!-- V·6a — Web: single reuse pipe → browser DOM -->
+  <section class="slide stage" data-bg="clean">
+    <div class="pipe">
+      <div class="pipe__layer" data-flip="vr-l1">
+        <span class="k">compiled</span><span class="t">vapor component — <b>import 'vue'</b></span>
+      </div>
+      <div class="pipe__arr">&#9660;</div>
+      <div class="pipe__layer" data-flip="vr-l2">
+        <span class="k">alias</span><span class="t">'vue' &rarr; vue-lynx/vapor</span>
+      </div>
+      <div class="pipe__arr">&#9660;</div>
+      <div class="pipe__layer pipe__layer--key" data-flip="vr-l3">
+        <span class="k">runtime</span><span class="t">@vue/runtime-vapor</span>
+        <span class="pipe__reuse">unmodified</span>
+      </div>
+      <div class="pipe__arr">&#9660;</div>
+      <div class="pipe__layer" data-flip="vr-l4">
+        <span class="k">shims</span><span class="t">document · Node · Element</span>
+      </div>
+      <div class="pipe__arr">&#9660;</div>
+      <div class="pipe__layer pipe__layer--key" data-flip="vr-l5">
+        <span class="k">surface</span><span class="t">ShadowElement — DOM-compatible</span>
+        <span class="pipe__reuse">the trick</span>
+      </div>
+      <div class="pipe__arr">&#9660;</div>
+      <div class="pipe__layer pipe__layer--main" data-flip="vr-l6">
+        <span class="k">host</span><span class="t">browser DOM — HTMLElement</span>
+      </div>
+    </div>
+    <p class="lead" data-mm-fade>
+      Vapor drives the browser DOM directly — compiled through surface, one stack
+      ending at <code>HTMLElement</code>. Upstream runs untouched.
+    </p>
+    <aside class="notes">
+      <p><strong>The reuse story on Web.</strong> Two green layers are the whole idea: <code>@vue/runtime-vapor</code> ships <em>unmodified</em>, because underneath it a DOM-compatible surface answers standard DOM calls — <code>insertBefore</code>, <code>cloneNode</code>, <code>setAttribute</code>. On the Web that surface <em>is</em> the browser DOM.</p>
+    </aside>
+  </section>
+
+  <!-- V·6b — Lynx: same layers, split across BG | MT -->
+  <section class="slide stage" data-bg="clean">
+    <div class="pipesplit">
+      <div class="pipesplit__side" data-flip="vr-col-bg">
+        <p class="pipesplit__lab" data-flip="vr-lab-bg"><i></i>Background · Vapor</p>
+        <div class="pipe pipe--side">
+          <div class="pipe__layer" data-flip="vr-l1">
+            <span class="k">compiled</span><span class="t">vapor component — <b>import 'vue'</b></span>
+          </div>
+          <div class="pipe__arr">&#9660;</div>
+          <div class="pipe__layer" data-flip="vr-l2">
+            <span class="k">alias</span><span class="t">'vue' &rarr; vue-lynx/vapor</span>
+          </div>
+          <div class="pipe__arr">&#9660;</div>
+          <div class="pipe__layer pipe__layer--key" data-flip="vr-l3">
+            <span class="k">runtime</span><span class="t">@vue/runtime-vapor</span>
+            <span class="pipe__reuse" data-mm-fade>unmodified</span>
+          </div>
+          <div class="pipe__arr">&#9660;</div>
+          <div class="pipe__layer" data-flip="vr-l4">
+            <span class="k">shims</span><span class="t">document · Node · Element</span>
+          </div>
+          <div class="pipe__arr">&#9660;</div>
+          <div class="pipe__layer pipe__layer--key" data-flip="vr-l5">
+            <span class="k">surface</span><span class="t">ShadowElement — DOM-compatible</span>
+            <span class="pipe__reuse" data-mm-fade>the trick</span>
+          </div>
+        </div>
+      </div>
+      <div class="pipesplit__rail" aria-hidden="true" data-mm-fade>
+        <span class="pipesplit__arrow">&rarr;</span>
+        <span class="pipesplit__cap">ops</span>
+      </div>
+      <div class="pipesplit__side" data-flip="vr-col-mt">
+        <p class="pipesplit__lab" data-flip="vr-lab-mt"><i></i>Main · interpreter</p>
+        <div class="pipe pipe--side">
+          <div class="pipe__layer pipe__layer--main" data-flip="vr-l6">
+            <span class="k">main</span><span class="t">ops stream &rarr; native elements</span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <p class="lead" data-mm-fade>
+      On Lynx, relocate the pipe: BG holds the DOM-shaped stack;
+      MT only ever sees the ops stream.
+    </p>
+    <aside class="notes">
+      <p><strong>Same layers, dual-thread home.</strong> compiled / alias / runtime / shims / ShadowElement stay on the background thread; <code>ops stream → native</code> sits on Main. Two green badges: <code>@vue/runtime-vapor</code> is <em>unmodified</em> because ShadowElement answers <code>insertBefore</code> / <code>cloneNode</code> / <code>setAttribute</code> — those calls become the ops stream vdom already uses.</p>
     </aside>
   </section>
 

--- a/slides/index.html
+++ b/slides/index.html
@@ -3188,9 +3188,15 @@ app.<span class="code-fn">use</span>(router)</pre>
       First question on Lynx: where does the template shape live on Main?
       <em>Not</em> baked into MTS — the first <code>t0()</code> ships this <code>structure</code> once.
     </p>
+    <p class="lead lead--sub" data-mm-fade style="margin-top:clamp(6px,1cqh,12px);font-size:clamp(14px,1.55cqw,20px)">
+      Why not deliver the tree at build time? History, not essence: upstream
+      Vapor codegen only emits an HTML string — BG parse + serialize was the
+      cheapest path.
+    </p>
     <aside class="notes">
       <p><strong>First question — what does Main actually receive?</strong> Vapor compiles to <code>template()</code> + <code>t0()</code> clone. On the Web that clone is the browser DOM. On Lynx the shape is <em>not</em> pre-placed in the MTS/Lepus bundle (unlike Element Templates&rsquo; baked <code>create()</code>).</p>
-      <p>On the <em>first</em> <code>t0()</code>, BG walks the inert ShadowElement prototype into a <code>TemplateNode</code> AST — <code>[tag, props|0, children[]]</code> — and pushes <code>REGISTER_TREE</code> once: <code>[16, treeId, structure, 0]</code>. Main only caches <code>{ structure }</code>; natives appear later on <code>CLONE_TREE</code>. Next: why the live pointers from <code>child(n0)</code> still can&rsquo;t cross the boundary.</p>
+      <p>On the <em>first</em> <code>t0()</code>, BG walks the inert ShadowElement prototype into a <code>TemplateNode</code> AST — <code>[tag, props|0, children[]]</code> — and pushes <code>REGISTER_TREE</code> once: <code>[16, treeId, structure, 0]</code>. Main only caches <code>{ structure }</code>; natives appear later on <code>CLONE_TREE</code>.</p>
+      <p><strong>Why not bake it at build time?</strong> Historical, not essential. Upstream Vapor&rsquo;s codegen only hands you an HTML string (<code>template('&lt;view&gt;…&lt;/view&gt;')</code>). The cheapest Lynx path was: BG runtime parses that string into ShadowElement, then serializes the same tree for <code>REGISTER_TREE</code>. A compile-time residual (ET-style) is still on the table — we just haven&rsquo;t paid for that codegen yet. Next: why the live pointers from <code>child(n0)</code> still can&rsquo;t cross the boundary.</p>
     </aside>
   </section>
 

--- a/slides/index.html
+++ b/slides/index.html
@@ -2934,113 +2934,102 @@ app.<span class="code-fn">use</span>(router)</pre>
     </aside>
   </section>
 
-  <!-- V·6a — Code reuse as dual-thread cols (BG DOM-shaped · MT ops) -->
-  <section class="slide stage">
-    <div class="ifrjoin ifrjoin--pipe ifrjoin--linked">
-      <div class="ifrjoin__cols">
-        <div class="ifrjoin__col" data-flip="vr-col-bg" style="--c:#5dd5a8">
-          <span class="ifrjoin__label" data-flip="vr-lab-bg"><i></i>Background · Vapor</span>
-          <span class="ifrjoin__role" data-mm-fade>DOM-shaped stack</span>
-          <div class="ifrjoin__stack">
-            <code class="ifrjoin__op" data-flip="vr-bg-1">compiled · import 'vue'</code>
-            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
-            <code class="ifrjoin__op" data-mm-fade>alias → vue-lynx/vapor</code>
-            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
-            <code class="ifrjoin__op" data-mm-fade>@vue/runtime-vapor</code>
-            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
-            <code class="ifrjoin__op" data-mm-fade>document · Node · Element</code>
-            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
-            <code class="ifrjoin__op" data-flip="vr-bg-5">ShadowElement</code>
+  <!-- V·6a — original pipe layers, split across BG | MT -->
+  <section class="slide stage" data-bg="clean">
+    <div class="pipesplit">
+      <div class="pipesplit__side" data-flip="vr-col-bg">
+        <p class="pipesplit__lab" data-flip="vr-lab-bg"><i></i>Background · Vapor</p>
+        <div class="pipe pipe--side">
+          <div class="pipe__layer" data-flip="vr-l1">
+            <span class="k">compiled</span><span class="t">vapor component — <b>import 'vue'</b></span>
           </div>
-          <span class="ifrjoin__hint" data-mm-fade>looks like the DOM</span>
-        </div>
-        <div class="ifrjoin__links">
-          <span class="ifrjoin__linkhead" data-mm-fade>5 steps</span>
-          <div class="ifrjoin__stack">
-            <span class="ifrjoin__link" data-flip="vrp-1" style="--c:#42b883"><b>1</b> compile</span>
-            <span class="ifrjoin__arr ifrjoin__arr--ghost" aria-hidden="true">&darr;</span>
-            <span class="ifrjoin__link" data-mm-fade style="--c:#E8B44A"><b>2</b> alias</span>
-            <span class="ifrjoin__arr ifrjoin__arr--ghost" aria-hidden="true">&darr;</span>
-            <span class="ifrjoin__link" data-mm-fade style="--c:#4FB8F0"><b>3</b> runtime</span>
-            <span class="ifrjoin__arr ifrjoin__arr--ghost" aria-hidden="true">&darr;</span>
-            <span class="ifrjoin__link" data-mm-fade style="--c:#9E86F0"><b>4</b> shims</span>
-            <span class="ifrjoin__arr ifrjoin__arr--ghost" aria-hidden="true">&darr;</span>
-            <span class="ifrjoin__link" data-flip="vrp-5" style="--c:#F27A9E"><b>5</b> ops</span>
+          <div class="pipe__arr">&#9660;</div>
+          <div class="pipe__layer" data-flip="vr-l2">
+            <span class="k">alias</span><span class="t">'vue' &rarr; vue-lynx/vapor</span>
+          </div>
+          <div class="pipe__arr">&#9660;</div>
+          <div class="pipe__layer" data-flip="vr-l3">
+            <span class="k">runtime</span><span class="t">@vue/runtime-vapor</span>
+          </div>
+          <div class="pipe__arr">&#9660;</div>
+          <div class="pipe__layer" data-flip="vr-l4">
+            <span class="k">shims</span><span class="t">document · Node · Element</span>
+          </div>
+          <div class="pipe__arr">&#9660;</div>
+          <div class="pipe__layer" data-flip="vr-l5">
+            <span class="k">surface</span><span class="t">ShadowElement — DOM-compatible</span>
           </div>
         </div>
-        <div class="ifrjoin__col" data-flip="vr-col-mt" style="--c:#56b8f0">
-          <span class="ifrjoin__label" data-flip="vr-lab-mt"><i></i>Main · interpreter</span>
-          <span class="ifrjoin__role" data-mm-fade>write / ops only</span>
-          <div class="ifrjoin__stack">
-            <code class="ifrjoin__op is-idle" data-flip="vr-mt-1">awaits stream</code>
-            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
-            <code class="ifrjoin__op is-idle" data-mm-fade>…</code>
-            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
-            <code class="ifrjoin__op is-idle" data-mm-fade>…</code>
-            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
-            <code class="ifrjoin__op" data-mm-fade>ops stream</code>
-            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
-            <code class="ifrjoin__op" data-flip="vr-mt-5">applyOps → native</code>
+      </div>
+      <div class="pipesplit__rail" aria-hidden="true" data-mm-fade>
+        <span class="pipesplit__arrow">&rarr;</span>
+        <span class="pipesplit__cap">ops</span>
+      </div>
+      <div class="pipesplit__side" data-flip="vr-col-mt">
+        <p class="pipesplit__lab" data-flip="vr-lab-mt"><i></i>Main · interpreter</p>
+        <div class="pipe pipe--side">
+          <div class="pipe__layer pipe__layer--main" data-flip="vr-l6">
+            <span class="k">main</span><span class="t">ops stream &rarr; native elements</span>
           </div>
-          <span class="ifrjoin__hint" data-mm-fade>no sync DOM walk from BG</span>
         </div>
       </div>
     </div>
-    <p class="lead arch-cap" data-mm-fade>
-      Vapor expects a browser DOM. Split across threads: BG gets a
-      DOM-<em>shaped</em> tree; MT only ever sees the ops stream.
+    <p class="lead" data-mm-fade>
+      Same layers as before — BG holds the DOM-shaped stack; MT only sees the ops stream.
     </p>
     <aside class="notes">
-      <p><strong>Same dual-thread columns as the IFR arc — read left, then right.</strong> Background: compiled Vapor still says <code>import 'vue'</code>, aliases into <code>vue-lynx/vapor</code>, and runs <code>@vue/runtime-vapor</code> over DOM shims onto <code>ShadowElement</code>. Main: write/ops only — no sync <code>firstChild</code> walk from BG. Five linked steps cross the boundary. Next slide folds the reuse punchline into those columns.</p>
+      <p><strong>Just relocate the pipe.</strong> The six layers didn&rsquo;t change — compiled / alias / runtime / shims / ShadowElement sit on the background thread; <code>ops stream → native</code> sits on Main. Next beat: light up the two reuse layers.</p>
     </aside>
   </section>
 
-  <!-- V·6b — reuse punchline: unmodified runtime + shared ops (magic-move) -->
-  <section class="slide stage">
-    <div class="ifrjoin ifrjoin--pipe ifrjoin--linked">
-      <div class="ifrjoin__cols">
-        <div class="ifrjoin__col" data-flip="vr-col-bg" style="--c:#5dd5a8">
-          <span class="ifrjoin__label" data-flip="vr-lab-bg"><i></i>Background · Vapor</span>
-          <span class="ifrjoin__role" data-mm-fade>upstream runs untouched</span>
-          <div class="ifrjoin__stack">
-            <code class="ifrjoin__op" data-flip="vr-bg-1">compiled · import 'vue'</code>
-            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
-            <code class="ifrjoin__op is-hero" data-mm-fade>@vue/runtime-vapor · unmodified</code>
-            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
-            <code class="ifrjoin__op is-hero" data-flip="vr-bg-5">ShadowElement · the trick</code>
+  <!-- V·6b — same split; highlight unmodified + the trick (magic-move) -->
+  <section class="slide stage" data-bg="clean">
+    <div class="pipesplit">
+      <div class="pipesplit__side" data-flip="vr-col-bg">
+        <p class="pipesplit__lab" data-flip="vr-lab-bg"><i></i>Background · Vapor</p>
+        <div class="pipe pipe--side">
+          <div class="pipe__layer" data-flip="vr-l1">
+            <span class="k">compiled</span><span class="t">vapor component — <b>import 'vue'</b></span>
           </div>
-          <span class="ifrjoin__hint" data-mm-fade>cloneNode · insertBefore · setAttribute</span>
+          <div class="pipe__arr">&#9660;</div>
+          <div class="pipe__layer" data-flip="vr-l2">
+            <span class="k">alias</span><span class="t">'vue' &rarr; vue-lynx/vapor</span>
+          </div>
+          <div class="pipe__arr">&#9660;</div>
+          <div class="pipe__layer pipe__layer--key" data-flip="vr-l3">
+            <span class="k">runtime</span><span class="t">@vue/runtime-vapor</span>
+            <span class="pipe__reuse" data-mm-fade>unmodified</span>
+          </div>
+          <div class="pipe__arr">&#9660;</div>
+          <div class="pipe__layer" data-flip="vr-l4">
+            <span class="k">shims</span><span class="t">document · Node · Element</span>
+          </div>
+          <div class="pipe__arr">&#9660;</div>
+          <div class="pipe__layer pipe__layer--key" data-flip="vr-l5">
+            <span class="k">surface</span><span class="t">ShadowElement — DOM-compatible</span>
+            <span class="pipe__reuse" data-mm-fade>the trick</span>
+          </div>
         </div>
-        <div class="ifrjoin__links">
-          <span class="ifrjoin__linkhead" data-mm-fade>3 steps</span>
-          <div class="ifrjoin__stack">
-            <span class="ifrjoin__link" data-flip="vrp-1" style="--c:#42b883"><b>1</b> vapor</span>
-            <span class="ifrjoin__arr ifrjoin__arr--ghost" aria-hidden="true">&darr;</span>
-            <span class="ifrjoin__link is-hero" data-mm-fade style="--c:#5dd5a8"><b>2</b> Shadow</span>
-            <span class="ifrjoin__arr ifrjoin__arr--ghost" aria-hidden="true">&darr;</span>
-            <span class="ifrjoin__link" data-flip="vrp-5" style="--c:#F27A9E"><b>3</b> ops</span>
+      </div>
+      <div class="pipesplit__rail" aria-hidden="true" data-mm-fade>
+        <span class="pipesplit__arrow">&rarr;</span>
+        <span class="pipesplit__cap">ops</span>
+      </div>
+      <div class="pipesplit__side" data-flip="vr-col-mt">
+        <p class="pipesplit__lab" data-flip="vr-lab-mt"><i></i>Main · interpreter</p>
+        <div class="pipe pipe--side">
+          <div class="pipe__layer pipe__layer--main" data-flip="vr-l6">
+            <span class="k">main</span><span class="t">ops stream &rarr; native elements</span>
           </div>
-        </div>
-        <div class="ifrjoin__col" data-flip="vr-col-mt" style="--c:#56b8f0">
-          <span class="ifrjoin__label" data-flip="vr-lab-mt"><i></i>Main · interpreter</span>
-          <span class="ifrjoin__role" data-mm-fade>same ops stream as vdom</span>
-          <div class="ifrjoin__stack">
-            <code class="ifrjoin__op" data-flip="vr-mt-1">DOM calls → ops</code>
-            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
-            <code class="ifrjoin__op is-hero" data-mm-fade>ops stream</code>
-            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
-            <code class="ifrjoin__op is-hero" data-flip="vr-mt-5">applyOps → native</code>
-          </div>
-          <span class="ifrjoin__hint" data-mm-fade>shared with vdom mode</span>
         </div>
       </div>
     </div>
-    <p class="lead arch-cap" data-mm-fade>
+    <p class="lead" data-mm-fade>
       Make BG <em>look like</em> the DOM — <code>@vue/runtime-vapor</code> ships
       unmodified; those calls become the same ops vdom already uses.
     </p>
     <aside class="notes">
-      <p><strong>Same figure, fewer links — the reuse punchline.</strong> Watch steps 2–4 fold into <code>ShadowElement</code>: <code>@vue/runtime-vapor</code> stays <em>unmodified</em> because the surface answers <code>insertBefore</code> / <code>cloneNode</code> / <code>setAttribute</code>. Those calls serialize into the ops stream Main already knows from vdom mode. Contract fit, not a fork.</p>
+      <p><strong>The reuse story, still the same layers.</strong> Two green badges light up on the BG stack: <code>@vue/runtime-vapor</code> is <em>unmodified</em> because ShadowElement answers <code>insertBefore</code> / <code>cloneNode</code> / <code>setAttribute</code>. Those calls become the ops stream on Main — the same one vdom mode already uses.</p>
     </aside>
   </section>
 

--- a/slides/index.html
+++ b/slides/index.html
@@ -3143,53 +3143,54 @@ app.<span class="code-fn">use</span>(router)</pre>
     </aside>
   </section>
 
-  <!-- V·5 — The Vapor output (compiled code) -->
+  <!-- V·5 — Compiled output + first question: structure ships once (not baked into MTS) -->
   <section class="slide stage" data-bg="clean">
-    <div style="display:flex;align-items:center;gap:clamp(14px,2.2cqw,36px);width:100%;justify-content:center">
-      <div class="codeframe" style="text-align:left;flex:0 0 auto">
-        <div class="codeframe__head">
-          <span class="dots"><span></span><span></span><span></span></span>
-          <span>Counter.vue</span>
-        </div>
-<pre><span class="code-tag">&lt;script setup vapor&gt;</span>
-<span class="code-key">const</span> count <span class="code-key">=</span> <span class="code-fn">ref</span>(<span class="code-str">0</span>)
-<span class="code-tag">&lt;/script&gt;</span>
-
-<span class="code-tag">&lt;template&gt;</span>
-  <span class="code-tag">&lt;view</span> <span class="code-attr">@tap</span>=<span class="code-str">"count++"</span><span class="code-tag">&gt;</span>
-    <span class="code-tag">&lt;text&gt;</span>Count: {{ count }}<span class="code-tag">&lt;/text&gt;</span>
-  <span class="code-tag">&lt;/view&gt;</span>
-<span class="code-tag">&lt;/template&gt;</span></pre>
-      </div>
-      <span class="vflow__arr is-brand" style="font-size:clamp(22px,2.6cqw,34px)">&rarr;</span>
-      <div class="codeframe" style="text-align:left;flex:0 1 auto">
+    <div style="display:flex;align-items:stretch;gap:clamp(10px,1.6cqw,24px);width:100%;justify-content:center;max-width:1180px">
+      <div class="codeframe" style="text-align:left;flex:0 1 34%;min-width:0">
         <div class="codeframe__head">
           <span class="dots"><span></span><span></span><span></span></span>
           <span>compiled · vapor</span>
         </div>
-<pre><span class="code-key">import</span> { <span class="code-fn">template</span>, <span class="code-fn">child</span>, <span class="code-fn">renderEffect</span>, <span class="code-fn">setText</span>, <span class="code-fn">on</span> } <span class="code-key">from</span> <span class="code-str">'vue'</span>
-
-<span class="code-com">// <span class="codenote">&#9312;</span> register the static shape — once</span>
-<span class="code-key">const</span> t0 <span class="code-key">=</span> <span class="code-fn">template</span>(<span class="code-str">'&lt;view&gt;&lt;text/&gt;&lt;/view&gt;'</span>)
+<pre><span class="code-key">const</span> t0 <span class="code-key">=</span> <span class="code-fn">template</span>(
+  <span class="code-str">'&lt;view&gt;&lt;text/&gt;&lt;/view&gt;'</span>
+)
 
 <span class="code-key">function</span> <span class="code-fn">render</span>(_ctx) {
-  <span class="code-key">const</span> n0 <span class="code-key">=</span> <span class="code-fn">t0</span>()            <span class="code-com">// <span class="codenote">&#9313;</span> clone it</span>
+  <span class="code-key">const</span> n0 <span class="code-key">=</span> <span class="code-fn">t0</span>()  <span class="code-com">// first clone</span>
   <span class="code-key">const</span> n1 <span class="code-key">=</span> <span class="code-fn">child</span>(n0)
   <span class="code-fn">on</span>(n0, <span class="code-str">'tap'</span>, () <span class="code-key">=&gt;</span> _ctx.count<span class="code-key">++</span>)
-  <span class="code-fn">renderEffect</span>(() <span class="code-key">=&gt;</span>       <span class="code-com">// <span class="codenote">&#9314;</span> fine-grained</span>
+  <span class="code-fn">renderEffect</span>(() <span class="code-key">=&gt;</span>
     <span class="code-fn">setText</span>(n1, <span class="code-str">'Count: '</span>, _ctx.count))
   <span class="code-key">return</span> n0
 }</pre>
       </div>
+      <span class="vflow__arr is-brand" style="font-size:clamp(20px,2.4cqw,32px);align-self:center">&rarr;</span>
+      <div class="codeframe" style="text-align:left;flex:1 1 58%;min-width:0">
+        <div class="codeframe__head">
+          <span class="dots"><span></span><span></span><span></span></span>
+          <span>REGISTER_TREE · first t0() only</span>
+        </div>
+<pre><span class="code-com">// not pre-baked into the MTS bundle —</span>
+<span class="code-com">// BG ships a data AST on the first clone</span>
+<span class="code-fn">pushOp</span>(OP.<span class="code-fn">REGISTER_TREE</span>, treeId, structure, <span class="code-str">0</span>)
+<span class="code-com">// wire: [16, treeId, structure, addressedOr0]</span>
+
+<span class="code-key">const</span> structure <span class="code-key">=</span> [                   <span class="code-com">// TemplateNode</span>
+  <span class="code-str">'view'</span>, <span class="code-str">0</span>, [
+    [<span class="code-str">'text'</span>, <span class="code-str">0</span>, []]
+  ]
+]
+<span class="code-com">// MT: templates.set(treeId, { structure })</span>
+<span class="code-com">//     — cache only; no native elements yet</span></pre>
+      </div>
     </div>
     <p class="lead" data-mm-fade>
-      <span class="codenote">&#9312;</span> a template registered once ·
-      <span class="codenote">&#9313;</span> cloned per instance ·
-      <span class="codenote">&#9314;</span> one effect that updates a single node.
+      First question on Lynx: where does the template shape live on Main?
+      <em>Not</em> baked into MTS — the first <code>t0()</code> ships this <code>structure</code> once.
     </p>
     <aside class="notes">
-      <p><strong>Read the right panel.</strong> Three moves: <code>template()</code> declares the static shape once; <code>t0()</code> clones it; <code>renderEffect()</code> is the only thing that re-runs — and it touches exactly one text node.</p>
-      <p>Note <code>from 'vue'</code> — the component doesn't know it's on Lynx. Next: why those live pointers are a problem across threads.</p>
+      <p><strong>First question — what does Main actually receive?</strong> Vapor compiles to <code>template()</code> + <code>t0()</code> clone. On the Web that clone is the browser DOM. On Lynx the shape is <em>not</em> pre-placed in the MTS/Lepus bundle (unlike Element Templates&rsquo; baked <code>create()</code>).</p>
+      <p>On the <em>first</em> <code>t0()</code>, BG walks the inert ShadowElement prototype into a <code>TemplateNode</code> AST — <code>[tag, props|0, children[]]</code> — and pushes <code>REGISTER_TREE</code> once: <code>[16, treeId, structure, 0]</code>. Main only caches <code>{ structure }</code>; natives appear later on <code>CLONE_TREE</code>. Next: why the live pointers from <code>child(n0)</code> still can&rsquo;t cross the boundary.</p>
     </aside>
   </section>
 
@@ -3326,9 +3327,9 @@ app.<span class="code-fn">use</span>(router)</pre>
       <div class="xwire">
         <div class="xwire__op">
           <span class="xwire__name">REGISTER_TREE</span>
-          <span class="xstruct"><i></i><i></i><i></i></span>
+          <span class="xwire__payload" data-mm-fade><code>[16, id, structure, 0]</code></span>
           <span class="xwire__line"></span>
-          <span class="xwire__count">once per template</span>
+          <span class="xwire__count">structure AST · first clone only</span>
         </div>
       </div>
       <div class="node node--main" data-flip="vx-mt">
@@ -3351,11 +3352,12 @@ app.<span class="code-fn">use</span>(router)</pre>
       </div>
     </div>
     <p class="lead" data-mm-fade>
-      Pointers can&rsquo;t cross the boundary — so both sides <em>walk the same pre-order</em> and name every node alike. No id map is ever sent.
+      That <code>structure</code> from the first <code>t0()</code> is cached on Main as an inert prototype.
+      Both sides walk the same pre-order — same uids, no id map.
     </p>
     <aside class="notes">
-      <p><strong>Names on the wire — step one.</strong> We just established Vapor needs addressable slots across threads. Sending every clone as create/append ops would make traffic <em>worse</em> than vdom.</p>
-      <p>Fix: send the structure once with <code>REGISTER_TREE</code>. Both threads assign element uids by walking it in the same pre-order — so no id map is ever transferred.</p>
+      <p><strong>Names on the wire — step one.</strong> We already saw the payload: a <code>TemplateNode</code> AST shipped once on the first clone — <em>not</em> baked into MTS. Main caches it as an inert prototype (still no natives).</p>
+      <p>Both threads assign element uids by walking that structure in the same pre-order — so no id map is ever transferred. Next beat: each instance is one <code>CLONE_TREE(base)</code>.</p>
     </aside>
   </section>
 

--- a/slides/index.html
+++ b/slides/index.html
@@ -24,7 +24,7 @@
     </button>
   </div>
   <div class="chrome chrome--bottom">
-    <span data-counter>01 / 129</span>
+    <span data-counter>01 / 132</span>
   </div>
   <div class="chrome chrome--bottom-right">
     <a href="https://vue.lynxjs.org" target="_blank" rel="noreferrer">vue.lynxjs.org</a>
@@ -2871,6 +2871,247 @@ app.<span class="code-fn">use</span>(router)</pre>
     </aside>
   </section>
 
+  <!-- V·8+9 — Benchmark: update speedup + ledger (merged) -->
+  <section class="slide stage" data-bg="clean">
+    <h2 class="h-section" style="text-align:center;font-size:clamp(24px,2.8cqw,40px);max-width:28ch;margin-bottom:clamp(8px,1.2cqh,14px)">
+      Where Vapor pulls away: <span class="brand-text">5.8–9.8&times;</span>.
+    </h2>
+    <div class="bench bench--compact">
+      <div class="bench__row">
+        <div class="bench__name">select row<small>2.95 &rarr; 0.30 ms</small></div>
+        <div class="bench__track"><div class="bench__fill" style="width:98%"></div></div>
+        <div class="bench__val">9.8&times;</div>
+      </div>
+      <div class="bench__row">
+        <div class="bench__name">remove row<small>2.85 &rarr; 0.40 ms</small></div>
+        <div class="bench__track"><div class="bench__fill" style="width:72%"></div></div>
+        <div class="bench__val">7.1&times;</div>
+      </div>
+      <div class="bench__row">
+        <div class="bench__name">swap rows<small>3.90 &rarr; 0.65 ms</small></div>
+        <div class="bench__track"><div class="bench__fill" style="width:61%"></div></div>
+        <div class="bench__val">6.0&times;</div>
+      </div>
+      <div class="bench__row">
+        <div class="bench__name">update every 10th<small>3.20 &rarr; 0.55 ms</small></div>
+        <div class="bench__track"><div class="bench__fill" style="width:59%"></div></div>
+        <div class="bench__val">5.8&times;</div>
+      </div>
+    </div>
+    <table class="btable btable--compact">
+      <thead>
+        <tr><th>metric · create-1k unless noted</th><th>vdom</th><th>vapor</th><th>delta</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="metric">create 1,000 rows · e2e</td>
+          <td>125.7 ms</td><td>144.5 ms</td>
+          <td class="flat">&asymp; parity</td>
+        </tr>
+        <tr>
+          <td class="metric">cross-thread ops / bytes</td>
+          <td>17k / 327 KB</td><td>7k / 160 KB</td>
+          <td class="win">&minus;59% / &minus;51%</td>
+        </tr>
+        <tr>
+          <td class="metric">bundle · gzip</td>
+          <td>39.2 KB</td><td>49.3 KB</td>
+          <td class="cost">+26%</td>
+        </tr>
+        <tr>
+          <td class="metric">first screen</td>
+          <td>121.7 ms</td><td>125.8 ms</td>
+          <td class="cost">+3%</td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="lead" data-mm-fade>
+      Big wins on updates and traffic; creation at parity; you pay in bundle size.
+    </p>
+    <aside class="notes">
+      <p><strong>The core result — then the honest scorecard.</strong> Vue&rsquo;s official benchmark, ported to Lynx, same app in both modes. Background-thread cost = reactivity + render + ops serialization — Vapor&rsquo;s structural win shows up unfiltered here (5.8–9.8×). End-to-end multipliers are smaller (2.1–6.3×) because both modes emit near-identical ops.</p>
+      <p>Don&rsquo;t oversell: creation is parity; the cost is a +26% bundle (Vapor runtime + DOM-compat shim). First screen is within noise. Green = win, pink = cost. Numbers: headless Chromium, Lynx for Web, medians with 95% CIs.</p>
+    </aside>
+  </section>
+
+  <!-- V·6a — Code reuse as dual-thread cols (BG DOM-shaped · MT ops) -->
+  <section class="slide stage">
+    <div class="ifrjoin ifrjoin--pipe ifrjoin--linked">
+      <div class="ifrjoin__cols">
+        <div class="ifrjoin__col" data-flip="vr-col-bg" style="--c:#5dd5a8">
+          <span class="ifrjoin__label" data-flip="vr-lab-bg"><i></i>Background · Vapor</span>
+          <span class="ifrjoin__role" data-mm-fade>DOM-shaped stack</span>
+          <div class="ifrjoin__stack">
+            <code class="ifrjoin__op" data-flip="vr-bg-1">compiled · import 'vue'</code>
+            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+            <code class="ifrjoin__op" data-mm-fade>alias → vue-lynx/vapor</code>
+            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+            <code class="ifrjoin__op" data-mm-fade>@vue/runtime-vapor</code>
+            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+            <code class="ifrjoin__op" data-mm-fade>document · Node · Element</code>
+            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+            <code class="ifrjoin__op" data-flip="vr-bg-5">ShadowElement</code>
+          </div>
+          <span class="ifrjoin__hint" data-mm-fade>looks like the DOM</span>
+        </div>
+        <div class="ifrjoin__links">
+          <span class="ifrjoin__linkhead" data-mm-fade>5 steps</span>
+          <div class="ifrjoin__stack">
+            <span class="ifrjoin__link" data-flip="vrp-1" style="--c:#42b883"><b>1</b> compile</span>
+            <span class="ifrjoin__arr ifrjoin__arr--ghost" aria-hidden="true">&darr;</span>
+            <span class="ifrjoin__link" data-mm-fade style="--c:#E8B44A"><b>2</b> alias</span>
+            <span class="ifrjoin__arr ifrjoin__arr--ghost" aria-hidden="true">&darr;</span>
+            <span class="ifrjoin__link" data-mm-fade style="--c:#4FB8F0"><b>3</b> runtime</span>
+            <span class="ifrjoin__arr ifrjoin__arr--ghost" aria-hidden="true">&darr;</span>
+            <span class="ifrjoin__link" data-mm-fade style="--c:#9E86F0"><b>4</b> shims</span>
+            <span class="ifrjoin__arr ifrjoin__arr--ghost" aria-hidden="true">&darr;</span>
+            <span class="ifrjoin__link" data-flip="vrp-5" style="--c:#F27A9E"><b>5</b> ops</span>
+          </div>
+        </div>
+        <div class="ifrjoin__col" data-flip="vr-col-mt" style="--c:#56b8f0">
+          <span class="ifrjoin__label" data-flip="vr-lab-mt"><i></i>Main · interpreter</span>
+          <span class="ifrjoin__role" data-mm-fade>write / ops only</span>
+          <div class="ifrjoin__stack">
+            <code class="ifrjoin__op is-idle" data-flip="vr-mt-1">awaits stream</code>
+            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+            <code class="ifrjoin__op is-idle" data-mm-fade>…</code>
+            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+            <code class="ifrjoin__op is-idle" data-mm-fade>…</code>
+            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+            <code class="ifrjoin__op" data-mm-fade>ops stream</code>
+            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+            <code class="ifrjoin__op" data-flip="vr-mt-5">applyOps → native</code>
+          </div>
+          <span class="ifrjoin__hint" data-mm-fade>no sync DOM walk from BG</span>
+        </div>
+      </div>
+    </div>
+    <p class="lead arch-cap" data-mm-fade>
+      Vapor expects a browser DOM. Split across threads: BG gets a
+      DOM-<em>shaped</em> tree; MT only ever sees the ops stream.
+    </p>
+    <aside class="notes">
+      <p><strong>Same dual-thread columns as the IFR arc — read left, then right.</strong> Background: compiled Vapor still says <code>import 'vue'</code>, aliases into <code>vue-lynx/vapor</code>, and runs <code>@vue/runtime-vapor</code> over DOM shims onto <code>ShadowElement</code>. Main: write/ops only — no sync <code>firstChild</code> walk from BG. Five linked steps cross the boundary. Next slide folds the reuse punchline into those columns.</p>
+    </aside>
+  </section>
+
+  <!-- V·6b — reuse punchline: unmodified runtime + shared ops (magic-move) -->
+  <section class="slide stage">
+    <div class="ifrjoin ifrjoin--pipe ifrjoin--linked">
+      <div class="ifrjoin__cols">
+        <div class="ifrjoin__col" data-flip="vr-col-bg" style="--c:#5dd5a8">
+          <span class="ifrjoin__label" data-flip="vr-lab-bg"><i></i>Background · Vapor</span>
+          <span class="ifrjoin__role" data-mm-fade>upstream runs untouched</span>
+          <div class="ifrjoin__stack">
+            <code class="ifrjoin__op" data-flip="vr-bg-1">compiled · import 'vue'</code>
+            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+            <code class="ifrjoin__op is-hero" data-mm-fade>@vue/runtime-vapor · unmodified</code>
+            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+            <code class="ifrjoin__op is-hero" data-flip="vr-bg-5">ShadowElement · the trick</code>
+          </div>
+          <span class="ifrjoin__hint" data-mm-fade>cloneNode · insertBefore · setAttribute</span>
+        </div>
+        <div class="ifrjoin__links">
+          <span class="ifrjoin__linkhead" data-mm-fade>3 steps</span>
+          <div class="ifrjoin__stack">
+            <span class="ifrjoin__link" data-flip="vrp-1" style="--c:#42b883"><b>1</b> vapor</span>
+            <span class="ifrjoin__arr ifrjoin__arr--ghost" aria-hidden="true">&darr;</span>
+            <span class="ifrjoin__link is-hero" data-mm-fade style="--c:#5dd5a8"><b>2</b> Shadow</span>
+            <span class="ifrjoin__arr ifrjoin__arr--ghost" aria-hidden="true">&darr;</span>
+            <span class="ifrjoin__link" data-flip="vrp-5" style="--c:#F27A9E"><b>3</b> ops</span>
+          </div>
+        </div>
+        <div class="ifrjoin__col" data-flip="vr-col-mt" style="--c:#56b8f0">
+          <span class="ifrjoin__label" data-flip="vr-lab-mt"><i></i>Main · interpreter</span>
+          <span class="ifrjoin__role" data-mm-fade>same ops stream as vdom</span>
+          <div class="ifrjoin__stack">
+            <code class="ifrjoin__op" data-flip="vr-mt-1">DOM calls → ops</code>
+            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+            <code class="ifrjoin__op is-hero" data-mm-fade>ops stream</code>
+            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+            <code class="ifrjoin__op is-hero" data-flip="vr-mt-5">applyOps → native</code>
+          </div>
+          <span class="ifrjoin__hint" data-mm-fade>shared with vdom mode</span>
+        </div>
+      </div>
+    </div>
+    <p class="lead arch-cap" data-mm-fade>
+      Make BG <em>look like</em> the DOM — <code>@vue/runtime-vapor</code> ships
+      unmodified; those calls become the same ops vdom already uses.
+    </p>
+    <aside class="notes">
+      <p><strong>Same figure, fewer links — the reuse punchline.</strong> Watch steps 2–4 fold into <code>ShadowElement</code>: <code>@vue/runtime-vapor</code> stays <em>unmodified</em> because the surface answers <code>insertBefore</code> / <code>cloneNode</code> / <code>setAttribute</code>. Those calls serialize into the ops stream Main already knows from vdom mode. Contract fit, not a fork.</p>
+    </aside>
+  </section>
+
+  <!-- V·10 — Workflow: one source, two renderers, verified -->
+  <section class="slide stage" data-bg="clean">
+    <div class="vsplit">
+      <div class="vsource">
+        <span class="node__label" style="color:var(--ink)">App.vue</span>
+        <span class="vrender__meta">byte-identical source<br/>+ one <code>vapor</code> attr</span>
+      </div>
+      <span class="vflow__arr is-brand" style="font-size:clamp(22px,2.6cqw,34px)">&rarr;</span>
+      <div class="vsplit__fork">
+        <div class="vrender vrender--teal">
+          <span class="vrender__name">VDOM</span>
+          <span class="vrender__meta">48 / 48 examples pass</span>
+        </div>
+        <div class="vrender vrender--vue">
+          <span class="vrender__name">Vapor</span>
+          <span class="vrender__meta">36 supported · <b>0.000%</b> visual diff</span>
+        </div>
+      </div>
+    </div>
+    <p class="lead" data-mm-fade>
+      Every example built &amp; driven in both modes through Lynx for Web.
+      The support matrix is generated from the run — it can't drift from what
+      actually passed.
+    </p>
+    <aside class="notes">
+      <p><strong>How we trust it.</strong> The Vapor app is <em>generated from the vdom source</em> — the only difference is the <code>vapor</code> attribute, so the workload is byte-for-byte identical. 36/36 supported examples hit 0.000% pixel diff against their vdom twin.</p>
+      <p>The matrix (<code>examples/vapor-support.json</code>, with per-entry source hashes) generates the docs table — it can't drift from the verification output.</p>
+    </aside>
+  </section>
+
+  <!-- V·10b — Upstream Vapor tests + host-fit (styled like the VDOM proof slide A7) -->
+  <section class="slide stage" data-bg="clean">
+    <div class="mega" style="font-size:clamp(52px,9cqw,140px)">
+      <span class="brand-text">545</span><small style="font-size:0.4em;color:var(--ink-mute)"> / 671 run · 0 fail</small>
+    </div>
+    <div class="skipbar">
+      <div class="skipbar__track">
+        <span class="skipbar__seg" style="flex:37;background:#F27A9E"></span>
+        <span class="skipbar__seg" style="flex:24;background:#4FB8F0"></span>
+        <span class="skipbar__seg" style="flex:20;background:#9E86F0"></span>
+        <span class="skipbar__seg" style="flex:18;background:#3deae7"></span>
+        <span class="skipbar__seg" style="flex:1;background:#8b93a3"></span>
+      </div>
+      <div class="skipbar__legend">
+        <span><i style="background:#F27A9E"></i><b>37%</b> SSR / hydration</span>
+        <span><i style="background:#4FB8F0"></i><b>24%</b> browser-only</span>
+        <span><i style="background:#9E86F0"></i><b>20%</b> vdom↔vapor interop</span>
+        <span><i style="background:#3deae7"></i><b>18%</b> Lynx diffs</span>
+        <span><i style="background:#8b93a3"></i><b>&lt;1%</b> test-infra</span>
+      </div>
+    </div>
+    <div class="affinity">
+      <span><b>81%</b> Vapor</span>
+      <span class="vs">vs</span>
+      <span class="aff-vdom"><b>57%</b> VDOM</span>
+    </div>
+    <p class="lead" data-mm-fade>
+      Vapor's own suite — <b>unmodified</b> on ShadowElement. It passes the
+      element-surface tests at 81% vs vdom's 57%: the closer fit to Lynx.
+    </p>
+    <aside class="notes">
+      <p><strong>Vapor gets its own upstream suite (PR #232).</strong> 30 <code>runtime-vapor</code> spec files run against the real <code>vue-lynx/vapor</code> surface and ShadowElement tree: <strong>545 pass, 120 skip, 0 fail</strong>. The skiplist is a <em>closed inventory</em> — every excluded test carries a reason, config load fails on anything unclassified.</p>
+      <p><strong>The skips aren't a broken list.</strong> SSR/hydration + vdom↔vapor interop are 57% of everything that doesn't run — neither is a Lynx-compatibility signal (no SSR surface exists; interop is deliberately unsupported). Browser-only platform is another 24%. Test-infra is under 1% — vs vdom's dominant 59% — because the raw-bundle re-export trick killed the private-import problem. The port even found a real bug (ShadowElement was reactivity-proxyable; <code>__v_skip</code> fixed it).</p>
+      <p><strong>The affinity point.</strong> On the tests that touch the actual element surface, Vapor passes 81% vs vdom's 57% — and needs <em>zero behavioral shims</em>: production <code>@vue/runtime-vapor</code> runs unmodified over ShadowElement, where vdom mode needed 1,074 LOC of simulation in the execution path. Vapor's host contract — clone a template + imperative setters — is just a closer fit to Lynx. (Contract fit, not speed.)</p>
+      <p><strong>The mic-drop number — 7× VDOM.</strong> Cross-framework suite (ReactLynx vs Vue VDOM vs Vue Vapor), real clicks to composed-DOM end state. The Vue-vs-Vue headline: Vapor 7.0× VDOM on the 10k select storm, 1.9× on update storm — same app, same bundle, one attribute apart.</p>
+    </aside>
+  </section>
+
   <!-- V·3 — Virtual DOM update path (concept, magic-move A) -->
   <section class="slide stage" data-bg="clean">
     <div class="vflow">
@@ -2969,45 +3210,116 @@ app.<span class="code-fn">use</span>(router)</pre>
     </p>
     <aside class="notes">
       <p><strong>Read the right panel.</strong> Three moves: <code>template()</code> declares the static shape once; <code>t0()</code> clones it; <code>renderEffect()</code> is the only thing that re-runs — and it touches exactly one text node.</p>
-      <p>Note <code>from 'vue'</code> — the component doesn't know it's on Lynx. That's the next slide.</p>
+      <p>Note <code>from 'vue'</code> — the component doesn't know it's on Lynx. Next: why those live pointers are a problem across threads.</p>
     </aside>
   </section>
 
-  <!-- V·6 — Code reuse: unmodified runtime-vapor on a DOM-shaped surface -->
-  <section class="slide stage" data-bg="clean">
-    <div class="pipe">
-      <div class="pipe__layer">
-        <span class="k">compiled</span><span class="t">vapor component — <b>import 'vue'</b></span>
+  <!-- E20pre-a — problem: Vapor needs DOM pointers; pointers can't cross -->
+  <section class="slide stage dspace" data-bg="clean">
+    <div style="display:flex;align-items:stretch;gap:clamp(16px,2.4cqw,40px);width:100%;justify-content:center;max-width:1080px">
+      <div class="codeframe" style="text-align:left;flex:1 1 0;min-width:0">
+        <div class="codeframe__head">
+          <span class="dots"><span></span><span></span><span></span></span>
+          <span>compiled · vapor</span>
+        </div>
+<pre><span class="code-key">const</span> n0 <span class="code-key">=</span> <span class="code-fn">t0</span>()
+<span class="code-key">const</span> n1 <span class="code-key">=</span> <span class="code-fn">child</span>(n0)     <span class="code-com">// walk → live pointer</span>
+<span class="code-fn">renderEffect</span>(() <span class="code-key">=&gt;</span>
+  <span class="code-fn">setText</span>(n1, <span class="code-str">'Count: '</span>, count))
+
+<span class="code-com">// HTML DOM does this walk too —</span>
+<span class="code-com">// firstChild / nextSibling</span></pre>
       </div>
-      <div class="pipe__arr">&#9660;</div>
-      <div class="pipe__layer">
-        <span class="k">alias</span><span class="t">'vue' &rarr; vue-lynx/vapor</span>
-      </div>
-      <div class="pipe__arr">&#9660;</div>
-      <div class="pipe__layer pipe__layer--key">
-        <span class="k">runtime</span><span class="t">@vue/runtime-vapor</span>
-        <span class="pipe__reuse">unmodified</span>
-      </div>
-      <div class="pipe__arr">&#9660;</div>
-      <div class="pipe__layer">
-        <span class="k">shims</span><span class="t">document · Node · Element</span>
-      </div>
-      <div class="pipe__arr">&#9660;</div>
-      <div class="pipe__layer pipe__layer--key">
-        <span class="k">surface</span><span class="t">ShadowElement — DOM-compatible</span>
-        <span class="pipe__reuse">the trick</span>
-      </div>
-      <div class="pipe__arr">&#9660;</div>
-      <div class="pipe__layer pipe__layer--main">
-        <span class="k">main</span><span class="t">ops stream &rarr; native elements</span>
+      <div class="dschem" style="flex:1 1 0;min-width:0;margin:0;display:flex;align-items:center">
+        <svg viewBox="0 0 420 220" role="img" aria-label="Pointers cannot cross the BG/MT thread boundary.">
+          <defs>
+            <marker id="dsArrowOk" markerWidth="9" markerHeight="9" refX="7" refY="4.5" orient="auto">
+              <path d="M0,0 L9,4.5 L0,9 Z" fill="#5dd5a8"/>
+            </marker>
+          </defs>
+          <rect class="box" x="8" y="36" width="150" height="148" rx="12"/>
+          <text class="lane" x="28" y="64">BG · shadow</text>
+          <text class="chip-t" x="28" y="108">holds <tspan fill="#a78fff" font-weight="700">n1</tspan></text>
+          <text class="chip-s" x="28" y="132">ShadowElement</text>
+          <text class="chip-s" x="28" y="152">live pointer</text>
+
+          <line class="wall" x1="210" y1="28" x2="210" y2="192"/>
+          <text class="walltag" x="210" y="110" transform="rotate(90 210 110)" text-anchor="middle">thread boundary</text>
+
+          <path class="flow-no" d="M160 112 L196 112"/>
+          <text class="no" x="202" y="117" font-size="16">✗</text>
+          <text class="chip-s" x="148" y="96" text-anchor="middle">n1</text>
+
+          <rect class="box" x="262" y="36" width="150" height="148" rx="12"/>
+          <text class="lane" x="282" y="64">MT · engine</text>
+          <text class="chip-t" x="282" y="108">write / ops only</text>
+          <text class="chip-s" x="282" y="132">no sync walk</text>
+          <text class="chip-s" x="282" y="152">from BG</text>
+        </svg>
       </div>
     </div>
     <p class="lead" data-mm-fade>
-      Vapor drives the browser DOM directly. We make the background thread's tree
-      <em>look like</em> the DOM — so upstream Vapor runs untouched.
+      <span class="codenote">&#9312;</span> Vapor&rsquo;s output needs <em>addressable</em> DOM pointers.
+      <span class="codenote">&#9313;</span> Those addresses <em>can&rsquo;t cross</em> threads.
     </p>
     <aside class="notes">
-      <p><strong>The reuse story.</strong> Two green layers are the whole idea: <code>@vue/runtime-vapor</code> ships <em>unmodified</em>, because underneath it the ShadowElement tree answers standard DOM calls — <code>insertBefore</code>, <code>cloneNode</code>, <code>setAttribute</code>. Those calls become the same ops stream vdom mode already uses.</p>
+      <p><strong>State the problem in two beats.</strong> Vapor compiles to code that walks and mutates a tree the way the HTML DOM does: <code>child(n0)</code> returns a live pointer; <code>setText(n1, …)</code> writes through it. That is the whole fine-grained story — the output <em>depends</em> on an addressable tree.</p>
+      <p><strong>Why not walk the engine tree?</strong> From BG, the engine element tree is write/ops-shaped — no sync <code>firstChild</code> walk. So Vapor walks a <em>BG shadow tree</em> (<code>ShadowElement</code>) instead. Those live pointers still can&rsquo;t cross to MT — next slide: the MT addressable tree that holds the names.</p>
+    </aside>
+  </section>
+
+  <!-- E20pre-b — BG shadow tree vs MT addressable tree -->
+  <section class="slide stage dspace" data-bg="clean">
+    <div class="dtrees" style="max-width:1080px">
+      <figure>
+        <p style="font-family:var(--mono);font-size:12.5px;color:var(--ink-mute);text-align:center;margin:0 0 10px">
+          <b style="color:var(--ink)">BG · shadow tree</b> — walk &amp; hold pointers
+        </p>
+        <div class="codeframe" style="text-align:left;width:100%">
+          <div class="codeframe__head">
+            <span class="dots"><span></span><span></span><span></span></span>
+            <span>ShadowElement</span>
+          </div>
+<pre><span class="code-key">const</span> n0 <span class="code-key">=</span> <span class="code-fn">t0</span>()
+<span class="code-key">const</span> n1 <span class="code-key">=</span> <span class="code-fn">child</span>(n0)   <span class="code-com">// live pointer</span>
+<span class="code-fn">renderEffect</span>(() <span class="code-key">=&gt;</span>
+  <span class="code-fn">setText</span>(n1, <span class="code-str">'Count: '</span>, count))
+
+<span class="code-com">// for Vapor — sync walk + mutate</span>
+<span class="code-com">// DOM-shaped retained nodes</span></pre>
+        </div>
+        <p style="font-family:var(--mono);font-size:12px;color:var(--ink-mute);text-align:center;margin:8px 0 0">
+          retained · Vue holds <code>n1</code>
+        </p>
+      </figure>
+      <figure>
+        <p style="font-family:var(--mono);font-size:12.5px;color:var(--ink-mute);text-align:center;margin:0 0 10px">
+          <b style="color:var(--ink)">MT · addressable tree</b> — <span style="color:var(--ds-name)">named</span> / <span style="color:var(--ds-name)">dense</span>
+        </p>
+        <div class="codeframe" style="text-align:left;width:100%">
+          <div class="codeframe__head">
+            <span class="dots"><span></span><span></span><span></span></span>
+            <span>inert prototype · by uid</span>
+          </div>
+<pre><span class="code-fn">CLONE_TREE</span>(base <span class="code-key">=</span> 2)
+<span class="code-com">// uid = base + slot</span>
+<span class="code-fn">SET_TEXT</span>(6, <span class="code-str">'Count: '</span> <span class="code-key">+</span> count)
+
+<span class="code-com">// for the protocol — same topology,</span>
+<span class="code-com">// every slot already has a name</span></pre>
+        </div>
+        <p style="font-family:var(--mono);font-size:12px;color:var(--ink-mute);text-align:center;margin:8px 0 0">
+          structural · ops address by name
+        </p>
+      </figure>
+    </div>
+    <p class="lead" data-mm-fade>
+      <span class="codenote">&#9314;</span> Same topology — <em>different nodes</em>.
+      BG walks to hold pointers; MT holds <b style="color:var(--ds-name)">names</b> so writes can land.
+    </p>
+    <aside class="notes">
+      <p><strong>Two trees, one job split in half.</strong> The <em>BG shadow tree</em> (<code>ShadowElement</code>) is what Vapor actually walks — live pointers, DOM-shaped, retained — so <code>child(n0)</code> / <code>setText(n1)</code> work like on HTML DOM. The engine element tree on MT is write/ops-shaped from BG&rsquo;s point of view, so Vapor cannot address it by walking.</p>
+      <p>The <em>MT addressable tree</em> is the other half: an inert prototype registered once, every slot named densely by the same pre-order walk (<code>uid = base + slot</code>). Vue never holds those nodes — the interpreter does, so <code>CLONE_TREE</code> / <code>SET_TEXT(6, …)</code> can land. Same shape as the shadow tree; different kind of node. Next: the wire protocol that ships those names — <code>REGISTER_TREE</code>, then <code>CLONE_TREE</code>.</p>
     </aside>
   </section>
 
@@ -3063,8 +3375,8 @@ app.<span class="code-fn">use</span>(router)</pre>
       Pointers can&rsquo;t cross the boundary — so both sides <em>walk the same pre-order</em> and name every node alike. No id map is ever sent.
     </p>
     <aside class="notes">
-      <p><strong>The problem first.</strong> Vapor's primitive is "clone a template, then bind." Naively, every cloned element would be its own create/append op — Vapor's cross-thread traffic would be <em>worse</em> than vdom's.</p>
-      <p>Fix, step one: send the structure once with <code>REGISTER_TREE</code>. Both threads assign element uids by walking it in the same pre-order — so no id map is ever transferred.</p>
+      <p><strong>Names on the wire — step one.</strong> We just established Vapor needs addressable slots across threads. Sending every clone as create/append ops would make traffic <em>worse</em> than vdom.</p>
+      <p>Fix: send the structure once with <code>REGISTER_TREE</code>. Both threads assign element uids by walking it in the same pre-order — so no id map is ever transferred.</p>
     </aside>
   </section>
 
@@ -3121,162 +3433,106 @@ app.<span class="code-fn">use</span>(router)</pre>
       </div>
     </div>
     <p class="lead" data-mm-fade>
-      create-1k across the boundary:
-      <span style="color:var(--ink-mute);text-decoration:line-through">17,000 ops · 327 KB</span>
-      &rarr; <b class="brand-text">7,000 ops · 160 KB</b>
+      Vapor&rsquo;s host contract <em>is</em> clone-a-template — each instance needs its own tree.
+      Naively that&rsquo;s create×N across the wire (worse than vdom).
+      <code>CLONE_TREE(base)</code> makes it <b class="brand-text">one named op</b> per instance:
+      <span style="color:var(--ink-mute);text-decoration:line-through">17k · 327 KB</span>
+      &rarr; <b class="brand-text">7k · 160 KB</b>.
     </p>
     <aside class="notes">
-      <p><strong>Fix, step two.</strong> Each instance is a single <code>CLONE_TREE(base)</code> — the Main Thread re-walks the cached structure from that base uid and materializes native elements.</p>
-      <p>These are Vue Lynx's own opcodes; the interpreter ships in the same bundle, so no Lynx engine change was needed. Result: −59% ops, −51% bytes on create-1k.</p>
+      <p><strong>Why clone at all?</strong> Vapor&rsquo;s blueprint is static (<code>template()</code> once); each component instance still needs its <em>own</em> nodes for effects, text, and events — same idea as DOM <code>cloneNode(true)</code>. That&rsquo;s the host contract: clone template + imperative setters.</p>
+      <p><strong>Why <code>CLONE_TREE</code> on Lynx?</strong> Pointers can&rsquo;t cross threads. If BG&rsquo;s clone became create/append per node, create-1k traffic would beat vdom. After <code>REGISTER_TREE</code>, each instance is one <code>CLONE_TREE(base)</code> — Main re-walks the cached prototype from that base uid and materializes native elements. Own opcodes; interpreter in the same bundle. Result: −59% ops, −51% bytes.</p>
     </aside>
   </section>
 
-  <!-- V·8 — Benchmark: update-path speedup (bar chart) -->
-  <section class="slide stage" data-bg="clean">
-    <h2 class="h-section" style="text-align:center;font-size:clamp(28px,3.4cqw,50px);max-width:24ch">
-      Where Vapor pulls away: <span class="brand-text">5.8–9.8&times;</span>.
-    </h2>
-    <div class="bench">
-      <div class="bench__row">
-        <div class="bench__name">select row<small>2.95 &rarr; 0.30 ms</small></div>
-        <div class="bench__track"><div class="bench__fill" style="width:98%"></div></div>
-        <div class="bench__val">9.8&times;</div>
-      </div>
-      <div class="bench__row">
-        <div class="bench__name">remove row<small>2.85 &rarr; 0.40 ms</small></div>
-        <div class="bench__track"><div class="bench__fill" style="width:72%"></div></div>
-        <div class="bench__val">7.1&times;</div>
-      </div>
-      <div class="bench__row">
-        <div class="bench__name">swap rows<small>3.90 &rarr; 0.65 ms</small></div>
-        <div class="bench__track"><div class="bench__fill" style="width:61%"></div></div>
-        <div class="bench__val">6.0&times;</div>
-      </div>
-      <div class="bench__row">
-        <div class="bench__name">update every 10th<small>3.20 &rarr; 0.55 ms</small></div>
-        <div class="bench__track"><div class="bench__fill" style="width:59%"></div></div>
-        <div class="bench__val">5.8&times;</div>
-      </div>
-    </div>
-    <p class="lead" data-mm-fade>
-      The entire delta is Vue work on the thread you share with your app logic —
-      lower background cost means more headroom before dropped frames.
-    </p>
-    <aside class="notes">
-      <p><strong>The core result.</strong> Vue's official benchmark, ported to Lynx, same app in both modes. Background-thread cost = reactivity + render + ops serialization — Vapor's structural win shows up unfiltered here.</p>
-      <p>End-to-end multipliers are smaller (2.1–6.3×) because both modes emit near-identical ops; the Main-Thread cost is shared.</p>
-    </aside>
-  </section>
-
-  <!-- V·9 — Benchmark: the whole ledger (table) -->
-  <section class="slide stage" data-bg="clean">
-    <table class="btable">
-      <thead>
-        <tr><th>metric · create-1k unless noted</th><th>vdom</th><th>vapor</th><th>delta</th></tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td class="metric">update / select / swap / remove · bg</td>
-          <td>3.2 / 3.0 / 3.9 / 2.9 ms</td>
-          <td>0.6 / 0.3 / 0.7 / 0.4 ms</td>
-          <td class="win">5.8–9.8&times; faster</td>
-        </tr>
-        <tr>
-          <td class="metric">create 1,000 rows · e2e</td>
-          <td>125.7 ms</td><td>144.5 ms</td>
-          <td class="flat">&asymp; parity</td>
-        </tr>
-        <tr>
-          <td class="metric">cross-thread ops / bytes</td>
-          <td>17k / 327 KB</td><td>7k / 160 KB</td>
-          <td class="win">&minus;59% / &minus;51%</td>
-        </tr>
-        <tr>
-          <td class="metric">bundle · gzip</td>
-          <td>39.2 KB</td><td>49.3 KB</td>
-          <td class="cost">+26%</td>
-        </tr>
-        <tr>
-          <td class="metric">first screen</td>
-          <td>121.7 ms</td><td>125.8 ms</td>
-          <td class="cost">+3%</td>
-        </tr>
-      </tbody>
-    </table>
-    <p class="lead" data-mm-fade>
-      Big wins on updates and traffic; creation at parity; you pay in bundle size.
-    </p>
-    <aside class="notes">
-      <p><strong>The honest scorecard.</strong> Don't oversell — creation is parity (it started 1.9× slower; ops telemetry drove it to even). The cost is a +26% bundle: the Vapor runtime plus the DOM-compat shim. First screen is within noise.</p>
-      <p>Green = win, pink = cost. Numbers: headless Chromium, Lynx for Web, medians with 95% CIs.</p>
-    </aside>
-  </section>
-
-  <!-- V·10 — Workflow: one source, two renderers, verified -->
-  <section class="slide stage" data-bg="clean">
-    <div class="vsplit">
-      <div class="vsource">
-        <span class="node__label" style="color:var(--ink)">App.vue</span>
-        <span class="vrender__meta">byte-identical source<br/>+ one <code>vapor</code> attr</span>
-      </div>
-      <span class="vflow__arr is-brand" style="font-size:clamp(22px,2.6cqw,34px)">&rarr;</span>
-      <div class="vsplit__fork">
-        <div class="vrender vrender--teal">
-          <span class="vrender__name">VDOM</span>
-          <span class="vrender__meta">48 / 48 examples pass</span>
+  <!-- E20pre-c — ShadowElement (VDOM & Vapor) vs Vapor AddressableNode -->
+  <section class="slide stage dspace" data-bg="clean">
+    <div class="dtsgrid dtsgrid--duo">
+      <div>
+        <p class="dtsgrid__tag"><b>VDOM &amp; Vapor</b> · <code>ShadowElement</code></p>
+        <div class="hostcmp">
+          <div class="hostcmp__data">
+            <span class="hostcmp__pill hostcmp__pill--both">shared data</span>
+            <code>ShadowElement { id · type · parent · firstChild · next }</code>
+          </div>
+          <div class="hostmtx" role="table" aria-label="VDOM vs Vapor host surface">
+            <div class="hostmtx__h" role="row">
+              <span class="hostmtx__api" role="columnheader"></span>
+              <span class="hostmtx__col hostmtx__col--vdom" role="columnheader">VDOM</span>
+              <span class="hostmtx__col hostmtx__col--vapor" role="columnheader">Vapor</span>
+            </div>
+            <div class="hostmtx__r" role="row">
+              <code class="hostmtx__api">createElement</code>
+              <span class="hostmtx__y hostmtx__y--vdom" role="cell">●</span>
+              <span class="hostmtx__n" role="cell">—</span>
+            </div>
+            <div class="hostmtx__r" role="row">
+              <code class="hostmtx__api">insert · remove</code>
+              <span class="hostmtx__y hostmtx__y--vdom" role="cell">●</span>
+              <span class="hostmtx__n" role="cell">—</span>
+            </div>
+            <div class="hostmtx__r" role="row">
+              <code class="hostmtx__api">parentNode · nextSibling</code>
+              <span class="hostmtx__y hostmtx__y--vdom" role="cell">●</span>
+              <span class="hostmtx__n" role="cell">—</span>
+            </div>
+            <div class="hostmtx__r" role="row">
+              <code class="hostmtx__api">patchProp</code>
+              <span class="hostmtx__y hostmtx__y--vdom" role="cell">●</span>
+              <span class="hostmtx__n" role="cell">—</span>
+            </div>
+            <div class="hostmtx__r hostmtx__r--share" role="row">
+              <code class="hostmtx__api">setText</code>
+              <span class="hostmtx__y hostmtx__y--vdom" role="cell">●</span>
+              <span class="hostmtx__y hostmtx__y--vapor" role="cell">●</span>
+            </div>
+            <div class="hostmtx__r" role="row">
+              <code class="hostmtx__api">template</code>
+              <span class="hostmtx__n" role="cell">—</span>
+              <span class="hostmtx__y hostmtx__y--vapor" role="cell">●</span>
+            </div>
+            <div class="hostmtx__r" role="row">
+              <code class="hostmtx__api">child</code>
+              <span class="hostmtx__n" role="cell">—</span>
+              <span class="hostmtx__y hostmtx__y--vapor" role="cell">●</span>
+            </div>
+            <div class="hostmtx__r" role="row">
+              <code class="hostmtx__api">on</code>
+              <span class="hostmtx__n" role="cell">—</span>
+              <span class="hostmtx__y hostmtx__y--vapor" role="cell">●</span>
+            </div>
+          </div>
         </div>
-        <div class="vrender vrender--vue">
-          <span class="vrender__name">Vapor</span>
-          <span class="vrender__meta">36 supported · <b>0.000%</b> visual diff</span>
-        </div>
+        <p style="font-family:var(--mono);font-size:12px;color:var(--ink-mute);text-align:center;margin:10px 0 0">
+          same tree · each column is what that renderer drives it with
+        </p>
       </div>
-    </div>
-    <p class="lead" data-mm-fade>
-      Every example built &amp; driven in both modes through Lynx for Web.
-      The support matrix is generated from the run — it can't drift from what
-      actually passed.
-    </p>
-    <aside class="notes">
-      <p><strong>How we trust it.</strong> The Vapor app is <em>generated from the vdom source</em> — the only difference is the <code>vapor</code> attribute, so the workload is byte-for-byte identical. 36/36 supported examples hit 0.000% pixel diff against their vdom twin.</p>
-      <p>The matrix (<code>examples/vapor-support.json</code>, with per-entry source hashes) generates the docs table — it can't drift from the verification output.</p>
-    </aside>
-  </section>
+      <div>
+        <p class="dtsgrid__tag"><b>Vapor</b> · <span style="color:var(--ds-name)">AddressableNode</span></p>
+        <div class="codeframe">
+          <div class="codeframe__head">
+            <span class="dots"><span></span><span></span><span></span></span>
+            <span>conceptual · MT dense names</span>
+          </div>
+<pre><span class="code-key">interface</span> <span class="code-fn">AddressableNode</span> {
+  uid: <span class="code-fn">number</span>   <span class="code-com">// = base + slot</span>
+  tag: <span class="code-fn">string</span>
+}
 
-  <!-- V·10b — Upstream Vapor tests + host-fit (styled like the VDOM proof slide A7) -->
-  <section class="slide stage" data-bg="clean">
-    <div class="mega" style="font-size:clamp(52px,9cqw,140px)">
-      <span class="brand-text">545</span><small style="font-size:0.4em;color:var(--ink-mute)"> / 671 run · 0 fail</small>
-    </div>
-    <div class="skipbar">
-      <div class="skipbar__track">
-        <span class="skipbar__seg" style="flex:37;background:#F27A9E"></span>
-        <span class="skipbar__seg" style="flex:24;background:#4FB8F0"></span>
-        <span class="skipbar__seg" style="flex:20;background:#9E86F0"></span>
-        <span class="skipbar__seg" style="flex:18;background:#3deae7"></span>
-        <span class="skipbar__seg" style="flex:1;background:#8b93a3"></span>
+<span class="code-com">// that&rsquo;s it — a name, not a pointer</span></pre>
+        </div>
+        <p style="font-family:var(--mono);font-size:12px;color:var(--ink-mute);text-align:center;margin:10px 0 0">
+          simple on purpose — just enough to address across threads
+        </p>
       </div>
-      <div class="skipbar__legend">
-        <span><i style="background:#F27A9E"></i><b>37%</b> SSR / hydration</span>
-        <span><i style="background:#4FB8F0"></i><b>24%</b> browser-only</span>
-        <span><i style="background:#9E86F0"></i><b>20%</b> vdom↔vapor interop</span>
-        <span><i style="background:#3deae7"></i><b>18%</b> Lynx diffs</span>
-        <span><i style="background:#8b93a3"></i><b>&lt;1%</b> test-infra</span>
-      </div>
-    </div>
-    <div class="affinity">
-      <span><b>81%</b> Vapor</span>
-      <span class="vs">vs</span>
-      <span class="aff-vdom"><b>57%</b> VDOM</span>
     </div>
     <p class="lead" data-mm-fade>
-      Vapor's own suite — <b>unmodified</b> on ShadowElement. It passes the
-      element-surface tests at 81% vs vdom's 57%: the closer fit to Lynx.
+      Same BG tree for both renderers; Vapor only needs a slice of it.
+      Across the wire, Vapor adds one more thing: a <b style="color:var(--ds-name)">name</b> per slot.
     </p>
     <aside class="notes">
-      <p><strong>Vapor gets its own upstream suite (PR #232).</strong> 30 <code>runtime-vapor</code> spec files run against the real <code>vue-lynx/vapor</code> surface and ShadowElement tree: <strong>545 pass, 120 skip, 0 fail</strong>. The skiplist is a <em>closed inventory</em> — every excluded test carries a reason, config load fails on anything unclassified.</p>
-      <p><strong>The skips aren't a broken list.</strong> SSR/hydration + vdom↔vapor interop are 57% of everything that doesn't run — neither is a Lynx-compatibility signal (no SSR surface exists; interop is deliberately unsupported). Browser-only platform is another 24%. Test-infra is under 1% — vs vdom's dominant 59% — because the raw-bundle re-export trick killed the private-import problem. The port even found a real bug (ShadowElement was reactivity-proxyable; <code>__v_skip</code> fixed it).</p>
-      <p><strong>The affinity point.</strong> On the tests that touch the actual element surface, Vapor passes 81% vs vdom's 57% — and needs <em>zero behavioral shims</em>: production <code>@vue/runtime-vapor</code> runs unmodified over ShadowElement, where vdom mode needed 1,074 LOC of simulation in the execution path. Vapor's host contract — clone a template + imperative setters — is just a closer fit to Lynx. (Contract fit, not speed.)</p>
-      <p><strong>The mic-drop number — 7× VDOM.</strong> Cross-framework suite (ReactLynx vs Vue VDOM vs Vue Vapor), real clicks to composed-DOM end state. The Vue-vs-Vue headline: Vapor 7.0× VDOM on the 10k select storm, 1.9× on update storm — same app, same bundle, one attribute apart.</p>
+      <p><strong>Left is a checklist, read by columns.</strong> Shared data first: both hold the same <code>ShadowElement</code>. Then the matrix — each row is an API, each column is a renderer. VDOM&rsquo;s column is the full <code>nodeOps</code> create/walk/diff surface plus <code>setText</code>. Vapor&rsquo;s column skips those (—) and instead drives the same tree via compiled <code>template</code> / <code>child</code> / <code>on</code>, overlapping only on <code>setText</code>.</p>
+      <p>Right: Vapor&rsquo;s MT <code>AddressableNode</code> is deliberately tiny — <code>uid</code> + <code>tag</code>. Not a second ShadowElement; just a name so writes can land.</p>
     </aside>
   </section>
 

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -449,6 +449,8 @@ export const ZH = {
     '<span class="codenote">①</span> 模板注册一次 · <span class="codenote">②</span> 每个实例克隆一份 · <span class="codenote">③</span> 一个 effect 只更新一个节点。',
   'First question on Lynx: where does the template shape live on Main? Not baked into MTS — the first t0() ships this structure once.':
     'Lynx 上的第一个疑问:模板形状在 Main 上住哪儿?<em>不是</em>打进 MTS 产物 —— 第一次 <code>t0()</code> 把这份 <code>structure</code> 传过去,只传一次。',
+  'Why not deliver the tree at build time? History, not essence: upstream Vapor codegen only emits an HTML string — BG parse + serialize was the cheapest path.':
+    '为什么不在构建期交付这棵树?历史原因,而非本质:上游 Vapor 的 codegen 只给出 HTML 字符串 —— BG runtime 顺手 parse + 序列化,是最省事的路。',
   'That structure from the first t0() is cached on Main as an inert prototype. Both sides walk the same pre-order — same uids, no id map.':
     '第一次 <code>t0()</code> 传来的那份 <code>structure</code>,在 Main 上缓存成惰性原型。两侧走同一趟前序 —— 相同 uid,从不传 id 映射。',
   'structure AST · first clone only': 'structure AST · 仅第一次 clone',
@@ -804,7 +806,7 @@ export const ZH_NOTES = [
   // 40b 代码复用 · Lynx 拆到 BG | MT
   `<p><strong>同一组层,双线程安家。</strong>compiled / alias / runtime / shims / ShadowElement 留在后台线程;<code>ops stream → native</code> 落在主线程。两枚绿标:<code>@vue/runtime-vapor</code> <em>原封不动</em>,因为 ShadowElement 会应答那些 DOM 调用 —— 它们变成 vdom 已经在用的同一条 ops 流。</p>`,
   // 39 Vapor 产物 · 第一个疑问:structure 第一次传过去
-  `<p><strong>第一个疑问 —— Main 到底收到什么?</strong>Vapor 编译成 <code>template()</code> + <code>t0()</code> 克隆。在 Web 上那次克隆就是浏览器 DOM。在 Lynx 上,形状<em>不会</em>预先打进 MTS/Lepus 产物(那是 Element Templates 的 baked <code>create()</code>)。</p><p>第一次 <code>t0()</code> 时,BG 把惰性 ShadowElement 原型走成 <code>TemplateNode</code> AST —— <code>[tag, props|0, children[]]</code> —— 并只推一次 <code>REGISTER_TREE</code>:<code>[16, treeId, structure, 0]</code>。Main 只缓存 <code>{ structure }</code>;原生节点要等后面的 <code>CLONE_TREE</code>。下一页:为什么 <code>child(n0)</code> 的活指针仍然过不了边界。</p>`,
+  `<p><strong>第一个疑问 —— Main 到底收到什么?</strong>Vapor 编译成 <code>template()</code> + <code>t0()</code> 克隆。在 Web 上那次克隆就是浏览器 DOM。在 Lynx 上,形状<em>不会</em>预先打进 MTS/Lepus 产物(那是 Element Templates 的 baked <code>create()</code>)。</p><p>第一次 <code>t0()</code> 时,BG 把惰性 ShadowElement 原型走成 <code>TemplateNode</code> AST —— <code>[tag, props|0, children[]]</code> —— 并只推一次 <code>REGISTER_TREE</code>:<code>[16, treeId, structure, 0]</code>。Main 只缓存 <code>{ structure }</code>;原生节点要等后面的 <code>CLONE_TREE</code>。</p><p><strong>为什么不在构建期 bake?</strong>历史原因,而非本质。上游 Vapor 的 codegen 只给你一段 HTML 字符串(<code>template('&lt;view&gt;…&lt;/view&gt;')</code>)。Lynx 上最省事的路就是:BG runtime 把字符串 parse 成 ShadowElement,再把同一棵树序列化进 <code>REGISTER_TREE</code>。构建期残差(ET 那种)仍然在桌面上 —— 只是还没为那套 codegen 买单。下一页:为什么 <code>child(n0)</code> 的活指针仍然过不了边界。</p>`,
   // 90pre-a E20pre-a · 问题:需要指针,指针过不了
   `<p><strong>用两拍把问题说清。</strong>Vapor 编译出来的代码,像操作 HTML DOM 一样走树、改树:<code>child(n0)</code> 返回活指针;<code>setText(n1, …)</code> 通过它写入。细粒度更新的故事全靠这个 —— 产物<em>依赖</em>一棵可寻址的树。</p><p><strong>为什么不直接走 engine tree?</strong>从 BG 看,engine element tree 是 write/ops 形的 —— 没有同步的 <code>firstChild</code> walk。所以 Vapor 改走 <em>BG shadow tree</em>(<code>ShadowElement</code>)。这些活指针照样过不了 MT —— 下一页:握着名字的那棵 MT addressable tree。</p>`,
   // 90pre-b E20pre-b · BG shadow vs MT addressable

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -450,6 +450,11 @@ export const ZH = {
 
   "Vapor drives the browser DOM directly. We make the background thread's tree look like the DOM — so upstream Vapor runs untouched.":
     'Vapor 直接驱动浏览器 DOM。我们让后台线程的那棵树“长得像”DOM —— 于是上游 Vapor 原封不动地跑起来。',
+  'Vapor drives the browser DOM directly — compiled through surface, one stack ending at HTMLElement. Upstream runs untouched.':
+    'Vapor 直接驱动浏览器 DOM —— 从 compiled 到 surface,一整条栈,尽头是 <code>HTMLElement</code>。上游原封不动。',
+  'On Lynx, relocate the pipe: BG holds the DOM-shaped stack; MT only ever sees the ops stream.':
+    '在 Lynx 上,把管线挪个家:BG 握着 DOM 形的栈;MT 永远只看见 ops 流。',
+  'browser DOM — HTMLElement': '浏览器 DOM —— <code>HTMLElement</code>',
 
   'Background · Vapor': '<span class="dot"></span>后台 · Vapor',
   'Main · interpreter': '<span class="dot"></span>主线程 · 解释器',
@@ -779,18 +784,18 @@ export const ZH_NOTES = [
   `<p><strong>Vapor 是什么 —— 没有虚拟 DOM。</strong>Vue 3.6 基于编译的渲染器:没有 vnode 树,没有逐组件 diff。预发布状态 —— 锁定在 <code>vue@3.6.0-beta.17</code>。</p><p><strong>同一份源码 —— 拨一下开关。</strong>按应用、构建期的开关:插件选项、入口 import、<code>vapor</code> 属性。两个纯入口 —— <code>vue-lynx</code> 与 <code>vue-lynx/vapor</code> —— 于是 vdom 专属 API 在 Vapor 应用里会在构建期报错,而不是在运行时出乱子。</p><p>我们要用数据支撑的主张:同样的 Vue,更新路径的开销小得多。</p>`,
   // 43+44 Benchmark · 更新柱状图 + 账本（合并）
   `<p><strong>核心结果 —— 再看诚实的成绩单。</strong>Vue 官方基准移植到 Lynx,同一个应用跑两种模式。后台线程开销 = 响应式 + 渲染 + ops 序列化 —— Vapor 的结构性优势在这里毫无遮掩地显现(5.8–9.8×)。端到端的倍数要小些(2.1–6.3×),因为两种模式发出的 ops 几乎一样。</p><p>别夸大:创建是打平的;代价是产物 +26%(Vapor 运行时 + DOM 兼容垫片)。首屏差异在噪声范围内。绿 = 赢,粉 = 代价。数据:headless Chromium、Lynx for Web、中位数带 95% 置信区间。</p>`,
-  // 40a 代码复用 · 原管线拆到 BG | MT
-  `<p><strong>只是把管线挪个家。</strong>六层没变 —— compiled / alias / runtime / shims / ShadowElement 落在后台线程;<code>ops stream → native</code> 落在主线程。下一拍点亮两层复用。</p>`,
-  // 40b 代码复用 · 点亮 unmodified + the trick
-  `<p><strong>复用故事,还是同一组层。</strong>BG 栈上两枚绿标亮起:<code>@vue/runtime-vapor</code> <em>原封不动</em>,因为 ShadowElement 会应答 <code>insertBefore</code> / <code>cloneNode</code> / <code>setAttribute</code>。这些调用变成 Main 上的 ops 流 —— 与 vdom 模式已经在用的同一条。</p>`,
-  // 45 工作流 · 一份源码两个渲染器
-  `<p><strong>凭什么信它。</strong>Vapor 应用是<em>从 vdom 源码生成的</em> —— 唯一差别是 <code>vapor</code> 属性,所以负载逐字节相同。36/36 个受支持示例与其 vdom 孪生体做到 0.000% 像素差。</p><p>矩阵(<code>examples/vapor-support.json</code>,带每条目源码哈希)生成文档表格 —— 不会与验证输出发生漂移。</p>`,
   // 45b Vapor 上游测试 + 亲近性 + 7× mic-drop
   `<p><strong>Vapor 也有了自己的上游测试(PR #232)。</strong>30 个 <code>runtime-vapor</code> spec 文件跑在真实的 <code>vue-lynx/vapor</code> 表面和 ShadowElement 树上:<strong>545 通过、120 skip、0 失败</strong>。skiplist 是一个<em>封闭清单</em> —— 每个被排除的测试都有理由,任何未归类项都会让配置加载直接失败。</p><p><strong>这些 skip 不是一堆坏掉的东西。</strong>SSR/hydration 加 vdom↔vapor 互操作占了不跑项的 57% —— 两者都不是 Lynx 兼容性信号(没有 SSR 表面;互操作是刻意不支持的)。浏览器专属平台再占 24%。测试设施只占不到 1%(对比 vdom 那边高达 59%),因为“原始 bundle 再导出”这招几乎消灭了私有 import 问题。这个移植还顺手抓到一个真 bug(ShadowElement 会被响应式代理;<code>__v_skip</code> 修掉了)。</p><p><strong>亲近性这一点。</strong>在真正触及元素表面的测试上,Vapor 以 81% 对 vdom 的 57% 通过 —— 而且<em>零行为级垫片</em>:生产版 <code>@vue/runtime-vapor</code> 原封不动跑在 ShadowElement 上,而 vdom 模式需要 1,074 行在执行路径里的模拟。Vapor 的宿主契约 —— 克隆模板 + 对节点的命令式 setter —— 天生就与 Lynx 更契合。(是契合度,不是速度。)</p><p><strong>压轴数字 —— 7× VDOM。</strong>跨框架套件(ReactLynx vs Vue VDOM vs Vue Vapor),真实点击到 composed-DOM 终态。Vue 对 Vue 的头条:10k select 风暴上 Vapor 7.0× VDOM,update 风暴 1.9× —— 同一个应用、同一个产物,只差一个属性。</p>`,
+  // 45 工作流 · 一份源码两个渲染器
+  `<p><strong>凭什么信它。</strong>Vapor 应用是<em>从 vdom 源码生成的</em> —— 唯一差别是 <code>vapor</code> 属性,所以负载逐字节相同。36/36 个受支持示例与其 vdom 孪生体做到 0.000% 像素差。</p><p>矩阵(<code>examples/vapor-support.json</code>,带每条目源码哈希)生成文档表格 —— 不会与验证输出发生漂移。</p>`,
   // 37 虚拟 DOM 更新路径
   `<p><strong>先立对比。</strong>从左到右过一遍五个方块。中间三个虚线的就是税:重跑、分配、diff —— 每次更新都要交,无论变了多少。</p><p>下一页用一次 magic move 把中间这段收掉。</p>`,
   // 38 Vapor 更新路径
-  `<p><strong>morph 的回报。</strong>中间三个方块刚刚消失了。状态和目标节点原地不动,一个响应式 effect 把它们连起来。</p><p>这就是全部要点:细粒度更新,而不是整树 diff。</p>`,
+  `<p><strong>morph 的回报。</strong>中间三个方块刚刚消失了。状态和目标节点原地不动,一个响应式 effect 把它们连起来。</p><p>这就是全部要点:细粒度更新,而不是整树 diff。下一拍:这条更新路径,在 Web 与 Lynx 上分别怎么落地。</p>`,
+  // 40a 代码复用 · Web 单管 → browser DOM
+  `<p><strong>Web 上的复用故事。</strong>两枚绿标就是全部要点:<code>@vue/runtime-vapor</code> <em>原封不动</em>,因为底下那层 DOM 兼容表面会应答 <code>insertBefore</code> / <code>cloneNode</code> / <code>setAttribute</code>。在 Web 上,那层表面<em>就是</em>浏览器 DOM。</p>`,
+  // 40b 代码复用 · Lynx 拆到 BG | MT
+  `<p><strong>同一组层,双线程安家。</strong>compiled / alias / runtime / shims / ShadowElement 留在后台线程;<code>ops stream → native</code> 落在主线程。两枚绿标:<code>@vue/runtime-vapor</code> <em>原封不动</em>,因为 ShadowElement 会应答那些 DOM 调用 —— 它们变成 vdom 已经在用的同一条 ops 流。</p>`,
   // 39 Vapor 产物
   `<p><strong>看右边这一版。</strong>三步:<code>template()</code> 一次性声明静态结构;<code>t0()</code> 克隆它;<code>renderEffect()</code> 是唯一会重跑的东西 —— 而它只碰一个文本节点。</p><p>注意 <code>from 'vue'</code> —— 组件并不知道自己在 Lynx 上。下一页:这些活指针为什么过不了线程边界。</p>`,
   // 90pre-a E20pre-a · 问题:需要指针,指针过不了

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -486,7 +486,77 @@ export const ZH = {
   "Vapor's own suite — unmodified on ShadowElement. It passes the element-surface tests at 81% vs vdom's 57%: the closer fit to Lynx.":
     'Vapor 自己的上游测试 —— 在 ShadowElement 上<b>原封不动</b>地跑。触及元素表面的那些测试,它以 81% 对 vdom 的 57% 通过:与 Lynx 更亲近的契合。',
 
-  };
+  
+  '① Vapor’s output needs addressable DOM pointers. ② Those addresses can’t cross threads.':
+    '<span class="codenote">①</span> Vapor 的产物需要<em>可寻址</em>的 DOM 指针。<span class="codenote">②</span> 这些地址<em>过不了</em>线程。',
+  'BG · shadow tree — walk & hold pointers':
+    '<b style="color:var(--ink)">BG · shadow tree</b> —— walk &amp; 握指针',
+  'MT · addressable tree — named / dense':
+    '<b style="color:var(--ink)">MT · addressable tree</b> —— <span style="color:var(--ds-name)">named</span> / <span style="color:var(--ds-name)">dense</span>',
+  'retained · Vue holds n1': 'retained · Vue 握着 <code>n1</code>',
+  'structural · ops address by name': '结构型 · ops 按名寻址',
+  '③ Same topology — different nodes. BG walks to hold pointers; MT holds names so writes can land.':
+    '<span class="codenote">③</span> 同一套拓扑 —— <em>不同的节点</em>。BG walk 是为了握指针;MT 握着 <b style="color:var(--ds-name)">名字</b>,写操作才能落地。',
+  'BG · ShadowNode — data (walkable)':
+    '<b>BG · ShadowNode</b> —— 数据(可 walk)',
+  'MT · AddressableNode — named / dense':
+    '<b>MT · AddressableNode</b> —— <span class="hot">named</span> / dense',
+  'VaporHost ⊆ VdomHost — ops on ShadowNode':
+    '<b>VaporHost</b> ⊆ <b>VdomHost</b> —— 作用在 ShadowNode 上的 ops',
+  'EngineFromBg — write / ops only':
+    '<b>EngineFromBg</b> —— 只写 / 只有 ops',
+  "Expressiveness, left to right: walk+mutate → names → write-only. Vapor’s host ops are a subset of VDOM’s on the same ShadowNode.":
+    '表达力从左到右:walk+mutate → <span style="color:var(--ds-name)">名字</span> → 只写。Vapor 的 host ops 是同一棵 ShadowNode 上 VDOM 的<em>子集</em>。',
+  'ShadowElement — shadow-element.ts':
+    '<b>ShadowElement</b> —— <code>shadow-element.ts</code>',
+  'AddressableNode — conceptual · dense':
+    '<b>AddressableNode</b> —— <span style="color:var(--ds-name)">概念</span> · dense',
+  'vapor imports ⊆ nodeOps — same ShadowElement':
+    '<b>vapor imports</b> ⊆ <b>nodeOps</b> —— 同一棵 ShadowElement',
+  'OP — internal/ops.ts · write by id':
+    '<b>OP</b> —— <code>internal/ops.ts</code> · 按 id 写',
+  "Three panels quote real code; only AddressableNode is a talk sketch. Vapor’s imports are a subset of nodeOps on the same ShadowElement.":
+    '三格摘自真实代码;只有 <b style="color:var(--ds-name)">AddressableNode</b> 是讲稿素描。Vapor 的 import 是同一棵 <code>ShadowElement</code> 上 <code>nodeOps</code> 的<em>子集</em>。',
+  'VDOM & Vapor · ShadowElement':
+    '<b>VDOM &amp; Vapor</b> · <code>ShadowElement</code>',
+  'Vapor · AddressableNode':
+    '<b>Vapor</b> · <span style="color:var(--ds-name)">AddressableNode</span>',
+  'Vapor uses a subset of what VDOM needs on this tree':
+    'Vapor 用的是 VDOM 在这棵树上需求的<em>子集</em>',
+  'same tree · Vapor skips the create / diff surface':
+    '同一棵树 · Vapor 跳过 create / diff 那一层',
+  'Vapor ⊂ VDOM on the same tree — top unused, bottom added':
+    '同一棵树上 Vapor ⊂ VDOM —— 上面不用,下面另加',
+  'same tree · each column is what that renderer drives it with':
+    '同一棵树 · 每列是该渲染器用什么驱动它',
+  'shared data': '共用数据',
+  'VDOM only': '仅 VDOM',
+  'both · ∩': '共用 · ∩',
+  'Vapor only': '仅 Vapor',
+  'create / walk / diff surface': 'create / walk / diff 那一层',
+  'same BG tree · shared write': '同一棵 BG 树 · 共用写入',
+  'compiled host — no create / insert / remove / patchProp':
+    '编译产物宿主 —— 没有 create / insert / remove / patchProp',
+  'simple on purpose — just enough to address across threads':
+    '刻意简单 —— 只够跨线程寻址',
+  'Same BG tree for both renderers; Vapor only needs a slice of it. Across the wire, Vapor adds one more thing: a name per slot.':
+    '两个渲染器共用同一棵 BG 树;Vapor 只要其中一块。过线时 Vapor 多一样东西:每个槽位一个 <b style="color:var(--ds-name)">名字</b>。',
+
+    'DOM-shaped stack': 'DOM 形的栈',
+  'write / ops only': '只写 / 只有 ops',
+  'looks like the DOM': '长得像 DOM',
+  'no sync DOM walk from BG': 'BG 侧没有同步 DOM walk',
+  'upstream runs untouched': '上游原封不动跑',
+  'same ops stream as vdom': '与 vdom 同一条 ops 流',
+  'shared with vdom mode': '与 vdom 模式共用',
+  'Vapor expects a browser DOM. Split across threads: BG gets a DOM-shaped tree; MT only ever sees the ops stream.':
+    'Vapor 期望的是浏览器 DOM。拆到双线程:BG 拿到一棵 DOM<em>形</em>的树;MT 永远只看见 ops 流。',
+  'Make BG look like the DOM — @vue/runtime-vapor ships unmodified; those calls become the same ops vdom already uses.':
+    '让 BG <em>长得像</em> DOM —— <code>@vue/runtime-vapor</code> 原封不动发布;那些调用变成 vdom 已经在用的同一串 ops。',
+  "Vapor’s host contract is clone-a-template — each instance needs its own tree. Naively that’s create×N across the wire (worse than vdom). CLONE_TREE(base) makes it one named op per instance: 17k · 327 KB → 7k · 160 KB.":
+    'Vapor 的宿主契约<em>就是</em>克隆模板 —— 每个实例要有自己的树。天真做法是跨线 create×N(比 vdom 更差)。<code>CLONE_TREE(base)</code> 把它收成每个实例 <b class="brand-text">一条命名 op</b>:<span style="color:var(--ink-mute);text-decoration:line-through">17k · 327 KB</span> → <b class="brand-text">7k · 160 KB</b>。',
+
+};
 
 // Speaker-view chrome labels.
 export const SPEAKER_LABELS = {
@@ -510,8 +580,6 @@ export const SPEAKER_LABELS = {
   },
 };
 
-// Speaker notes, indexed by slide order (matches the <section.slide>
-// sequence). null → keep the English source for that slide.
 export const ZH_NOTES = [
   // 0 纯黑开场 · 只有 beam
   `<p><strong>纯黑开场 —— 只有背景的光。</strong>先在黑暗里停一拍,再让第一个 logo 落下。</p>`,
@@ -706,26 +774,32 @@ export const ZH_NOTES = [
   // ---- One more thing · Vue Vapor deep dive (12 slides) ----
   // 36 Vapor 标题 + 开关代码（原“拨一下开关”并入）
   `<p><strong>Vapor 是什么 —— 没有虚拟 DOM。</strong>Vue 3.6 基于编译的渲染器:没有 vnode 树,没有逐组件 diff。预发布状态 —— 锁定在 <code>vue@3.6.0-beta.17</code>。</p><p><strong>同一份源码 —— 拨一下开关。</strong>按应用、构建期的开关:插件选项、入口 import、<code>vapor</code> 属性。两个纯入口 —— <code>vue-lynx</code> 与 <code>vue-lynx/vapor</code> —— 于是 vdom 专属 API 在 Vapor 应用里会在构建期报错,而不是在运行时出乱子。</p><p>我们要用数据支撑的主张:同样的 Vue,更新路径的开销小得多。</p>`,
+  // 43+44 Benchmark · 更新柱状图 + 账本（合并）
+  `<p><strong>核心结果 —— 再看诚实的成绩单。</strong>Vue 官方基准移植到 Lynx,同一个应用跑两种模式。后台线程开销 = 响应式 + 渲染 + ops 序列化 —— Vapor 的结构性优势在这里毫无遮掩地显现(5.8–9.8×)。端到端的倍数要小些(2.1–6.3×),因为两种模式发出的 ops 几乎一样。</p><p>别夸大:创建是打平的;代价是产物 +26%(Vapor 运行时 + DOM 兼容垫片)。首屏差异在噪声范围内。绿 = 赢,粉 = 代价。数据:headless Chromium、Lynx for Web、中位数带 95% 置信区间。</p>`,
+  // 40a 代码复用 · 双线程列（BG DOM 形 · MT ops）
+  `<p><strong>和 IFR 那章一样的双线程栏 —— 先左后右。</strong>Background:编译后的 Vapor 仍写 <code>import 'vue'</code>,alias 进 <code>vue-lynx/vapor</code>,在 DOM shim 上跑 <code>@vue/runtime-vapor</code>,落到 <code>ShadowElement</code>。Main:只写/只有 ops —— BG 侧没有同步的 <code>firstChild</code> walk。中间五步过线。下一页把复用的 punchline 折进这两栏。</p>`,
+  // 40b 代码复用 · punchline（magic-move）
+  `<p><strong>同一张图,更少的环节 —— 复用 punchline。</strong>看 2–4 步折进 <code>ShadowElement</code>:<code>@vue/runtime-vapor</code> 保持<em>原封不动</em>,因为表面会应答 <code>insertBefore</code> / <code>cloneNode</code> / <code>setAttribute</code>。这些调用序列化成 Main 在 vdom 模式里已经认识的 ops 流。是契约契合,不是 fork。</p>`,
+  // 45 工作流 · 一份源码两个渲染器
+  `<p><strong>凭什么信它。</strong>Vapor 应用是<em>从 vdom 源码生成的</em> —— 唯一差别是 <code>vapor</code> 属性,所以负载逐字节相同。36/36 个受支持示例与其 vdom 孪生体做到 0.000% 像素差。</p><p>矩阵(<code>examples/vapor-support.json</code>,带每条目源码哈希)生成文档表格 —— 不会与验证输出发生漂移。</p>`,
+  // 45b Vapor 上游测试 + 亲近性 + 7× mic-drop
+  `<p><strong>Vapor 也有了自己的上游测试(PR #232)。</strong>30 个 <code>runtime-vapor</code> spec 文件跑在真实的 <code>vue-lynx/vapor</code> 表面和 ShadowElement 树上:<strong>545 通过、120 skip、0 失败</strong>。skiplist 是一个<em>封闭清单</em> —— 每个被排除的测试都有理由,任何未归类项都会让配置加载直接失败。</p><p><strong>这些 skip 不是一堆坏掉的东西。</strong>SSR/hydration 加 vdom↔vapor 互操作占了不跑项的 57% —— 两者都不是 Lynx 兼容性信号(没有 SSR 表面;互操作是刻意不支持的)。浏览器专属平台再占 24%。测试设施只占不到 1%(对比 vdom 那边高达 59%),因为“原始 bundle 再导出”这招几乎消灭了私有 import 问题。这个移植还顺手抓到一个真 bug(ShadowElement 会被响应式代理;<code>__v_skip</code> 修掉了)。</p><p><strong>亲近性这一点。</strong>在真正触及元素表面的测试上,Vapor 以 81% 对 vdom 的 57% 通过 —— 而且<em>零行为级垫片</em>:生产版 <code>@vue/runtime-vapor</code> 原封不动跑在 ShadowElement 上,而 vdom 模式需要 1,074 行在执行路径里的模拟。Vapor 的宿主契约 —— 克隆模板 + 对节点的命令式 setter —— 天生就与 Lynx 更契合。(是契合度,不是速度。)</p><p><strong>压轴数字 —— 7× VDOM。</strong>跨框架套件(ReactLynx vs Vue VDOM vs Vue Vapor),真实点击到 composed-DOM 终态。Vue 对 Vue 的头条:10k select 风暴上 Vapor 7.0× VDOM,update 风暴 1.9× —— 同一个应用、同一个产物,只差一个属性。</p>`,
   // 37 虚拟 DOM 更新路径
   `<p><strong>先立对比。</strong>从左到右过一遍五个方块。中间三个虚线的就是税:重跑、分配、diff —— 每次更新都要交,无论变了多少。</p><p>下一页用一次 magic move 把中间这段收掉。</p>`,
   // 38 Vapor 更新路径
   `<p><strong>morph 的回报。</strong>中间三个方块刚刚消失了。状态和目标节点原地不动,一个响应式 effect 把它们连起来。</p><p>这就是全部要点:细粒度更新,而不是整树 diff。</p>`,
   // 39 Vapor 产物
-  `<p><strong>看右边这一版。</strong>三步:<code>template()</code> 一次性声明静态结构;<code>t0()</code> 克隆它;<code>renderEffect()</code> 是唯一会重跑的东西 —— 而它只碰一个文本节点。</p><p>注意 <code>from 'vue'</code> —— 组件并不知道自己在 Lynx 上。这正是下一页。</p>`,
-  // 40 代码复用 · 管线
-  `<p><strong>复用的故事。</strong>两条绿色的层就是全部诀窍:<code>@vue/runtime-vapor</code> <em>原封不动</em>发布,因为它底下的 ShadowElement 树会响应标准 DOM 调用 —— <code>insertBefore</code>、<code>cloneNode</code>、<code>setAttribute</code>。这些调用变成 vdom 模式已经在用的同一串 ops。</p>`,
+  `<p><strong>看右边这一版。</strong>三步:<code>template()</code> 一次性声明静态结构;<code>t0()</code> 克隆它;<code>renderEffect()</code> 是唯一会重跑的东西 —— 而它只碰一个文本节点。</p><p>注意 <code>from 'vue'</code> —— 组件并不知道自己在 Lynx 上。下一页:这些活指针为什么过不了线程边界。</p>`,
+  // 90pre-a E20pre-a · 问题:需要指针,指针过不了
+  `<p><strong>用两拍把问题说清。</strong>Vapor 编译出来的代码,像操作 HTML DOM 一样走树、改树:<code>child(n0)</code> 返回活指针;<code>setText(n1, …)</code> 通过它写入。细粒度更新的故事全靠这个 —— 产物<em>依赖</em>一棵可寻址的树。</p><p><strong>为什么不直接走 engine tree?</strong>从 BG 看,engine element tree 是 write/ops 形的 —— 没有同步的 <code>firstChild</code> walk。所以 Vapor 改走 <em>BG shadow tree</em>(<code>ShadowElement</code>)。这些活指针照样过不了 MT —— 下一页:握着名字的那棵 MT addressable tree。</p>`,
+  // 90pre-b E20pre-b · BG shadow vs MT addressable
+  `<p><strong>两棵树,一分为二。</strong><em>BG shadow tree</em>(<code>ShadowElement</code>)才是 Vapor 真正在走的 —— 活指针、DOM 形、retained —— 于是 <code>child(n0)</code> / <code>setText(n1)</code> 能像在 HTML DOM 上一样工作。从 BG 看,MT 上的 engine element tree 是 write/ops 形,没法靠 walk 去寻址。</p><p><em>MT addressable tree</em> 是另一半:一次性注册的惰性原型,每个槽位按同一趟前序稠密命名(<code>uid = base + slot</code>)。Vue 从不握住这些节点 —— 解释器握着,于是 <code>CLONE_TREE</code> / <code>SET_TEXT(6, …)</code> 才能落地。和 shadow tree 同构,节点种类不同。下一页:把这些名字送过线的协议 —— <code>REGISTER_TREE</code>,然后 <code>CLONE_TREE</code>。</p>`,
   // 41 跨线程 · 注册
-  `<p><strong>先讲问题。</strong>Vapor 的原语是“克隆模板,再绑定”。天真做法下,每个克隆出的元素都是一条 create/append op —— Vapor 的跨线程流量会比 vdom <em>更差</em>。</p><p>修复第一步:用 <code>REGISTER_TREE</code> 把结构只发一次。两条线程各自以相同的前序遍历分配 uid —— 于是根本不用传任何 id 映射。</p>`,
-  // 42 跨线程 · 克隆
-  `<p><strong>修复第二步。</strong>每个实例就是一条 <code>CLONE_TREE(base)</code> —— 主线程从这个 base uid 重走缓存好的结构,生成原生元素。</p><p>这些是 Vue Lynx 自己的 opcode;解释器和后台代码在同一个产物里,所以无需改 Lynx 引擎。结果:create-1k 上 −59% ops、−51% 字节。</p>`,
-  // 43 Benchmark · 更新柱状图
-  `<p><strong>核心结果。</strong>Vue 官方基准移植到 Lynx,同一个应用跑两种模式。后台线程开销 = 响应式 + 渲染 + ops 序列化 —— Vapor 的结构性优势在这里毫无遮掩地显现。</p><p>端到端的倍数要小些(2.1–6.3×),因为两种模式发出的 ops 几乎一样;主线程开销是共享的。</p>`,
-  // 44 Benchmark · 账本
-  `<p><strong>诚实的成绩单。</strong>别夸大 —— 创建是打平的(一开始慢 1.9×;是 ops 遥测把它推到持平)。代价是产物 +26%:Vapor 运行时加上 DOM 兼容垫片。首屏差异在噪声范围内。</p><p>绿 = 赢,粉 = 代价。数据:headless Chromium、Lynx for Web、中位数带 95% 置信区间。</p>`,
-  // 45 工作流 · 一份源码两个渲染器
-  `<p><strong>凭什么信它。</strong>Vapor 应用是<em>从 vdom 源码生成的</em> —— 唯一差别是 <code>vapor</code> 属性,所以负载逐字节相同。36/36 个受支持示例与其 vdom 孪生体做到 0.000% 像素差。</p><p>矩阵(<code>examples/vapor-support.json</code>,带每条目源码哈希)生成文档表格 —— 不会与验证输出发生漂移。</p>`,
-  // 45b Vapor 上游测试 + 亲近性 + 7× mic-drop
-  `<p><strong>Vapor 也有了自己的上游测试(PR #232)。</strong>30 个 <code>runtime-vapor</code> spec 文件跑在真实的 <code>vue-lynx/vapor</code> 表面和 ShadowElement 树上:<strong>545 通过、120 skip、0 失败</strong>。skiplist 是一个<em>封闭清单</em> —— 每个被排除的测试都有理由,任何未归类项都会让配置加载直接失败。</p><p><strong>这些 skip 不是一堆坏掉的东西。</strong>SSR/hydration 加 vdom↔vapor 互操作占了不跑项的 57% —— 两者都不是 Lynx 兼容性信号(没有 SSR 表面;互操作是刻意不支持的)。浏览器专属平台再占 24%。测试设施只占不到 1%(对比 vdom 那边高达 59%),因为“原始 bundle 再导出”这招几乎消灭了私有 import 问题。这个移植还顺手抓到一个真 bug(ShadowElement 会被响应式代理;<code>__v_skip</code> 修掉了)。</p><p><strong>亲近性这一点。</strong>在真正触及元素表面的测试上,Vapor 以 81% 对 vdom 的 57% 通过 —— 而且<em>零行为级垫片</em>:生产版 <code>@vue/runtime-vapor</code> 原封不动跑在 ShadowElement 上,而 vdom 模式需要 1,074 行在执行路径里的模拟。Vapor 的宿主契约 —— 克隆模板 + 对节点的命令式 setter —— 天生就与 Lynx 更契合。(是契合度,不是速度。)</p><p><strong>压轴数字 —— 7× VDOM。</strong>跨框架套件(ReactLynx vs Vue VDOM vs Vue Vapor),真实点击到 composed-DOM 终态。Vue 对 Vue 的头条:10k select 风暴上 Vapor 7.0× VDOM,update 风暴 1.9× —— 同一个应用、同一个产物,只差一个属性。</p>`,
+  `<p><strong>名字上线 —— 第一步。</strong>前面刚说清 Vapor 需要跨线程可寻址的槽位。若每个克隆都当 create/append 发,流量会比 vdom <em>更差</em>。</p><p>修复:用 <code>REGISTER_TREE</code> 把结构只发一次。两条线程各自以相同的前序遍历分配 uid —— 于是根本不用传任何 id 映射。</p>`,
+  // 42 跨线程 · 克隆（为什么要 clone）
+  `<p><strong>为什么要 clone?</strong>Vapor 的蓝图是静态的(<code>template()</code> 一次);每个组件实例仍要<em>自己的</em>节点给 effect、文本和事件 —— 和 DOM <code>cloneNode(true)</code> 同一套心智。宿主契约就是:克隆模板 + 命令式 setter。</p><p><strong>为什么 Lynx 上是 <code>CLONE_TREE</code>?</strong>指针过不了线程。若 BG 的 clone 变成逐节点 create/append,create-1k 流量会比 vdom 更差。<code>REGISTER_TREE</code> 之后,每个实例一条 <code>CLONE_TREE(base)</code> —— Main 从该 base uid 重走缓存原型并物化原生元素。自有 opcode;解释器在同一产物里。结果:−59% ops、−51% 字节。</p>`,
+  // 90pre-c E20pre-c · ShadowElement (VDOM & Vapor) vs AddressableNode
+  `<p><strong>左边是一张对照表,按列读。</strong>先看共用数据:两边握同一份 <code>ShadowElement</code>。再看矩阵 —— 每行一个 API,每列一个渲染器。VDOM 列是完整 <code>nodeOps</code> 的 create/walk/diff,外加 <code>setText</code>。Vapor 列把那些标成 — ,改用编译出来的 <code>template</code> / <code>child</code> / <code>on</code> 驱动同一棵树,重叠点只有 <code>setText</code>。</p><p>右边:Vapor 的 MT <code>AddressableNode</code> 故意很瘦 —— <code>uid</code> + <code>tag</code>。不是第二棵 ShadowElement;只是一个名字,好让写入落地。</p>`,
   // 90a E20a · 稠密 vs 稀疏 (Vapor tree vs ET)
   `<p><strong>指针过不去,名字就得接管 —— 而发名字有两种发法。</strong>Vapor <em>稠密</em>地发:一趟前序遍历给每个节点一个 uid(2–7)。两条线程跑的是同一趟遍历,于是无需传一个字节就能对齐每个名字 —— 可寻址集合是开放的(任何节点都可能被 effect、事件或 ref 摸到)。</p><p>Element Templates <em>稀疏</em>地发:VDOM 编译器早已证明了一个封闭的动态点集合(holes),diff 又保证静态节点永远不会被寻址 —— 于是只有 hole 拿到名字,灰色节点对协议完全隐形。稀疏不是省出来的,是<em>证出来的</em>。同一份模板,设计空间上的两个坐标。</p>`,
   // 90b E20b · 动静光谱 · retained → write-only
@@ -772,5 +846,4 @@ export const ZH_NOTES = [
   `<p><strong>个人的证据。</strong>这一年我回头把 10 年前的自己想做的项目全都翻新了一遍:十年没动过的个人网站(hux.pro);我的第一个 Vue 项目,Vue 0.12;还有这套 deck —— 手 vibe 的 HTML,底下没有任何 slide 库,正是当年那个 slides 编辑器的直系后代。</p><p><strong>转折 —— 可我做的,还是前端。</strong>那我整天在做什么呢,从敲代码变成 prompt?我只是又换了一门语言 —— 汇编到 C 到 JS 到……自然语言。源变了,工作没变:我仍然在把人的意图,翻译成人能看见、能触摸的东西。这从来就是这份工作。这<em>就是</em>前端。</p>`,
   // 97 E27 · 前端永生
   `<p><strong>真正的收尾。</strong>小字划掉:前端已死。大字:前端永生。谢谢 —— 这次是真的 —— 然后留在这页做 Q&amp;A。</p><p>Q&amp;A 弹药:"能上生产吗?" —— pre-alpha,架构稳,已覆盖的部分测试充分。"Android?" —— 同一份产物,两端都跑。"AI 会取代 Vue 吗?" —— 你刚看完整个答案。</p>`,
-
 ];

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -447,6 +447,13 @@ export const ZH = {
 
   '① a template registered once · ② cloned per instance · ③ one effect that updates a single node.':
     '<span class="codenote">①</span> 模板注册一次 · <span class="codenote">②</span> 每个实例克隆一份 · <span class="codenote">③</span> 一个 effect 只更新一个节点。',
+  'First question on Lynx: where does the template shape live on Main? Not baked into MTS — the first t0() ships this structure once.':
+    'Lynx 上的第一个疑问:模板形状在 Main 上住哪儿?<em>不是</em>打进 MTS 产物 —— 第一次 <code>t0()</code> 把这份 <code>structure</code> 传过去,只传一次。',
+  'That structure from the first t0() is cached on Main as an inert prototype. Both sides walk the same pre-order — same uids, no id map.':
+    '第一次 <code>t0()</code> 传来的那份 <code>structure</code>,在 Main 上缓存成惰性原型。两侧走同一趟前序 —— 相同 uid,从不传 id 映射。',
+  'structure AST · first clone only': 'structure AST · 仅第一次 clone',
+  'REGISTER_TREE · first t0() only': '<code>REGISTER_TREE</code> · 仅第一次 <code>t0()</code>',
+  '[16, id, structure, 0]': '<code>[16, id, structure, 0]</code>',
 
   "Vapor drives the browser DOM directly. We make the background thread's tree look like the DOM — so upstream Vapor runs untouched.":
     'Vapor 直接驱动浏览器 DOM。我们让后台线程的那棵树“长得像”DOM —— 于是上游 Vapor 原封不动地跑起来。',
@@ -796,14 +803,14 @@ export const ZH_NOTES = [
   `<p><strong>Web 上的复用故事。</strong>两枚绿标就是全部要点:<code>@vue/runtime-vapor</code> <em>原封不动</em>,因为底下那层 DOM 兼容表面会应答 <code>insertBefore</code> / <code>cloneNode</code> / <code>setAttribute</code>。在 Web 上,那层表面<em>就是</em>浏览器 DOM。</p>`,
   // 40b 代码复用 · Lynx 拆到 BG | MT
   `<p><strong>同一组层,双线程安家。</strong>compiled / alias / runtime / shims / ShadowElement 留在后台线程;<code>ops stream → native</code> 落在主线程。两枚绿标:<code>@vue/runtime-vapor</code> <em>原封不动</em>,因为 ShadowElement 会应答那些 DOM 调用 —— 它们变成 vdom 已经在用的同一条 ops 流。</p>`,
-  // 39 Vapor 产物
-  `<p><strong>看右边这一版。</strong>三步:<code>template()</code> 一次性声明静态结构;<code>t0()</code> 克隆它;<code>renderEffect()</code> 是唯一会重跑的东西 —— 而它只碰一个文本节点。</p><p>注意 <code>from 'vue'</code> —— 组件并不知道自己在 Lynx 上。下一页:这些活指针为什么过不了线程边界。</p>`,
+  // 39 Vapor 产物 · 第一个疑问:structure 第一次传过去
+  `<p><strong>第一个疑问 —— Main 到底收到什么?</strong>Vapor 编译成 <code>template()</code> + <code>t0()</code> 克隆。在 Web 上那次克隆就是浏览器 DOM。在 Lynx 上,形状<em>不会</em>预先打进 MTS/Lepus 产物(那是 Element Templates 的 baked <code>create()</code>)。</p><p>第一次 <code>t0()</code> 时,BG 把惰性 ShadowElement 原型走成 <code>TemplateNode</code> AST —— <code>[tag, props|0, children[]]</code> —— 并只推一次 <code>REGISTER_TREE</code>:<code>[16, treeId, structure, 0]</code>。Main 只缓存 <code>{ structure }</code>;原生节点要等后面的 <code>CLONE_TREE</code>。下一页:为什么 <code>child(n0)</code> 的活指针仍然过不了边界。</p>`,
   // 90pre-a E20pre-a · 问题:需要指针,指针过不了
   `<p><strong>用两拍把问题说清。</strong>Vapor 编译出来的代码,像操作 HTML DOM 一样走树、改树:<code>child(n0)</code> 返回活指针;<code>setText(n1, …)</code> 通过它写入。细粒度更新的故事全靠这个 —— 产物<em>依赖</em>一棵可寻址的树。</p><p><strong>为什么不直接走 engine tree?</strong>从 BG 看,engine element tree 是 write/ops 形的 —— 没有同步的 <code>firstChild</code> walk。所以 Vapor 改走 <em>BG shadow tree</em>(<code>ShadowElement</code>)。这些活指针照样过不了 MT —— 下一页:握着名字的那棵 MT addressable tree。</p>`,
   // 90pre-b E20pre-b · BG shadow vs MT addressable
   `<p><strong>两棵树,一分为二。</strong><em>BG shadow tree</em>(<code>ShadowElement</code>)才是 Vapor 真正在走的 —— 活指针、DOM 形、retained —— 于是 <code>child(n0)</code> / <code>setText(n1)</code> 能像在 HTML DOM 上一样工作。从 BG 看,MT 上的 engine element tree 是 write/ops 形,没法靠 walk 去寻址。</p><p><em>MT addressable tree</em> 是另一半:一次性注册的惰性原型,每个槽位按同一趟前序稠密命名(<code>uid = base + slot</code>)。Vue 从不握住这些节点 —— 解释器握着,于是 <code>CLONE_TREE</code> / <code>SET_TEXT(6, …)</code> 才能落地。和 shadow tree 同构,节点种类不同。下一页:把这些名字送过线的协议 —— <code>REGISTER_TREE</code>,然后 <code>CLONE_TREE</code>。</p>`,
   // 41 跨线程 · 注册
-  `<p><strong>名字上线 —— 第一步。</strong>前面刚说清 Vapor 需要跨线程可寻址的槽位。若每个克隆都当 create/append 发,流量会比 vdom <em>更差</em>。</p><p>修复:用 <code>REGISTER_TREE</code> 把结构只发一次。两条线程各自以相同的前序遍历分配 uid —— 于是根本不用传任何 id 映射。</p>`,
+  `<p><strong>名字上线 —— 第一步。</strong>载荷我们已经见过:第一次 clone 时传过去的 <code>TemplateNode</code> AST —— <em>不是</em>打进 MTS。Main 把它缓存成惰性原型(还没有原生节点)。</p><p>两条线程按同一趟前序给这份 structure 分配 uid —— 于是根本不用传任何 id 映射。下一拍:每个实例一条 <code>CLONE_TREE(base)</code>。</p>`,
   // 42 跨线程 · 克隆（为什么要 clone）
   `<p><strong>为什么要 clone?</strong>Vapor 的蓝图是静态的(<code>template()</code> 一次);每个组件实例仍要<em>自己的</em>节点给 effect、文本和事件 —— 和 DOM <code>cloneNode(true)</code> 同一套心智。宿主契约就是:克隆模板 + 命令式 setter。</p><p><strong>为什么 Lynx 上是 <code>CLONE_TREE</code>?</strong>指针过不了线程。若 BG 的 clone 变成逐节点 create/append,create-1k 流量会比 vdom 更差。<code>REGISTER_TREE</code> 之后,每个实例一条 <code>CLONE_TREE(base)</code> —— Main 从该 base uid 重走缓存原型并物化原生元素。自有 opcode;解释器在同一产物里。结果:−59% ops、−51% 字节。</p>`,
   // 90pre-c E20pre-c · ShadowElement (VDOM & Vapor) vs AddressableNode

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -556,6 +556,9 @@ export const ZH = {
   "Vapor’s host contract is clone-a-template — each instance needs its own tree. Naively that’s create×N across the wire (worse than vdom). CLONE_TREE(base) makes it one named op per instance: 17k · 327 KB → 7k · 160 KB.":
     'Vapor 的宿主契约<em>就是</em>克隆模板 —— 每个实例要有自己的树。天真做法是跨线 create×N(比 vdom 更差)。<code>CLONE_TREE(base)</code> 把它收成每个实例 <b class="brand-text">一条命名 op</b>:<span style="color:var(--ink-mute);text-decoration:line-through">17k · 327 KB</span> → <b class="brand-text">7k · 160 KB</b>。',
 
+  'Same layers as before — BG holds the DOM-shaped stack; MT only sees the ops stream.':
+    '还是原来那些层 —— BG 握着 DOM 形的栈;MT 只看见 ops 流。',
+
 };
 
 // Speaker-view chrome labels.
@@ -776,10 +779,10 @@ export const ZH_NOTES = [
   `<p><strong>Vapor 是什么 —— 没有虚拟 DOM。</strong>Vue 3.6 基于编译的渲染器:没有 vnode 树,没有逐组件 diff。预发布状态 —— 锁定在 <code>vue@3.6.0-beta.17</code>。</p><p><strong>同一份源码 —— 拨一下开关。</strong>按应用、构建期的开关:插件选项、入口 import、<code>vapor</code> 属性。两个纯入口 —— <code>vue-lynx</code> 与 <code>vue-lynx/vapor</code> —— 于是 vdom 专属 API 在 Vapor 应用里会在构建期报错,而不是在运行时出乱子。</p><p>我们要用数据支撑的主张:同样的 Vue,更新路径的开销小得多。</p>`,
   // 43+44 Benchmark · 更新柱状图 + 账本（合并）
   `<p><strong>核心结果 —— 再看诚实的成绩单。</strong>Vue 官方基准移植到 Lynx,同一个应用跑两种模式。后台线程开销 = 响应式 + 渲染 + ops 序列化 —— Vapor 的结构性优势在这里毫无遮掩地显现(5.8–9.8×)。端到端的倍数要小些(2.1–6.3×),因为两种模式发出的 ops 几乎一样。</p><p>别夸大:创建是打平的;代价是产物 +26%(Vapor 运行时 + DOM 兼容垫片)。首屏差异在噪声范围内。绿 = 赢,粉 = 代价。数据:headless Chromium、Lynx for Web、中位数带 95% 置信区间。</p>`,
-  // 40a 代码复用 · 双线程列（BG DOM 形 · MT ops）
-  `<p><strong>和 IFR 那章一样的双线程栏 —— 先左后右。</strong>Background:编译后的 Vapor 仍写 <code>import 'vue'</code>,alias 进 <code>vue-lynx/vapor</code>,在 DOM shim 上跑 <code>@vue/runtime-vapor</code>,落到 <code>ShadowElement</code>。Main:只写/只有 ops —— BG 侧没有同步的 <code>firstChild</code> walk。中间五步过线。下一页把复用的 punchline 折进这两栏。</p>`,
-  // 40b 代码复用 · punchline（magic-move）
-  `<p><strong>同一张图,更少的环节 —— 复用 punchline。</strong>看 2–4 步折进 <code>ShadowElement</code>:<code>@vue/runtime-vapor</code> 保持<em>原封不动</em>,因为表面会应答 <code>insertBefore</code> / <code>cloneNode</code> / <code>setAttribute</code>。这些调用序列化成 Main 在 vdom 模式里已经认识的 ops 流。是契约契合,不是 fork。</p>`,
+  // 40a 代码复用 · 原管线拆到 BG | MT
+  `<p><strong>只是把管线挪个家。</strong>六层没变 —— compiled / alias / runtime / shims / ShadowElement 落在后台线程;<code>ops stream → native</code> 落在主线程。下一拍点亮两层复用。</p>`,
+  // 40b 代码复用 · 点亮 unmodified + the trick
+  `<p><strong>复用故事,还是同一组层。</strong>BG 栈上两枚绿标亮起:<code>@vue/runtime-vapor</code> <em>原封不动</em>,因为 ShadowElement 会应答 <code>insertBefore</code> / <code>cloneNode</code> / <code>setAttribute</code>。这些调用变成 Main 上的 ops 流 —— 与 vdom 模式已经在用的同一条。</p>`,
   // 45 工作流 · 一份源码两个渲染器
   `<p><strong>凭什么信它。</strong>Vapor 应用是<em>从 vdom 源码生成的</em> —— 唯一差别是 <code>vapor</code> 属性,所以负载逐字节相同。36/36 个受支持示例与其 vdom 孪生体做到 0.000% 像素差。</p><p>矩阵(<code>examples/vapor-support.json</code>,带每条目源码哈希)生成文档表格 —— 不会与验证输出发生漂移。</p>`,
   // 45b Vapor 上游测试 + 亲近性 + 7× mic-drop

--- a/slides/src/main.js
+++ b/slides/src/main.js
@@ -840,6 +840,7 @@ const I18N_SELECTOR = [
   '.demo__caption', '.videopair figcaption',
   '.tile', '.wlab', '.wattr', '.wg b',
   '.ifrjoin__label', '.ifrjoin__role', '.ifrjoin__pill', '.ifrjoin__out',
+  '.hostcmp__pill', '.hostmtx__col',
   '.ifrjoin__hint', '.ifrjoin__linkhead', '.ifrjoin__link',
   '.node__cap', '.xwire__count',
 ].map((s) => `.slide ${s}`).join(', ') + ', .gate-legend span';

--- a/slides/src/main.js
+++ b/slides/src/main.js
@@ -842,7 +842,7 @@ const I18N_SELECTOR = [
   '.ifrjoin__label', '.ifrjoin__role', '.ifrjoin__pill', '.ifrjoin__out',
   '.hostcmp__pill', '.hostmtx__col',
   '.ifrjoin__hint', '.ifrjoin__linkhead', '.ifrjoin__link',
-  '.node__cap', '.xwire__count',
+  '.node__cap', '.xwire__count', '.xwire__payload',
 ].map((s) => `.slide ${s}`).join(', ') + ', .gate-legend span';
 
 let i18nEls = [];

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -3462,6 +3462,121 @@ vl-media.snap.is-missing .vl-ph__kind { color: rgba(15, 18, 22, 0.65); }
 .node__cap { display: block; text-align: center; font-family: var(--mono); font-size: 11px; color: var(--ink-mute); margin-top: 2px; }
 .node__cap b { color: var(--ds-name); font-weight: 600; }
 
+/* d.ts surface comparison (E20pre-c) */
+.dtsgrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: clamp(10px, 1.4cqw, 18px) clamp(14px, 2cqw, 28px);
+  width: 100%;
+  max-width: 1100px;
+  margin: 0 auto;
+  align-items: stretch;
+}
+.dtsgrid--duo { max-width: 1000px; gap: clamp(18px, 2.4cqw, 36px); }
+.dtsgrid--duo .codeframe { font-size: 13px; }
+.dtsgrid--duo .codeframe pre { padding: 16px 18px; line-height: 1.55; }
+.dtsgrid .codeframe { font-size: 11.5px; text-align: left; }
+.dtsgrid .codeframe pre { padding: 12px 14px; line-height: 1.5; }
+.dtsgrid__tag {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  color: var(--ink-mute);
+  letter-spacing: 0.04em;
+  margin: 0 0 8px;
+  text-align: center;
+}
+.dtsgrid__tag b { color: var(--ink); font-weight: 600; }
+.dtsgrid__tag .hot { color: var(--ds-name); }
+
+/* E20pre-c — VDOM vs Vapor host-surface checklist */
+.hostcmp {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border-radius: 14px;
+  border: 1px solid color-mix(in srgb, var(--ink-faint) 70%, transparent);
+  background: color-mix(in srgb, var(--paper) 88%, transparent);
+  padding: 12px;
+  text-align: left;
+}
+.hostcmp__data {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 10px;
+  margin: 0;
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid color-mix(in srgb, var(--ink) 16%, transparent);
+  background: color-mix(in srgb, var(--ink-faint) 40%, transparent);
+}
+.hostcmp__data code {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--ink-soft);
+  line-height: 1.35;
+}
+.hostcmp__pill {
+  display: inline-block;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+  padding: 2px 8px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  flex: 0 0 auto;
+}
+.hostcmp__pill--both {
+  color: var(--ink);
+  border-color: color-mix(in srgb, var(--ink) 22%, transparent);
+  background: color-mix(in srgb, var(--ink-faint) 55%, transparent);
+}
+.hostmtx {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 64px 64px;
+  gap: 0;
+  font-family: var(--mono);
+}
+.hostmtx__h,
+.hostmtx__r {
+  display: contents;
+}
+.hostmtx__h > * {
+  padding: 4px 6px 8px;
+  font-size: 11.5px;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+  border-bottom: 1px solid color-mix(in srgb, var(--ink-faint) 80%, transparent);
+}
+.hostmtx__col--vdom { color: #6FA8FF; text-align: center; }
+.hostmtx__col--vapor { color: #42b883; text-align: center; }
+.hostmtx__r > * {
+  padding: 6px 6px;
+  border-bottom: 1px solid color-mix(in srgb, var(--ink-faint) 45%, transparent);
+  font-size: 12.5px;
+  line-height: 1.3;
+}
+.hostmtx__r:last-child > * { border-bottom: 0; }
+.hostmtx__api {
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 12.5px;
+}
+.hostmtx__y,
+.hostmtx__n {
+  text-align: center;
+  font-weight: 600;
+}
+.hostmtx__y { color: var(--ink); }
+.hostmtx__y--vdom { color: #6FA8FF; }
+.hostmtx__y--vapor { color: #42b883; }
+.hostmtx__n { color: color-mix(in srgb, var(--ink-mute) 70%, transparent); font-weight: 500; }
+.hostmtx__r--share > * {
+  background: color-mix(in srgb, var(--ink-faint) 35%, transparent);
+}
+
+
 /* =========================================================
    IV · Instant First-Frame Rendering + Element Templates.
    Reuses the runtime chapter's .flow / .fb / .farr / .fcenter
@@ -4282,6 +4397,37 @@ vl-media.snap.is-missing .vl-ph__kind { color: rgba(15, 18, 22, 0.65); }
   color: var(--vue-green);
   min-width: 3.2ch;
   text-align: right;
+}
+
+/* Merged bench + ledger on one slide */
+.bench--compact {
+  gap: clamp(6px, 1cqh, 10px);
+  margin-bottom: clamp(8px, 1.4cqh, 14px);
+}
+.bench--compact .bench__row {
+  gap: clamp(8px, 1.2cqw, 14px);
+}
+.bench--compact .bench__name {
+  font-size: clamp(11px, 1.1cqw, 13px);
+}
+.bench--compact .bench__track {
+  height: clamp(12px, 1.8cqh, 18px);
+}
+.bench--compact .bench__val {
+  font-size: clamp(14px, 1.6cqw, 22px);
+}
+.btable--compact {
+  width: min(100%, 860px);
+}
+.btable--compact th,
+.btable--compact td {
+  padding: clamp(5px, 0.85cqh, 9px) clamp(10px, 1.2cqw, 16px);
+}
+.btable--compact tbody td {
+  font-size: clamp(12px, 1.2cqw, 15px);
+}
+.btable--compact thead th {
+  font-size: 10px;
 }
 
 /* ---- Benchmark data table ---- */

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -4304,7 +4304,7 @@ vl-media.snap.is-missing .vl-ph__kind { color: rgba(15, 18, 22, 0.65); }
 .pipesplit {
   display: grid;
   grid-template-columns: minmax(0, 1.35fr) auto minmax(0, 0.85fr);
-  align-items: center;
+  align-items: end;
   gap: clamp(12px, 1.8cqw, 28px);
   width: min(100%, 1080px);
   margin: 0 auto;
@@ -4314,6 +4314,10 @@ vl-media.snap.is-missing .vl-ph__kind { color: rgba(15, 18, 22, 0.65); }
   flex-direction: column;
   gap: 10px;
   min-width: 0;
+  align-self: stretch;
+}
+.pipesplit__side:last-child {
+  justify-content: flex-end;
 }
 .pipesplit__lab {
   margin: 0;
@@ -4344,7 +4348,7 @@ vl-media.snap.is-missing .vl-ph__kind { color: rgba(15, 18, 22, 0.65); }
   flex-direction: column;
   align-items: center;
   gap: 6px;
-  padding-top: 28px;
+  padding-bottom: 14px;
 }
 .pipesplit__arrow {
   font-family: var(--mono);

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -4300,6 +4300,66 @@ vl-media.snap.is-missing .vl-ph__kind { color: rgba(15, 18, 22, 0.65); }
   line-height: 0.5;
 }
 
+/* Original pipe layers, parked on BG | MT (V·6a/b) */
+.pipesplit {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) auto minmax(0, 0.85fr);
+  align-items: center;
+  gap: clamp(12px, 1.8cqw, 28px);
+  width: min(100%, 1080px);
+  margin: 0 auto;
+}
+.pipesplit__side {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 0;
+}
+.pipesplit__lab {
+  margin: 0;
+  font-family: var(--mono);
+  font-size: 12.5px;
+  letter-spacing: 0.04em;
+  color: var(--ink-mute);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.pipesplit__lab i {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--vue-green);
+  display: inline-block;
+}
+.pipesplit__side:last-child .pipesplit__lab i {
+  background: #56b8f0;
+}
+.pipe--side {
+  width: 100%;
+  margin: 0;
+}
+.pipesplit__rail {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding-top: 28px;
+}
+.pipesplit__arrow {
+  font-family: var(--mono);
+  font-size: clamp(22px, 2.4cqw, 32px);
+  color: var(--vue-green);
+  line-height: 1;
+}
+.pipesplit__cap {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
+}
+
 /* ---- Cross-thread template wire (sits in the .archflow middle) ---- */
 .xwire {
   align-self: center;

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -4409,6 +4409,16 @@ vl-media.snap.is-missing .vl-ph__kind { color: rgba(15, 18, 22, 0.65); }
   color: var(--ink-mute);
 }
 .xwire__count b { color: var(--vue-green); }
+.xwire__payload {
+  font-family: var(--mono);
+  font-size: clamp(9px, 0.95cqw, 11px);
+  color: var(--ink-mute);
+  letter-spacing: 0.02em;
+}
+.xwire__payload code {
+  color: var(--vue-green);
+  font-size: inherit;
+}
 /* structure glyph — a tiny nested-block tree that "crosses once" */
 .xstruct { display: inline-flex; gap: 3px; align-items: center; }
 .xstruct i {

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -4300,7 +4300,7 @@ vl-media.snap.is-missing .vl-ph__kind { color: rgba(15, 18, 22, 0.65); }
   line-height: 0.5;
 }
 
-/* Original pipe layers, parked on BG | MT (V·6a/b) */
+/* Lynx: original pipe layers parked on BG | MT (V·6b) */
 .pipesplit {
   display: grid;
   grid-template-columns: minmax(0, 1.35fr) auto minmax(0, 0.85fr);

--- a/slides/src/tree-surfaces.d.ts
+++ b/slides/src/tree-surfaces.d.ts
@@ -1,0 +1,63 @@
+/**
+ * Tree surfaces — expressiveness sketch for the VueConf deck.
+ *
+ * Left:  ShadowElement — real BG node (VDOM & Vapor share it;
+ *        Vapor's host surface is a subset of VDOM's nodeOps).
+ * Right: AddressableNode — conceptual MT dense/named slot (Vapor).
+ *
+ * Anchors:
+ *   ShadowElement → runtime/src/shadow-element.ts
+ *   nodeOps       → runtime/src/node-ops.ts
+ *   vapor imports → compiled SFC / @vue/runtime-vapor via 'vue'
+ */
+
+// ---------------------------------------------------------------------------
+// VDOM & Vapor · ShadowElement (real)
+// ---------------------------------------------------------------------------
+
+/** packages/vue-lynx/runtime/src/shadow-element.ts */
+export declare class ShadowElement {
+  id: number;
+  type: string;
+  parent: ShadowElement | null;
+  firstChild: ShadowElement | null;
+  lastChild: ShadowElement | null;
+  prev: ShadowElement | null;
+  next: ShadowElement | null;
+
+  _textValue: string;
+  _style: Record<string, unknown>;
+  _baseClass: string;
+
+  insertBefore(child: ShadowElement, anchor: ShadowElement | null): void;
+  removeChild(child: ShadowElement): void;
+}
+
+/**
+ * Host surface on the same ShadowElement — checklist:
+ *
+ *   shared data: ShadowElement { id · type · parent · firstChild · next }
+ *
+ *                VDOM   Vapor
+ *   createElement  ●      —
+ *   insert/remove  ●      —
+ *   parent/next    ●      —
+ *   patchProp      ●      —
+ *   setText        ●      ●
+ *   template       —      ●
+ *   child          —      ●
+ *   on             —      ●
+ */
+
+// ---------------------------------------------------------------------------
+// Vapor · AddressableNode (conceptual — MT dense names)
+// ---------------------------------------------------------------------------
+
+/** @conceptual — talk sketch; not a type in packages/ today. */
+export interface AddressableNode {
+  /** uid = base + preorder slot */
+  readonly uid: number;
+  readonly tag: string;
+}
+
+export {};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a dedicated setup slide **immediately before** the existing “Vapor dense tree vs Element Templates” comparison (E20a).

The new slide explains, with dual codeframes matching nearby Vapor slides:

1. **Dense** — in-process Vapor keeps live pointers (`child` / `setText`); the addressable set is open (effect / event / ref may touch any node).
2. **Cross-thread addressable** — pointers cannot cross BG→MT, so both sides agree on a preorder walk (`uid = base + slot`) and ops like `SET_TEXT(6, …)` address nodes by name without an id map.

Also bumps the deck counter to 126 and wires ZH visible strings + speaker notes.

## Test plan

- [x] `grep -c '<section class="slide"'` = notes = `ZH_NOTES.length` = 126
- [x] ZH lead / caption keys resolve via `normalizeKey`
- [ ] Visual check EN + ZH screenshots of slide `#103`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3e75bb8-7a48-4a54-86e5-bfc4a38e4121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3e75bb8-7a48-4a54-86e5-bfc4a38e4121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

