### PR TITLE
feat(slides): Straightforward IFR + dual-thread hydrate join

### DIFF
--- a/slides/index.html
+++ b/slides/index.html
@@ -2107,27 +2107,27 @@ app.<span class="code-fn">use</span>(router)</pre>
     </aside>
   </section>
 
-  <!-- IFR3 — Straightforward IFR: dual-thread ops + hydrate join -->
+  <!-- IFR3 — Straightforward IFR: dual-thread ops + hydrate join (BG left · MT right) -->
   <section class="slide stage">
     <h2 class="h-section" style="text-align:center;max-width:20ch">
       <span class="brand-text">Straightforward</span> IFR
     </h2>
     <div class="ifrjoin">
       <div class="ifrjoin__cols">
-        <div class="ifrjoin__col" style="--c:#56b8f0">
-          <span class="ifrjoin__label"><i></i>Main (UI) thread</span>
-          <span class="ifrjoin__role">records</span>
-          <code class="ifrjoin__op is-match">SET_TEXT 3 "Hi"</code>
-          <code class="ifrjoin__op is-patch">SET_TEXT 3 "Hi"</code>
-          <code class="ifrjoin__op is-tear">CREATE 4 view</code>
-        </div>
-        <div class="ifrjoin__rail" aria-hidden="true"></div>
         <div class="ifrjoin__col" style="--c:#5dd5a8">
           <span class="ifrjoin__label"><i></i>Background thread</span>
           <span class="ifrjoin__role">first batches</span>
           <code class="ifrjoin__op is-match">SET_TEXT 3 "Hi"</code>
           <code class="ifrjoin__op is-patch">SET_TEXT 3 "你好"</code>
           <code class="ifrjoin__op is-tear">CREATE 4 text</code>
+        </div>
+        <div class="ifrjoin__rail" aria-hidden="true"></div>
+        <div class="ifrjoin__col" style="--c:#56b8f0">
+          <span class="ifrjoin__label"><i></i>Main (UI) thread</span>
+          <span class="ifrjoin__role">records</span>
+          <code class="ifrjoin__op is-match">SET_TEXT 3 "Hi"</code>
+          <code class="ifrjoin__op is-patch">SET_TEXT 3 "Hi"</code>
+          <code class="ifrjoin__op is-tear">CREATE 4 view</code>
         </div>
       </div>
       <div class="ifrjoin__join">
@@ -2169,94 +2169,171 @@ app.<span class="code-fn">use</span>(router)</pre>
       <p><strong>The second lever.</strong> IFR moves the paint earlier;
       enabling it turns on Element Templates by default. They make the render
       itself an order of magnitude cheaper — and shrink the cross-thread protocol
-      for <em>every</em> update, not just the first frame.</p>
+      for <em>every</em> update, not just the first frame. Watch the next two
+      slides: the shared data-flow between BTS and MTS collapses from five
+      steps to three.</p>
     </aside>
   </section>
 
-  <!-- IFR5 — without ET: dual-thread fat VDOM → opcode pipelines -->
+  <!-- IFR5 — without ET: dual-thread + lit 5-step data-flow bridge -->
   <section class="slide stage">
-    <div class="ifrjoin ifrjoin--pipe">
-      <div class="ifrjoin__cols">
-        <div class="ifrjoin__col" data-flip="et-col-bg" style="--c:#5dd5a8">
-          <span class="ifrjoin__label" data-flip="et-lab-bg"><i></i>Background · BTS</span>
-          <span class="ifrjoin__role" data-mm-fade>VDOM tree &rarr; opcodes</span>
-          <code class="ifrjoin__op" data-mm-fade>VDOM</code>
-          <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
-          <code class="ifrjoin__op" data-mm-fade>ShadowElement</code>
-          <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
-          <code class="ifrjoin__op is-fat" data-mm-fade>CREATE · SET · APPEND &hellip;</code>
-          <span class="ifrjoin__hint" data-mm-fade>many ops / node</span>
+    <div class="etbridge">
+      <div class="etbridge__side" data-flip="et-col-bg" style="--c:#5dd5a8">
+        <span class="ifrjoin__label" data-flip="et-lab-bg"><i></i>Background · BTS</span>
+        <span class="ifrjoin__role" data-mm-fade>VDOM tree &rarr; opcodes</span>
+        <p class="etbridge__blurb" data-mm-fade>Walks ShadowElement, emits a long flat stream.</p>
+      </div>
+      <div class="etbridge__flow">
+        <div class="etb-row">
+          <i class="etb-tick etb-tick--l" aria-hidden="true"></i>
+          <div class="etb" data-flip="etp-vdom" style="--c:#42b883">VDOM<small>one vnode / node</small></div>
+          <i class="etb-tick etb-tick--r" aria-hidden="true"></i>
         </div>
-        <div class="ifrjoin__rail" aria-hidden="true"></div>
-        <div class="ifrjoin__col" data-flip="et-col-mt" style="--c:#56b8f0">
-          <span class="ifrjoin__label" data-flip="et-lab-mt"><i></i>Main IFR · MTS</span>
-          <span class="ifrjoin__role" data-mm-fade>same chain, local apply</span>
-          <code class="ifrjoin__op" data-mm-fade>VDOM</code>
-          <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
-          <code class="ifrjoin__op" data-mm-fade>record ops</code>
-          <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
-          <code class="ifrjoin__op is-fat" data-mm-fade>CREATE · SET · APPEND &hellip;</code>
-          <span class="ifrjoin__hint" data-mm-fade>applyOps &rarr; PAPI &rarr; paint</span>
+        <span class="etb-arr" data-mm-fade>&darr;</span>
+        <div class="etb-row" data-mm-fade>
+          <i class="etb-tick etb-tick--l" aria-hidden="true"></i>
+          <div class="etb" style="--c:#E8B44A">Shadow<small>one node</small></div>
+          <i class="etb-tick etb-tick--r" aria-hidden="true"></i>
         </div>
+        <span class="etb-arr" data-mm-fade>&darr;</span>
+        <div class="etb-row" data-mm-fade>
+          <i class="etb-tick etb-tick--l" aria-hidden="true"></i>
+          <div class="etb" style="--c:#4FB8F0">ops<small>several frames</small></div>
+          <i class="etb-tick etb-tick--r" aria-hidden="true"></i>
+        </div>
+        <span class="etb-arr" data-mm-fade>&darr;</span>
+        <div class="etb-row" data-mm-fade>
+          <i class="etb-tick etb-tick--l" aria-hidden="true"></i>
+          <div class="etb" style="--c:#56b8f0">interp<small>a switch loop</small></div>
+          <i class="etb-tick etb-tick--r" aria-hidden="true"></i>
+        </div>
+        <span class="etb-arr" data-mm-fade>&darr;</span>
+        <div class="etb-row">
+          <i class="etb-tick etb-tick--l" aria-hidden="true"></i>
+          <div class="etb" data-flip="etp-papi" style="--c:#F27A9E">PAPI<small>__CreateView</small></div>
+          <i class="etb-tick etb-tick--r" aria-hidden="true"></i>
+        </div>
+        <span class="etbridge__tag" data-mm-fade>&times; every static node</span>
+      </div>
+      <div class="etbridge__side" data-flip="et-col-mt" style="--c:#56b8f0">
+        <span class="ifrjoin__label" data-flip="et-lab-mt"><i></i>Main IFR · MTS</span>
+        <span class="ifrjoin__role" data-mm-fade>same chain, local apply</span>
+        <p class="etbridge__blurb" data-mm-fade>Records ops, applyOps &rarr; paint on-thread.</p>
       </div>
     </div>
     <p class="lead arch-cap" data-mm-fade>
       Without ET, BTS and MTS IFR both pay the fat
-      <b>VDOM &rarr; opcode</b> chain — just on different threads.
+      <b>5-step</b> data-flow — linked across the thread boundary.
     </p>
     <aside class="notes">
-      <p><strong>Same code, two threads, still expensive.</strong> BTS walks the
-      VDOM into ShadowElement and emits a long flat opcode stream. MTS IFR runs
-      the same Vue + <code>nodeOps</code> during <code>loadTemplate</code>, records
-      the same shape of ops, and applies them locally to paint. IFR moved
-      <em>when</em> paint happens — it did not shrink the work yet.</p>
+      <p><strong>Same code, two threads, still expensive.</strong> The lit chain
+      in the middle is the shared protocol: VDOM → Shadow → ops → interp →
+      PAPI, once per static node. BTS emits it; MTS IFR records and applies it
+      locally. IFR moved <em>when</em> paint happens — the next slide collapses
+      <em>how much</em> work the chain does.</p>
     </aside>
   </section>
 
-  <!-- IFR6 — with ET: BTS emits INSTANTIATE; MTS IFR runs create() -->
+  <!-- IFR6 — with ET: bridge collapses 5 → 3 (magic-move) -->
   <section class="slide stage">
-    <div class="ifrjoin ifrjoin--pipe">
-      <div class="ifrjoin__cols">
-        <div class="ifrjoin__col" data-flip="et-col-bg" style="--c:#5dd5a8">
-          <span class="ifrjoin__label" data-flip="et-lab-bg"><i></i>Background · BTS</span>
-          <span class="ifrjoin__role" data-mm-fade>VDOM &rarr; one template op</span>
-          <code class="ifrjoin__op" data-mm-fade>VDOM · __vlx-tpl</code>
-          <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
-          <code class="ifrjoin__op is-hero" data-mm-fade>INSTANTIATE_TEMPLATE</code>
-          <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
-          <code class="ifrjoin__op" data-mm-fade>SET_* holes only</code>
-          <span class="ifrjoin__hint" data-mm-fade>one op · whole subtree</span>
+    <div class="etbridge">
+      <div class="etbridge__side" data-flip="et-col-bg" style="--c:#5dd5a8">
+        <span class="ifrjoin__label" data-flip="et-lab-bg"><i></i>Background · BTS</span>
+        <span class="ifrjoin__role" data-mm-fade>VDOM &rarr; one template op</span>
+        <p class="etbridge__blurb" data-mm-fade>Emits INSTANTIATE_TEMPLATE + hole SET_*.</p>
+      </div>
+      <div class="etbridge__flow">
+        <div class="etb-row">
+          <i class="etb-tick etb-tick--l" aria-hidden="true"></i>
+          <div class="etb" data-flip="etp-vdom" style="--c:#42b883">one vnode<small>__vlx-tpl:…</small></div>
+          <i class="etb-tick etb-tick--r" aria-hidden="true"></i>
         </div>
-        <div class="ifrjoin__rail" aria-hidden="true"></div>
-        <div class="ifrjoin__col" data-flip="et-col-mt" style="--c:#56b8f0">
-          <span class="ifrjoin__label" data-flip="et-lab-mt"><i></i>Main IFR · MTS</span>
-          <span class="ifrjoin__role" data-mm-fade>opcode &rarr; create() PAPI</span>
-          <code class="ifrjoin__op" data-mm-fade>VDOM · __vlx-tpl</code>
-          <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
-          <code class="ifrjoin__op is-hero" data-mm-fade>INSTANTIATE_TEMPLATE</code>
-          <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
-          <code class="ifrjoin__op is-hero" data-mm-fade>create() &rarr; __CreateView&hellip;</code>
-          <span class="ifrjoin__hint" data-mm-fade>straight-line PAPI &rarr; paint</span>
+        <span class="etb-arr" data-mm-fade>&darr;</span>
+        <div class="etb-row" data-mm-fade>
+          <i class="etb-tick etb-tick--l" aria-hidden="true"></i>
+          <div class="etb is-hero" style="--c:#5dd5a8">INSTANTIATE_TEMPLATE<small>one op · whole subtree</small></div>
+          <i class="etb-tick etb-tick--r" aria-hidden="true"></i>
         </div>
+        <span class="etb-arr" data-mm-fade>&darr;</span>
+        <div class="etb-row">
+          <i class="etb-tick etb-tick--l" aria-hidden="true"></i>
+          <div class="etb" data-flip="etp-papi" style="--c:#F27A9E">create()<small>straight-line PAPI</small></div>
+          <i class="etb-tick etb-tick--r" aria-hidden="true"></i>
+        </div>
+        <span class="etbridge__tag" data-mm-fade>holes update via ordinary <b>SET_*</b> ops</span>
+      </div>
+      <div class="etbridge__side" data-flip="et-col-mt" style="--c:#56b8f0">
+        <span class="ifrjoin__label" data-flip="et-lab-mt"><i></i>Main IFR · MTS</span>
+        <span class="ifrjoin__role" data-mm-fade>opcode &rarr; create() PAPI</span>
+        <p class="etbridge__blurb" data-mm-fade>Interpreter runs create() &rarr; paint.</p>
       </div>
     </div>
     <p class="lead arch-cap" data-mm-fade>
-      ET converts the static subtree into a compiled <code>create()</code> —
-      BTS sends <b>one</b> op; MTS IFR runs that function as straight-line PAPI.
+      ET collapses the bridge to <b>3 steps</b> — BTS sends one op; MTS IFR
+      runs the compiled <code>create()</code> as straight-line PAPI.
     </p>
     <aside class="notes">
-      <p><strong>How ET lands on each thread.</strong> The compiler lowers the
-      static shell to <code>registerElementTemplate(id, holes, create)</code>.
-      BTS still starts from a VDOM tree, but the static block is one vnode that
-      emits <code>INSTANTIATE_TEMPLATE</code> plus hole <code>SET_*</code>s — not
-      per-node <code>CREATE</code>s. On MTS IFR the same opcode hits the local
-      interpreter, which calls the baked <code>create()</code> — a straight-line
-      sequence of Element PAPI. Next slide: what each side's tree looks like,
-      and what actually crosses the wire.</p>
+      <p><strong>Watch the middle collapse.</strong> VDOM and PAPI stay put
+      (magic-move); Shadow / ops / interp fold into one
+      <code>INSTANTIATE_TEMPLATE</code>. Framework templates — typed Element
+      PAPI, not Lynx binary engine templates. Next: why Vue can do this —
+      compiler-hinted VDOM already carries Block structure.</p>
     </aside>
   </section>
 
-  <!-- IFR6b — dual-thread trees + what syncs (learn from V·7a archflow) -->
+  <!-- IFR7 — compiler: Block-hinted VDOM → element template -->
+  <section class="slide stage">
+    <div class="etcode">
+      <div class="codeframe etcode__src">
+        <div class="codeframe__head">
+          <span class="dots"><span></span><span></span><span></span></span>
+          <span>Card.vue · template</span>
+        </div>
+<pre><span class="et-static">&lt;<span class="code-tag">view</span> <span class="code-attr">class</span>=<span class="code-str">"card"</span>&gt;</span>
+  <span class="et-static">&lt;<span class="code-tag">image</span> <span class="code-attr">class</span>=<span class="code-str">"icon"</span> /&gt;</span>
+  <span class="et-static">&lt;<span class="code-tag">text</span> <span class="code-attr">class</span>=<span class="code-str">"title"</span>&gt;</span><span class="et-hole">{{ title }}</span><span class="et-static">&lt;/<span class="code-tag">text</span>&gt;</span>
+  <span class="et-static">&lt;<span class="code-tag">view</span> <span class="et-hole">:class</span>=<span class="et-hole">"badge"</span>&gt;…&lt;/<span class="code-tag">view</span>&gt;</span>
+<span class="et-static">&lt;/<span class="code-tag">view</span>&gt;</span></pre>
+      </div>
+      <div class="etcode__legend" aria-hidden="true">
+        <span><i class="et-sw is-static"></i>Block · static</span>
+        <span><i class="et-sw is-hole"></i>Block · hole</span>
+      </div>
+      <div class="codeframe etcode__out">
+        <div class="codeframe__head">
+          <span class="dots"><span></span><span></span><span></span></span>
+          <span>compiler output</span>
+        </div>
+<pre><span class="code-fn">registerElementTemplate</span>(
+  <span class="code-str">"__vlx-tpl:rflz…"</span>,
+  [<span class="code-str">"#text"</span>, <span class="code-str">"class"</span>], <span class="code-com">// holes</span>
+  <span class="code-key">function</span> (P) {
+    <span class="code-com">…straight-line PAPI…</span>
+    <span class="code-key">return</span> [e0, e3, e5]
+  },
+)</pre>
+      </div>
+    </div>
+    <p class="lead arch-cap" data-mm-fade>
+      Vue already ships <b>compiler-hinted VDOM</b> — a Block marks static
+      structure vs dynamic holes. That hint is what we lower into
+      <code>create()</code>.
+    </p>
+    <aside class="notes">
+      <p><strong>Why Vue can do this.</strong> Vue's compiler already partitions
+      a template into a Block: static nodes vs dynamic holes
+      (<code>patchFlag</code> / dynamicChildren). Element Templates reuse that
+      structure information — bake the static shell into
+      <code>registerElementTemplate(id, holes, create)</code>, leave only the
+      holes on the vnode path. Eligible = plain Lynx elements with value/text
+      dynamics; components, slots, <code>v-if</code>/<code>v-for</code> hosts,
+      <code>&lt;list&gt;</code>, ref/id stay on the normal path (their plain
+      bodies can still lower). Next: the sparse trees on each thread, and what
+      actually crosses the wire.</p>
+    </aside>
+  </section>
+
+  <!-- IFR8 — dual-thread trees + what syncs (was IFR6b) -->
   <section class="slide stage" data-bg="clean">
     <div class="archflow">
       <div class="node">
@@ -2324,63 +2401,18 @@ app.<span class="code-fn">use</span>(router)</pre>
       protocol-invisible (ghosted). Only holes get names (<code>h0</code>…).
       MTS IFR materializes the same shape via the compiled
       <code>create()</code> — a native element tree with the same sparse hole
-      ids.</p>
+      ids. That sparsity is exactly the Block the previous slide compiled.</p>
       <p><strong>What syncs.</strong> Unlike Vapor's <code>REGISTER_TREE</code>,
       ET does not send structure: <code>registerElementTemplate</code> already
       shipped <code>create()</code> in both bundles. Across the wire:
       <code>INSTANTIATE_TEMPLATE(tplId)</code> (once per instance) +
       <code>SET_*</code> for hole values only. On IFR, MTS recorded those ops
       at first paint; BTS's first batches hydrate against that recording —
-      skip / patch / rebuild, same join as before.</p>
+      skip / patch / rebuild, same join as Straightforward IFR.</p>
     </aside>
   </section>
 
-  <!-- IFR7 — baked skeleton + holes + generated create() -->
-  <section class="slide stage">
-    <div class="etcode">
-      <div class="codeframe etcode__src">
-        <div class="codeframe__head">
-          <span class="dots"><span></span><span></span><span></span></span>
-          <span>Card.vue · template</span>
-        </div>
-<pre><span class="et-static">&lt;<span class="code-tag">view</span> <span class="code-attr">class</span>=<span class="code-str">"card"</span>&gt;</span>
-  <span class="et-static">&lt;<span class="code-tag">image</span> <span class="code-attr">class</span>=<span class="code-str">"icon"</span> /&gt;</span>
-  <span class="et-static">&lt;<span class="code-tag">text</span> <span class="code-attr">class</span>=<span class="code-str">"title"</span>&gt;</span><span class="et-hole">{{ title }}</span><span class="et-static">&lt;/<span class="code-tag">text</span>&gt;</span>
-  <span class="et-static">&lt;<span class="code-tag">view</span> <span class="et-hole">:class</span>=<span class="et-hole">"badge"</span>&gt;…&lt;/<span class="code-tag">view</span>&gt;</span>
-<span class="et-static">&lt;/<span class="code-tag">view</span>&gt;</span></pre>
-      </div>
-      <div class="etcode__legend" aria-hidden="true">
-        <span><i class="et-sw is-static"></i>baked skeleton</span>
-        <span><i class="et-sw is-hole"></i>dynamic hole</span>
-      </div>
-      <div class="codeframe etcode__out">
-        <div class="codeframe__head">
-          <span class="dots"><span></span><span></span><span></span></span>
-          <span>compiler output</span>
-        </div>
-<pre><span class="code-fn">registerElementTemplate</span>(
-  <span class="code-str">"__vlx-tpl:rflz…"</span>,
-  [<span class="code-str">"#text"</span>, <span class="code-str">"class"</span>], <span class="code-com">// holes</span>
-  <span class="code-key">function</span> (P) {
-    <span class="code-com">…straight-line PAPI…</span>
-    <span class="code-key">return</span> [e0, e3, e5]
-  },
-)</pre>
-      </div>
-    </div>
-    <p class="lead arch-cap" data-mm-fade>
-      Static structure bakes into a <code>create()</code> skeleton; only the
-      holes — dynamic text, class, style, attrs — stay on the vnode path.
-    </p>
-    <aside class="notes">
-      <p>Eligible = every node is a plain Lynx element and only values or text
-      are dynamic. Components, slots, <code>v-if</code>/<code>v-for</code> hosts,
-      <code>&lt;list&gt;</code>, ref/id nodes stay on the normal vnode path;
-      their plain-element bodies can still lower. Scoped-CSS scope ids bake in.</p>
-    </aside>
-  </section>
-
-  <!-- IFR8 — benchmark table (proof) -->
+  <!-- IFR9 — benchmark table (proof) -->
   <section class="slide stage">
     <table class="bench-table">
       <thead>
@@ -2422,7 +2454,7 @@ app.<span class="code-fn">use</span>(router)</pre>
     </aside>
   </section>
 
-  <!-- IFR9 — benchmark data-viz (proof) -->
+  <!-- IFR10 — benchmark data-viz (proof) -->
   <section class="slide stage">
     <div class="bench-viz">
       <div class="bench-chart">

--- a/slides/index.html
+++ b/slides/index.html
@@ -24,7 +24,7 @@
     </button>
   </div>
   <div class="chrome chrome--bottom">
-    <span data-counter>01 / 127</span>
+    <span data-counter>01 / 128</span>
   </div>
   <div class="chrome chrome--bottom-right">
     <a href="https://vue.lynxjs.org" target="_blank" rel="noreferrer">vue.lynxjs.org</a>
@@ -2251,8 +2251,87 @@ app.<span class="code-fn">use</span>(router)</pre>
       emits <code>INSTANTIATE_TEMPLATE</code> plus hole <code>SET_*</code>s — not
       per-node <code>CREATE</code>s. On MTS IFR the same opcode hits the local
       interpreter, which calls the baked <code>create()</code> — a straight-line
-      sequence of Element PAPI. Next slide shows the source &rarr; compiler
-      output.</p>
+      sequence of Element PAPI. Next slide: what each side's tree looks like,
+      and what actually crosses the wire.</p>
+    </aside>
+  </section>
+
+  <!-- IFR6b — dual-thread trees + what syncs (learn from V·7a archflow) -->
+  <section class="slide stage" data-bg="clean">
+    <div class="archflow">
+      <div class="node">
+        <span class="node__label"><i></i>Background · BTS</span>
+        <h3 class="node__title">VDOM · sparse</h3>
+        <svg class="dtree" viewBox="0 0 300 170" role="img" aria-label="BTS sparse tree: static nodes ghosted, only holes named">
+          <line class="edge ghost" x1="150" y1="28" x2="46" y2="60"/>
+          <line class="edge" x1="150" y1="28" x2="212" y2="60"/>
+          <line class="edge" x1="212" y1="82" x2="156" y2="114"/>
+          <line class="edge ghost" x1="212" y1="82" x2="254" y2="114"/>
+          <line class="edge" x1="157" y1="136" x2="157" y2="148"/>
+          <g><rect class="nodebox st" x="110" y="6" width="80" height="22" rx="5"/><text class="tag" x="128" y="21">card</text><rect class="uidbg" x="168" y="0" width="42" height="14" rx="6"/><text class="uid" x="172" y="11">root</text></g>
+          <g class="ghost"><rect class="nodebox" x="16" y="60" width="60" height="22" rx="5"/><text class="tag" x="30" y="75">icon</text></g>
+          <g class="ghost"><rect class="nodebox" x="182" y="60" width="60" height="22" rx="5"/><text class="tag" x="194" y="75">body</text></g>
+          <g><rect class="nodebox dy" x="126" y="114" width="60" height="22" rx="5"/><text class="tag" x="137" y="129">title</text><rect class="uidbg" x="164" y="108" width="42" height="14" rx="6"/><text class="uid" x="170" y="119">h0</text></g>
+          <g><rect class="nodebox dy" x="133" y="148" width="48" height="18" rx="5"/><text class="tag" x="140" y="161" style="font-size:9px">#text</text></g>
+          <g class="ghost"><rect class="nodebox" x="224" y="114" width="60" height="22" rx="5"/><text class="tag" x="236" y="129">desc</text></g>
+        </svg>
+        <span class="node__cap">static ghosted · only <b>holes</b> named</span>
+      </div>
+      <div class="xwire">
+        <div class="xwire__op">
+          <span class="xwire__name">INSTANTIATE_TEMPLATE</span>
+          <span class="xstruct"><i></i><i></i><i></i></span>
+          <span class="xwire__line"></span>
+          <span class="xwire__count">tpl id · not the tree</span>
+        </div>
+        <div class="xwire__op">
+          <span class="xwire__name">SET_* holes</span>
+          <span class="xwire__line is-multi"></span>
+          <span class="xwire__count">values only · e.g. h0</span>
+        </div>
+        <div class="xwire__op">
+          <span class="xwire__name">hydrate join</span>
+          <span class="xwire__line"></span>
+          <span class="xwire__count">ops vs recording</span>
+        </div>
+      </div>
+      <div class="node node--main">
+        <span class="node__label"><i></i>Main IFR · MTS</span>
+        <h3 class="node__title">native · create()</h3>
+        <svg class="dtree" viewBox="0 0 300 170" role="img" aria-label="MTS native tree from create(), same sparse hole ids">
+          <line class="edge ghost" x1="150" y1="28" x2="46" y2="60"/>
+          <line class="edge" x1="150" y1="28" x2="212" y2="60"/>
+          <line class="edge" x1="212" y1="82" x2="156" y2="114"/>
+          <line class="edge ghost" x1="212" y1="82" x2="254" y2="114"/>
+          <line class="edge" x1="157" y1="136" x2="157" y2="148"/>
+          <g><rect class="nodebox st" x="110" y="6" width="80" height="22" rx="5"/><text class="tag" x="128" y="21">card</text><rect class="uidbg" x="168" y="0" width="42" height="14" rx="6"/><text class="uid" x="172" y="11">root</text></g>
+          <g class="ghost"><rect class="nodebox" x="16" y="60" width="60" height="22" rx="5"/><text class="tag" x="30" y="75">icon</text></g>
+          <g class="ghost"><rect class="nodebox" x="182" y="60" width="60" height="22" rx="5"/><text class="tag" x="194" y="75">body</text></g>
+          <g><rect class="nodebox dy" x="126" y="114" width="60" height="22" rx="5"/><text class="tag" x="137" y="129">title</text><rect class="uidbg" x="164" y="108" width="42" height="14" rx="6"/><text class="uid" x="170" y="119">h0</text></g>
+          <g><rect class="nodebox dy" x="133" y="148" width="48" height="18" rx="5"/><text class="tag" x="140" y="161" style="font-size:9px">#text</text></g>
+          <g class="ghost"><rect class="nodebox" x="224" y="114" width="60" height="22" rx="5"/><text class="tag" x="236" y="129">desc</text></g>
+        </svg>
+        <span class="node__cap">create() builds · <b>same hole ids</b></span>
+      </div>
+    </div>
+    <p class="lead" data-mm-fade>
+      Structure never crosses — both bundles already share <code>create()</code>.
+      The wire carries the <b>tpl id</b> and <b>hole values</b>; hydrate joins those ops.
+    </p>
+    <aside class="notes">
+      <p><strong>What each side's tree is.</strong> BTS keeps a sparse VDOM /
+      ShadowElement view: static nodes exist for Vue's sync reads but are
+      protocol-invisible (ghosted). Only holes get names (<code>h0</code>…).
+      MTS IFR materializes the same shape via the compiled
+      <code>create()</code> — a native element tree with the same sparse hole
+      ids.</p>
+      <p><strong>What syncs.</strong> Unlike Vapor's <code>REGISTER_TREE</code>,
+      ET does not send structure: <code>registerElementTemplate</code> already
+      shipped <code>create()</code> in both bundles. Across the wire:
+      <code>INSTANTIATE_TEMPLATE(tplId)</code> (once per instance) +
+      <code>SET_*</code> for hole values only. On IFR, MTS recorded those ops
+      at first paint; BTS's first batches hydrate against that recording —
+      skip / patch / rebuild, same join as before.</p>
     </aside>
   </section>
 

--- a/slides/index.html
+++ b/slides/index.html
@@ -24,7 +24,7 @@
     </button>
   </div>
   <div class="chrome chrome--bottom">
-    <span data-counter>01 / 126</span>
+    <span data-counter>01 / 127</span>
   </div>
   <div class="chrome chrome--bottom-right">
     <a href="https://vue.lynxjs.org" target="_blank" rel="noreferrer">vue.lynxjs.org</a>
@@ -2068,35 +2068,42 @@ app.<span class="code-fn">use</span>(router)</pre>
     </aside>
   </section>
 
-  <!-- IFR2 — IFR: paint first, hydrate later (magic-move the paint flag) -->
+  <!-- IFR2 — IFR: paint first, then hydrate joins (timeline + join bar) -->
   <section class="slide stage">
-    <div class="ifrtl">
-      <div class="ifrlane" style="--c:#56b8f0;top:6%;height:38%">
-        <span class="ifrlane__label"><i></i>Main (UI) thread</span>
-        <div class="tblk" style="--c:#56b8f0;left:3%;width:16%;top:58%">loadTemplate</div>
-        <div class="tblk" style="--c:#56b8f0;left:21%;width:24%;top:58%">render</div>
-        <div class="tblk is-paint" data-flip="ifr-paint" style="left:47%;width:15%;top:58%">paint</div>
-        <div class="tblk is-idle" style="left:64%;width:33%;top:58%">hands the tree over &rarr;</div>
+    <div class="ifrseq">
+      <div class="ifrtl ifrtl--joinhead">
+        <div class="ifrlane" style="--c:#56b8f0;top:4%;height:42%">
+          <span class="ifrlane__label"><i></i>Main (UI) thread</span>
+          <div class="tblk" style="--c:#56b8f0;left:3%;width:17%;top:58%">loadTemplate</div>
+          <div class="tblk" style="--c:#56b8f0;left:22%;width:16%;top:58%">render</div>
+          <div class="tblk is-paint" data-flip="ifr-paint" style="left:40%;width:14%;top:58%">paint</div>
+          <div class="tblk" style="--c:#56b8f0;left:57%;width:16%;top:58%">records</div>
+        </div>
+        <div class="ifrlane" style="--c:#5dd5a8;top:54%;height:42%">
+          <span class="ifrlane__label"><i></i>Background thread</span>
+          <div class="tblk" style="--c:#5dd5a8;left:3%;width:16%;top:58%">boot</div>
+          <div class="tblk" style="--c:#5dd5a8;left:21%;width:16%;top:58%">render</div>
+          <div class="tblk" style="--c:#5dd5a8;left:40%;width:28%;top:58%">first batches</div>
+        </div>
       </div>
-      <div class="ifrlane" style="--c:#5dd5a8;top:56%;height:38%">
-        <span class="ifrlane__label"><i></i>Background thread</span>
-        <div class="tblk" style="--c:#5dd5a8;left:3%;width:20%;top:58%">boot</div>
-        <div class="tblk" style="--c:#5dd5a8;left:25%;width:30%;top:58%">render</div>
-        <div class="tblk" style="--c:#3deae7;left:57%;width:22%;top:58%">hydrate</div>
+      <div class="ifrjoin__join">
+        <span class="ifrjoin__elbow ifrjoin__elbow--l" aria-hidden="true"></span>
+        <span class="ifrjoin__pill">hydrate · thread join</span>
+        <span class="ifrjoin__elbow ifrjoin__elbow--r" aria-hidden="true"></span>
       </div>
     </div>
     <p class="lead arch-cap" data-mm-fade>
-      IFR puts the whole runtime in the <b style="color:#56b8f0">main-thread</b>
-      bundle — it renders during <code>loadTemplate</code>, so
-      <b>paint lands first</b> and the background boots alongside.
+      IFR paints on the <b style="color:#56b8f0">main thread</b> during
+      <code>loadTemplate</code> — then <b>hydrate joins</b> the two ops streams.
     </p>
     <aside class="notes">
       <p><strong>首屏直出 — ported from ReactLynx.</strong> With
       <code>enableIFR</code>, the main-thread bundle carries the full Vue runtime
       + app (not just worklets). <code>renderPage</code> mounts it synchronously
       inside <code>loadTemplate</code> — watch the <strong>paint</strong> flag
-      jump left. The background thread still runs the same code, just in
-      parallel and off the critical path.</p>
+      jump left. MT <em>records</em> its ops; BG boots in parallel and sends its
+      first batches. The glowing pill is the join — next slide opens what's
+      inside it.</p>
     </aside>
   </section>
 
@@ -2149,6 +2156,20 @@ app.<span class="code-fn">use</span>(router)</pre>
       A mismatch only loses the perf win, never correctness (logs
       <code>IFR hydration mismatch</code> in dev). Deterministic ids &amp;
       <code>vue:N</code> signs route taps to Vue with no rebinding.</p>
+    </aside>
+  </section>
+
+  <!-- IFR4 — Element Templates: the pivot (when vs how-much) -->
+  <section class="slide stage">
+    <h2 class="h-section" style="text-align:center;max-width:24ch">
+      IFR changes <em class="ifr-em">when</em> the frame renders.<br/>
+      <span class="brand-text">Element Templates</span> change how much work it does.
+    </h2>
+    <aside class="notes">
+      <p><strong>The second lever.</strong> IFR moves the paint earlier;
+      enabling it turns on Element Templates by default. They make the render
+      itself an order of magnitude cheaper — and shrink the cross-thread protocol
+      for <em>every</em> update, not just the first frame.</p>
     </aside>
   </section>
 

--- a/slides/index.html
+++ b/slides/index.html
@@ -24,7 +24,7 @@
     </button>
   </div>
   <div class="chrome chrome--bottom">
-    <span data-counter>01 / 128</span>
+    <span data-counter>01 / 129</span>
   </div>
   <div class="chrome chrome--bottom-right">
     <a href="https://vue.lynxjs.org" target="_blank" rel="noreferrer">vue.lynxjs.org</a>
@@ -2040,6 +2040,18 @@ app.<span class="code-fn">use</span>(router)</pre>
     </aside>
   </section>
 
+  <!-- IFR0 — section title -->
+  <section class="slide stage">
+    <h2 class="h-section" style="text-align:center;max-width:10ch">
+      <span class="brand-text">IFR</span>
+    </h2>
+    <aside class="notes">
+      <p><strong>Instant First-Frame Rendering.</strong> Last piece of the
+      engineering chapter: paint the first frame before the background is ready —
+      then make that paint cheap with Element Templates.</p>
+    </aside>
+  </section>
+
   <!-- IFR1 — the first frame waits a full lap -->
   <section class="slide stage">
     <div class="ifrtl">
@@ -2159,19 +2171,135 @@ app.<span class="code-fn">use</span>(router)</pre>
     </aside>
   </section>
 
-  <!-- IFR4 — Element Templates: the pivot (when vs how-much) -->
+  <!-- IFR7 — compiler: Block-hinted VDOM → element template -->
   <section class="slide stage">
-    <h2 class="h-section" style="text-align:center;max-width:24ch">
-      IFR changes <em class="ifr-em">when</em> the frame renders.<br/>
-      <span class="brand-text">Element Templates</span> change how much work it does.
-    </h2>
+    <div class="etcode">
+      <div class="codeframe etcode__src">
+        <div class="codeframe__head">
+          <span class="dots"><span></span><span></span><span></span></span>
+          <span>Card.vue · template</span>
+        </div>
+<pre><span class="et-static">&lt;<span class="code-tag">view</span> <span class="code-attr">class</span>=<span class="code-str">"card"</span>&gt;</span>
+  <span class="et-static">&lt;<span class="code-tag">image</span> <span class="code-attr">class</span>=<span class="code-str">"icon"</span> /&gt;</span>
+  <span class="et-static">&lt;<span class="code-tag">text</span> <span class="code-attr">class</span>=<span class="code-str">"title"</span>&gt;</span><span class="et-hole">{{ title }}</span><span class="et-static">&lt;/<span class="code-tag">text</span>&gt;</span>
+  <span class="et-static">&lt;<span class="code-tag">view</span> <span class="et-hole">:class</span>=<span class="et-hole">"badge"</span>&gt;…&lt;/<span class="code-tag">view</span>&gt;</span>
+<span class="et-static">&lt;/<span class="code-tag">view</span>&gt;</span></pre>
+      </div>
+      <div class="etcode__legend" aria-hidden="true">
+        <span><i class="et-sw is-static"></i>Block · static</span>
+        <span><i class="et-sw is-hole"></i>Block · hole</span>
+      </div>
+      <div class="codeframe etcode__out">
+        <div class="codeframe__head">
+          <span class="dots"><span></span><span></span><span></span></span>
+          <span>compiler output</span>
+        </div>
+<pre><span class="code-fn">registerElementTemplate</span>(
+  <span class="code-str">"__vlx-tpl:rflz…"</span>,
+  [<span class="code-str">"#text"</span>, <span class="code-str">"class"</span>], <span class="code-com">// holes</span>
+  <span class="code-key">function</span> (P) {
+    <span class="code-com">…straight-line PAPI…</span>
+    <span class="code-key">return</span> [e0, e3, e5]
+  },
+)</pre>
+      </div>
+    </div>
+    <p class="lead arch-cap" data-mm-fade>
+      Vue already ships <b>compiler-hinted VDOM</b> — a Block marks static
+      structure vs dynamic holes. That hint is what we lower into
+      <code>create()</code>.
+    </p>
     <aside class="notes">
-      <p><strong>The second lever.</strong> IFR moves the paint earlier;
-      enabling it turns on Element Templates by default. They make the render
-      itself an order of magnitude cheaper — and shrink the cross-thread protocol
-      for <em>every</em> update, not just the first frame. Watch the next two
-      slides: the shared data-flow between BTS and MTS collapses from five
-      steps to three.</p>
+      <p><strong>Enter Element Templates — via Vue's Block.</strong> Hydrate
+      still joins two fat paths. Vue's compiler already partitions a template
+      into a Block: static nodes vs dynamic holes
+      (<code>patchFlag</code> / dynamicChildren). Element Templates reuse that
+      structure — bake the static shell into
+      <code>registerElementTemplate(id, holes, create)</code>, leave only the
+      holes on the vnode path. Eligible = plain Lynx elements with value/text
+      dynamics; components, slots, <code>v-if</code>/<code>v-for</code> hosts,
+      <code>&lt;list&gt;</code>, ref/id stay on the normal path (their plain
+      bodies can still lower). Next: the sparse trees on each thread, and what
+      actually crosses the wire.</p>
+    </aside>
+  </section>
+
+  <!-- IFR8 — dual-thread trees + what syncs (was IFR6b) -->
+  <section class="slide stage" data-bg="clean">
+    <div class="archflow">
+      <div class="node">
+        <span class="node__label"><i></i>Background · BTS</span>
+        <h3 class="node__title">VDOM · sparse</h3>
+        <svg class="dtree" viewBox="0 0 300 170" role="img" aria-label="BTS sparse tree: static nodes ghosted, only holes named">
+          <line class="edge ghost" x1="150" y1="28" x2="46" y2="60"/>
+          <line class="edge" x1="150" y1="28" x2="212" y2="60"/>
+          <line class="edge" x1="212" y1="82" x2="156" y2="114"/>
+          <line class="edge ghost" x1="212" y1="82" x2="254" y2="114"/>
+          <line class="edge" x1="157" y1="136" x2="157" y2="148"/>
+          <g><rect class="nodebox st" x="110" y="6" width="80" height="22" rx="5"/><text class="tag" x="128" y="21">card</text><rect class="uidbg" x="168" y="0" width="42" height="14" rx="6"/><text class="uid" x="172" y="11">root</text></g>
+          <g class="ghost"><rect class="nodebox" x="16" y="60" width="60" height="22" rx="5"/><text class="tag" x="30" y="75">icon</text></g>
+          <g class="ghost"><rect class="nodebox" x="182" y="60" width="60" height="22" rx="5"/><text class="tag" x="194" y="75">body</text></g>
+          <g><rect class="nodebox dy" x="126" y="114" width="60" height="22" rx="5"/><text class="tag" x="137" y="129">title</text><rect class="uidbg" x="164" y="108" width="42" height="14" rx="6"/><text class="uid" x="170" y="119">h0</text></g>
+          <g><rect class="nodebox dy" x="133" y="148" width="48" height="18" rx="5"/><text class="tag" x="140" y="161" style="font-size:9px">#text</text></g>
+          <g class="ghost"><rect class="nodebox" x="224" y="114" width="60" height="22" rx="5"/><text class="tag" x="236" y="129">desc</text></g>
+        </svg>
+        <span class="node__cap">static ghosted · only <b>holes</b> named</span>
+      </div>
+      <div class="xwire">
+        <div class="xwire__op">
+          <span class="xwire__name">INSTANTIATE_TEMPLATE</span>
+          <span class="xstruct"><i></i><i></i><i></i></span>
+          <span class="xwire__line"></span>
+          <span class="xwire__count">tpl id · not the tree</span>
+        </div>
+        <div class="xwire__op">
+          <span class="xwire__name">SET_* holes</span>
+          <span class="xwire__line is-multi"></span>
+          <span class="xwire__count">values only · e.g. h0</span>
+        </div>
+        <div class="xwire__op">
+          <span class="xwire__name">hydrate join</span>
+          <span class="xwire__line"></span>
+          <span class="xwire__count">ops vs recording</span>
+        </div>
+      </div>
+      <div class="node node--main">
+        <span class="node__label"><i></i>Main IFR · MTS</span>
+        <h3 class="node__title">native · create()</h3>
+        <svg class="dtree" viewBox="0 0 300 170" role="img" aria-label="MTS native tree from create(), same sparse hole ids">
+          <line class="edge ghost" x1="150" y1="28" x2="46" y2="60"/>
+          <line class="edge" x1="150" y1="28" x2="212" y2="60"/>
+          <line class="edge" x1="212" y1="82" x2="156" y2="114"/>
+          <line class="edge ghost" x1="212" y1="82" x2="254" y2="114"/>
+          <line class="edge" x1="157" y1="136" x2="157" y2="148"/>
+          <g><rect class="nodebox st" x="110" y="6" width="80" height="22" rx="5"/><text class="tag" x="128" y="21">card</text><rect class="uidbg" x="168" y="0" width="42" height="14" rx="6"/><text class="uid" x="172" y="11">root</text></g>
+          <g class="ghost"><rect class="nodebox" x="16" y="60" width="60" height="22" rx="5"/><text class="tag" x="30" y="75">icon</text></g>
+          <g class="ghost"><rect class="nodebox" x="182" y="60" width="60" height="22" rx="5"/><text class="tag" x="194" y="75">body</text></g>
+          <g><rect class="nodebox dy" x="126" y="114" width="60" height="22" rx="5"/><text class="tag" x="137" y="129">title</text><rect class="uidbg" x="164" y="108" width="42" height="14" rx="6"/><text class="uid" x="170" y="119">h0</text></g>
+          <g><rect class="nodebox dy" x="133" y="148" width="48" height="18" rx="5"/><text class="tag" x="140" y="161" style="font-size:9px">#text</text></g>
+          <g class="ghost"><rect class="nodebox" x="224" y="114" width="60" height="22" rx="5"/><text class="tag" x="236" y="129">desc</text></g>
+        </svg>
+        <span class="node__cap">create() builds · <b>same hole ids</b></span>
+      </div>
+    </div>
+    <p class="lead" data-mm-fade>
+      Structure never crosses — both bundles already share <code>create()</code>.
+      The wire carries the <b>tpl id</b> and <b>hole values</b>; hydrate joins those ops.
+    </p>
+    <aside class="notes">
+      <p><strong>What each side's tree is.</strong> BTS keeps a sparse VDOM /
+      ShadowElement view: static nodes exist for Vue's sync reads but are
+      protocol-invisible (ghosted). Only holes get names (<code>h0</code>…).
+      MTS IFR materializes the same shape via the compiled
+      <code>create()</code> — a native element tree with the same sparse hole
+      ids. That sparsity is exactly the Block the previous slide compiled.</p>
+      <p><strong>What syncs.</strong> Unlike Vapor's <code>REGISTER_TREE</code>,
+      ET does not send structure: <code>registerElementTemplate</code> already
+      shipped <code>create()</code> in both bundles. Across the wire:
+      <code>INSTANTIATE_TEMPLATE(tplId)</code> (once per instance) +
+      <code>SET_*</code> for hole values only. On IFR, MTS recorded those ops
+      at first paint; BTS's first batches hydrate against that recording —
+      skip / patch / rebuild, same join as Straightforward IFR. Next: without ET, both threads still walk the fat five-step path.</p>
     </aside>
   </section>
 
@@ -2289,181 +2417,23 @@ app.<span class="code-fn">use</span>(router)</pre>
       <code>INSTANTIATE_TEMPLATE</code> chip; VDOM and PAPI/<code>create()</code>
       stay put (magic-move). BTS still starts from a VDOM tree, but the static
       block is one vnode that emits INSTANTIATE + hole SET_*s. MTS IFR's
-      interpreter calls the baked <code>create()</code>. Next: why Vue can do
-      this — compiler-hinted VDOM already carries Block structure.</p>
+      interpreter calls the baked <code>create()</code>. Next: the one-line summary — IFR changes
+      <em>when</em>; Element Templates change how much.</p>
     </aside>
   </section>
 
-  <!-- IFR7 — compiler: Block-hinted VDOM → element template -->
+  <!-- IFR4 — Element Templates: the pivot (when vs how-much) -->
   <section class="slide stage">
-    <div class="etcode">
-      <div class="codeframe etcode__src">
-        <div class="codeframe__head">
-          <span class="dots"><span></span><span></span><span></span></span>
-          <span>Card.vue · template</span>
-        </div>
-<pre><span class="et-static">&lt;<span class="code-tag">view</span> <span class="code-attr">class</span>=<span class="code-str">"card"</span>&gt;</span>
-  <span class="et-static">&lt;<span class="code-tag">image</span> <span class="code-attr">class</span>=<span class="code-str">"icon"</span> /&gt;</span>
-  <span class="et-static">&lt;<span class="code-tag">text</span> <span class="code-attr">class</span>=<span class="code-str">"title"</span>&gt;</span><span class="et-hole">{{ title }}</span><span class="et-static">&lt;/<span class="code-tag">text</span>&gt;</span>
-  <span class="et-static">&lt;<span class="code-tag">view</span> <span class="et-hole">:class</span>=<span class="et-hole">"badge"</span>&gt;…&lt;/<span class="code-tag">view</span>&gt;</span>
-<span class="et-static">&lt;/<span class="code-tag">view</span>&gt;</span></pre>
-      </div>
-      <div class="etcode__legend" aria-hidden="true">
-        <span><i class="et-sw is-static"></i>Block · static</span>
-        <span><i class="et-sw is-hole"></i>Block · hole</span>
-      </div>
-      <div class="codeframe etcode__out">
-        <div class="codeframe__head">
-          <span class="dots"><span></span><span></span><span></span></span>
-          <span>compiler output</span>
-        </div>
-<pre><span class="code-fn">registerElementTemplate</span>(
-  <span class="code-str">"__vlx-tpl:rflz…"</span>,
-  [<span class="code-str">"#text"</span>, <span class="code-str">"class"</span>], <span class="code-com">// holes</span>
-  <span class="code-key">function</span> (P) {
-    <span class="code-com">…straight-line PAPI…</span>
-    <span class="code-key">return</span> [e0, e3, e5]
-  },
-)</pre>
-      </div>
-    </div>
-    <p class="lead arch-cap" data-mm-fade>
-      Vue already ships <b>compiler-hinted VDOM</b> — a Block marks static
-      structure vs dynamic holes. That hint is what we lower into
-      <code>create()</code>.
-    </p>
+    <h2 class="h-section" style="text-align:center;max-width:24ch">
+      IFR changes <em class="ifr-em">when</em> the frame renders.<br/>
+      <span class="brand-text">Element Templates</span> change how much work it does.
+    </h2>
     <aside class="notes">
-      <p><strong>Why Vue can do this.</strong> Vue's compiler already partitions
-      a template into a Block: static nodes vs dynamic holes
-      (<code>patchFlag</code> / dynamicChildren). Element Templates reuse that
-      structure information — bake the static shell into
-      <code>registerElementTemplate(id, holes, create)</code>, leave only the
-      holes on the vnode path. Eligible = plain Lynx elements with value/text
-      dynamics; components, slots, <code>v-if</code>/<code>v-for</code> hosts,
-      <code>&lt;list&gt;</code>, ref/id stay on the normal path (their plain
-      bodies can still lower). Next: the sparse trees on each thread, and what
-      actually crosses the wire.</p>
-    </aside>
-  </section>
-
-  <!-- IFR8 — dual-thread trees + what syncs (was IFR6b) -->
-  <section class="slide stage" data-bg="clean">
-    <div class="archflow">
-      <div class="node">
-        <span class="node__label"><i></i>Background · BTS</span>
-        <h3 class="node__title">VDOM · sparse</h3>
-        <svg class="dtree" viewBox="0 0 300 170" role="img" aria-label="BTS sparse tree: static nodes ghosted, only holes named">
-          <line class="edge ghost" x1="150" y1="28" x2="46" y2="60"/>
-          <line class="edge" x1="150" y1="28" x2="212" y2="60"/>
-          <line class="edge" x1="212" y1="82" x2="156" y2="114"/>
-          <line class="edge ghost" x1="212" y1="82" x2="254" y2="114"/>
-          <line class="edge" x1="157" y1="136" x2="157" y2="148"/>
-          <g><rect class="nodebox st" x="110" y="6" width="80" height="22" rx="5"/><text class="tag" x="128" y="21">card</text><rect class="uidbg" x="168" y="0" width="42" height="14" rx="6"/><text class="uid" x="172" y="11">root</text></g>
-          <g class="ghost"><rect class="nodebox" x="16" y="60" width="60" height="22" rx="5"/><text class="tag" x="30" y="75">icon</text></g>
-          <g class="ghost"><rect class="nodebox" x="182" y="60" width="60" height="22" rx="5"/><text class="tag" x="194" y="75">body</text></g>
-          <g><rect class="nodebox dy" x="126" y="114" width="60" height="22" rx="5"/><text class="tag" x="137" y="129">title</text><rect class="uidbg" x="164" y="108" width="42" height="14" rx="6"/><text class="uid" x="170" y="119">h0</text></g>
-          <g><rect class="nodebox dy" x="133" y="148" width="48" height="18" rx="5"/><text class="tag" x="140" y="161" style="font-size:9px">#text</text></g>
-          <g class="ghost"><rect class="nodebox" x="224" y="114" width="60" height="22" rx="5"/><text class="tag" x="236" y="129">desc</text></g>
-        </svg>
-        <span class="node__cap">static ghosted · only <b>holes</b> named</span>
-      </div>
-      <div class="xwire">
-        <div class="xwire__op">
-          <span class="xwire__name">INSTANTIATE_TEMPLATE</span>
-          <span class="xstruct"><i></i><i></i><i></i></span>
-          <span class="xwire__line"></span>
-          <span class="xwire__count">tpl id · not the tree</span>
-        </div>
-        <div class="xwire__op">
-          <span class="xwire__name">SET_* holes</span>
-          <span class="xwire__line is-multi"></span>
-          <span class="xwire__count">values only · e.g. h0</span>
-        </div>
-        <div class="xwire__op">
-          <span class="xwire__name">hydrate join</span>
-          <span class="xwire__line"></span>
-          <span class="xwire__count">ops vs recording</span>
-        </div>
-      </div>
-      <div class="node node--main">
-        <span class="node__label"><i></i>Main IFR · MTS</span>
-        <h3 class="node__title">native · create()</h3>
-        <svg class="dtree" viewBox="0 0 300 170" role="img" aria-label="MTS native tree from create(), same sparse hole ids">
-          <line class="edge ghost" x1="150" y1="28" x2="46" y2="60"/>
-          <line class="edge" x1="150" y1="28" x2="212" y2="60"/>
-          <line class="edge" x1="212" y1="82" x2="156" y2="114"/>
-          <line class="edge ghost" x1="212" y1="82" x2="254" y2="114"/>
-          <line class="edge" x1="157" y1="136" x2="157" y2="148"/>
-          <g><rect class="nodebox st" x="110" y="6" width="80" height="22" rx="5"/><text class="tag" x="128" y="21">card</text><rect class="uidbg" x="168" y="0" width="42" height="14" rx="6"/><text class="uid" x="172" y="11">root</text></g>
-          <g class="ghost"><rect class="nodebox" x="16" y="60" width="60" height="22" rx="5"/><text class="tag" x="30" y="75">icon</text></g>
-          <g class="ghost"><rect class="nodebox" x="182" y="60" width="60" height="22" rx="5"/><text class="tag" x="194" y="75">body</text></g>
-          <g><rect class="nodebox dy" x="126" y="114" width="60" height="22" rx="5"/><text class="tag" x="137" y="129">title</text><rect class="uidbg" x="164" y="108" width="42" height="14" rx="6"/><text class="uid" x="170" y="119">h0</text></g>
-          <g><rect class="nodebox dy" x="133" y="148" width="48" height="18" rx="5"/><text class="tag" x="140" y="161" style="font-size:9px">#text</text></g>
-          <g class="ghost"><rect class="nodebox" x="224" y="114" width="60" height="22" rx="5"/><text class="tag" x="236" y="129">desc</text></g>
-        </svg>
-        <span class="node__cap">create() builds · <b>same hole ids</b></span>
-      </div>
-    </div>
-    <p class="lead" data-mm-fade>
-      Structure never crosses — both bundles already share <code>create()</code>.
-      The wire carries the <b>tpl id</b> and <b>hole values</b>; hydrate joins those ops.
-    </p>
-    <aside class="notes">
-      <p><strong>What each side's tree is.</strong> BTS keeps a sparse VDOM /
-      ShadowElement view: static nodes exist for Vue's sync reads but are
-      protocol-invisible (ghosted). Only holes get names (<code>h0</code>…).
-      MTS IFR materializes the same shape via the compiled
-      <code>create()</code> — a native element tree with the same sparse hole
-      ids. That sparsity is exactly the Block the previous slide compiled.</p>
-      <p><strong>What syncs.</strong> Unlike Vapor's <code>REGISTER_TREE</code>,
-      ET does not send structure: <code>registerElementTemplate</code> already
-      shipped <code>create()</code> in both bundles. Across the wire:
-      <code>INSTANTIATE_TEMPLATE(tplId)</code> (once per instance) +
-      <code>SET_*</code> for hole values only. On IFR, MTS recorded those ops
-      at first paint; BTS's first batches hydrate against that recording —
-      skip / patch / rebuild, same join as Straightforward IFR.</p>
-    </aside>
-  </section>
-
-  <!-- IFR9 — benchmark table (proof) -->
-  <section class="slide stage">
-    <table class="bench-table">
-      <thead>
-        <tr><th>configuration</th><th>FCP</th><th>render cost</th><th>TTI proxy</th><th>bundle gzip</th></tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td class="bench-cfg">No IFR</td>
-          <td>96.6 ms</td><td>9.4 ms</td><td>1.00&times;</td><td>1.00&times;</td>
-        </tr>
-        <tr class="bench-row--hero">
-          <td class="bench-cfg">IFR + ET <span class="chip chip--brand">recommended</span></td>
-          <td class="is-good">75.4 ms <small>&minus;22%</small></td>
-          <td class="is-good">1.3 ms</td>
-          <td>~1.36&times;</td>
-          <td class="is-cost">~2.26&times;</td>
-        </tr>
-        <tr>
-          <td class="bench-cfg">IFR without ET</td>
-          <td>75.8 ms <small>&minus;22%</small></td>
-          <td>8.4 ms</td>
-          <td>~1.36&times;</td>
-          <td class="is-cost">~2.26&times;</td>
-        </tr>
-      </tbody>
-    </table>
-    <p class="lead arch-cap" data-mm-fade>
-      FCP across a real Web Worker + IPC (Lynx for Web) — suite median
-      &minus;12% to &minus;19%, ReactLynx control &minus;23%. ET stays flat on
-      FCP; its win is render cost (~1,000 el, jitless) and ops payload.
-    </p>
-    <aside class="notes">
-      <p>Separate campaigns, not one trace. The FCP win (median &minus;12…&minus;19%,
-      ReactLynx control &minus;23%) comes from removing background boot + IPC —
-      it needs a real thread boundary, and both IFR rows share it (ET is flat on
-      web FCP). Element Templates' own win is render cost 9.4&nbsp;ms →
-      <strong>1.3&nbsp;ms</strong> (~6&ndash;15&times; across reruns) and the ops
-      payload — the reason ET is on by default. Cost: ~2.26&times; gzip.</p>
+      <p><strong>The two levers, in one line.</strong> You just watched the shared
+      BTS↔MTS data-flow collapse from five steps to three. IFR moves the paint
+      earlier; Element Templates make the render itself an order of magnitude
+      cheaper — and shrink the cross-thread protocol for <em>every</em> update,
+      not just the first frame. Next: the numbers.</p>
     </aside>
   </section>
 
@@ -2515,6 +2485,27 @@ app.<span class="code-fn">use</span>(router)</pre>
       for a static-heavy screen drops ~78&nbsp;KB → 69&nbsp;bytes. PAPI call
       counts only drop 5&ndash;20% — native element work is a shared floor; what
       lowers away is the framework JS and the protocol around it.</p>
+    </aside>
+  </section>
+
+  <!-- IFR9 — FCP punchline (−22%) -->
+  <section class="slide stage">
+    <div class="mega" style="font-size:clamp(72px,12cqw,168px);line-height:0.92">
+      <span class="brand-text">&minus;22%</span>
+    </div>
+    <p class="lead" style="text-align:center;max-width:28ch;margin-inline:auto" data-mm-fade>
+      FCP with IFR · Lynx for Web
+    </p>
+    <p class="lead arch-cap" data-mm-fade>
+      Suite median &minus;12% to &minus;19%. ReactLynx control &minus;23%.
+      ET stays flat on FCP — its win is the render cost and ops payload you just saw.
+    </p>
+    <aside class="notes">
+      <p><strong>The headline number.</strong> FCP across a real Web Worker + IPC
+      (Lynx for Web): this row &minus;22%, suite median &minus;12…&minus;19%,
+      ReactLynx control &minus;23%. The win is removing background boot + IPC —
+      both IFR rows share it. ET is flat on web FCP; you already saw its own win
+      on render cost and ops payload. Cost: ~2.26&times; gzip, TTI proxy ~1.36&times;.</p>
     </aside>
   </section>
 

--- a/slides/index.html
+++ b/slides/index.html
@@ -2117,17 +2117,17 @@ app.<span class="code-fn">use</span>(router)</pre>
         <div class="ifrjoin__col" style="--c:#56b8f0">
           <span class="ifrjoin__label"><i></i>Main (UI) thread</span>
           <span class="ifrjoin__role">records</span>
-          <code class="ifrjoin__op">SET_TEXT 3 "Hi"</code>
-          <code class="ifrjoin__op">SET_TEXT 3 "Hi"</code>
-          <code class="ifrjoin__op">CREATE 4 view</code>
+          <code class="ifrjoin__op is-match">SET_TEXT 3 "Hi"</code>
+          <code class="ifrjoin__op is-patch">SET_TEXT 3 "Hi"</code>
+          <code class="ifrjoin__op is-tear">CREATE 4 view</code>
         </div>
         <div class="ifrjoin__rail" aria-hidden="true"></div>
         <div class="ifrjoin__col" style="--c:#5dd5a8">
           <span class="ifrjoin__label"><i></i>Background thread</span>
           <span class="ifrjoin__role">first batches</span>
-          <code class="ifrjoin__op">SET_TEXT 3 "Hi"</code>
-          <code class="ifrjoin__op is-diff">SET_TEXT 3 "你好"</code>
-          <code class="ifrjoin__op is-diff">CREATE 4 text</code>
+          <code class="ifrjoin__op is-match">SET_TEXT 3 "Hi"</code>
+          <code class="ifrjoin__op is-patch">SET_TEXT 3 "你好"</code>
+          <code class="ifrjoin__op is-tear">CREATE 4 text</code>
         </div>
       </div>
       <div class="ifrjoin__join">
@@ -2173,48 +2173,86 @@ app.<span class="code-fn">use</span>(router)</pre>
     </aside>
   </section>
 
-  <!-- IFR5 — the pipeline, per node (reuses the runtime flow boxes) -->
+  <!-- IFR5 — without ET: dual-thread fat VDOM → opcode pipelines -->
   <section class="slide stage">
-    <div class="flow ifr-pipe">
-      <div class="fb" data-flip="etp-vdom" style="--c:#42b883;left:9%;top:50%">VDOM<small>one vnode / node</small></div>
-      <span class="farr" data-mm-fade style="left:21%;top:50%">&rarr;</span>
-      <div class="fb" data-mm-fade style="--c:#E8B44A;left:32%;top:50%">Shadow<small>one node</small></div>
-      <span class="farr" data-mm-fade style="left:42%;top:50%">&rarr;</span>
-      <div class="fb" data-mm-fade style="--c:#4FB8F0;left:51%;top:50%">ops<small>several frames</small></div>
-      <span class="farr" data-mm-fade style="left:60%;top:50%">&rarr;</span>
-      <div class="fb" data-mm-fade style="--c:#56b8f0;left:69%;top:50%">interp<small>a switch loop</small></div>
-      <span class="farr" data-mm-fade style="left:79%;top:50%">&rarr;</span>
-      <div class="fb" data-flip="etp-papi" style="--c:#F27A9E;left:90%;top:50%">PAPI<small>__CreateView</small></div>
-      <span class="fcenter" data-mm-fade style="left:50%;top:88%">&times; every static node</span>
+    <div class="ifrjoin ifrjoin--pipe">
+      <div class="ifrjoin__cols">
+        <div class="ifrjoin__col" data-flip="et-col-bg" style="--c:#5dd5a8">
+          <span class="ifrjoin__label" data-flip="et-lab-bg"><i></i>Background · BTS</span>
+          <span class="ifrjoin__role" data-mm-fade>VDOM tree &rarr; opcodes</span>
+          <code class="ifrjoin__op" data-mm-fade>VDOM</code>
+          <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+          <code class="ifrjoin__op" data-mm-fade>ShadowElement</code>
+          <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+          <code class="ifrjoin__op is-fat" data-mm-fade>CREATE · SET · APPEND &hellip;</code>
+          <span class="ifrjoin__hint" data-mm-fade>many ops / node</span>
+        </div>
+        <div class="ifrjoin__rail" aria-hidden="true"></div>
+        <div class="ifrjoin__col" data-flip="et-col-mt" style="--c:#56b8f0">
+          <span class="ifrjoin__label" data-flip="et-lab-mt"><i></i>Main IFR · MTS</span>
+          <span class="ifrjoin__role" data-mm-fade>same chain, local apply</span>
+          <code class="ifrjoin__op" data-mm-fade>VDOM</code>
+          <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+          <code class="ifrjoin__op" data-mm-fade>record ops</code>
+          <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+          <code class="ifrjoin__op is-fat" data-mm-fade>CREATE · SET · APPEND &hellip;</code>
+          <span class="ifrjoin__hint" data-mm-fade>applyOps &rarr; PAPI &rarr; paint</span>
+        </div>
+      </div>
     </div>
     <p class="lead arch-cap" data-mm-fade>
-      Normally every static element pays the whole chain — a vnode, a shadow
-      node, ops frames, a thread crossing, an interpreter dispatch.
+      Without ET, BTS and MTS IFR both pay the fat
+      <b>VDOM &rarr; opcode</b> chain — just on different threads.
     </p>
     <aside class="notes">
-      <p>The same pipeline from the Runtime chapter — but notice it runs
-      <em>per node</em>, even for structure that never changes.</p>
+      <p><strong>Same code, two threads, still expensive.</strong> BTS walks the
+      VDOM into ShadowElement and emits a long flat opcode stream. MTS IFR runs
+      the same Vue + <code>nodeOps</code> during <code>loadTemplate</code>, records
+      the same shape of ops, and applies them locally to paint. IFR moved
+      <em>when</em> paint happens — it did not shrink the work yet.</p>
     </aside>
   </section>
 
-  <!-- IFR6 — Element Templates collapse the pipeline (magic-move) -->
+  <!-- IFR6 — with ET: BTS emits INSTANTIATE; MTS IFR runs create() -->
   <section class="slide stage">
-    <div class="flow ifr-pipe">
-      <div class="fb" data-flip="etp-vdom" style="--c:#42b883;left:16%;top:50%">one vnode<small>__vlx-tpl:…</small></div>
-      <span class="farr" data-mm-fade style="left:33%;top:50%">&rarr;</span>
-      <div class="fb is-hero" data-mm-fade style="--c:#5dd5a8;left:50%;top:50%">INSTANTIATE_TEMPLATE<small>one op · whole subtree</small></div>
-      <span class="farr" data-mm-fade style="left:67%;top:50%">&rarr;</span>
-      <div class="fb" data-flip="etp-papi" style="--c:#F27A9E;left:84%;top:50%">create()<small>straight-line PAPI</small></div>
-      <span class="fcenter" data-mm-fade style="left:50%;top:88%">holes update via ordinary <b>SET_*</b> ops</span>
+    <div class="ifrjoin ifrjoin--pipe">
+      <div class="ifrjoin__cols">
+        <div class="ifrjoin__col" data-flip="et-col-bg" style="--c:#5dd5a8">
+          <span class="ifrjoin__label" data-flip="et-lab-bg"><i></i>Background · BTS</span>
+          <span class="ifrjoin__role" data-mm-fade>VDOM &rarr; one template op</span>
+          <code class="ifrjoin__op" data-mm-fade>VDOM · __vlx-tpl</code>
+          <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+          <code class="ifrjoin__op is-hero" data-mm-fade>INSTANTIATE_TEMPLATE</code>
+          <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+          <code class="ifrjoin__op" data-mm-fade>SET_* holes only</code>
+          <span class="ifrjoin__hint" data-mm-fade>one op · whole subtree</span>
+        </div>
+        <div class="ifrjoin__rail" aria-hidden="true"></div>
+        <div class="ifrjoin__col" data-flip="et-col-mt" style="--c:#56b8f0">
+          <span class="ifrjoin__label" data-flip="et-lab-mt"><i></i>Main IFR · MTS</span>
+          <span class="ifrjoin__role" data-mm-fade>opcode &rarr; create() PAPI</span>
+          <code class="ifrjoin__op" data-mm-fade>VDOM · __vlx-tpl</code>
+          <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+          <code class="ifrjoin__op is-hero" data-mm-fade>INSTANTIATE_TEMPLATE</code>
+          <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+          <code class="ifrjoin__op is-hero" data-mm-fade>create() &rarr; __CreateView&hellip;</code>
+          <span class="ifrjoin__hint" data-mm-fade>straight-line PAPI &rarr; paint</span>
+        </div>
+      </div>
     </div>
     <p class="lead arch-cap" data-mm-fade>
-      The compiler lowers the static subtree to one <code>create()</code>
-      function. Vue sends <b>one</b> op; only the dynamic holes travel after.
+      ET converts the static subtree into a compiled <code>create()</code> —
+      BTS sends <b>one</b> op; MTS IFR runs that function as straight-line PAPI.
     </p>
     <aside class="notes">
-      <p>Watch <code>VDOM</code> and <code>PAPI</code> stay put while the middle
-      of the pipeline collapses. These are <em>framework</em> templates —
-      ordinary typed Element PAPI calls, not Lynx's binary engine templates.</p>
+      <p><strong>How ET lands on each thread.</strong> The compiler lowers the
+      static shell to <code>registerElementTemplate(id, holes, create)</code>.
+      BTS still starts from a VDOM tree, but the static block is one vnode that
+      emits <code>INSTANTIATE_TEMPLATE</code> plus hole <code>SET_*</code>s — not
+      per-node <code>CREATE</code>s. On MTS IFR the same opcode hits the local
+      interpreter, which calls the baked <code>create()</code> — a straight-line
+      sequence of Element PAPI. Next slide shows the source &rarr; compiler
+      output.</p>
     </aside>
   </section>
 

--- a/slides/index.html
+++ b/slides/index.html
@@ -2175,109 +2175,122 @@ app.<span class="code-fn">use</span>(router)</pre>
     </aside>
   </section>
 
-  <!-- IFR5 — without ET: dual-thread + lit 5-step data-flow bridge -->
+  <!-- IFR5 — without ET: original dual-thread cols + 5 linked steps -->
   <section class="slide stage">
-    <div class="etbridge">
-      <div class="etbridge__side" data-flip="et-col-bg" style="--c:#5dd5a8">
-        <span class="ifrjoin__label" data-flip="et-lab-bg"><i></i>Background · BTS</span>
-        <span class="ifrjoin__role" data-mm-fade>VDOM tree &rarr; opcodes</span>
-        <p class="etbridge__blurb" data-mm-fade>Walks ShadowElement, emits a long flat stream.</p>
-      </div>
-      <div class="etbridge__flow">
-        <div class="etb-row">
-          <i class="etb-tick etb-tick--l" aria-hidden="true"></i>
-          <div class="etb" data-flip="etp-vdom" style="--c:#42b883">VDOM<small>one vnode / node</small></div>
-          <i class="etb-tick etb-tick--r" aria-hidden="true"></i>
+    <div class="ifrjoin ifrjoin--pipe ifrjoin--linked">
+      <div class="ifrjoin__cols">
+        <div class="ifrjoin__col" data-flip="et-col-bg" style="--c:#5dd5a8">
+          <span class="ifrjoin__label" data-flip="et-lab-bg"><i></i>Background · BTS</span>
+          <span class="ifrjoin__role" data-mm-fade>VDOM tree &rarr; opcodes</span>
+          <div class="ifrjoin__stack">
+            <code class="ifrjoin__op" data-flip="et-bg-1">VDOM</code>
+            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+            <code class="ifrjoin__op" data-mm-fade>ShadowElement</code>
+            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+            <code class="ifrjoin__op is-fat" data-mm-fade>CREATE · SET · APPEND &hellip;</code>
+            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+            <code class="ifrjoin__op is-idle" data-mm-fade>stream &rarr;</code>
+            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+            <code class="ifrjoin__op is-idle" data-mm-fade>awaits hydrate</code>
+          </div>
+          <span class="ifrjoin__hint" data-mm-fade>many ops / node</span>
         </div>
-        <span class="etb-arr" data-mm-fade>&darr;</span>
-        <div class="etb-row" data-mm-fade>
-          <i class="etb-tick etb-tick--l" aria-hidden="true"></i>
-          <div class="etb" style="--c:#E8B44A">Shadow<small>one node</small></div>
-          <i class="etb-tick etb-tick--r" aria-hidden="true"></i>
+        <div class="ifrjoin__links">
+          <span class="ifrjoin__linkhead" data-mm-fade>5 steps</span>
+          <div class="ifrjoin__stack">
+            <span class="ifrjoin__link" data-flip="etp-vdom" style="--c:#42b883"><b>1</b> VDOM</span>
+            <span class="ifrjoin__arr ifrjoin__arr--ghost" aria-hidden="true">&darr;</span>
+            <span class="ifrjoin__link" data-mm-fade style="--c:#E8B44A"><b>2</b> Shadow</span>
+            <span class="ifrjoin__arr ifrjoin__arr--ghost" aria-hidden="true">&darr;</span>
+            <span class="ifrjoin__link" data-mm-fade style="--c:#4FB8F0"><b>3</b> ops</span>
+            <span class="ifrjoin__arr ifrjoin__arr--ghost" aria-hidden="true">&darr;</span>
+            <span class="ifrjoin__link" data-mm-fade style="--c:#56b8f0"><b>4</b> interp</span>
+            <span class="ifrjoin__arr ifrjoin__arr--ghost" aria-hidden="true">&darr;</span>
+            <span class="ifrjoin__link" data-flip="etp-papi" style="--c:#F27A9E"><b>5</b> PAPI</span>
+          </div>
         </div>
-        <span class="etb-arr" data-mm-fade>&darr;</span>
-        <div class="etb-row" data-mm-fade>
-          <i class="etb-tick etb-tick--l" aria-hidden="true"></i>
-          <div class="etb" style="--c:#4FB8F0">ops<small>several frames</small></div>
-          <i class="etb-tick etb-tick--r" aria-hidden="true"></i>
+        <div class="ifrjoin__col" data-flip="et-col-mt" style="--c:#56b8f0">
+          <span class="ifrjoin__label" data-flip="et-lab-mt"><i></i>Main IFR · MTS</span>
+          <span class="ifrjoin__role" data-mm-fade>same chain, local apply</span>
+          <div class="ifrjoin__stack">
+            <code class="ifrjoin__op" data-flip="et-mt-1">VDOM</code>
+            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+            <code class="ifrjoin__op" data-mm-fade>record ops</code>
+            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+            <code class="ifrjoin__op is-fat" data-mm-fade>CREATE · SET · APPEND &hellip;</code>
+            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+            <code class="ifrjoin__op" data-mm-fade>applyOps</code>
+            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+            <code class="ifrjoin__op" data-flip="et-mt-5">PAPI &rarr; paint</code>
+          </div>
+          <span class="ifrjoin__hint" data-mm-fade>applyOps &rarr; PAPI &rarr; paint</span>
         </div>
-        <span class="etb-arr" data-mm-fade>&darr;</span>
-        <div class="etb-row" data-mm-fade>
-          <i class="etb-tick etb-tick--l" aria-hidden="true"></i>
-          <div class="etb" style="--c:#56b8f0">interp<small>a switch loop</small></div>
-          <i class="etb-tick etb-tick--r" aria-hidden="true"></i>
-        </div>
-        <span class="etb-arr" data-mm-fade>&darr;</span>
-        <div class="etb-row">
-          <i class="etb-tick etb-tick--l" aria-hidden="true"></i>
-          <div class="etb" data-flip="etp-papi" style="--c:#F27A9E">PAPI<small>__CreateView</small></div>
-          <i class="etb-tick etb-tick--r" aria-hidden="true"></i>
-        </div>
-        <span class="etbridge__tag" data-mm-fade>&times; every static node</span>
-      </div>
-      <div class="etbridge__side" data-flip="et-col-mt" style="--c:#56b8f0">
-        <span class="ifrjoin__label" data-flip="et-lab-mt"><i></i>Main IFR · MTS</span>
-        <span class="ifrjoin__role" data-mm-fade>same chain, local apply</span>
-        <p class="etbridge__blurb" data-mm-fade>Records ops, applyOps &rarr; paint on-thread.</p>
       </div>
     </div>
     <p class="lead arch-cap" data-mm-fade>
       Without ET, BTS and MTS IFR both pay the fat
-      <b>5-step</b> data-flow — linked across the thread boundary.
+      <b>VDOM &rarr; opcode</b> chain — five linked steps across the boundary.
     </p>
     <aside class="notes">
-      <p><strong>Same code, two threads, still expensive.</strong> The lit chain
-      in the middle is the shared protocol: VDOM → Shadow → ops → interp →
-      PAPI, once per static node. BTS emits it; MTS IFR records and applies it
-      locally. IFR moved <em>when</em> paint happens — the next slide collapses
-      <em>how much</em> work the chain does.</p>
+      <p><strong>Same code, two threads, still expensive.</strong> Same dual-thread
+      columns as before — the numbered chips in the middle light up the shared
+      5-step protocol: VDOM → Shadow → ops → interp → PAPI. BTS emits the
+      stream; MTS IFR records and applies it locally. IFR moved <em>when</em>
+      paint happens — next slide collapses those five links to three.</p>
     </aside>
   </section>
 
-  <!-- IFR6 — with ET: bridge collapses 5 → 3 (magic-move) -->
+  <!-- IFR6 — with ET: same dual-thread cols, links collapse 5 → 3 -->
   <section class="slide stage">
-    <div class="etbridge">
-      <div class="etbridge__side" data-flip="et-col-bg" style="--c:#5dd5a8">
-        <span class="ifrjoin__label" data-flip="et-lab-bg"><i></i>Background · BTS</span>
-        <span class="ifrjoin__role" data-mm-fade>VDOM &rarr; one template op</span>
-        <p class="etbridge__blurb" data-mm-fade>Emits INSTANTIATE_TEMPLATE + hole SET_*.</p>
-      </div>
-      <div class="etbridge__flow">
-        <div class="etb-row">
-          <i class="etb-tick etb-tick--l" aria-hidden="true"></i>
-          <div class="etb" data-flip="etp-vdom" style="--c:#42b883">one vnode<small>__vlx-tpl:…</small></div>
-          <i class="etb-tick etb-tick--r" aria-hidden="true"></i>
+    <div class="ifrjoin ifrjoin--pipe ifrjoin--linked">
+      <div class="ifrjoin__cols">
+        <div class="ifrjoin__col" data-flip="et-col-bg" style="--c:#5dd5a8">
+          <span class="ifrjoin__label" data-flip="et-lab-bg"><i></i>Background · BTS</span>
+          <span class="ifrjoin__role" data-mm-fade>VDOM &rarr; one template op</span>
+          <div class="ifrjoin__stack">
+            <code class="ifrjoin__op" data-flip="et-bg-1">VDOM · __vlx-tpl</code>
+            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+            <code class="ifrjoin__op is-hero" data-mm-fade>INSTANTIATE_TEMPLATE</code>
+            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+            <code class="ifrjoin__op" data-mm-fade>SET_* holes only</code>
+          </div>
+          <span class="ifrjoin__hint" data-mm-fade>one op · whole subtree</span>
         </div>
-        <span class="etb-arr" data-mm-fade>&darr;</span>
-        <div class="etb-row" data-mm-fade>
-          <i class="etb-tick etb-tick--l" aria-hidden="true"></i>
-          <div class="etb is-hero" style="--c:#5dd5a8">INSTANTIATE_TEMPLATE<small>one op · whole subtree</small></div>
-          <i class="etb-tick etb-tick--r" aria-hidden="true"></i>
+        <div class="ifrjoin__links">
+          <span class="ifrjoin__linkhead" data-mm-fade>3 steps</span>
+          <div class="ifrjoin__stack">
+            <span class="ifrjoin__link" data-flip="etp-vdom" style="--c:#42b883"><b>1</b> vnode</span>
+            <span class="ifrjoin__arr ifrjoin__arr--ghost" aria-hidden="true">&darr;</span>
+            <span class="ifrjoin__link is-hero" data-mm-fade style="--c:#5dd5a8"><b>2</b> INSTANTIATE</span>
+            <span class="ifrjoin__arr ifrjoin__arr--ghost" aria-hidden="true">&darr;</span>
+            <span class="ifrjoin__link" data-flip="etp-papi" style="--c:#F27A9E"><b>3</b> create()</span>
+          </div>
         </div>
-        <span class="etb-arr" data-mm-fade>&darr;</span>
-        <div class="etb-row">
-          <i class="etb-tick etb-tick--l" aria-hidden="true"></i>
-          <div class="etb" data-flip="etp-papi" style="--c:#F27A9E">create()<small>straight-line PAPI</small></div>
-          <i class="etb-tick etb-tick--r" aria-hidden="true"></i>
+        <div class="ifrjoin__col" data-flip="et-col-mt" style="--c:#56b8f0">
+          <span class="ifrjoin__label" data-flip="et-lab-mt"><i></i>Main IFR · MTS</span>
+          <span class="ifrjoin__role" data-mm-fade>opcode &rarr; create() PAPI</span>
+          <div class="ifrjoin__stack">
+            <code class="ifrjoin__op" data-flip="et-mt-1">VDOM · __vlx-tpl</code>
+            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+            <code class="ifrjoin__op is-hero" data-mm-fade>INSTANTIATE_TEMPLATE</code>
+            <span class="ifrjoin__arr" data-mm-fade>&darr;</span>
+            <code class="ifrjoin__op is-hero" data-flip="et-mt-5">create() &rarr; PAPI</code>
+          </div>
+          <span class="ifrjoin__hint" data-mm-fade>straight-line PAPI &rarr; paint</span>
         </div>
-        <span class="etbridge__tag" data-mm-fade>holes update via ordinary <b>SET_*</b> ops</span>
-      </div>
-      <div class="etbridge__side" data-flip="et-col-mt" style="--c:#56b8f0">
-        <span class="ifrjoin__label" data-flip="et-lab-mt"><i></i>Main IFR · MTS</span>
-        <span class="ifrjoin__role" data-mm-fade>opcode &rarr; create() PAPI</span>
-        <p class="etbridge__blurb" data-mm-fade>Interpreter runs create() &rarr; paint.</p>
       </div>
     </div>
     <p class="lead arch-cap" data-mm-fade>
-      ET collapses the bridge to <b>3 steps</b> — BTS sends one op; MTS IFR
-      runs the compiled <code>create()</code> as straight-line PAPI.
+      ET collapses the same dual-thread picture to <b>3 linked steps</b> —
+      BTS sends one op; MTS IFR runs <code>create()</code> as straight-line PAPI.
     </p>
     <aside class="notes">
-      <p><strong>Watch the middle collapse.</strong> VDOM and PAPI stay put
-      (magic-move); Shadow / ops / interp fold into one
-      <code>INSTANTIATE_TEMPLATE</code>. Framework templates — typed Element
-      PAPI, not Lynx binary engine templates. Next: why Vue can do this —
-      compiler-hinted VDOM already carries Block structure.</p>
+      <p><strong>Same figure, fewer links.</strong> Watch steps 2–4 fold into one
+      <code>INSTANTIATE_TEMPLATE</code> chip; VDOM and PAPI/<code>create()</code>
+      stay put (magic-move). BTS still starts from a VDOM tree, but the static
+      block is one vnode that emits INSTANTIATE + hole SET_*s. MTS IFR's
+      interpreter calls the baked <code>create()</code>. Next: why Vue can do
+      this — compiler-hinted VDOM already carries Block structure.</p>
     </aside>
   </section>
 

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -222,24 +222,38 @@ export const ZH = {
     '常规下每个静态元素都要付整条链 —— 一个 vnode、一个影子节点、若干 ops 帧、一次跨线程、一次解释器分发。',
   'Without ET, BTS and MTS IFR both pay the fat VDOM → opcode chain — just on different threads.':
     '没有 ET 时,BTS 和 MTS IFR 都要付那条肥胖的 <b>VDOM → opcode</b> 链 —— 只是跑在不同线程上。',
+  'Without ET, BTS and MTS IFR both pay the fat 5-step data-flow — linked across the thread boundary.':
+    '没有 ET 时,BTS 和 MTS IFR 都要付那条肥胖的 <b>5 步</b> data-flow —— 跨线程边界连在一起。',
   'The compiler lowers the static subtree to one create() function. Vue sends one op; only the dynamic holes travel after.':
     '编译器把静态子树下沉成一个 <code>create()</code> 函数。Vue 只发<b>一个</b> op;之后只有动态空洞在传输。',
   'ET converts the static subtree into a compiled create() — BTS sends one op; MTS IFR runs that function as straight-line PAPI.':
     'ET 把静态子树编译成 <code>create()</code> —— BTS 只发<b>一个</b> op;MTS IFR 把它当直线 PAPI 跑。',
+  'ET collapses the bridge to 3 steps — BTS sends one op; MTS IFR runs the compiled create() as straight-line PAPI.':
+    'ET 把桥塌成 <b>3 步</b> —— BTS 只发一个 op;MTS IFR 把编译好的 <code>create()</code> 当直线 PAPI 跑。',
   'Static structure bakes into a create() skeleton; only the holes — dynamic text, class, style, attrs — stay on the vnode path.':
     '静态结构烘焙进 <code>create()</code> 骨架;只有空洞 —— 动态的文本、class、style、属性 —— 留在 vnode 路径上。',
-  // dual-thread ET pipe labels / roles
+  'Vue already ships compiler-hinted VDOM — a Block marks static structure vs dynamic holes. That hint is what we lower into create().':
+    'Vue 本来就有 <b>compiler-hinted VDOM</b> —— Block 标出静态结构 vs 动态空洞。我们正是把这份 hint 下沉成 <code>create()</code>。',
+  // dual-thread ET pipe / bridge blurbs
   'Background · BTS': '<i></i>后台 · BTS',
   'Main IFR · MTS': '<i></i>主线程 IFR · MTS',
   'VDOM tree → opcodes': 'VDOM 树 → opcodes',
   'same chain, local apply': '同一条链,本地 apply',
   'VDOM → one template op': 'VDOM → 一个模板 op',
   'opcode → create() PAPI': 'opcode → create() PAPI',
-  'many ops / node': '每节点很多 ops',
-  'applyOps → PAPI → paint': 'applyOps → PAPI → paint',
-  'one op · whole subtree': '一个 op · 整棵子树',
-  'straight-line PAPI → paint': '直线 PAPI → paint',
-  // IFR6b · trees + sync wire
+  'Walks ShadowElement, emits a long flat stream.':
+    '走进 ShadowElement,吐出一长串扁平流。',
+  'Records ops, applyOps → paint on-thread.':
+    '录下 ops,本地 applyOps → paint。',
+  'Emits INSTANTIATE_TEMPLATE + hole SET_*.':
+    '发出 INSTANTIATE_TEMPLATE + hole 的 SET_*。',
+  'Interpreter runs create() → paint.':
+    '解释器跑 create() → paint。',
+  'Block · static': 'Block · 静态',
+  'Block · hole': 'Block · 空洞',
+  'baked skeleton': '烘焙骨架',
+  'dynamic hole': '动态空洞',
+  // IFR8 · trees + sync wire
   'VDOM · sparse': 'VDOM · 稀疏',
   'native · create()': 'native · create()',
   'static ghosted · only holes named': '静态变灰 · 只有 <b>holes</b> 有名',
@@ -612,18 +626,18 @@ export const ZH_NOTES = [
   // IFR3 · Straightforward IFR
   `<p><strong>Straightforward IFR —— hydration 当作 thread join。</strong>没有特殊的首帧格式:同一份 Vue 运行时 + 应用(同一套 <code>nodeOps</code>)在 <code>loadTemplate</code> 期间跑在主线程上并<em>录下</em>扁平 ops 流。后台并行启动,随后最初的 <code>vuePatchUpdate</code> 批次逐帧走这份录制 —— 是一次 join,不是重写:相同 → 跳过,值不同 → 打补丁,结构分歧 → 拆掉重建。不一致只损失性能收益,绝不损失正确性(开发期打印 <code>IFR hydration mismatch</code>)。确定性 id 与 <code>vue:N</code> 签名让点击无需重绑就路由回 Vue。</p>`,
   // IFR4 · Element Templates 转折
-  `<p><strong>第二个杠杆。</strong>IFR 把绘制提前;打开它会默认打开 Element Templates。它们让渲染本身便宜一个数量级 —— 而且瘦身的是<em>每一次</em>更新的跨线程协议,不只首帧。</p>`,
-  // IFR5 · 双线程无 ET：肥胖 VDOM→opcode
-  `<p><strong>同一份代码,两条线程,仍然很贵。</strong>BTS 把 VDOM 走进 ShadowElement,吐出一长串扁平 opcode。MTS IFR 在 <code>loadTemplate</code> 期间跑同一份 Vue + <code>nodeOps</code>,录下同形状的 ops,本地 apply 出画面。IFR 改的是<em>何时</em> paint —— 还没把活变少。</p>`,
-  // IFR6 · 双线程有 ET：INSTANTIATE → create()
-  `<p><strong>ET 怎么落到两条线程。</strong>编译器把静态壳下沉成 <code>registerElementTemplate(id, holes, create)</code>。BTS 仍从 VDOM 起步,但静态块变成一个 vnode,只发 <code>INSTANTIATE_TEMPLATE</code> 加空洞 <code>SET_*</code> —— 不再逐节点 <code>CREATE</code>。MTS IFR 上同一个 opcode 进本地解释器,调用烘焙好的 <code>create()</code> —— 一串直线 Element PAPI。下一页:两边的树长什么样,以及线上到底同步了什么。</p>`,
-  // IFR6b · 双线程树 + 同步内容
-  `<p><strong>两边的树分别是什么。</strong>BTS 侧是稀疏的 VDOM / ShadowElement:静态节点仍在(满足 Vue 的同步读取),但对协议隐形(变灰);只有 hole 有名字(<code>h0</code>…)。MTS IFR 用编译好的 <code>create()</code> 物化同一形状 —— 一棵原生元素树,hole id 对齐。</p><p><strong>同步了什么。</strong>和 Vapor 的 <code>REGISTER_TREE</code> 不同,ET 不传结构:<code>registerElementTemplate</code> 已经把 <code>create()</code> 打进两边产物。跨线只有 <code>INSTANTIATE_TEMPLATE(tplId)</code>(每个实例一次)+ hole 的 <code>SET_*</code> 值。IFR 下 MTS 首屏已录下这些 ops;BTS 最初几批拿去和录制对账 —— 仍是 skip / patch / rebuild 那次 join。</p>`,
-  // IFR7 · 骨架 + 空洞
-  `<p>可下沉 = 每个节点都是纯 Lynx 元素、只有值或文本动态。组件、插槽、<code>v-if</code>/<code>v-for</code> 宿主、<code>&lt;list&gt;</code>、带 ref/id 的节点留在普通 vnode 路径;它们的纯元素子体仍可下沉。scoped-CSS 的 scope id 会被烘焙进去。</p>`,
-  // IFR8 · 基准测试表
+  `<p><strong>第二个杠杆。</strong>IFR 把绘制提前;打开它会默认打开 Element Templates。它们让渲染本身便宜一个数量级 —— 而且瘦身的是<em>每一次</em>更新的跨线程协议,不只首帧。看接下来两页:BTS 与 MTS 之间那条共享 data-flow 从五步塌成三步。</p>`,
+  // IFR5 · 双线程 + 点亮的 5 步桥
+  `<p><strong>同一份代码,两条线程,仍然很贵。</strong>中间点亮的链就是共享协议:VDOM → Shadow → ops → interp → PAPI,每个静态节点走一遍。BTS 发出它;MTS IFR 录下并本地 apply。IFR 改的是<em>何时</em> paint —— 下一页把链<em>做多少活</em>塌掉。</p>`,
+  // IFR6 · 桥 5→3 magic-move
+  `<p><strong>看中间塌陷。</strong>VDOM 和 PAPI 留在原地(magic-move);Shadow / ops / interp 折成一个 <code>INSTANTIATE_TEMPLATE</code>。框架级模板 —— 带类型的 Element PAPI,不是 Lynx 二进制引擎模板。下一页:为什么 Vue 能这么做 —— compiler-hinted VDOM 本来就带着 Block 结构。</p>`,
+  // IFR7 · Compiler-hinted Block → ET
+  `<p><strong>为什么 Vue 能这么做。</strong>Vue 的编译器早就把模板切成 Block:静态节点 vs 动态空洞(<code>patchFlag</code> / dynamicChildren)。Element Templates 复用这份结构信息 —— 把静态壳烘焙进 <code>registerElementTemplate(id, holes, create)</code>,只把空洞留在 vnode 路径。可下沉 = 纯 Lynx 元素且只有值/文本动态;组件、插槽、<code>v-if</code>/<code>v-for</code> 宿主、<code>&lt;list&gt;</code>、ref/id 留在普通路径(它们的纯元素子体仍可下沉)。下一页:两边的稀疏树,以及线上到底同步了什么。</p>`,
+  // IFR8 · 双线程树 + 同步内容
+  `<p><strong>两边的树分别是什么。</strong>BTS 侧是稀疏的 VDOM / ShadowElement:静态节点仍在(满足 Vue 的同步读取),但对协议隐形(变灰);只有 hole 有名字(<code>h0</code>…)。MTS IFR 用编译好的 <code>create()</code> 物化同一形状 —— 一棵原生元素树,hole id 对齐。这份稀疏,正是上一页编译出来的 Block。</p><p><strong>同步了什么。</strong>和 Vapor 的 <code>REGISTER_TREE</code> 不同,ET 不传结构:<code>registerElementTemplate</code> 已经把 <code>create()</code> 打进两边产物。跨线只有 <code>INSTANTIATE_TEMPLATE(tplId)</code>(每个实例一次)+ hole 的 <code>SET_*</code> 值。IFR 下 MTS 首屏已录下这些 ops;BTS 最初几批拿去和录制对账 —— 仍是 Straightforward IFR 那次 skip / patch / rebuild join。</p>`,
+  // IFR9 · 基准测试表
   `<p>几组独立的实验,不是一条 trace。FCP 收益(中位数 −12…−19%,ReactLynx 对照 −23%)来自去掉后台启动 + IPC —— 需要真实的线程边界,两种 IFR 配置都能拿到(ET 对 web FCP 基本持平)。Element Templates 自己的收益在渲染开销 9.4ms → <strong>1.3ms</strong>(多次重跑约 6–15×)和 ops 负载 —— 这也是 ET 默认打开的原因。代价:约 2.26× gzip。</p>`,
-  // IFR9 · 基准测试图
+  // IFR10 · 基准测试图
   `<p>左:渲染开销随 ET 塌陷。右:静态偏重屏幕的跨线程协议从约 78KB 降到 69 字节。PAPI 调用次数只降 5–20% —— 原生元素工作是共享地板;被下沉掉的是框架 JS 和它周围的协议。</p>`,
   // H1 · 2 weeks + X 复盘(合并)
   `<p><strong>现在这个数字说得通了 —— 顺便告诉大家去哪儿读。</strong>这一章的一切 —— 渲染器、工具链、MTS —— 是两周的夜晚和周末做出来的:plan 写成 spec,agent harness 执行,上游测试当 reward signal,AGENTS.md 固化调试手册。完整方法论写在 X 上(这里内嵌了,vue.lynxjs.org 首页的 badge 也链着它)—— 扫码就能在手机上读。给在座各位一个安静的结论:Lynx 出乎意料地 <em>AI 可读</em> —— Web 标准的 API 和真 CSS,意味着模型的 Web 直觉基本直接迁移。然后收束:"这就是它怎么被做出来的 —— 接下来看看它加起来意味着什么。"</p>`,

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -200,6 +200,8 @@ export const ZH = {
     '没有 IFR,首帧要等<em>整整一圈</em> —— 后台启动、渲染、送 ops —— 全部跑完才有画面。',
   'IFR puts the whole runtime in the main-thread bundle — it renders during loadTemplate, so paint lands first and the background boots alongside.':
     'IFR 把整个运行时放进<b style="color:#56b8f0">主线程</b>产物 —— 它在 <code>loadTemplate</code> 期间渲染,于是<b>先出画面</b>,后台在一旁并行启动。',
+  'IFR paints on the main thread during loadTemplate — then hydrate joins the two ops streams.':
+    'IFR 在 <code>loadTemplate</code> 期间于<b style="color:#56b8f0">主线程</b>绘制 —— 然后 <b>hydrate</b> 把两条 ops 流 join 起来。',
   "The MT render records its ops; the BG's first batches hydrate against them. Correctness never depends on the two matching — deterministic ids & vue:N signs route taps to Vue with no rebinding.":
     '主线程渲染时录下自己的 ops;后台最初的几批拿去和它水合对账。正确性从不依赖两者一致 —— 确定性 id 与 <code>vue:N</code> 签名让点击无需重绑就路由回 Vue。',
   'Both threads render. The ops stream is the recording — the MT records its ops; the BG\'s first batches hydrate against them. Correctness never depends on the two matching.':
@@ -580,10 +582,12 @@ export const ZH_NOTES = [
   `<p><strong>复刻即证明。</strong>lynxjs.org 用两个教程教 MTS,都是为 ReactLynx 写的。两个都在 Vue Lynx 上重做了,live 在我们的文档站上 —— 同样的拖拽物理、同样的吸附、同样的主线程滚动条。平台教程能干净地移植过来,能力就是真的在。</p><p><strong>现场:</strong>慢慢拖 —— 指示器逐像素同步;一甩,吸附。</p>`,
   // IFR1 · 空白首帧
   `<p><strong>往返的代价。</strong>前六页讲的 VDOM → ShadowElement → ops → PAPI,在第一帧之前必须先整整跑一圈。设备上,这一圈再加后台线程启动与 bundle 求值,就是几十毫秒的白屏。</p>`,
-  // IFR2 · IFR:先出画面
-  `<p><strong>首屏直出 —— 从 ReactLynx 移植。</strong>开了 <code>enableIFR</code>,主线程产物就带上完整 Vue 运行时 + 应用(不只是 worklet)。<code>renderPage</code> 在 <code>loadTemplate</code> 里同步挂载 —— 看 <strong>paint</strong> 旗标跳到左边。后台线程照样跑同一份代码,只是并行、离开关键路径。</p>`,
+  // IFR2 · IFR:先出画面 + join
+  `<p><strong>首屏直出 —— 从 ReactLynx 移植。</strong>开了 <code>enableIFR</code>,主线程产物就带上完整 Vue 运行时 + 应用(不只是 worklet)。<code>renderPage</code> 在 <code>loadTemplate</code> 里同步挂载 —— 看 <strong>paint</strong> 旗标跳到左边。主线程<em>录下</em>自己的 ops;后台并行启动并送出最初几批。发光的 pill 就是 join —— 下一页打开它里面是什么。</p>`,
   // IFR3 · Straightforward IFR
   `<p><strong>Straightforward IFR —— hydration 当作 thread join。</strong>没有特殊的首帧格式:同一份 Vue 运行时 + 应用(同一套 <code>nodeOps</code>)在 <code>loadTemplate</code> 期间跑在主线程上并<em>录下</em>扁平 ops 流。后台并行启动,随后最初的 <code>vuePatchUpdate</code> 批次逐帧走这份录制 —— 是一次 join,不是重写:相同 → 跳过,值不同 → 打补丁,结构分歧 → 拆掉重建。不一致只损失性能收益,绝不损失正确性(开发期打印 <code>IFR hydration mismatch</code>)。确定性 id 与 <code>vue:N</code> 签名让点击无需重绑就路由回 Vue。</p>`,
+  // IFR4 · Element Templates 转折
+  `<p><strong>第二个杠杆。</strong>IFR 把绘制提前;打开它会默认打开 Element Templates。它们让渲染本身便宜一个数量级 —— 而且瘦身的是<em>每一次</em>更新的跨线程协议,不只首帧。</p>`,
   // IFR5 · 逐节点的管线
   `<p>还是 Runtime 那章的同一条管线 —— 但注意它是<em>逐节点</em>跑的,哪怕这些结构永远不变。</p>`,
   // IFR6 · ET 折叠管线

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -220,10 +220,25 @@ export const ZH = {
   'structural → rebuild': '结构分歧 → 重建',
   'Normally every static element pays the whole chain — a vnode, a shadow node, ops frames, a thread crossing, an interpreter dispatch.':
     '常规下每个静态元素都要付整条链 —— 一个 vnode、一个影子节点、若干 ops 帧、一次跨线程、一次解释器分发。',
+  'Without ET, BTS and MTS IFR both pay the fat VDOM → opcode chain — just on different threads.':
+    '没有 ET 时,BTS 和 MTS IFR 都要付那条肥胖的 <b>VDOM → opcode</b> 链 —— 只是跑在不同线程上。',
   'The compiler lowers the static subtree to one create() function. Vue sends one op; only the dynamic holes travel after.':
     '编译器把静态子树下沉成一个 <code>create()</code> 函数。Vue 只发<b>一个</b> op;之后只有动态空洞在传输。',
+  'ET converts the static subtree into a compiled create() — BTS sends one op; MTS IFR runs that function as straight-line PAPI.':
+    'ET 把静态子树编译成 <code>create()</code> —— BTS 只发<b>一个</b> op;MTS IFR 把它当直线 PAPI 跑。',
   'Static structure bakes into a create() skeleton; only the holes — dynamic text, class, style, attrs — stay on the vnode path.':
     '静态结构烘焙进 <code>create()</code> 骨架;只有空洞 —— 动态的文本、class、style、属性 —— 留在 vnode 路径上。',
+  // dual-thread ET pipe labels / roles
+  'Background · BTS': '<i></i>后台 · BTS',
+  'Main IFR · MTS': '<i></i>主线程 IFR · MTS',
+  'VDOM tree → opcodes': 'VDOM 树 → opcodes',
+  'same chain, local apply': '同一条链,本地 apply',
+  'VDOM → one template op': 'VDOM → 一个模板 op',
+  'opcode → create() PAPI': 'opcode → create() PAPI',
+  'many ops / node': '每节点很多 ops',
+  'applyOps → PAPI → paint': 'applyOps → PAPI → paint',
+  'one op · whole subtree': '一个 op · 整棵子树',
+  'straight-line PAPI → paint': '直线 PAPI → paint',
   'FCP across a real Web Worker + IPC (Lynx for Web) — suite median −12% to −19%, ReactLynx control −23%. ET stays flat on FCP; its win is render cost (~1,000 el, jitless) and ops payload.':
     'FCP:跨真实 Web Worker + IPC(Lynx for Web)—— 全套中位数 −12% 到 −19%,ReactLynx 对照 −23%。ET 对 FCP 基本持平;它的收益在渲染开销(约 1,000 元素,jitless)和 ops 负载。',
   'Element Templates shrink the recorded ops payload 3–1000× — and that protocol shrink helps every update, not just the first frame.':
@@ -588,10 +603,10 @@ export const ZH_NOTES = [
   `<p><strong>Straightforward IFR —— hydration 当作 thread join。</strong>没有特殊的首帧格式:同一份 Vue 运行时 + 应用(同一套 <code>nodeOps</code>)在 <code>loadTemplate</code> 期间跑在主线程上并<em>录下</em>扁平 ops 流。后台并行启动,随后最初的 <code>vuePatchUpdate</code> 批次逐帧走这份录制 —— 是一次 join,不是重写:相同 → 跳过,值不同 → 打补丁,结构分歧 → 拆掉重建。不一致只损失性能收益,绝不损失正确性(开发期打印 <code>IFR hydration mismatch</code>)。确定性 id 与 <code>vue:N</code> 签名让点击无需重绑就路由回 Vue。</p>`,
   // IFR4 · Element Templates 转折
   `<p><strong>第二个杠杆。</strong>IFR 把绘制提前;打开它会默认打开 Element Templates。它们让渲染本身便宜一个数量级 —— 而且瘦身的是<em>每一次</em>更新的跨线程协议,不只首帧。</p>`,
-  // IFR5 · 逐节点的管线
-  `<p>还是 Runtime 那章的同一条管线 —— 但注意它是<em>逐节点</em>跑的,哪怕这些结构永远不变。</p>`,
-  // IFR6 · ET 折叠管线
-  `<p>看 <code>VDOM</code> 和 <code>PAPI</code> 留在原地,而管线中段整个塌陷。这是<em>框架级</em>模板 —— 普通的带类型 Element PAPI 调用,不是 Lynx 的二进制引擎模板。</p>`,
+  // IFR5 · 双线程无 ET：肥胖 VDOM→opcode
+  `<p><strong>同一份代码,两条线程,仍然很贵。</strong>BTS 把 VDOM 走进 ShadowElement,吐出一长串扁平 opcode。MTS IFR 在 <code>loadTemplate</code> 期间跑同一份 Vue + <code>nodeOps</code>,录下同形状的 ops,本地 apply 出画面。IFR 改的是<em>何时</em> paint —— 还没把活变少。</p>`,
+  // IFR6 · 双线程有 ET：INSTANTIATE → create()
+  `<p><strong>ET 怎么落到两条线程。</strong>编译器把静态壳下沉成 <code>registerElementTemplate(id, holes, create)</code>。BTS 仍从 VDOM 起步,但静态块变成一个 vnode,只发 <code>INSTANTIATE_TEMPLATE</code> 加空洞 <code>SET_*</code> —— 不再逐节点 <code>CREATE</code>。MTS IFR 上同一个 opcode 进本地解释器,调用烘焙好的 <code>create()</code> —— 一串直线 Element PAPI。下一页看源码 → 编译产物。</p>`,
   // IFR7 · 骨架 + 空洞
   `<p>可下沉 = 每个节点都是纯 Lynx 元素、只有值或文本动态。组件、插槽、<code>v-if</code>/<code>v-for</code> 宿主、<code>&lt;list&gt;</code>、带 ref/id 的节点留在普通 vnode 路径;它们的纯元素子体仍可下沉。scoped-CSS 的 scope id 会被烘焙进去。</p>`,
   // IFR8 · 基准测试表

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -285,6 +285,10 @@ export const ZH = {
     '结构从不跨线 —— 两边产物里已经共享 <code>create()</code>。线上走的是 <b>tpl id</b> 和 <b>hole 值</b>;hydrate 把这些 ops join 起来。',
   'FCP across a real Web Worker + IPC (Lynx for Web) — suite median −12% to −19%, ReactLynx control −23%. ET stays flat on FCP; its win is render cost (~1,000 el, jitless) and ops payload.':
     'FCP:跨真实 Web Worker + IPC(Lynx for Web)—— 全套中位数 −12% 到 −19%,ReactLynx 对照 −23%。ET 对 FCP 基本持平;它的收益在渲染开销(约 1,000 元素,jitless)和 ops 负载。',
+  'FCP with IFR · Lynx for Web':
+    'FCP with IFR · Lynx for Web',
+  'Suite median −12% to −19%. ReactLynx control −23%. ET stays flat on FCP — its win is the render cost and ops payload you just saw.':
+    '全套中位数 −12% 到 −19%。ReactLynx 对照 −23%。ET 对 FCP 基本持平 —— 它的收益就是你刚看过的渲染开销与 ops 负载。',
   'Element Templates shrink the recorded ops payload 3–1000× — and that protocol shrink helps every update, not just the first frame.':
     'Element Templates 把录制的 ops 负载缩小 3–1000× —— 这份协议瘦身惠及每一次更新,不只是首帧。',
   'A tool, not a default-on switch — but for content-first screens, IFR + ET is the recommended setup.':
@@ -639,26 +643,28 @@ export const ZH_NOTES = [
   `<p>MTS 的全部表面积,一个文件讲完:<code>'main thread'</code> 标记函数,<code>main-thread-bind*</code> 挂到事件上,<code>useMainThreadRef()</code> 给出同步元素访问 —— <code>setStyleProperty</code> 在手指移动的同一帧落地。</p><p><strong>先复用,再演化。</strong>引擎层我们直接跑 ReactLynx 的 worklet runtime 和它的 API 形状(<code>main-thread-bind*</code>、<code>useMainThreadRef</code>)—— 久经考验,而且在 Lynx 生态里通用。但 Vue 值得 Vue 形状的人体工学:想象 <code>&lt;script main-thread setup&gt;</code>、主线程的 computed/watch。这个设计空间是开放的 —— 也是社区留下印记的好地方。</p>`,
   // 51 C4 · 教程复刻
   `<p><strong>复刻即证明。</strong>lynxjs.org 用两个教程教 MTS,都是为 ReactLynx 写的。两个都在 Vue Lynx 上重做了,live 在我们的文档站上 —— 同样的拖拽物理、同样的吸附、同样的主线程滚动条。平台教程能干净地移植过来,能力就是真的在。</p><p><strong>现场:</strong>慢慢拖 —— 指示器逐像素同步;一甩,吸附。</p>`,
+  // IFR0 · 小节标题
+  `<p><strong>Instant First-Frame Rendering。</strong>工程章最后一块:在后台还没准备好之前画出首帧 —— 再用 Element Templates 让这一笔本身变便宜。</p>`,
   // IFR1 · 空白首帧
   `<p><strong>往返的代价。</strong>前六页讲的 VDOM → ShadowElement → ops → PAPI,在第一帧之前必须先整整跑一圈。设备上,这一圈再加后台线程启动与 bundle 求值,就是几十毫秒的白屏。</p>`,
   // IFR2 · IFR:先出画面 + join
   `<p><strong>首屏直出 —— 从 ReactLynx 移植。</strong>开了 <code>enableIFR</code>,主线程产物就带上完整 Vue 运行时 + 应用(不只是 worklet)。<code>renderPage</code> 在 <code>loadTemplate</code> 里同步挂载 —— 看 <strong>paint</strong> 旗标跳到左边。主线程<em>录下</em>自己的 ops;后台并行启动并送出最初几批。发光的 pill 就是 join —— 下一页打开它里面是什么。</p>`,
   // IFR3 · Straightforward IFR
   `<p><strong>Straightforward IFR —— hydration 当作 thread join。</strong>没有特殊的首帧格式:同一份 Vue 运行时 + 应用(同一套 <code>nodeOps</code>)在 <code>loadTemplate</code> 期间跑在主线程上并<em>录下</em>扁平 ops 流。后台并行启动,随后最初的 <code>vuePatchUpdate</code> 批次逐帧走这份录制 —— 是一次 join,不是重写:相同 → 跳过,值不同 → 打补丁,结构分歧 → 拆掉重建。不一致只损失性能收益,绝不损失正确性(开发期打印 <code>IFR hydration mismatch</code>)。确定性 id 与 <code>vue:N</code> 签名让点击无需重绑就路由回 Vue。</p>`,
-  // IFR4 · Element Templates 转折
-  `<p><strong>第二个杠杆。</strong>IFR 把绘制提前;打开它会默认打开 Element Templates。它们让渲染本身便宜一个数量级 —— 而且瘦身的是<em>每一次</em>更新的跨线程协议,不只首帧。看接下来两页:BTS 与 MTS 之间那条共享 data-flow 从五步塌成三步。</p>`,
+  // IFR7 · Compiler-hinted Block → ET（紧接 Straightforward）
+  `<p><strong>进入 Element Templates —— 从 Vue 的 Block 说起。</strong>hydrate 仍然在 join 两条肥胖路径。Vue 的编译器早就把模板切成 Block:静态节点 vs 动态空洞(<code>patchFlag</code> / dynamicChildren)。Element Templates 复用这份结构 —— 把静态壳烘焙进 <code>registerElementTemplate(id, holes, create)</code>,只把空洞留在 vnode 路径。可下沉 = 纯 Lynx 元素且只有值/文本动态;组件、插槽、<code>v-if</code>/<code>v-for</code> 宿主、<code>&lt;list&gt;</code>、ref/id 留在普通路径(它们的纯元素子体仍可下沉)。下一页:两边的稀疏树,以及线上到底同步了什么。</p>`,
+  // IFR8 · 双线程树 + 同步内容
+  `<p><strong>两边的树分别是什么。</strong>BTS 侧是稀疏的 VDOM / ShadowElement:静态节点仍在(满足 Vue 的同步读取),但对协议隐形(变灰);只有 hole 有名字(<code>h0</code>…)。MTS IFR 用编译好的 <code>create()</code> 物化同一形状 —— 一棵原生元素树,hole id 对齐。这份稀疏,正是上一页编译出来的 Block。</p><p><strong>同步了什么。</strong>和 Vapor 的 <code>REGISTER_TREE</code> 不同,ET 不传结构:<code>registerElementTemplate</code> 已经把 <code>create()</code> 打进两边产物。跨线只有 <code>INSTANTIATE_TEMPLATE(tplId)</code>(每个实例一次)+ hole 的 <code>SET_*</code> 值。IFR 下 MTS 首屏已录下这些 ops;BTS 最初几批拿去和录制对账 —— 仍是 Straightforward IFR 那次 skip / patch / rebuild join。下一页:没有 ET 时,两条线程仍走肥胖的五步路径。</p>`,
   // IFR5 · 原双线程图 + 中间 5 步连接
   `<p><strong>同一份代码,两条线程,仍然很贵。</strong>还是原来那两列 —— 中间编号芯片点亮共享的 5 步协议:VDOM → Shadow → ops → interp → PAPI。BTS 发出流;MTS IFR 录下并本地 apply。IFR 改的是<em>何时</em> paint —— 下一页把这五条连接塌成三条。</p>`,
   // IFR6 · 同一张图,连接 5→3
-  `<p><strong>同一张图,更少连接。</strong>看 2–4 步折进一个 <code>INSTANTIATE_TEMPLATE</code> 芯片;VDOM 和 PAPI/<code>create()</code> 留在原地(magic-move)。BTS 仍从 VDOM 起步,但静态块是一个 vnode,只发 INSTANTIATE + hole SET_*。MTS IFR 的解释器调用烘焙好的 <code>create()</code>。下一页:为什么 Vue 能这么做 —— compiler-hinted VDOM 本来就带着 Block 结构。</p>`,
-  // IFR7 · Compiler-hinted Block → ET
-  `<p><strong>为什么 Vue 能这么做。</strong>Vue 的编译器早就把模板切成 Block:静态节点 vs 动态空洞(<code>patchFlag</code> / dynamicChildren)。Element Templates 复用这份结构信息 —— 把静态壳烘焙进 <code>registerElementTemplate(id, holes, create)</code>,只把空洞留在 vnode 路径。可下沉 = 纯 Lynx 元素且只有值/文本动态;组件、插槽、<code>v-if</code>/<code>v-for</code> 宿主、<code>&lt;list&gt;</code>、ref/id 留在普通路径(它们的纯元素子体仍可下沉)。下一页:两边的稀疏树,以及线上到底同步了什么。</p>`,
-  // IFR8 · 双线程树 + 同步内容
-  `<p><strong>两边的树分别是什么。</strong>BTS 侧是稀疏的 VDOM / ShadowElement:静态节点仍在(满足 Vue 的同步读取),但对协议隐形(变灰);只有 hole 有名字(<code>h0</code>…)。MTS IFR 用编译好的 <code>create()</code> 物化同一形状 —— 一棵原生元素树,hole id 对齐。这份稀疏,正是上一页编译出来的 Block。</p><p><strong>同步了什么。</strong>和 Vapor 的 <code>REGISTER_TREE</code> 不同,ET 不传结构:<code>registerElementTemplate</code> 已经把 <code>create()</code> 打进两边产物。跨线只有 <code>INSTANTIATE_TEMPLATE(tplId)</code>(每个实例一次)+ hole 的 <code>SET_*</code> 值。IFR 下 MTS 首屏已录下这些 ops;BTS 最初几批拿去和录制对账 —— 仍是 Straightforward IFR 那次 skip / patch / rebuild join。</p>`,
-  // IFR9 · 基准测试表
-  `<p>几组独立的实验,不是一条 trace。FCP 收益(中位数 −12…−19%,ReactLynx 对照 −23%)来自去掉后台启动 + IPC —— 需要真实的线程边界,两种 IFR 配置都能拿到(ET 对 web FCP 基本持平)。Element Templates 自己的收益在渲染开销 9.4ms → <strong>1.3ms</strong>(多次重跑约 6–15×)和 ops 负载 —— 这也是 ET 默认打开的原因。代价:约 2.26× gzip。</p>`,
-  // IFR10 · 基准测试图
+  `<p><strong>同一张图,更少连接。</strong>看 2–4 步折进一个 <code>INSTANTIATE_TEMPLATE</code> 芯片;VDOM 和 PAPI/<code>create()</code> 留在原地(magic-move)。BTS 仍从 VDOM 起步,但静态块是一个 vnode,只发 INSTANTIATE + hole SET_*。MTS IFR 的解释器调用烘焙好的 <code>create()</code>。下一页:一句话收束 —— IFR 改<em>何时</em>;Element Templates 改做多少活。</p>`,
+  // IFR4 · Element Templates 转折（收束）
+  `<p><strong>两个杠杆,一句话。</strong>你刚看完 BTS↔MTS 共享 data-flow 从五步塌成三步。IFR 把绘制提前;Element Templates 让渲染本身便宜一个数量级 —— 而且瘦身的是<em>每一次</em>更新的跨线程协议,不只首帧。下一页:数字。</p>`,
+  // IFR10 · 基准测试图（ops / 渲染开销）
   `<p>左:渲染开销随 ET 塌陷。右:静态偏重屏幕的跨线程协议从约 78KB 降到 69 字节。PAPI 调用次数只降 5–20% —— 原生元素工作是共享地板;被下沉掉的是框架 JS 和它周围的协议。</p>`,
+  // IFR9 · FCP 大字 −22%
+  `<p><strong>标题数字。</strong>FCP:跨真实 Web Worker + IPC(Lynx for Web)—— 这一行 −22%,全套中位数 −12…−19%,ReactLynx 对照 −23%。收益来自去掉后台启动 + IPC —— 两种 IFR 配置都能拿到。ET 对 web FCP 基本持平;它自己的收益你上一页已经看过(渲染开销与 ops 负载)。代价:约 2.26× gzip,TTI proxy ~1.36×。</p>`,
   // H1 · 2 weeks + X 复盘(合并)
   `<p><strong>现在这个数字说得通了 —— 顺便告诉大家去哪儿读。</strong>这一章的一切 —— 渲染器、工具链、MTS —— 是两周的夜晚和周末做出来的:plan 写成 spec,agent harness 执行,上游测试当 reward signal,AGENTS.md 固化调试手册。完整方法论写在 X 上(这里内嵌了,vue.lynxjs.org 首页的 badge 也链着它)—— 扫码就能在手机上读。给在座各位一个安静的结论:Lynx 出乎意料地 <em>AI 可读</em> —— Web 标准的 API 和真 CSS,意味着模型的 Web 直觉基本直接迁移。然后收束:"这就是它怎么被做出来的 —— 接下来看看它加起来意味着什么。"</p>`,
   // 65 Close · 一行 npm 命令（含原 combine / 搭把手 / 另一个团队 / what's there / 假收尾）

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -239,6 +239,16 @@ export const ZH = {
   'applyOps → PAPI → paint': 'applyOps → PAPI → paint',
   'one op · whole subtree': '一个 op · 整棵子树',
   'straight-line PAPI → paint': '直线 PAPI → paint',
+  // IFR6b · trees + sync wire
+  'VDOM · sparse': 'VDOM · 稀疏',
+  'native · create()': 'native · create()',
+  'static ghosted · only holes named': '静态变灰 · 只有 <b>holes</b> 有名',
+  'create() builds · same hole ids': 'create() 建树 · <b>同一套 hole id</b>',
+  'tpl id · not the tree': 'tpl id · 不是整棵树',
+  'values only · e.g. h0': '只有值 · 如 h0',
+  'ops vs recording': 'ops 对账录制',
+  'Structure never crosses — both bundles already share create(). The wire carries the tpl id and hole values; hydrate joins those ops.':
+    '结构从不跨线 —— 两边产物里已经共享 <code>create()</code>。线上走的是 <b>tpl id</b> 和 <b>hole 值</b>;hydrate 把这些 ops join 起来。',
   'FCP across a real Web Worker + IPC (Lynx for Web) — suite median −12% to −19%, ReactLynx control −23%. ET stays flat on FCP; its win is render cost (~1,000 el, jitless) and ops payload.':
     'FCP:跨真实 Web Worker + IPC(Lynx for Web)—— 全套中位数 −12% 到 −19%,ReactLynx 对照 −23%。ET 对 FCP 基本持平;它的收益在渲染开销(约 1,000 元素,jitless)和 ops 负载。',
   'Element Templates shrink the recorded ops payload 3–1000× — and that protocol shrink helps every update, not just the first frame.':
@@ -606,7 +616,9 @@ export const ZH_NOTES = [
   // IFR5 · 双线程无 ET：肥胖 VDOM→opcode
   `<p><strong>同一份代码,两条线程,仍然很贵。</strong>BTS 把 VDOM 走进 ShadowElement,吐出一长串扁平 opcode。MTS IFR 在 <code>loadTemplate</code> 期间跑同一份 Vue + <code>nodeOps</code>,录下同形状的 ops,本地 apply 出画面。IFR 改的是<em>何时</em> paint —— 还没把活变少。</p>`,
   // IFR6 · 双线程有 ET：INSTANTIATE → create()
-  `<p><strong>ET 怎么落到两条线程。</strong>编译器把静态壳下沉成 <code>registerElementTemplate(id, holes, create)</code>。BTS 仍从 VDOM 起步,但静态块变成一个 vnode,只发 <code>INSTANTIATE_TEMPLATE</code> 加空洞 <code>SET_*</code> —— 不再逐节点 <code>CREATE</code>。MTS IFR 上同一个 opcode 进本地解释器,调用烘焙好的 <code>create()</code> —— 一串直线 Element PAPI。下一页看源码 → 编译产物。</p>`,
+  `<p><strong>ET 怎么落到两条线程。</strong>编译器把静态壳下沉成 <code>registerElementTemplate(id, holes, create)</code>。BTS 仍从 VDOM 起步,但静态块变成一个 vnode,只发 <code>INSTANTIATE_TEMPLATE</code> 加空洞 <code>SET_*</code> —— 不再逐节点 <code>CREATE</code>。MTS IFR 上同一个 opcode 进本地解释器,调用烘焙好的 <code>create()</code> —— 一串直线 Element PAPI。下一页:两边的树长什么样,以及线上到底同步了什么。</p>`,
+  // IFR6b · 双线程树 + 同步内容
+  `<p><strong>两边的树分别是什么。</strong>BTS 侧是稀疏的 VDOM / ShadowElement:静态节点仍在(满足 Vue 的同步读取),但对协议隐形(变灰);只有 hole 有名字(<code>h0</code>…)。MTS IFR 用编译好的 <code>create()</code> 物化同一形状 —— 一棵原生元素树,hole id 对齐。</p><p><strong>同步了什么。</strong>和 Vapor 的 <code>REGISTER_TREE</code> 不同,ET 不传结构:<code>registerElementTemplate</code> 已经把 <code>create()</code> 打进两边产物。跨线只有 <code>INSTANTIATE_TEMPLATE(tplId)</code>(每个实例一次)+ hole 的 <code>SET_*</code> 值。IFR 下 MTS 首屏已录下这些 ops;BTS 最初几批拿去和录制对账 —— 仍是 skip / patch / rebuild 那次 join。</p>`,
   // IFR7 · 骨架 + 空洞
   `<p>可下沉 = 每个节点都是纯 Lynx 元素、只有值或文本动态。组件、插槽、<code>v-if</code>/<code>v-for</code> 宿主、<code>&lt;list&gt;</code>、带 ref/id 的节点留在普通 vnode 路径;它们的纯元素子体仍可下沉。scoped-CSS 的 scope id 会被烘焙进去。</p>`,
   // IFR8 · 基准测试表

--- a/slides/src/i18n.js
+++ b/slides/src/i18n.js
@@ -224,12 +224,32 @@ export const ZH = {
     '没有 ET 时,BTS 和 MTS IFR 都要付那条肥胖的 <b>VDOM → opcode</b> 链 —— 只是跑在不同线程上。',
   'Without ET, BTS and MTS IFR both pay the fat 5-step data-flow — linked across the thread boundary.':
     '没有 ET 时,BTS 和 MTS IFR 都要付那条肥胖的 <b>5 步</b> data-flow —— 跨线程边界连在一起。',
+  'Without ET, BTS and MTS IFR both pay the fat VDOM → opcode chain — five linked steps across the boundary.':
+    '没有 ET 时,BTS 和 MTS IFR 都要付那条肥胖的 <b>VDOM → opcode</b> 链 —— 跨边界的五步连接。',
   'The compiler lowers the static subtree to one create() function. Vue sends one op; only the dynamic holes travel after.':
     '编译器把静态子树下沉成一个 <code>create()</code> 函数。Vue 只发<b>一个</b> op;之后只有动态空洞在传输。',
   'ET converts the static subtree into a compiled create() — BTS sends one op; MTS IFR runs that function as straight-line PAPI.':
     'ET 把静态子树编译成 <code>create()</code> —— BTS 只发<b>一个</b> op;MTS IFR 把它当直线 PAPI 跑。',
   'ET collapses the bridge to 3 steps — BTS sends one op; MTS IFR runs the compiled create() as straight-line PAPI.':
     'ET 把桥塌成 <b>3 步</b> —— BTS 只发一个 op;MTS IFR 把编译好的 <code>create()</code> 当直线 PAPI 跑。',
+  'ET collapses the same dual-thread picture to 3 linked steps — BTS sends one op; MTS IFR runs create() as straight-line PAPI.':
+    'ET 把同一张双线程图塌成 <b>3 步连接</b> —— BTS 只发一个 op;MTS IFR 把 <code>create()</code> 当直线 PAPI 跑。',
+  '5 steps': '5 步',
+  '3 steps': '3 步',
+  '1 VDOM': '<b>1</b> VDOM',
+  '2 Shadow': '<b>2</b> Shadow',
+  '3 ops': '<b>3</b> ops',
+  '4 interp': '<b>4</b> interp',
+  '5 PAPI': '<b>5</b> PAPI',
+  '1 vnode': '<b>1</b> vnode',
+  '2 INSTANTIATE': '<b>2</b> INSTANTIATE',
+  '3 create()': '<b>3</b> create()',
+  'many ops / node': '每节点很多 ops',
+  'stream →': 'stream →',
+  'awaits hydrate': '等 hydrate',
+  'applyOps': 'applyOps',
+  'PAPI → paint': 'PAPI → paint',
+  'create() → PAPI': 'create() → PAPI',
   'Static structure bakes into a create() skeleton; only the holes — dynamic text, class, style, attrs — stay on the vnode path.':
     '静态结构烘焙进 <code>create()</code> 骨架;只有空洞 —— 动态的文本、class、style、属性 —— 留在 vnode 路径上。',
   'Vue already ships compiler-hinted VDOM — a Block marks static structure vs dynamic holes. That hint is what we lower into create().':
@@ -627,10 +647,10 @@ export const ZH_NOTES = [
   `<p><strong>Straightforward IFR —— hydration 当作 thread join。</strong>没有特殊的首帧格式:同一份 Vue 运行时 + 应用(同一套 <code>nodeOps</code>)在 <code>loadTemplate</code> 期间跑在主线程上并<em>录下</em>扁平 ops 流。后台并行启动,随后最初的 <code>vuePatchUpdate</code> 批次逐帧走这份录制 —— 是一次 join,不是重写:相同 → 跳过,值不同 → 打补丁,结构分歧 → 拆掉重建。不一致只损失性能收益,绝不损失正确性(开发期打印 <code>IFR hydration mismatch</code>)。确定性 id 与 <code>vue:N</code> 签名让点击无需重绑就路由回 Vue。</p>`,
   // IFR4 · Element Templates 转折
   `<p><strong>第二个杠杆。</strong>IFR 把绘制提前;打开它会默认打开 Element Templates。它们让渲染本身便宜一个数量级 —— 而且瘦身的是<em>每一次</em>更新的跨线程协议,不只首帧。看接下来两页:BTS 与 MTS 之间那条共享 data-flow 从五步塌成三步。</p>`,
-  // IFR5 · 双线程 + 点亮的 5 步桥
-  `<p><strong>同一份代码,两条线程,仍然很贵。</strong>中间点亮的链就是共享协议:VDOM → Shadow → ops → interp → PAPI,每个静态节点走一遍。BTS 发出它;MTS IFR 录下并本地 apply。IFR 改的是<em>何时</em> paint —— 下一页把链<em>做多少活</em>塌掉。</p>`,
-  // IFR6 · 桥 5→3 magic-move
-  `<p><strong>看中间塌陷。</strong>VDOM 和 PAPI 留在原地(magic-move);Shadow / ops / interp 折成一个 <code>INSTANTIATE_TEMPLATE</code>。框架级模板 —— 带类型的 Element PAPI,不是 Lynx 二进制引擎模板。下一页:为什么 Vue 能这么做 —— compiler-hinted VDOM 本来就带着 Block 结构。</p>`,
+  // IFR5 · 原双线程图 + 中间 5 步连接
+  `<p><strong>同一份代码,两条线程,仍然很贵。</strong>还是原来那两列 —— 中间编号芯片点亮共享的 5 步协议:VDOM → Shadow → ops → interp → PAPI。BTS 发出流;MTS IFR 录下并本地 apply。IFR 改的是<em>何时</em> paint —— 下一页把这五条连接塌成三条。</p>`,
+  // IFR6 · 同一张图,连接 5→3
+  `<p><strong>同一张图,更少连接。</strong>看 2–4 步折进一个 <code>INSTANTIATE_TEMPLATE</code> 芯片;VDOM 和 PAPI/<code>create()</code> 留在原地(magic-move)。BTS 仍从 VDOM 起步,但静态块是一个 vnode,只发 INSTANTIATE + hole SET_*。MTS IFR 的解释器调用烘焙好的 <code>create()</code>。下一页:为什么 Vue 能这么做 —— compiler-hinted VDOM 本来就带着 Block 结构。</p>`,
   // IFR7 · Compiler-hinted Block → ET
   `<p><strong>为什么 Vue 能这么做。</strong>Vue 的编译器早就把模板切成 Block:静态节点 vs 动态空洞(<code>patchFlag</code> / dynamicChildren)。Element Templates 复用这份结构信息 —— 把静态壳烘焙进 <code>registerElementTemplate(id, holes, create)</code>,只把空洞留在 vnode 路径。可下沉 = 纯 Lynx 元素且只有值/文本动态;组件、插槽、<code>v-if</code>/<code>v-for</code> 宿主、<code>&lt;list&gt;</code>、ref/id 留在普通路径(它们的纯元素子体仍可下沉)。下一页:两边的稀疏树,以及线上到底同步了什么。</p>`,
   // IFR8 · 双线程树 + 同步内容

--- a/slides/src/main.js
+++ b/slides/src/main.js
@@ -840,7 +840,7 @@ const I18N_SELECTOR = [
   '.demo__caption', '.videopair figcaption',
   '.tile', '.wlab', '.wattr', '.wg b',
   '.ifrjoin__label', '.ifrjoin__role', '.ifrjoin__pill', '.ifrjoin__out',
-  '.ifrjoin__hint',
+  '.ifrjoin__hint', '.node__cap', '.xwire__count',
 ].map((s) => `.slide ${s}`).join(', ') + ', .gate-legend span';
 
 let i18nEls = [];

--- a/slides/src/main.js
+++ b/slides/src/main.js
@@ -840,6 +840,7 @@ const I18N_SELECTOR = [
   '.demo__caption', '.videopair figcaption',
   '.tile', '.wlab', '.wattr', '.wg b',
   '.ifrjoin__label', '.ifrjoin__role', '.ifrjoin__pill', '.ifrjoin__out',
+  '.ifrjoin__hint',
 ].map((s) => `.slide ${s}`).join(', ') + ', .gate-legend span';
 
 let i18nEls = [];

--- a/slides/src/main.js
+++ b/slides/src/main.js
@@ -841,6 +841,7 @@ const I18N_SELECTOR = [
   '.tile', '.wlab', '.wattr', '.wg b',
   '.ifrjoin__label', '.ifrjoin__role', '.ifrjoin__pill', '.ifrjoin__out',
   '.ifrjoin__hint', '.node__cap', '.xwire__count',
+  '.etbridge__blurb', '.etbridge__tag',
 ].map((s) => `.slide ${s}`).join(', ') + ', .gate-legend span';
 
 let i18nEls = [];

--- a/slides/src/main.js
+++ b/slides/src/main.js
@@ -840,8 +840,8 @@ const I18N_SELECTOR = [
   '.demo__caption', '.videopair figcaption',
   '.tile', '.wlab', '.wattr', '.wg b',
   '.ifrjoin__label', '.ifrjoin__role', '.ifrjoin__pill', '.ifrjoin__out',
-  '.ifrjoin__hint', '.node__cap', '.xwire__count',
-  '.etbridge__blurb', '.etbridge__tag',
+  '.ifrjoin__hint', '.ifrjoin__linkhead', '.ifrjoin__link',
+  '.node__cap', '.xwire__count',
 ].map((s) => `.slide ${s}`).join(', ') + ', .gate-legend span';
 
 let i18nEls = [];

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -3468,6 +3468,18 @@ vl-media.snap.is-missing .vl-ph__kind { color: rgba(15, 18, 22, 0.65); }
   width: min(100%, 1040px);
   height: clamp(260px, 42cqh, 340px);
 }
+/* IFR2: timeline + join bar stacked */
+.ifrseq {
+  width: min(100%, 1040px);
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: clamp(4px, 0.8cqh, 10px);
+}
+.ifrtl--joinhead {
+  height: clamp(200px, 32cqh, 260px);
+  width: 100%;
+}
 .ifrlane {
   position: absolute;
   left: 0;

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -2432,6 +2432,13 @@ body.is-blackout::after {
   background: currentColor;
   box-shadow: 0 0 10px currentColor;
 }
+.node__label i {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 10px currentColor;
+  display: inline-block;
+  flex: none;
+}
 .node__title {
   font-family: var(--display);
   font-weight: 600;

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -3681,106 +3681,98 @@ vl-media.snap.is-missing .vl-ph__kind { color: rgba(15, 18, 22, 0.65); }
   gap: 6px;
 }
 
-/* ---- ET data-flow bridge (5 → 3 between BTS / MTS) ---- */
-.etbridge {
-  width: min(100%, 1100px);
-  display: grid;
-  grid-template-columns: minmax(150px, 0.95fr) minmax(260px, 1.35fr) minmax(150px, 0.95fr);
-  gap: clamp(8px, 1.2cqw, 18px);
-  align-items: stretch;
+/* ---- Linked dual-thread pipe: same cols, numbered cross-links ---- */
+.ifrjoin--linked {
+  width: min(100%, 1040px);
 }
-.etbridge__side {
+.ifrjoin--linked .ifrjoin__cols {
+  grid-template-columns: 1fr minmax(108px, 148px) 1fr;
+  align-items: stretch;
+  min-height: 0;
+}
+.ifrjoin--linked .ifrjoin__col:first-child { margin-right: clamp(4px, 0.6cqw, 10px); }
+.ifrjoin--linked .ifrjoin__col:last-child { margin-left: clamp(4px, 0.6cqw, 10px); }
+.ifrjoin--linked .ifrjoin__stack {
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  gap: 8px;
-  padding: clamp(14px, 2cqh, 20px) clamp(12px, 1.6cqw, 18px);
-  border-radius: 14px;
-  border: 1px solid color-mix(in srgb, var(--c, #5dd5a8) 26%, transparent);
-  background: color-mix(in srgb, var(--c, #5dd5a8) 6%, transparent);
-  text-align: left;
+  gap: 6px;
+  flex: 1;
+}
+.ifrjoin--linked .ifrjoin__links {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
+  padding: clamp(14px, 2cqh, 20px) 0;
+  min-width: 0;
+}
+.ifrjoin__linkhead {
+  display: flex;
+  align-items: flex-end;
   justify-content: center;
-}
-.etbridge__blurb {
-  margin: 4px 0 0;
-  font-size: clamp(12px, 1.15cqw, 14px);
-  line-height: 1.4;
-  color: var(--ink-soft);
-  max-width: none;
-}
-.etbridge__flow {
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  justify-content: center;
-  gap: 4px;
-  padding: 6px 0;
-}
-.etb-row {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  align-items: center;
-  gap: 0;
-}
-.etb-tick {
-  display: block;
-  height: 1.5px;
-}
-.etb-tick--l {
-  background: linear-gradient(90deg, transparent, color-mix(in srgb, #5dd5a8 55%, transparent));
-  margin-right: 6px;
-}
-.etb-tick--r {
-  background: linear-gradient(90deg, color-mix(in srgb, #56b8f0 55%, transparent), transparent);
-  margin-left: 6px;
-}
-.etb {
-  justify-self: center;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 2px;
-  padding: 8px 14px;
-  border-radius: 10px;
-  border: 1.5px solid var(--c, #5dd5a8);
-  background: color-mix(in srgb, var(--c, #5dd5a8) 13%, var(--paper));
-  font-family: var(--display);
-  font-weight: 600;
-  font-size: clamp(12px, 1.2cqw, 15px);
-  color: color-mix(in srgb, var(--c, #5dd5a8) 80%, var(--ink));
-  white-space: nowrap;
-  min-width: clamp(120px, 16cqw, 180px);
+  /* match label + role block above the op stack */
+  min-height: calc(1.1em + 1.1em + 8px + 2px);
+  padding-bottom: 2px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ink-mute);
   text-align: center;
 }
-.etb small {
+.ifrjoin__link {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
   font-family: var(--mono);
-  font-weight: 400;
-  font-size: 9.5px;
+  font-size: clamp(11px, 1.05cqw, 13px);
+  font-weight: 600;
   letter-spacing: 0.02em;
-  color: var(--ink-mute);
+  color: color-mix(in srgb, var(--c, #5dd5a8) 82%, var(--ink));
+  padding: 7px 8px;
+  border-radius: 8px;
+  border: 1.5px solid color-mix(in srgb, var(--c, #5dd5a8) 55%, transparent);
+  background: color-mix(in srgb, var(--c, #5dd5a8) 14%, var(--paper));
+  white-space: nowrap;
+  z-index: 1;
 }
-.etb.is-hero {
-  box-shadow: 0 0 18px -4px var(--c, #5dd5a8);
+.ifrjoin__link::before,
+.ifrjoin__link::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  width: clamp(10px, 1.4cqw, 18px);
+  height: 1.5px;
+  pointer-events: none;
+}
+.ifrjoin__link::before {
+  right: calc(100% + 2px);
+  background: linear-gradient(90deg, transparent, color-mix(in srgb, #5dd5a8 60%, transparent));
+}
+.ifrjoin__link::after {
+  left: calc(100% + 2px);
+  background: linear-gradient(90deg, color-mix(in srgb, #56b8f0 60%, transparent), transparent);
+}
+.ifrjoin__link b {
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+.ifrjoin__link.is-hero {
+  box-shadow: 0 0 16px -6px var(--c, #5dd5a8);
   border-width: 1.8px;
 }
-.etb-arr {
-  display: block;
-  text-align: center;
-  font-family: var(--mono);
-  font-size: 12px;
+.ifrjoin__op.is-idle {
   color: var(--ink-mute);
-  line-height: 1;
+  border-style: dashed;
+  border-color: color-mix(in srgb, var(--ink-mute) 35%, transparent);
+  background: transparent;
 }
-.etbridge__tag {
-  display: block;
-  text-align: center;
-  margin-top: 8px;
-  font-family: var(--mono);
-  font-size: 11px;
-  letter-spacing: 0.04em;
-  color: var(--ink-mute);
+.ifrjoin__arr--ghost {
+  visibility: hidden;
 }
-.etbridge__tag b { color: var(--ink-soft); font-weight: 600; }
 
 .ifrjoin__join {
   display: grid;

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -3624,6 +3624,55 @@ vl-media.snap.is-missing .vl-ph__kind { color: rgba(15, 18, 22, 0.65); }
   border-color: color-mix(in srgb, #F27A9E 40%, transparent);
   background: color-mix(in srgb, #F27A9E 9%, var(--paper));
 }
+.ifrjoin__op.is-match {
+  color: var(--vue-green);
+  border-color: color-mix(in srgb, var(--vue-green) 40%, transparent);
+  background: color-mix(in srgb, var(--vue-green) 12%, var(--paper));
+}
+.ifrjoin__op.is-patch {
+  color: #E8B44A;
+  border-color: color-mix(in srgb, #E8B44A 45%, transparent);
+  background: color-mix(in srgb, #E8B44A 12%, var(--paper));
+}
+.ifrjoin__op.is-tear {
+  color: #f4a6ba;
+  border-color: color-mix(in srgb, #F27A9E 45%, transparent);
+  background: color-mix(in srgb, #F27A9E 12%, var(--paper));
+}
+.ifrjoin__op.is-fat {
+  color: #f4a6ba;
+  border-color: color-mix(in srgb, #F27A9E 35%, transparent);
+  background: color-mix(in srgb, #F27A9E 8%, var(--paper));
+}
+.ifrjoin__op.is-hero {
+  color: color-mix(in srgb, var(--c, #5dd5a8) 15%, var(--ink));
+  font-weight: 600;
+  border-color: color-mix(in srgb, var(--c, #5dd5a8) 55%, transparent);
+  background: color-mix(in srgb, var(--c, #5dd5a8) 18%, var(--paper));
+  box-shadow: 0 0 16px -6px var(--c, #5dd5a8);
+}
+.ifrjoin__arr {
+  display: block;
+  text-align: center;
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1;
+  color: var(--ink-mute);
+  margin: -2px 0;
+}
+.ifrjoin__hint {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: var(--ink-mute);
+  margin-top: 2px;
+}
+.ifrjoin--pipe .ifrjoin__cols {
+  min-height: clamp(240px, 38cqh, 300px);
+}
+.ifrjoin--pipe .ifrjoin__col {
+  gap: 6px;
+}
 .ifrjoin__join {
   display: grid;
   grid-template-columns: 1fr auto 1fr;

--- a/slides/src/styles.css
+++ b/slides/src/styles.css
@@ -3680,6 +3680,108 @@ vl-media.snap.is-missing .vl-ph__kind { color: rgba(15, 18, 22, 0.65); }
 .ifrjoin--pipe .ifrjoin__col {
   gap: 6px;
 }
+
+/* ---- ET data-flow bridge (5 → 3 between BTS / MTS) ---- */
+.etbridge {
+  width: min(100%, 1100px);
+  display: grid;
+  grid-template-columns: minmax(150px, 0.95fr) minmax(260px, 1.35fr) minmax(150px, 0.95fr);
+  gap: clamp(8px, 1.2cqw, 18px);
+  align-items: stretch;
+}
+.etbridge__side {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 8px;
+  padding: clamp(14px, 2cqh, 20px) clamp(12px, 1.6cqw, 18px);
+  border-radius: 14px;
+  border: 1px solid color-mix(in srgb, var(--c, #5dd5a8) 26%, transparent);
+  background: color-mix(in srgb, var(--c, #5dd5a8) 6%, transparent);
+  text-align: left;
+  justify-content: center;
+}
+.etbridge__blurb {
+  margin: 4px 0 0;
+  font-size: clamp(12px, 1.15cqw, 14px);
+  line-height: 1.4;
+  color: var(--ink-soft);
+  max-width: none;
+}
+.etbridge__flow {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: center;
+  gap: 4px;
+  padding: 6px 0;
+}
+.etb-row {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 0;
+}
+.etb-tick {
+  display: block;
+  height: 1.5px;
+}
+.etb-tick--l {
+  background: linear-gradient(90deg, transparent, color-mix(in srgb, #5dd5a8 55%, transparent));
+  margin-right: 6px;
+}
+.etb-tick--r {
+  background: linear-gradient(90deg, color-mix(in srgb, #56b8f0 55%, transparent), transparent);
+  margin-left: 6px;
+}
+.etb {
+  justify-self: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 8px 14px;
+  border-radius: 10px;
+  border: 1.5px solid var(--c, #5dd5a8);
+  background: color-mix(in srgb, var(--c, #5dd5a8) 13%, var(--paper));
+  font-family: var(--display);
+  font-weight: 600;
+  font-size: clamp(12px, 1.2cqw, 15px);
+  color: color-mix(in srgb, var(--c, #5dd5a8) 80%, var(--ink));
+  white-space: nowrap;
+  min-width: clamp(120px, 16cqw, 180px);
+  text-align: center;
+}
+.etb small {
+  font-family: var(--mono);
+  font-weight: 400;
+  font-size: 9.5px;
+  letter-spacing: 0.02em;
+  color: var(--ink-mute);
+}
+.etb.is-hero {
+  box-shadow: 0 0 18px -4px var(--c, #5dd5a8);
+  border-width: 1.8px;
+}
+.etb-arr {
+  display: block;
+  text-align: center;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--ink-mute);
+  line-height: 1;
+}
+.etbridge__tag {
+  display: block;
+  text-align: center;
+  margin-top: 8px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  color: var(--ink-mute);
+}
+.etbridge__tag b { color: var(--ink-soft); font-weight: 600; }
+
 .ifrjoin__join {
   display: grid;
   grid-template-columns: 1fr auto 1fr;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Tightens the Instant First-Frame section around a clear dual-thread **join** visual language.

### Ladder
1. **IFR1** — blank-frame timeline (unchanged; timing story)
2. **IFR2** — paint-first timeline + bottom `hydrate · thread join` bar (records / first batches)
3. **IFR3** — **Straightforward IFR**: left/right ops columns, center rail, hydrate join, skip/patch/rebuild
4. **IFR4** — restored when/how-much pivot into Element Templates
5. **IFR5–9** — ET pipeline + benchmarks (unchanged)

Runtime-chapter `flane` magic-move timelines are left alone — only join-shaped IFR narration adopts the new left/right + join pattern.

Deck 125 → 127. ZH notes + i18n for new captions/pills.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4289e08f-64f0-478d-b82e-c8106e499243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4289e08f-64f0-478d-b82e-c8106e499243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

