### PR TITLE
feat(website): add Vapor mode nav teaser linking to the vapor preview

### DIFF
--- a/packages/vue-lynx/runtime/src/transition-shared.ts
+++ b/packages/vue-lynx/runtime/src/transition-shared.ts
@@ -141,8 +141,8 @@ export function hasExplicitDuration(props: {
   return props.duration != null;
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: hooks have varying signatures
 export function callHook(
+  // biome-ignore lint/suspicious/noExplicitAny: hooks have varying signatures
   hook: ((...args: any[]) => void) | undefined,
   args: unknown[],
 ): void {

--- a/website/src/components/vapor-nav/InfoPopover.tsx
+++ b/website/src/components/vapor-nav/InfoPopover.tsx
@@ -6,18 +6,23 @@ interface InfoPopoverProps {
   label: string;
   /** Where the panel opens relative to the trigger. */
   direction?: 'down' | 'up';
+  /** Extra content rendered inside the trigger before the ⓘ glyph. */
+  trigger?: ReactNode;
   /** Panel contents. */
   children: ReactNode;
   className?: string;
 }
 
 /**
- * Small ⓘ affordance that toggles an explanatory popover. Closes on outside
- * pointerdown and Escape. Works on touch, where `title` tooltips don't exist.
+ * Shared ⓘ affordance: a small trigger (optionally carrying extra content,
+ * e.g. the coverage count) that toggles an explanatory popover. Closes on
+ * outside pointerdown and Escape. Works on touch, where `title` tooltips
+ * don't exist.
  */
 export function InfoPopover({
   label,
   direction = 'down',
+  trigger,
   children,
   className,
 }: InfoPopoverProps) {
@@ -53,6 +58,7 @@ export function InfoPopover({
         aria-expanded={open}
         onClick={() => setOpen((value) => !value)}
       >
+        {trigger}
         <svg
           className="info-popover__glyph"
           width="12"

--- a/website/src/components/vapor-nav/InfoPopover.tsx
+++ b/website/src/components/vapor-nav/InfoPopover.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+
+interface InfoPopoverProps {
+  /** Accessible name for the trigger button. */
+  label: string;
+  /** Where the panel opens relative to the trigger. */
+  direction?: 'down' | 'up';
+  /** Panel contents. */
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * Small ⓘ affordance that toggles an explanatory popover. Closes on outside
+ * pointerdown and Escape. Works on touch, where `title` tooltips don't exist.
+ */
+export function InfoPopover({
+  label,
+  direction = 'down',
+  children,
+  className,
+}: InfoPopoverProps) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const close = (event: Event) => {
+      if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('pointerdown', close);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('pointerdown', close);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  return (
+    <span
+      ref={rootRef}
+      className={`info-popover${className ? ` ${className}` : ''}`}
+      data-direction={direction}
+    >
+      <button
+        type="button"
+        className="info-popover__button"
+        aria-label={label}
+        aria-expanded={open}
+        onClick={() => setOpen((value) => !value)}
+      >
+        <svg
+          className="info-popover__glyph"
+          width="12"
+          height="12"
+          viewBox="0 0 16 16"
+          aria-hidden="true"
+        >
+          <circle cx="8" cy="8" r="7" fill="none" stroke="currentColor" strokeWidth="1.4" />
+          <circle cx="8" cy="4.9" r="0.9" fill="currentColor" />
+          <rect x="7.25" y="6.8" width="1.5" height="5" rx="0.75" fill="currentColor" />
+        </svg>
+      </button>
+      {open && (
+        <div className="info-popover__panel" role="note">
+          {children}
+        </div>
+      )}
+    </span>
+  );
+}
+
+export default InfoPopover;

--- a/website/src/components/vapor-nav/VaporModeNavLink.tsx
+++ b/website/src/components/vapor-nav/VaporModeNavLink.tsx
@@ -12,7 +12,7 @@ const copy = {
     label: 'Switch to Vapor mode — opens the Vapor preview site',
     description: 'Vapor mode lives on a separate preview build',
     off: 'VDOM',
-    on: 'Vapor',
+    on: 'Vapor preview',
     infoLabel: 'About Vapor mode',
     infoBefore: 'Vapor mode is under active exploration on the ',
     infoAfter:
@@ -23,7 +23,7 @@ const copy = {
     label: '切换到 Vapor mode —— 打开 Vapor 预览站点',
     description: 'Vapor mode 位于独立的预览构建中',
     off: 'VDOM',
-    on: 'Vapor',
+    on: 'Vapor 预览',
     infoLabel: '关于 Vapor mode',
     infoBefore: 'Vapor mode 正在 ',
     infoAfter:
@@ -32,32 +32,13 @@ const copy = {
   },
 } as const;
 
-const ExternalArrow = () => (
-  <svg
-    className="vapor-nav-link__arrow"
-    width="9"
-    height="9"
-    viewBox="0 0 16 16"
-    fill="none"
-    aria-hidden="true"
-  >
-    <path
-      d="M5 11L11 5M11 5H6M11 5V10"
-      stroke="currentColor"
-      strokeWidth="2"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-  </svg>
-);
-
 /**
  * Nav-bar teaser for Vapor mode: the same petite switch the Vapor preview
  * site carries in its nav, rendered permanently "off" (VDOM). It is a link,
  * not a toggle — flipping it takes you to the Vapor build of this site,
- * where the real switch lives. The trailing ↗ marks it as a trip to another
- * site; the ⓘ chip spells out where Vapor actually lives before anyone
- * leaves the page.
+ * where the real switch lives — so the flipped label reads "Vapor preview",
+ * not just "Vapor". The ⓘ chip spells out where Vapor actually lives before
+ * anyone leaves the page.
  */
 export function VaporModeNavLink({ locale = 'en' }: VaporModeNavLinkProps) {
   const labels = copy[locale];
@@ -80,7 +61,6 @@ export function VaporModeNavLink({ locale = 'en' }: VaporModeNavLinkProps) {
           </span>
           <span className="vapor-nav-link__knob" />
         </span>
-        <ExternalArrow />
       </a>
       <InfoPopover label={labels.infoLabel} direction="down">
         <p>

--- a/website/src/components/vapor-nav/VaporModeNavLink.tsx
+++ b/website/src/components/vapor-nav/VaporModeNavLink.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import { InfoPopover } from './InfoPopover';
 
 /** Short production path that redirects to the `vapor` branch preview build. */
@@ -9,66 +11,62 @@ interface VaporModeNavLinkProps {
 
 const copy = {
   en: {
-    label: 'Switch to Vapor mode — opens the Vapor preview site',
+    label: 'Open the Vapor preview site',
     description: 'Vapor mode lives on a separate preview build',
-    off: 'VDOM',
-    on: 'Vapor preview',
     infoLabel: 'About Vapor mode',
-    infoBefore: 'Vapor mode is under active exploration on the ',
-    infoAfter:
-      ' branch. Its docs and live examples ship as a separate preview build — this site always renders with the VDOM runtime.',
+    infoBody:
+      'Vapor mode is under active exploration on the vapor branch. Its docs and live examples ship as a separate preview build — this site always renders with the VDOM runtime.',
     infoLink: 'Open the Vapor preview',
   },
   zh: {
-    label: '切换到 Vapor mode —— 打开 Vapor 预览站点',
+    label: '打开 Vapor 预览站点',
     description: 'Vapor mode 位于独立的预览构建中',
-    off: 'VDOM',
-    on: 'Vapor 预览',
     infoLabel: '关于 Vapor mode',
-    infoBefore: 'Vapor mode 正在 ',
-    infoAfter:
-      ' 分支上探索中，其文档与可运行示例发布在独立的预览构建里 —— 本站始终使用 VDOM 运行时渲染。',
+    infoBody:
+      'Vapor mode 正在 vapor 分支上探索中，其文档与可运行示例发布在独立的预览构建里 —— 本站始终使用 VDOM 运行时渲染。',
     infoLink: '打开 Vapor 预览站点',
   },
 } as const;
 
 /**
- * Nav-bar teaser for Vapor mode: the same petite switch the Vapor preview
- * site carries in its nav, rendered permanently "off" (VDOM). It is a link,
- * not a toggle — flipping it takes you to the Vapor build of this site,
- * where the real switch lives — so the flipped label reads "Vapor preview",
- * not just "Vapor". The ⓘ chip spells out where Vapor actually lives before
- * anyone leaves the page.
+ * The `vapor` branch site's nav switch, markup and styles taken as-is. The
+ * only change is what it does: there is nothing to toggle here, so the switch
+ * is a link to the Vapor build. Pointer hover / keyboard focus previews the
+ * flip; activating it opens the preview site in a new tab.
  */
 export function VaporModeNavLink({ locale = 'en' }: VaporModeNavLinkProps) {
   const labels = copy[locale];
+  // Preview the flip on mouse/keyboard only — a tap on touch would leave the
+  // switch stuck in the Vapor state with nothing to flip it back.
+  const [on, setOn] = useState(false);
 
   return (
-    <div className="vapor-nav-link" title={labels.description}>
+    <div
+      className="go-mode-nav-control"
+      data-mode={on ? 'vapor' : 'vdom'}
+      title={labels.description}
+    >
       <a
-        className="vapor-nav-link__switch"
+        className="go-mode-nav-control__switch"
         href={VAPOR_SITE_HREF}
         target="_blank"
         rel="noopener noreferrer"
         aria-label={labels.label}
+        onMouseEnter={() => setOn(true)}
+        onMouseLeave={() => setOn(false)}
+        onFocus={() => setOn(true)}
+        onBlur={() => setOn(false)}
       >
-        <span className="vapor-nav-link__track" aria-hidden="true">
-          <span className="vapor-nav-link__mode vapor-nav-link__mode--off">
-            {labels.off}
+        <span className="go-mode-nav-control__track" aria-hidden="true">
+          <span className="go-mode-nav-control__mode">
+            {on ? 'Vapor' : 'VDOM'}
           </span>
-          <span className="vapor-nav-link__mode vapor-nav-link__mode--on">
-            {labels.on}
-          </span>
-          <span className="vapor-nav-link__knob" />
+          <span className="go-mode-nav-control__knob" />
         </span>
       </a>
       <InfoPopover label={labels.infoLabel} direction="down">
-        <p>
-          {labels.infoBefore}
-          <code className="vapor-nav-link__branch">vapor</code>
-          {labels.infoAfter}
-        </p>
-        <a href={VAPOR_SITE_HREF} target="_blank" rel="noreferrer">
+        <p>{labels.infoBody}</p>
+        <a href={VAPOR_SITE_HREF} target="_blank" rel="noopener noreferrer">
           {labels.infoLink} →
         </a>
       </InfoPopover>

--- a/website/src/components/vapor-nav/VaporModeNavLink.tsx
+++ b/website/src/components/vapor-nav/VaporModeNavLink.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { InfoPopover } from './InfoPopover';
 
@@ -31,14 +31,42 @@ const copy = {
 /**
  * The `vapor` branch site's nav switch, markup and styles taken as-is. The
  * only change is what it does: there is nothing to toggle here, so the switch
- * is a link to the Vapor build. Pointer hover / keyboard focus previews the
- * flip; activating it opens the preview site in a new tab.
+ * is a link to the Vapor build, and flipping it means "this is where you're
+ * going".
+ *
+ * The flip is driven per input type, because each one answers "am I about to
+ * leave?" at a different moment:
+ *
+ * - mouse: on hover, so the destination is previewed before committing;
+ * - keyboard: on focus-visible, the hover equivalent;
+ * - touch: on press, since there is no hover — the knob travels as the tap
+ *   opens the preview site, then settles back on its own.
+ *
+ * The touch flip un-flips on a timer rather than on the tab backgrounding:
+ * opening a link may or may not background this page, and either way you
+ * should never come back to a switch stuck on Vapor while you're still
+ * looking at the VDOM site.
  */
 export function VaporModeNavLink({ locale = 'en' }: VaporModeNavLinkProps) {
   const labels = copy[locale];
-  // Preview the flip on mouse/keyboard only — a tap on touch would leave the
-  // switch stuck in the Vapor state with nothing to flip it back.
   const [on, setOn] = useState(false);
+  const settleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearSettle = useCallback(() => {
+    if (settleTimer.current !== null) {
+      clearTimeout(settleTimer.current);
+      settleTimer.current = null;
+    }
+  }, []);
+
+  /** Flip, then let it settle back once the knob has finished travelling. */
+  const flipAndSettle = useCallback(() => {
+    setOn(true);
+    clearSettle();
+    settleTimer.current = setTimeout(() => setOn(false), 600);
+  }, [clearSettle]);
+
+  useEffect(() => clearSettle, [clearSettle]);
 
   return (
     <div
@@ -52,10 +80,35 @@ export function VaporModeNavLink({ locale = 'en' }: VaporModeNavLinkProps) {
         target="_blank"
         rel="noopener noreferrer"
         aria-label={labels.label}
-        onMouseEnter={() => setOn(true)}
-        onMouseLeave={() => setOn(false)}
-        onFocus={() => setOn(true)}
-        onBlur={() => setOn(false)}
+        onPointerEnter={(event) => {
+          if (event.pointerType === 'mouse') {
+            clearSettle();
+            setOn(true);
+          }
+        }}
+        onPointerLeave={(event) => {
+          if (event.pointerType === 'mouse') setOn(false);
+        }}
+        onPointerDown={(event) => {
+          if (event.pointerType !== 'mouse') flipAndSettle();
+        }}
+        onPointerCancel={() => {
+          clearSettle();
+          setOn(false);
+        }}
+        onFocus={(event) => {
+          // Only keyboard focus previews — a tap also focuses the anchor, and
+          // that used to leave the switch flipped until something else stole
+          // focus.
+          if (event.currentTarget.matches(':focus-visible')) {
+            clearSettle();
+            setOn(true);
+          }
+        }}
+        onBlur={() => {
+          clearSettle();
+          setOn(false);
+        }}
       >
         <span className="go-mode-nav-control__track" aria-hidden="true">
           <span className="go-mode-nav-control__mode">

--- a/website/src/components/vapor-nav/VaporModeNavLink.tsx
+++ b/website/src/components/vapor-nav/VaporModeNavLink.tsx
@@ -9,57 +9,71 @@ interface VaporModeNavLinkProps {
 
 const copy = {
   en: {
-    label: 'Switch to Vapor mode — opens the Vapor preview site',
-    description: 'Vapor mode lives on a separate preview build',
-    off: 'VDOM',
-    on: 'Vapor',
+    label: 'Vapor mode',
+    /** Sits under the label inside the pill — the "this is elsewhere" cue. */
+    tag: 'preview site',
+    title: 'Opens the Vapor preview site in a new tab',
     infoLabel: 'About Vapor mode',
     infoBefore: 'Vapor mode is under active exploration on the ',
     infoAfter:
-      ' branch. Its docs and live examples ship as a separate preview build — this site always renders with the VDOM runtime.',
-    infoLink: 'Open the Vapor preview',
+      ' branch. Its docs and live examples ship as a separate preview build — this site always renders with the VDOM runtime, and nothing here changes when you open it.',
+    infoLink: 'Open the Vapor preview site',
   },
   zh: {
-    label: '切换到 Vapor mode —— 打开 Vapor 预览站点',
-    description: 'Vapor mode 位于独立的预览构建中',
-    off: 'VDOM',
-    on: 'Vapor',
+    label: 'Vapor mode',
+    tag: '预览站点',
+    title: '在新标签页打开 Vapor 预览站点',
     infoLabel: '关于 Vapor mode',
     infoBefore: 'Vapor mode 正在 ',
     infoAfter:
-      ' 分支上探索中，其文档与可运行示例发布在独立的预览构建里 —— 本站始终使用 VDOM 运行时渲染。',
+      ' 分支上探索中，其文档与可运行示例发布在独立的预览构建里 —— 本站始终使用 VDOM 运行时渲染，打开预览站点不会改变本站的任何内容。',
     infoLink: '打开 Vapor 预览站点',
   },
 } as const;
 
+const ExternalArrow = () => (
+  <svg
+    className="vapor-nav-link__arrow"
+    width="11"
+    height="11"
+    viewBox="0 0 16 16"
+    fill="none"
+    aria-hidden="true"
+  >
+    <path
+      d="M5 11L11 5M11 5H6M11 5V10"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
 /**
- * Nav-bar teaser for Vapor mode: the same petite switch the Vapor preview
- * site carries in its nav, rendered permanently "off" (VDOM). It is a link,
- * not a toggle — flipping it takes you to the Vapor build of this site,
- * where the real switch lives. The ⓘ chip explains where Vapor actually
- * lives before anyone leaves the page.
+ * Nav-bar pointer to the Vapor preview build. Deliberately *not* shaped like
+ * a switch: Vapor is a separate deployment of this site, not a mode you can
+ * flip in place, so the control is a gradient-outlined pill that reads
+ * "Vapor mode · preview site ↗" and opens in a new tab. The ⓘ chip spells
+ * out that nothing on this page changes.
  */
 export function VaporModeNavLink({ locale = 'en' }: VaporModeNavLinkProps) {
   const labels = copy[locale];
 
   return (
-    <div className="vapor-nav-link" title={labels.description}>
+    <div className="vapor-nav-link">
       <a
-        className="vapor-nav-link__switch"
+        className="vapor-nav-link__pill"
         href={VAPOR_SITE_HREF}
         target="_blank"
-        rel="noreferrer"
-        aria-label={labels.label}
+        rel="noopener noreferrer"
+        title={labels.title}
       >
-        <span className="vapor-nav-link__track" aria-hidden="true">
-          <span className="vapor-nav-link__mode vapor-nav-link__mode--off">
-            {labels.off}
-          </span>
-          <span className="vapor-nav-link__mode vapor-nav-link__mode--on">
-            {labels.on}
-          </span>
-          <span className="vapor-nav-link__knob" />
+        <span className="vapor-nav-link__text">
+          <span className="vapor-nav-link__label">{labels.label}</span>
+          <span className="vapor-nav-link__tag">{labels.tag}</span>
         </span>
+        <ExternalArrow />
       </a>
       <InfoPopover label={labels.infoLabel} direction="down">
         <p>
@@ -67,7 +81,7 @@ export function VaporModeNavLink({ locale = 'en' }: VaporModeNavLinkProps) {
           <code className="vapor-nav-link__branch">vapor</code>
           {labels.infoAfter}
         </p>
-        <a href={VAPOR_SITE_HREF} target="_blank" rel="noreferrer">
+        <a href={VAPOR_SITE_HREF} target="_blank" rel="noopener noreferrer">
           {labels.infoLink} →
         </a>
       </InfoPopover>

--- a/website/src/components/vapor-nav/VaporModeNavLink.tsx
+++ b/website/src/components/vapor-nav/VaporModeNavLink.tsx
@@ -9,24 +9,25 @@ interface VaporModeNavLinkProps {
 
 const copy = {
   en: {
-    label: 'Vapor mode',
-    /** Sits under the label inside the pill — the "this is elsewhere" cue. */
-    tag: 'preview site',
-    title: 'Opens the Vapor preview site in a new tab',
+    label: 'Switch to Vapor mode — opens the Vapor preview site',
+    description: 'Vapor mode lives on a separate preview build',
+    off: 'VDOM',
+    on: 'Vapor',
     infoLabel: 'About Vapor mode',
     infoBefore: 'Vapor mode is under active exploration on the ',
     infoAfter:
-      ' branch. Its docs and live examples ship as a separate preview build — this site always renders with the VDOM runtime, and nothing here changes when you open it.',
-    infoLink: 'Open the Vapor preview site',
+      ' branch. Its docs and live examples ship as a separate preview build — this site always renders with the VDOM runtime.',
+    infoLink: 'Open the Vapor preview',
   },
   zh: {
-    label: 'Vapor mode',
-    tag: '预览站点',
-    title: '在新标签页打开 Vapor 预览站点',
+    label: '切换到 Vapor mode —— 打开 Vapor 预览站点',
+    description: 'Vapor mode 位于独立的预览构建中',
+    off: 'VDOM',
+    on: 'Vapor',
     infoLabel: '关于 Vapor mode',
     infoBefore: 'Vapor mode 正在 ',
     infoAfter:
-      ' 分支上探索中，其文档与可运行示例发布在独立的预览构建里 —— 本站始终使用 VDOM 运行时渲染，打开预览站点不会改变本站的任何内容。',
+      ' 分支上探索中，其文档与可运行示例发布在独立的预览构建里 —— 本站始终使用 VDOM 运行时渲染。',
     infoLink: '打开 Vapor 预览站点',
   },
 } as const;
@@ -34,8 +35,8 @@ const copy = {
 const ExternalArrow = () => (
   <svg
     className="vapor-nav-link__arrow"
-    width="11"
-    height="11"
+    width="9"
+    height="9"
     viewBox="0 0 16 16"
     fill="none"
     aria-hidden="true"
@@ -43,7 +44,7 @@ const ExternalArrow = () => (
     <path
       d="M5 11L11 5M11 5H6M11 5V10"
       stroke="currentColor"
-      strokeWidth="1.8"
+      strokeWidth="2"
       strokeLinecap="round"
       strokeLinejoin="round"
     />
@@ -51,27 +52,33 @@ const ExternalArrow = () => (
 );
 
 /**
- * Nav-bar pointer to the Vapor preview build. Deliberately *not* shaped like
- * a switch: Vapor is a separate deployment of this site, not a mode you can
- * flip in place, so the control is a gradient-outlined pill that reads
- * "Vapor mode · preview site ↗" and opens in a new tab. The ⓘ chip spells
- * out that nothing on this page changes.
+ * Nav-bar teaser for Vapor mode: the same petite switch the Vapor preview
+ * site carries in its nav, rendered permanently "off" (VDOM). It is a link,
+ * not a toggle — flipping it takes you to the Vapor build of this site,
+ * where the real switch lives. The trailing ↗ marks it as a trip to another
+ * site; the ⓘ chip spells out where Vapor actually lives before anyone
+ * leaves the page.
  */
 export function VaporModeNavLink({ locale = 'en' }: VaporModeNavLinkProps) {
   const labels = copy[locale];
 
   return (
-    <div className="vapor-nav-link">
+    <div className="vapor-nav-link" title={labels.description}>
       <a
-        className="vapor-nav-link__pill"
+        className="vapor-nav-link__switch"
         href={VAPOR_SITE_HREF}
         target="_blank"
         rel="noopener noreferrer"
-        title={labels.title}
+        aria-label={labels.label}
       >
-        <span className="vapor-nav-link__text">
-          <span className="vapor-nav-link__label">{labels.label}</span>
-          <span className="vapor-nav-link__tag">{labels.tag}</span>
+        <span className="vapor-nav-link__track" aria-hidden="true">
+          <span className="vapor-nav-link__mode vapor-nav-link__mode--off">
+            {labels.off}
+          </span>
+          <span className="vapor-nav-link__mode vapor-nav-link__mode--on">
+            {labels.on}
+          </span>
+          <span className="vapor-nav-link__knob" />
         </span>
         <ExternalArrow />
       </a>
@@ -81,7 +88,7 @@ export function VaporModeNavLink({ locale = 'en' }: VaporModeNavLinkProps) {
           <code className="vapor-nav-link__branch">vapor</code>
           {labels.infoAfter}
         </p>
-        <a href={VAPOR_SITE_HREF} target="_blank" rel="noopener noreferrer">
+        <a href={VAPOR_SITE_HREF} target="_blank" rel="noreferrer">
           {labels.infoLink} →
         </a>
       </InfoPopover>

--- a/website/src/components/vapor-nav/VaporModeNavLink.tsx
+++ b/website/src/components/vapor-nav/VaporModeNavLink.tsx
@@ -1,0 +1,78 @@
+import { InfoPopover } from './InfoPopover';
+
+/** Short production path that redirects to the `vapor` branch preview build. */
+export const VAPOR_SITE_HREF = '/vapor';
+
+interface VaporModeNavLinkProps {
+  locale?: 'en' | 'zh';
+}
+
+const copy = {
+  en: {
+    label: 'Switch to Vapor mode — opens the Vapor preview site',
+    description: 'Vapor mode lives on a separate preview build',
+    off: 'VDOM',
+    on: 'Vapor',
+    infoLabel: 'About Vapor mode',
+    infoBefore: 'Vapor mode is under active exploration on the ',
+    infoAfter:
+      ' branch. Its docs and live examples ship as a separate preview build — this site always renders with the VDOM runtime.',
+    infoLink: 'Open the Vapor preview',
+  },
+  zh: {
+    label: '切换到 Vapor mode —— 打开 Vapor 预览站点',
+    description: 'Vapor mode 位于独立的预览构建中',
+    off: 'VDOM',
+    on: 'Vapor',
+    infoLabel: '关于 Vapor mode',
+    infoBefore: 'Vapor mode 正在 ',
+    infoAfter:
+      ' 分支上探索中，其文档与可运行示例发布在独立的预览构建里 —— 本站始终使用 VDOM 运行时渲染。',
+    infoLink: '打开 Vapor 预览站点',
+  },
+} as const;
+
+/**
+ * Nav-bar teaser for Vapor mode: the same petite switch the Vapor preview
+ * site carries in its nav, rendered permanently "off" (VDOM). It is a link,
+ * not a toggle — flipping it takes you to the Vapor build of this site,
+ * where the real switch lives. The ⓘ chip explains where Vapor actually
+ * lives before anyone leaves the page.
+ */
+export function VaporModeNavLink({ locale = 'en' }: VaporModeNavLinkProps) {
+  const labels = copy[locale];
+
+  return (
+    <div className="vapor-nav-link" title={labels.description}>
+      <a
+        className="vapor-nav-link__switch"
+        href={VAPOR_SITE_HREF}
+        target="_blank"
+        rel="noreferrer"
+        aria-label={labels.label}
+      >
+        <span className="vapor-nav-link__track" aria-hidden="true">
+          <span className="vapor-nav-link__mode vapor-nav-link__mode--off">
+            {labels.off}
+          </span>
+          <span className="vapor-nav-link__mode vapor-nav-link__mode--on">
+            {labels.on}
+          </span>
+          <span className="vapor-nav-link__knob" />
+        </span>
+      </a>
+      <InfoPopover label={labels.infoLabel} direction="down">
+        <p>
+          {labels.infoBefore}
+          <code className="vapor-nav-link__branch">vapor</code>
+          {labels.infoAfter}
+        </p>
+        <a href={VAPOR_SITE_HREF} target="_blank" rel="noreferrer">
+          {labels.infoLink} →
+        </a>
+      </InfoPopover>
+    </div>
+  );
+}
+
+export default VaporModeNavLink;

--- a/website/src/components/vapor-nav/vapor-nav.scss
+++ b/website/src/components/vapor-nav/vapor-nav.scss
@@ -1,10 +1,11 @@
 /* ---------------------------------------------------------------------------
- * Vapor mode nav teaser — a petite VDOM/Vapor switch that is really a link to
- * the Vapor preview build, plus a ⓘ popover explaining where Vapor lives.
- * Mirrors the switch shipped in the `vapor` branch site's nav.
+ * Vapor mode nav pointer — a gradient-outlined pill that opens the Vapor
+ * preview build in a new tab, plus a ⓘ popover explaining where Vapor lives.
+ * Intentionally not switch-shaped: Vapor is a separate deployment, not an
+ * in-place mode, so the affordance reads as "leave for another site".
  * ------------------------------------------------------------------------- */
 
-/* Homepage brand gradient, reused for the "flipped to Vapor" preview state. */
+/* Homepage brand gradient, used for the pill's outline and its hover fill. */
 @mixin vapor-nav-gradient {
   background-image: linear-gradient(
     270deg,
@@ -32,116 +33,112 @@
   position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 5px;
+  gap: 4px;
   color: var(--rp-c-text-2);
-  font-size: 12px;
   line-height: 1;
   white-space: nowrap;
 }
 
-.vapor-nav-link__switch {
-  display: inline-flex;
-  align-items: center;
-  padding: 4px 0;
-  border: 0;
-  background: transparent;
-  color: inherit;
-  cursor: pointer;
-  font: inherit;
-  line-height: 1;
-  text-decoration: none;
-}
-
-.vapor-nav-link__switch:focus-visible {
-  outline: 2px solid var(--rp-c-brand);
-  outline-offset: 2px;
-  border-radius: 999px;
-}
-
-.vapor-nav-link__track {
+/* The pill itself. The gradient lives on the element and is masked down to a
+   1px ring, so the resting state is an outline and hover fills it in. */
+.vapor-nav-link__pill {
   position: relative;
   display: inline-flex;
   align-items: center;
-  width: 62px;
-  height: 22px;
-  flex: none;
+  gap: 5px;
+  padding: 5px 9px;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--rp-c-text-3) 26%, transparent);
-  box-shadow: inset 0 1px 2px rgb(0 0 0 / 8%);
-  transition: background-color 240ms ease-out, box-shadow 240ms ease-out;
+  /* Keeps the hover-fill pseudo-element (z-index: -1) behind the pill's own
+     content but in front of whatever the nav paints underneath. */
+  isolation: isolate;
+  color: color-mix(in srgb, var(--major-brand-color) 82%, var(--rp-c-text-1));
+  text-decoration: none;
+  transition: color 200ms ease-out, transform 200ms ease-out;
 }
 
-/* Mode names sit in the free half of the track and cross-fade, so the knob's
-   motion and the label swap can never nudge the surrounding nav layout. */
-.vapor-nav-link__mode {
+/* Gradient ring, drawn as a masked pseudo-element so it can animate and
+   thicken independently of the pill's own background. */
+.vapor-nav-link__pill::before {
+  content: '';
   position: absolute;
-  top: 0;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  height: 100%;
-  font-size: 10px;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  transition: opacity 200ms ease-out, color 200ms ease-out;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1px;
+  mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  mask-composite: exclude;
+  -webkit-mask-composite: xor;
+  opacity: 0.75;
+  transition: opacity 200ms ease-out;
+
+  @include vapor-nav-gradient;
 }
 
-.vapor-nav-link__mode--off {
-  right: 11px;
-  left: 27px;
-  color: var(--rp-c-text-2);
-}
-
-.vapor-nav-link__mode--on {
-  right: 27px;
-  left: 11px;
-  color: #fff;
+/* Hover/focus fills the pill — a small "you're heading somewhere else" beat. */
+.vapor-nav-link__pill::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  border-radius: inherit;
   opacity: 0;
-  text-shadow: 0 1px 1px rgb(0 0 0 / 22%);
+  transition: opacity 200ms ease-out;
+
+  @include vapor-nav-gradient;
 }
 
-.vapor-nav-link__knob {
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
-  background: #fff;
-  box-shadow: 0 1px 2px rgb(0 0 0 / 25%);
-  transition: transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
+.vapor-nav-link__pill:hover,
+.vapor-nav-link__pill:focus-visible {
+  color: #fff;
 }
 
-/* Hover/focus previews the flip: the switch slides to Vapor and lights up
-   with the brand gradient — a hint of what the destination site looks like. */
-@mixin vapor-nav-flipped {
-  .vapor-nav-link__track {
-    @include vapor-nav-gradient;
-
-    box-shadow: 0 1px 6px color-mix(in srgb, var(--major-brand-color) 45%, transparent);
-  }
-
-  .vapor-nav-link__mode--off {
-    opacity: 0;
-  }
-
-  .vapor-nav-link__mode--on {
-    opacity: 1;
-  }
-
-  .vapor-nav-link__knob {
-    transform: translateX(40px);
-  }
+.vapor-nav-link__pill:hover::before,
+.vapor-nav-link__pill:focus-visible::before {
+  opacity: 0;
 }
 
-@media (hover: hover) {
-  .vapor-nav-link__switch:hover {
-    @include vapor-nav-flipped;
-  }
+.vapor-nav-link__pill:hover::after,
+.vapor-nav-link__pill:focus-visible::after {
+  opacity: 1;
 }
 
-.vapor-nav-link__switch:focus-visible {
-  @include vapor-nav-flipped;
+.vapor-nav-link__pill:focus-visible {
+  outline: 2px solid var(--rp-c-brand);
+  outline-offset: 2px;
+}
+
+/* Two-line stack: the mode name, and under it the reminder that this is a
+   different deployment. */
+.vapor-nav-link__text {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.vapor-nav-link__label {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.vapor-nav-link__tag {
+  font-size: 9px;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  opacity: 0.72;
+}
+
+/* The ↗ nudges outward on hover — the universal "opens elsewhere" cue. */
+.vapor-nav-link__arrow {
+  flex: none;
+  transition: transform 200ms ease-out;
+}
+
+.vapor-nav-link__pill:hover .vapor-nav-link__arrow,
+.vapor-nav-link__pill:focus-visible .vapor-nav-link__arrow {
+  transform: translate(1px, -1px);
 }
 
 /* ---------------------------------------------------------------------------
@@ -240,35 +237,34 @@
  * Responsive / input adjustments
  * ------------------------------------------------------------------------- */
 
-/* Touch: pad the hit area invisibly — the control stays petite. */
-@media (pointer: coarse) {
-  .vapor-nav-link__switch {
-    padding: 8px 2px;
-  }
-}
-
 /* Narrow viewports: the nav collapses into the hamburger menu, so drop the
-   teaser rather than crowding the logo. */
-@media (max-width: 640px) {
+   pointer rather than crowding the logo. */
+@media (max-width: 720px) {
   .vapor-nav-link {
     display: none;
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .vapor-nav-link__mode,
-  .vapor-nav-link__track,
-  .vapor-nav-link__knob {
+  .vapor-nav-link__pill,
+  .vapor-nav-link__pill::before,
+  .vapor-nav-link__pill::after,
+  .vapor-nav-link__arrow {
     transition: none;
   }
 
-  .vapor-nav-link__switch:hover .vapor-nav-link__track,
-  .vapor-nav-link__switch:focus-visible .vapor-nav-link__track {
+  .vapor-nav-link__pill::before,
+  .vapor-nav-link__pill::after {
     animation: none;
     background-image: linear-gradient(
       135deg,
       var(--major-brand-color),
       var(--gradient-brand-color)
     );
+  }
+
+  .vapor-nav-link__pill:hover .vapor-nav-link__arrow,
+  .vapor-nav-link__pill:focus-visible .vapor-nav-link__arrow {
+    transform: none;
   }
 }

--- a/website/src/components/vapor-nav/vapor-nav.scss
+++ b/website/src/components/vapor-nav/vapor-nav.scss
@@ -1,11 +1,10 @@
 /* ---------------------------------------------------------------------------
- * Vapor mode nav pointer — a gradient-outlined pill that opens the Vapor
- * preview build in a new tab, plus a ⓘ popover explaining where Vapor lives.
- * Intentionally not switch-shaped: Vapor is a separate deployment, not an
- * in-place mode, so the affordance reads as "leave for another site".
+ * Vapor mode nav teaser — a petite VDOM/Vapor switch that is really a link to
+ * the Vapor preview build, plus a ⓘ popover explaining where Vapor lives.
+ * Mirrors the switch shipped in the `vapor` branch site's nav.
  * ------------------------------------------------------------------------- */
 
-/* Homepage brand gradient, used for the pill's outline and its hover fill. */
+/* Homepage brand gradient, reused for the "flipped to Vapor" preview state. */
 @mixin vapor-nav-gradient {
   background-image: linear-gradient(
     270deg,
@@ -33,112 +32,130 @@
   position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: 5px;
   color: var(--rp-c-text-2);
+  font-size: 12px;
   line-height: 1;
   white-space: nowrap;
 }
 
-/* The pill itself. The gradient lives on the element and is masked down to a
-   1px ring, so the resting state is an outline and hover fills it in. */
-.vapor-nav-link__pill {
+.vapor-nav-link__switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 4px 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  line-height: 1;
+  text-decoration: none;
+}
+
+.vapor-nav-link__switch:focus-visible {
+  outline: 2px solid var(--rp-c-brand);
+  outline-offset: 2px;
+  border-radius: 999px;
+}
+
+.vapor-nav-link__track {
   position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 5px;
-  padding: 5px 9px;
+  width: 62px;
+  height: 22px;
+  flex: none;
   border-radius: 999px;
-  /* Keeps the hover-fill pseudo-element (z-index: -1) behind the pill's own
-     content but in front of whatever the nav paints underneath. */
-  isolation: isolate;
-  color: color-mix(in srgb, var(--major-brand-color) 82%, var(--rp-c-text-1));
-  text-decoration: none;
-  transition: color 200ms ease-out, transform 200ms ease-out;
+  background: color-mix(in srgb, var(--rp-c-text-3) 26%, transparent);
+  box-shadow: inset 0 1px 2px rgb(0 0 0 / 8%);
+  transition: background-color 240ms ease-out, box-shadow 240ms ease-out;
 }
 
-/* Gradient ring, drawn as a masked pseudo-element so it can animate and
-   thicken independently of the pill's own background. */
-.vapor-nav-link__pill::before {
-  content: '';
+/* Mode names sit in the free half of the track and cross-fade, so the knob's
+   motion and the label swap can never nudge the surrounding nav layout. */
+.vapor-nav-link__mode {
   position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  padding: 1px;
-  mask:
-    linear-gradient(#fff 0 0) content-box,
-    linear-gradient(#fff 0 0);
-  mask-composite: exclude;
-  -webkit-mask-composite: xor;
-  opacity: 0.75;
-  transition: opacity 200ms ease-out;
-
-  @include vapor-nav-gradient;
-}
-
-/* Hover/focus fills the pill — a small "you're heading somewhere else" beat. */
-.vapor-nav-link__pill::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  z-index: -1;
-  border-radius: inherit;
-  opacity: 0;
-  transition: opacity 200ms ease-out;
-
-  @include vapor-nav-gradient;
-}
-
-.vapor-nav-link__pill:hover,
-.vapor-nav-link__pill:focus-visible {
-  color: #fff;
-}
-
-.vapor-nav-link__pill:hover::before,
-.vapor-nav-link__pill:focus-visible::before {
-  opacity: 0;
-}
-
-.vapor-nav-link__pill:hover::after,
-.vapor-nav-link__pill:focus-visible::after {
-  opacity: 1;
-}
-
-.vapor-nav-link__pill:focus-visible {
-  outline: 2px solid var(--rp-c-brand);
-  outline-offset: 2px;
-}
-
-/* Two-line stack: the mode name, and under it the reminder that this is a
-   different deployment. */
-.vapor-nav-link__text {
+  top: 0;
   display: inline-flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.vapor-nav-link__label {
-  font-size: 12px;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  font-size: 10px;
   font-weight: 600;
-  letter-spacing: 0.01em;
+  letter-spacing: 0.02em;
+  transition: opacity 200ms ease-out, color 200ms ease-out;
 }
 
-.vapor-nav-link__tag {
-  font-size: 9px;
-  font-weight: 500;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  opacity: 0.72;
+.vapor-nav-link__mode--off {
+  right: 11px;
+  left: 27px;
+  color: var(--rp-c-text-2);
 }
 
-/* The ↗ nudges outward on hover — the universal "opens elsewhere" cue. */
+.vapor-nav-link__mode--on {
+  right: 27px;
+  left: 11px;
+  color: #fff;
+  opacity: 0;
+  text-shadow: 0 1px 1px rgb(0 0 0 / 22%);
+}
+
+.vapor-nav-link__knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 25%);
+  transition: transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* Trailing ↗ — the switch leads to another deployment, not an in-place mode,
+   so it carries the same cue any external link would. */
 .vapor-nav-link__arrow {
   flex: none;
-  transition: transform 200ms ease-out;
+  color: var(--rp-c-text-3);
+  transition: transform 200ms ease-out, color 200ms ease-out;
 }
 
-.vapor-nav-link__pill:hover .vapor-nav-link__arrow,
-.vapor-nav-link__pill:focus-visible .vapor-nav-link__arrow {
-  transform: translate(1px, -1px);
+/* Hover/focus previews the flip: the switch slides to Vapor and lights up
+   with the brand gradient — a hint of what the destination site looks like. */
+@mixin vapor-nav-flipped {
+  .vapor-nav-link__track {
+    @include vapor-nav-gradient;
+
+    box-shadow: 0 1px 6px color-mix(in srgb, var(--major-brand-color) 45%, transparent);
+  }
+
+  .vapor-nav-link__mode--off {
+    opacity: 0;
+  }
+
+  .vapor-nav-link__mode--on {
+    opacity: 1;
+  }
+
+  .vapor-nav-link__knob {
+    transform: translateX(40px);
+  }
+
+  .vapor-nav-link__arrow {
+    color: var(--rp-c-text-1);
+    transform: translate(1px, -1px);
+  }
+}
+
+@media (hover: hover) {
+  .vapor-nav-link__switch:hover {
+    @include vapor-nav-flipped;
+  }
+}
+
+.vapor-nav-link__switch:focus-visible {
+  @include vapor-nav-flipped;
 }
 
 /* ---------------------------------------------------------------------------
@@ -237,34 +254,73 @@
  * Responsive / input adjustments
  * ------------------------------------------------------------------------- */
 
-/* Narrow viewports: the nav collapses into the hamburger menu, so drop the
-   pointer rather than crowding the logo. */
-@media (max-width: 720px) {
+/* Touch: pad the hit area invisibly — the control stays petite. */
+@media (pointer: coarse) {
+  .vapor-nav-link__switch {
+    padding: 8px 2px;
+  }
+}
+
+/* Narrow viewports: the nav collapses to logo + hamburger, which leaves room
+   for the teaser — keep it, just tighter. Shrinking the track (and the knob's
+   travel with it) keeps the proportions rather than squashing them. */
+@media (max-width: 640px) {
   .vapor-nav-link {
-    display: none;
+    gap: 3px;
+  }
+
+  .vapor-nav-link__track {
+    width: 54px;
+    height: 20px;
+  }
+
+  .vapor-nav-link__mode--off {
+    right: 9px;
+    left: 24px;
+  }
+
+  .vapor-nav-link__mode--on {
+    right: 24px;
+    left: 9px;
+  }
+
+  .vapor-nav-link__knob {
+    width: 16px;
+    height: 16px;
+  }
+
+  .vapor-nav-link__switch:hover .vapor-nav-link__knob,
+  .vapor-nav-link__switch:focus-visible .vapor-nav-link__knob {
+    transform: translateX(34px);
+  }
+
+  /* Stay right-anchored to the ⓘ (which sits well right of the logo) and let
+     the panel shrink to the viewport rather than running off either edge. */
+  .info-popover__panel {
+    width: min(252px, calc(100vw - 24px));
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .vapor-nav-link__pill,
-  .vapor-nav-link__pill::before,
-  .vapor-nav-link__pill::after,
+  .vapor-nav-link__mode,
+  .vapor-nav-link__track,
+  .vapor-nav-link__knob,
   .vapor-nav-link__arrow {
     transition: none;
   }
 
-  .vapor-nav-link__pill::before,
-  .vapor-nav-link__pill::after {
+  .vapor-nav-link__switch:hover .vapor-nav-link__arrow,
+  .vapor-nav-link__switch:focus-visible .vapor-nav-link__arrow {
+    transform: none;
+  }
+
+  .vapor-nav-link__switch:hover .vapor-nav-link__track,
+  .vapor-nav-link__switch:focus-visible .vapor-nav-link__track {
     animation: none;
     background-image: linear-gradient(
       135deg,
       var(--major-brand-color),
       var(--gradient-brand-color)
     );
-  }
-
-  .vapor-nav-link__pill:hover .vapor-nav-link__arrow,
-  .vapor-nav-link__pill:focus-visible .vapor-nav-link__arrow {
-    transform: none;
   }
 }

--- a/website/src/components/vapor-nav/vapor-nav.scss
+++ b/website/src/components/vapor-nav/vapor-nav.scss
@@ -4,7 +4,7 @@
  * Mirrors the switch shipped in the `vapor` branch site's nav.
  * ------------------------------------------------------------------------- */
 
-/* Homepage brand gradient, reused for the "flipped to Vapor" preview state. */
+/* Homepage brand gradient, reused for the "flipped to Vapor preview" state. */
 @mixin vapor-nav-gradient {
   background-image: linear-gradient(
     270deg,
@@ -42,7 +42,11 @@
 .vapor-nav-link__switch {
   display: inline-flex;
   align-items: center;
-  gap: 3px;
+  /* Fixed box, track right-aligned inside it: the track grows leftward into
+     the nav's empty space when flipped, so the ⓘ and everything right of it
+     never move. */
+  width: 112px;
+  justify-content: flex-end;
   padding: 4px 0;
   border: 0;
   background: transparent;
@@ -69,7 +73,10 @@
   border-radius: 999px;
   background: color-mix(in srgb, var(--rp-c-text-3) 26%, transparent);
   box-shadow: inset 0 1px 2px rgb(0 0 0 / 8%);
-  transition: background-color 240ms ease-out, box-shadow 240ms ease-out;
+  transition:
+    width 240ms cubic-bezier(0.22, 1, 0.36, 1),
+    background-color 240ms ease-out,
+    box-shadow 240ms ease-out;
 }
 
 /* Mode names sit in the free half of the track and cross-fade, so the knob's
@@ -113,20 +120,15 @@
   transition: transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-/* Trailing ↗ — the switch leads to another deployment, not an in-place mode,
-   so it carries the same cue any external link would. */
-.vapor-nav-link__arrow {
-  flex: none;
-  color: var(--rp-c-text-3);
-  transition: transform 200ms ease-out, color 200ms ease-out;
-}
-
 /* Hover/focus previews the flip: the switch slides to Vapor and lights up
    with the brand gradient — a hint of what the destination site looks like. */
 @mixin vapor-nav-flipped {
+  /* Widen to fit the longer "Vapor preview" label — the destination is a
+     separate build, and the flipped label should say so. */
   .vapor-nav-link__track {
     @include vapor-nav-gradient;
 
+    width: 112px;
     box-shadow: 0 1px 6px color-mix(in srgb, var(--major-brand-color) 45%, transparent);
   }
 
@@ -139,12 +141,7 @@
   }
 
   .vapor-nav-link__knob {
-    transform: translateX(40px);
-  }
-
-  .vapor-nav-link__arrow {
-    color: var(--rp-c-text-1);
-    transform: translate(1px, -1px);
+    transform: translateX(90px);
   }
 }
 
@@ -269,6 +266,10 @@
     gap: 3px;
   }
 
+  .vapor-nav-link__switch {
+    width: 96px;
+  }
+
   .vapor-nav-link__track {
     width: 54px;
     height: 20px;
@@ -289,9 +290,14 @@
     height: 16px;
   }
 
+  .vapor-nav-link__switch:hover .vapor-nav-link__track,
+  .vapor-nav-link__switch:focus-visible .vapor-nav-link__track {
+    width: 96px;
+  }
+
   .vapor-nav-link__switch:hover .vapor-nav-link__knob,
   .vapor-nav-link__switch:focus-visible .vapor-nav-link__knob {
-    transform: translateX(34px);
+    transform: translateX(76px);
   }
 
   /* Stay right-anchored to the ⓘ (which sits well right of the logo) and let
@@ -304,14 +310,8 @@
 @media (prefers-reduced-motion: reduce) {
   .vapor-nav-link__mode,
   .vapor-nav-link__track,
-  .vapor-nav-link__knob,
-  .vapor-nav-link__arrow {
+  .vapor-nav-link__knob {
     transition: none;
-  }
-
-  .vapor-nav-link__switch:hover .vapor-nav-link__arrow,
-  .vapor-nav-link__switch:focus-visible .vapor-nav-link__arrow {
-    transform: none;
   }
 
   .vapor-nav-link__switch:hover .vapor-nav-link__track,

--- a/website/src/components/vapor-nav/vapor-nav.scss
+++ b/website/src/components/vapor-nav/vapor-nav.scss
@@ -1,0 +1,274 @@
+/* ---------------------------------------------------------------------------
+ * Vapor mode nav teaser — a petite VDOM/Vapor switch that is really a link to
+ * the Vapor preview build, plus a ⓘ popover explaining where Vapor lives.
+ * Mirrors the switch shipped in the `vapor` branch site's nav.
+ * ------------------------------------------------------------------------- */
+
+/* Homepage brand gradient, reused for the "flipped to Vapor" preview state. */
+@mixin vapor-nav-gradient {
+  background-image: linear-gradient(
+    270deg,
+    var(--major-brand-color),
+    var(--gradient-brand-color),
+    var(--second-brand-color),
+    var(--gradient-brand-color),
+    var(--major-brand-color)
+  );
+  background-size: 220% 100%;
+  animation: vapor-nav-gradient-drift 6s linear infinite;
+}
+
+@keyframes vapor-nav-gradient-drift {
+  0% {
+    background-position: 0% 50%;
+  }
+
+  100% {
+    background-position: -220% 50%;
+  }
+}
+
+.vapor-nav-link {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--rp-c-text-2);
+  font-size: 12px;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.vapor-nav-link__switch {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+  line-height: 1;
+  text-decoration: none;
+}
+
+.vapor-nav-link__switch:focus-visible {
+  outline: 2px solid var(--rp-c-brand);
+  outline-offset: 2px;
+  border-radius: 999px;
+}
+
+.vapor-nav-link__track {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  width: 62px;
+  height: 22px;
+  flex: none;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--rp-c-text-3) 26%, transparent);
+  box-shadow: inset 0 1px 2px rgb(0 0 0 / 8%);
+  transition: background-color 240ms ease-out, box-shadow 240ms ease-out;
+}
+
+/* Mode names sit in the free half of the track and cross-fade, so the knob's
+   motion and the label swap can never nudge the surrounding nav layout. */
+.vapor-nav-link__mode {
+  position: absolute;
+  top: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  transition: opacity 200ms ease-out, color 200ms ease-out;
+}
+
+.vapor-nav-link__mode--off {
+  right: 11px;
+  left: 27px;
+  color: var(--rp-c-text-2);
+}
+
+.vapor-nav-link__mode--on {
+  right: 27px;
+  left: 11px;
+  color: #fff;
+  opacity: 0;
+  text-shadow: 0 1px 1px rgb(0 0 0 / 22%);
+}
+
+.vapor-nav-link__knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 2px rgb(0 0 0 / 25%);
+  transition: transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+/* Hover/focus previews the flip: the switch slides to Vapor and lights up
+   with the brand gradient — a hint of what the destination site looks like. */
+@mixin vapor-nav-flipped {
+  .vapor-nav-link__track {
+    @include vapor-nav-gradient;
+
+    box-shadow: 0 1px 6px color-mix(in srgb, var(--major-brand-color) 45%, transparent);
+  }
+
+  .vapor-nav-link__mode--off {
+    opacity: 0;
+  }
+
+  .vapor-nav-link__mode--on {
+    opacity: 1;
+  }
+
+  .vapor-nav-link__knob {
+    transform: translateX(40px);
+  }
+}
+
+@media (hover: hover) {
+  .vapor-nav-link__switch:hover {
+    @include vapor-nav-flipped;
+  }
+}
+
+.vapor-nav-link__switch:focus-visible {
+  @include vapor-nav-flipped;
+}
+
+/* ---------------------------------------------------------------------------
+ * ⓘ popover
+ * ------------------------------------------------------------------------- */
+
+.info-popover {
+  position: relative;
+  display: inline-flex;
+}
+
+.info-popover__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  min-height: 18px;
+  padding: 0;
+  border: 0;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--rp-c-text-3);
+  cursor: pointer;
+  font: inherit;
+  line-height: 1;
+  transition: color 160ms ease-out, background-color 160ms ease-out;
+}
+
+.info-popover__button:hover,
+.info-popover__button[aria-expanded='true'] {
+  color: var(--rp-c-text-1);
+}
+
+.info-popover__button:focus-visible {
+  outline: 2px solid var(--rp-c-brand);
+  outline-offset: 1px;
+}
+
+.info-popover__glyph {
+  flex: none;
+}
+
+.info-popover__panel {
+  position: absolute;
+  z-index: 100;
+  top: calc(100% + 10px);
+  right: 0;
+  width: 252px;
+  padding: 10px 12px;
+  border: 1px solid var(--rp-c-divider);
+  border-radius: 10px;
+  background: var(--rp-c-bg);
+  box-shadow: 0 8px 24px rgb(0 0 0 / 12%);
+  color: var(--rp-c-text-2);
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 1.55;
+  white-space: normal;
+  text-align: left;
+}
+
+.info-popover[data-direction='up'] .info-popover__panel {
+  top: auto;
+  bottom: calc(100% + 10px);
+}
+
+.info-popover__panel p {
+  margin: 0 0 6px;
+  color: var(--rp-c-text-2);
+}
+
+.info-popover__panel p:last-child {
+  margin-bottom: 0;
+}
+
+.info-popover__panel a {
+  color: var(--rp-c-brand);
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.info-popover__panel a:hover {
+  text-decoration: underline;
+}
+
+.vapor-nav-link__branch {
+  padding: 1px 4px;
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--rp-c-text-3) 16%, transparent);
+  color: var(--rp-c-text-1);
+  font-family: var(--rp-font-family-mono, monospace);
+  font-size: 0.92em;
+}
+
+/* ---------------------------------------------------------------------------
+ * Responsive / input adjustments
+ * ------------------------------------------------------------------------- */
+
+/* Touch: pad the hit area invisibly — the control stays petite. */
+@media (pointer: coarse) {
+  .vapor-nav-link__switch {
+    padding: 8px 2px;
+  }
+}
+
+/* Narrow viewports: the nav collapses into the hamburger menu, so drop the
+   teaser rather than crowding the logo. */
+@media (max-width: 640px) {
+  .vapor-nav-link {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .vapor-nav-link__mode,
+  .vapor-nav-link__track,
+  .vapor-nav-link__knob {
+    transition: none;
+  }
+
+  .vapor-nav-link__switch:hover .vapor-nav-link__track,
+  .vapor-nav-link__switch:focus-visible .vapor-nav-link__track {
+    animation: none;
+    background-image: linear-gradient(
+      135deg,
+      var(--major-brand-color),
+      var(--gradient-brand-color)
+    );
+  }
+}

--- a/website/src/components/vapor-nav/vapor-nav.scss
+++ b/website/src/components/vapor-nav/vapor-nav.scss
@@ -1,11 +1,11 @@
 /* ---------------------------------------------------------------------------
- * Vapor mode nav teaser — a petite VDOM/Vapor switch that is really a link to
- * the Vapor preview build, plus a ⓘ popover explaining where Vapor lives.
- * Mirrors the switch shipped in the `vapor` branch site's nav.
+ * VDOM/Vapor segmented control (site nav) — petite pill with a sliding
+ * thumb. In Vapor state the thumb fills with the homepage's moving brand
+ * gradient (same stops + drift as the hero `.brand` text and badge hover).
  * ------------------------------------------------------------------------- */
 
-/* Homepage brand gradient, reused for the "flipped to Vapor preview" state. */
-@mixin vapor-nav-gradient {
+/* Homepage brand gradient, shared by the toggle thumb and the Vapor badge. */
+@mixin vapor-gradient {
   background-image: linear-gradient(
     270deg,
     var(--major-brand-color),
@@ -15,10 +15,10 @@
     var(--major-brand-color)
   );
   background-size: 220% 100%;
-  animation: vapor-nav-gradient-drift 6s linear infinite;
+  animation: vapor-gradient-drift 6s linear infinite;
 }
 
-@keyframes vapor-nav-gradient-drift {
+@keyframes vapor-gradient-drift {
   0% {
     background-position: 0% 50%;
   }
@@ -28,7 +28,7 @@
   }
 }
 
-.vapor-nav-link {
+.go-mode-nav-control {
   position: relative;
   display: inline-flex;
   align-items: center;
@@ -39,14 +39,12 @@
   white-space: nowrap;
 }
 
-.vapor-nav-link__switch {
+/* A single labeled switch: VDOM is simply "off". The mode name lives in
+   the track's empty space — "VDOM" right of the knob when off, "Vapor" left
+   of it (on the moving gradient) when on. */
+.go-mode-nav-control__switch {
   display: inline-flex;
   align-items: center;
-  /* Fixed box, track right-aligned inside it: the track grows leftward into
-     the nav's empty space when flipped, so the ⓘ and everything right of it
-     never move. */
-  width: 112px;
-  justify-content: flex-end;
   padding: 4px 0;
   border: 0;
   background: transparent;
@@ -54,16 +52,26 @@
   cursor: pointer;
   font: inherit;
   line-height: 1;
-  text-decoration: none;
 }
 
-.vapor-nav-link__switch:focus-visible {
+.go-mode-nav-control__switch:focus-visible {
   outline: 2px solid var(--rp-c-brand);
   outline-offset: 2px;
   border-radius: 999px;
 }
 
-.vapor-nav-link__track {
+/* Pages with nothing to switch keep the control, dimmed — no pop-in/out. */
+.go-mode-nav-control[data-dormant] {
+  opacity: 0.45;
+  transition: opacity 200ms ease-out;
+}
+
+.go-mode-nav-control[data-dormant]:hover,
+.go-mode-nav-control[data-dormant]:focus-within {
+  opacity: 1;
+}
+
+.go-mode-nav-control__track {
   position: relative;
   display: inline-flex;
   align-items: center;
@@ -73,42 +81,47 @@
   border-radius: 999px;
   background: color-mix(in srgb, var(--rp-c-text-3) 26%, transparent);
   box-shadow: inset 0 1px 2px rgb(0 0 0 / 8%);
-  transition:
-    width 240ms cubic-bezier(0.22, 1, 0.36, 1),
-    background-color 240ms ease-out,
-    box-shadow 240ms ease-out;
+  transition: background-color 240ms ease-out, box-shadow 240ms ease-out;
 }
 
-/* Mode names sit in the free half of the track and cross-fade, so the knob's
-   motion and the label swap can never nudge the surrounding nav layout. */
-.vapor-nav-link__mode {
+.go-mode-nav-control[data-mode='vapor'] .go-mode-nav-control__track {
+  @include vapor-gradient;
+
+  box-shadow: 0 1px 6px color-mix(in srgb, var(--major-brand-color) 45%, transparent);
+}
+
+/* Mode name in the free half of the track. Absolute so the knob's motion
+   and the label swap can't nudge the layout. */
+.go-mode-nav-control__mode {
   position: absolute;
   top: 0;
+  right: 11px;
+  left: 27px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   height: 100%;
+  color: var(--rp-c-text-2);
   font-size: 10px;
   font-weight: 600;
   letter-spacing: 0.02em;
-  transition: opacity 200ms ease-out, color 200ms ease-out;
+  transition: color 200ms ease-out;
 }
 
-.vapor-nav-link__mode--off {
-  right: 11px;
-  left: 27px;
-  color: var(--rp-c-text-2);
+@media (hover: hover) {
+  .go-mode-nav-control__switch:hover .go-mode-nav-control__mode {
+    color: var(--rp-c-text-1);
+  }
 }
 
-.vapor-nav-link__mode--on {
+.go-mode-nav-control[data-mode='vapor'] .go-mode-nav-control__mode {
   right: 27px;
   left: 11px;
   color: #fff;
-  opacity: 0;
   text-shadow: 0 1px 1px rgb(0 0 0 / 22%);
 }
 
-.vapor-nav-link__knob {
+.go-mode-nav-control__knob {
   position: absolute;
   top: 2px;
   left: 2px;
@@ -120,43 +133,12 @@
   transition: transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
-/* Hover/focus previews the flip: the switch slides to Vapor and lights up
-   with the brand gradient — a hint of what the destination site looks like. */
-@mixin vapor-nav-flipped {
-  /* Widen to fit the longer "Vapor preview" label — the destination is a
-     separate build, and the flipped label should say so. */
-  .vapor-nav-link__track {
-    @include vapor-nav-gradient;
-
-    width: 112px;
-    box-shadow: 0 1px 6px color-mix(in srgb, var(--major-brand-color) 45%, transparent);
-  }
-
-  .vapor-nav-link__mode--off {
-    opacity: 0;
-  }
-
-  .vapor-nav-link__mode--on {
-    opacity: 1;
-  }
-
-  .vapor-nav-link__knob {
-    transform: translateX(90px);
-  }
-}
-
-@media (hover: hover) {
-  .vapor-nav-link__switch:hover {
-    @include vapor-nav-flipped;
-  }
-}
-
-.vapor-nav-link__switch:focus-visible {
-  @include vapor-nav-flipped;
+.go-mode-nav-control[data-mode='vapor'] .go-mode-nav-control__knob {
+  transform: translateX(40px);
 }
 
 /* ---------------------------------------------------------------------------
- * ⓘ popover
+ * Shared ⓘ popover (nav scope explainer, coverage chip, badge reasons).
  * ------------------------------------------------------------------------- */
 
 .info-popover {
@@ -168,6 +150,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 3px;
   min-width: 18px;
   min-height: 18px;
   padding: 0;
@@ -238,84 +221,25 @@
   text-decoration: underline;
 }
 
-.vapor-nav-link__branch {
-  padding: 1px 4px;
-  border-radius: 4px;
-  background: color-mix(in srgb, var(--rp-c-text-3) 16%, transparent);
-  color: var(--rp-c-text-1);
-  font-family: var(--rp-font-family-mono, monospace);
-  font-size: 0.92em;
-}
-
 /* ---------------------------------------------------------------------------
- * Responsive / input adjustments
+ * Responsive / input adjustments — verbatim from the `vapor` branch.
  * ------------------------------------------------------------------------- */
 
-/* Touch: pad the hit area invisibly — the control stays petite. */
+/* Touch: pad the switch's hit area invisibly — the control stays petite. */
 @media (pointer: coarse) {
-  .vapor-nav-link__switch {
+  .go-mode-nav-control__switch {
     padding: 8px 2px;
   }
 }
 
-/* Narrow viewports: the nav collapses to logo + hamburger, which leaves room
-   for the teaser — keep it, just tighter. Shrinking the track (and the knob's
-   travel with it) keeps the proportions rather than squashing them. */
-@media (max-width: 640px) {
-  .vapor-nav-link {
-    gap: 3px;
-  }
-
-  .vapor-nav-link__switch {
-    width: 96px;
-  }
-
-  .vapor-nav-link__track {
-    width: 54px;
-    height: 20px;
-  }
-
-  .vapor-nav-link__mode--off {
-    right: 9px;
-    left: 24px;
-  }
-
-  .vapor-nav-link__mode--on {
-    right: 24px;
-    left: 9px;
-  }
-
-  .vapor-nav-link__knob {
-    width: 16px;
-    height: 16px;
-  }
-
-  .vapor-nav-link__switch:hover .vapor-nav-link__track,
-  .vapor-nav-link__switch:focus-visible .vapor-nav-link__track {
-    width: 96px;
-  }
-
-  .vapor-nav-link__switch:hover .vapor-nav-link__knob,
-  .vapor-nav-link__switch:focus-visible .vapor-nav-link__knob {
-    transform: translateX(76px);
-  }
-
-  /* Stay right-anchored to the ⓘ (which sits well right of the logo) and let
-     the panel shrink to the viewport rather than running off either edge. */
-  .info-popover__panel {
-    width: min(252px, calc(100vw - 24px));
-  }
-}
-
 @media (prefers-reduced-motion: reduce) {
-  .vapor-nav-link__mode,
-  .vapor-nav-link__track,
-  .vapor-nav-link__knob {
+  .go-mode-nav-control__mode,
+  .go-mode-nav-control__track,
+  .go-mode-nav-control__knob {
     transition: none;
   }
 
-  .vapor-nav-link__switch:hover .vapor-nav-link__track,
-  .vapor-nav-link__switch:focus-visible .vapor-nav-link__track {
+  .go-mode-nav-control[data-mode='vapor'] .go-mode-nav-control__track {
     animation: none;
     background-image: linear-gradient(
       135deg,

--- a/website/theme/index.scss
+++ b/website/theme/index.scss
@@ -1,5 +1,6 @@
 @use 'sass:color';
 @import './semi.scss';
+@import '../src/components/vapor-nav/vapor-nav.scss';
 
 // ======== Vue Lynx brand colors =========
 $vue-green: #42b883;

--- a/website/theme/index.tsx
+++ b/website/theme/index.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState, useCallback } from 'react';
+import { useLang } from '@rspress/core/runtime';
 import {
   HomeLayout as BaseHomeLayout,
+  Layout as BaseLayout,
 } from '@rspress/core/theme-original';
 
 import './index.scss';
@@ -11,6 +13,7 @@ import {
   MeteorsBackground,
   ShowCase,
 } from '../src/components/home-comps';
+import { VaporModeNavLink } from '../src/components/vapor-nav/VaporModeNavLink';
 
 import { AGENT_PROMPT } from './agent-prompt';
 
@@ -234,6 +237,27 @@ function HomeLayout(props: Parameters<typeof BaseHomeLayout>[0]) {
   );
 }
 
-export { HomeLayout };
+/**
+ * Site nav gets a Vapor mode teaser: a switch-shaped link over to the Vapor
+ * preview build, with an ⓘ explaining that Vapor is still an exploration on
+ * the `vapor` branch.
+ */
+function Layout({ beforeNavMenu, ...props }: Parameters<typeof BaseLayout>[0]) {
+  const locale = useLang().startsWith('zh') ? 'zh' : 'en';
+
+  return (
+    <BaseLayout
+      {...props}
+      beforeNavMenu={(
+        <>
+          <VaporModeNavLink locale={locale} />
+          {beforeNavMenu}
+        </>
+      )}
+    />
+  );
+}
+
+export { HomeLayout, Layout };
 
 export * from '@rspress/core/theme-original';


### PR DESCRIPTION
## What

Surfaces the Vapor preview build from the main site's nav bar — plus a drive-by fix for the `main` lint failure that was blocking CI.

- **Nav control.** The `vapor` branch site's nav switch, taken as-is: the `.go-mode-nav-control` / `.info-popover` rules copied verbatim from that branch's `vapor-status.scss`, `InfoPopover.tsx` copied unmodified, and the same markup driven by the same `data-mode` attribute (62×22 track, 18px knob, 10px label, 40px knob travel).
- **The one intended difference.** There is no render mode to toggle on this site, so the `<button role="switch">` becomes an `<a href="/vapor" target="_blank" rel="noopener noreferrer">` — `/vapor` being the existing Vercel redirect to the `vapor` branch preview. Flipping the switch means "this is where you're going".
- **ⓘ popover.** Explains that Vapor mode is under active exploration on the `vapor` branch, that its docs and live examples ship as a separate preview build, and that this site always renders with the VDOM runtime. Carries a direct "Open the Vapor preview →" link. Closes on outside pointerdown and Escape, so it works on touch — which also makes it the discoverability affordance where hover doesn't exist.
- **Lint fix.** `packages/vue-lynx/runtime/src/transition-shared.ts` — the `// biome-ignore lint/suspicious/noExplicitAny` sat above `export function callHook(` rather than on the annotated parameter, so biome flagged both the `any` and the now-ineffective suppression. `pnpm lint` has failed on `main` since #316; moving the comment onto line 146 makes `biome check .` clean.

## Why

`/vapor` shipped in #318 as a hidden redirect — there was no way to discover the Vapor preview from the main site. This surfaces it without implying Vapor is available here, and without inventing a second visual language for the same control.

## Interaction

Each input type flips the switch at the moment it answers "am I about to leave?":

| Input | Trigger | Behaviour |
| --- | --- | --- |
| Mouse | `pointerenter` / `pointerleave` | Hover previews the destination, moving away flips back |
| Keyboard | `focus`, gated on `:focus-visible` | Same as hover |
| Touch | `pointerdown` | The knob travels as the tap opens the preview, then settles back after 600ms |

The `:focus-visible` gate matters: a tap also focuses the anchor, which previously left the switch stuck on Vapor until something else stole focus. The touch flip settles on a timer rather than on the tab backgrounding, because opening a link may not background the page at all.

## Changes

| File | Purpose |
| --- | --- |
| `website/src/components/vapor-nav/vapor-nav.scss` | `.go-mode-nav-control` + `.info-popover` styles, verbatim from the `vapor` branch |
| `website/src/components/vapor-nav/InfoPopover.tsx` | Copied unmodified from the `vapor` branch |
| `website/src/components/vapor-nav/VaporModeNavLink.tsx` | Same markup, switch swapped for a link; per-input flip; en/zh copy |
| `website/theme/index.tsx` | Custom `Layout` injecting the control via `beforeNavMenu` |
| `website/theme/index.scss` | Imports the stylesheet |
| `packages/vue-lynx/runtime/src/transition-shared.ts` | Lint suppression moved onto the line it annotates |

## Details

- Localized: `useLang()` picks the en/zh copy. The flipped label stays the branch's own "Vapor" — "preview" lives in the ⓘ popover and the `aria-label`, since a longer string doesn't fit the 62px track without changing the branch's geometry.
- Visible at every width, including mobile, exactly as on the `vapor` branch — no width-based hiding.
- `pointer: coarse` pads the hit area; `prefers-reduced-motion` drops the gradient drift and transitions. Both verbatim from the branch.
- Rendered on every page including the home page.

## Verification

- `biome check .` clean; `changeset status --since=origin/main` passes.
- `pnpm build` in `website/` succeeds; markup and copy verified in the emitted HTML for both locales.
- Measured against the branch's geometry in a headless browser: track `62×22`, label `10px`, knob left in the VDOM state.
- All three input paths exercised on the built output: mouse `vdom → vapor → vdom`; Tab-focus → `vapor`; a real touch tap flips, opens the popup, and returns to `vdom` on its own without needing another tap elsewhere.
- Confirmed on the deployed preview: `target="_blank"` / `rel="noopener noreferrer"` on the anchors, `/vapor` returning `307 → vue-lynx-git-vapor-huxpros-projects.vercel.app`, and the shipped bundle carrying the `onPointerDown` / `:focus-visible` / 600ms-settle logic.