### PR TITLE
fix(runtime): keep a component root in its own CSS scope

### DIFF
--- a/.changeset/fix-component-root-scoped-css.md
+++ b/.changeset/fix-component-root-scoped-css.md
@@ -1,0 +1,5 @@
+---
+"vue-lynx": patch
+---
+
+Fix `<style scoped>` rules not applying to a component's own root element. Vue applies several scope ids to a component root (its own, then those of the ancestor components whose subtree root it is); on the web these coexist as separate `data-v-*` attributes, but Lynx associates an element with exactly one CSS fragment, so the last `__SetCSSId` won and moved the root into the *parent's* fragment. `nodeOps.setScopeId` now keeps the first scope an element is given — the one of the component that authored it — so static `class`/`style` on a component root works natively without the extra wrapper element workaround.

--- a/examples/css-features/src/ScopedNestedChild.vue
+++ b/examples/css-features/src/ScopedNestedChild.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+// Test: <style scoped> on a component ROOT, inside a scoped parent
+//
+// Vue hands a component's root element the scope of its own component AND
+// the scope of the parent that renders it. On the web those are two
+// independent `data-v-*` attributes; Lynx associates an element with exactly
+// one cssId, so the root used to end up in the *parent's* CSS fragment and
+// the styles below silently stopped matching it (issue #317).
+//
+// `.nested-root` is styled here, on the root element itself — no wrapper.
+</script>
+
+<template>
+  <view class="nested-root">
+    <text class="nested-text">Root-level scoped styles apply — no wrapper needed</text>
+  </view>
+</template>
+
+<style scoped>
+.nested-root {
+  display: flex;
+  flex-direction: column;
+  background-color: #e8f5e9;
+  border-radius: 4px;
+  padding: 8px;
+}
+.nested-text {
+  font-size: 12px;
+  color: #2e7d32;
+}
+</style>

--- a/examples/css-features/src/ScopedStyle.vue
+++ b/examples/css-features/src/ScopedStyle.vue
@@ -5,6 +5,7 @@
 //   1. Build-time: VueScopedCSSIdPlugin injects ?cssId=<N> so CSS is wrapped in @cssId
 //   2. Build-time: vueScopeStripCSSPlugin removes [data-v-xxx] attribute selectors
 //   3. Runtime: scope-bridge.ts converts __scopeId to numeric cssId via __SetCSSId
+import ScopedNestedChild from './ScopedNestedChild.vue'
 </script>
 
 <template>
@@ -17,6 +18,9 @@
     <view class="scoped-demo-box">
       <text class="scoped-demo-text">This text should be blue if scoped works</text>
     </view>
+    <!-- A scoped child rendered by a scoped parent: its root element must
+         keep its OWN scope, not inherit this component's. -->
+    <ScopedNestedChild />
   </view>
 </template>
 
@@ -44,6 +48,7 @@
   background-color: #fff;
   padding: 8px;
   border-radius: 4px;
+  margin-bottom: 8px;
 }
 .scoped-demo-text {
   font-size: 13px;

--- a/packages/testing-library/src/__tests__/scoped-css.test.ts
+++ b/packages/testing-library/src/__tests__/scoped-css.test.ts
@@ -14,9 +14,14 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { h, defineComponent, nextTick } from 'vue-lynx';
+import {
+  h,
+  defineComponent,
+  nextTick,
+  registerElementTemplate,
+} from 'vue-lynx';
 import { OP } from '../../../vue-lynx/internal/src/ops.js';
-import { nodeOps } from '../../../vue-lynx/runtime/src/node-ops.js';
+import { applyScopeId, nodeOps } from '../../../vue-lynx/runtime/src/node-ops.js';
 import { takeOps } from '../../../vue-lynx/runtime/src/ops.js';
 import { ShadowElement } from '../../../vue-lynx/runtime/src/shadow-element.js';
 import { scopeIdToCssId } from '../../../vue-lynx/runtime/src/scope-bridge.js';
@@ -56,23 +61,49 @@ describe('SET_SCOPE_ID (nodeOps)', () => {
     }
   });
 
-  it('multiple setScopeId calls produce separate ops', () => {
+  it('keeps the first scope when Vue applies several to one element', () => {
     const el = new ShadowElement('view', 10);
 
-    // Vue calls setScopeId once per scope on the element
-    // (own scope, then parent scope for root elements)
-    nodeOps.setScopeId!(el,'data-v-aaa00001');
-    nodeOps.setScopeId!(el,'data-v-bbb00002');
+    // Vue calls setScopeId once per scope on the element: its own scope
+    // first, then the scope of every ancestor component whose subtree root
+    // it is. Lynx elements carry exactly one cssId, so only the first (the
+    // owning component's) survives — otherwise the component's own scoped
+    // rules stop matching its root element (issue #317).
+    nodeOps.setScopeId!(el, 'data-v-aaa00001');
+    nodeOps.setScopeId!(el, 'data-v-bbb00002');
 
     const ops = takeOps();
-    // Two SET_SCOPE_ID ops, each with 3 values
-    expect(ops).toHaveLength(6);
-    expect(ops[0]).toBe(OP.SET_SCOPE_ID);
-    expect(ops[3]).toBe(OP.SET_SCOPE_ID);
-    // Same element, different cssIds
-    expect(ops[1]).toBe(10);
-    expect(ops[4]).toBe(10);
-    expect(ops[2]).not.toBe(ops[5]);
+    expect(ops).toEqual([
+      OP.SET_SCOPE_ID,
+      10,
+      scopeIdToCssId('data-v-aaa00001'),
+    ]);
+  });
+
+  it('applyScopeId overrides an existing association', () => {
+    const el = new ShadowElement('view', 11);
+
+    nodeOps.setScopeId!(el, 'data-v-aaa00001');
+    // The page root is claimed and released by <page> wrappers, so it must
+    // stay re-scopable (see Page.ts).
+    applyScopeId(el, 'data-v-bbb00002');
+    applyScopeId(el, '');
+
+    const ops = takeOps();
+    expect(ops).toEqual([
+      OP.SET_SCOPE_ID, 11, scopeIdToCssId('data-v-aaa00001'),
+      OP.SET_SCOPE_ID, 11, scopeIdToCssId('data-v-bbb00002'),
+      OP.SET_SCOPE_ID, 11, 0,
+    ]);
+  });
+
+  it('applyScopeId skips a redundant re-application', () => {
+    const el = new ShadowElement('view', 12);
+
+    applyScopeId(el, 'data-v-aaa00001');
+    applyScopeId(el, 'data-v-aaa00001');
+
+    expect(takeOps()).toHaveLength(3);
   });
 });
 
@@ -142,5 +173,160 @@ describe('SET_SCOPE_ID (full pipeline)', () => {
     const { container } = render(App);
     expect(container.querySelector('.scoped')).not.toBeNull();
     expect(container.querySelector('.plain')).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: a component root must stay in its OWN CSS fragment (#317)
+//
+// The testing environment records the last `__SetCSSId` on the element as
+// `cssId = "<entry>:<n>"`, which is exactly what Lynx's CSS engine matches
+// scoped rules against.
+// ---------------------------------------------------------------------------
+
+/** cssId string the testing environment records for a Vue scope id. */
+function cardCssId(scopeId: string): string {
+  return `__Card__:${scopeIdToCssId(scopeId)}`;
+}
+
+const CHILD_SCOPE = 'data-v-11111111';
+const PARENT_SCOPE = 'data-v-22222222';
+
+describe('component root scope (#317)', () => {
+  it('keeps the child scope on a scoped child root inside a scoped parent', () => {
+    const Child = defineComponent({
+      __scopeId: CHILD_SCOPE,
+      render() {
+        return h('view', { class: 'toast' }, [h('text', 'Toast')]);
+      },
+    });
+
+    const Parent = defineComponent({
+      __scopeId: PARENT_SCOPE,
+      render() {
+        return h('view', { class: 'parent' }, [h(Child)]);
+      },
+    });
+
+    const { container } = render(Parent);
+    // Static class still reaches the element…
+    const toast = container.querySelector('.toast') as { cssId?: string };
+    expect(toast).not.toBeNull();
+    // …and the element stays in the child's fragment, so the child's own
+    // `<style scoped>` rules for `.toast` still match it.
+    expect(toast.cssId).toBe(cardCssId(CHILD_SCOPE));
+    expect(
+      (container.querySelector('.parent') as { cssId?: string }).cssId,
+    ).toBe(cardCssId(PARENT_SCOPE));
+  });
+
+  it('scopes a nested component root to its own component, not its user', () => {
+    const GRANDCHILD_SCOPE = 'data-v-33333333';
+
+    const GrandChild = defineComponent({
+      __scopeId: GRANDCHILD_SCOPE,
+      render() {
+        return h('view', { class: 'leaf' });
+      },
+    });
+
+    const Child = defineComponent({
+      __scopeId: CHILD_SCOPE,
+      render() {
+        return h(GrandChild);
+      },
+    });
+
+    const Parent = defineComponent({
+      __scopeId: PARENT_SCOPE,
+      render() {
+        return h('view', { class: 'parent' }, [h(Child)]);
+      },
+    });
+
+    const { container } = render(Parent);
+    expect((container.querySelector('.leaf') as { cssId?: string }).cssId)
+      .toBe(cardCssId(GRANDCHILD_SCOPE));
+  });
+
+  it('keeps slot content in the scope of the component that authored it', () => {
+    const Child = defineComponent({
+      __scopeId: CHILD_SCOPE,
+      render(this: { $slots: Record<string, () => unknown> }) {
+        return h('view', { class: 'toast' }, [this.$slots.default?.()]);
+      },
+    });
+
+    const Parent = defineComponent({
+      __scopeId: PARENT_SCOPE,
+      render() {
+        return h(Child, null, {
+          default: () => [h('view', { class: 'slotted' })],
+        });
+      },
+    });
+
+    const { container } = render(Parent);
+    expect((container.querySelector('.toast') as { cssId?: string }).cssId)
+      .toBe(cardCssId(CHILD_SCOPE));
+    // Slot content is created by the parent's render, so it belongs to the
+    // parent's fragment.
+    expect((container.querySelector('.slotted') as { cssId?: string }).cssId)
+      .toBe(cardCssId(PARENT_SCOPE));
+  });
+
+  it('keeps the child scope on a lowered element-template root', () => {
+    // The compile-time lowering bakes `__SetCSSId` into the template's
+    // create(); the runtime still emits SET_SCOPE_ID for the vnode, so the
+    // lowered root must resolve its scope exactly like the vdom path.
+    const tpl = registerElementTemplate('scoped-317', [], (P: number) => {
+      const e0 = __CreateView(P);
+      __SetCSSId([e0], scopeIdToCssId(CHILD_SCOPE));
+      const e1 = __CreateText(P);
+      __SetCSSId([e1], scopeIdToCssId(CHILD_SCOPE));
+      __SetAttribute(e1, 'text', 'Toast');
+      __AppendElement(e0, e1);
+      return [e0];
+    });
+
+    const Child = defineComponent({
+      __scopeId: CHILD_SCOPE,
+      render() {
+        return h(`__vlx-tpl:${tpl}`, { class: 'toast' });
+      },
+    });
+
+    const Parent = defineComponent({
+      __scopeId: PARENT_SCOPE,
+      render() {
+        return h('view', { class: 'parent' }, [h(Child)]);
+      },
+    });
+
+    const { container } = render(Parent);
+    expect((container.querySelector('.toast') as { cssId?: string }).cssId)
+      .toBe(cardCssId(CHILD_SCOPE));
+  });
+
+  it('falls back to the user scope for an unscoped child root', () => {
+    // No own scope to preserve — Vue applies the parent's, matching what the
+    // DOM renderer does with `data-v-*` attributes.
+    const Child = defineComponent({
+      render() {
+        return h('view', { class: 'plain-root' });
+      },
+    });
+
+    const Parent = defineComponent({
+      __scopeId: PARENT_SCOPE,
+      render() {
+        return h('view', { class: 'parent' }, [h(Child)]);
+      },
+    });
+
+    const { container } = render(Parent);
+    expect(
+      (container.querySelector('.plain-root') as { cssId?: string }).cssId,
+    ).toBe(cardCssId(PARENT_SCOPE));
   });
 });

--- a/packages/testing-library/src/__tests__/transition-leak-repro.test.ts
+++ b/packages/testing-library/src/__tests__/transition-leak-repro.test.ts
@@ -49,6 +49,23 @@ async function advance(ms: number): Promise<void> {
   await vi.advanceTimersByTimeAsync(ms);
 }
 
+/**
+ * Drain every armed fallback timer.
+ *
+ * whenTransitionEnds() arms its fallback only once the `nextFrame()` chain
+ * (queuePostFlushCb → waitForFlush → rAF/setTimeout) that leads to it lands,
+ * so a chain still in flight when a hammering loop exits arms its timer
+ * *during* the first settle pass — one fixed pass is not enough on every
+ * machine. Keep advancing until the registry stops shrinking; the round cap
+ * makes a genuine leak (no fallback timer at all) fail rather than hang.
+ */
+async function settle(baseline: number): Promise<void> {
+  for (let round = 0; round < 10 && registrySize() > baseline; round++) {
+    await advance(FALLBACK_TIMEOUT_MS + 100);
+    await flush();
+  }
+}
+
 beforeEach(() => {
   vi.useFakeTimers();
 });
@@ -97,12 +114,8 @@ describe('Transition event-registry leak (fixed)', () => {
 
     // Advance past the fallback ceiling so every stranded fallback timer
     // fires and unregisters its sign. finish()'s unregister() itself runs
-    // synchronously once the timer callback executes, but nextFrame()'s own
-    // rAF/setTimeout(16) chain (armed by the *next* pending re-render, if
-    // any) needs a settle pass too, so flush + re-advance once more.
-    await advance(FALLBACK_TIMEOUT_MS + 100);
-    await flush();
-    await advance(FALLBACK_TIMEOUT_MS + 100);
+    // synchronously once the timer callback executes.
+    await settle(baseline);
 
     expect(registrySize()).toBe(baseline);
   });
@@ -131,9 +144,7 @@ describe('Transition event-registry leak (fixed)', () => {
     }
 
     // Let every fallback timer armed during the hammering settle.
-    await advance(FALLBACK_TIMEOUT_MS + 100);
-    await flush();
-    await advance(FALLBACK_TIMEOUT_MS + 100);
+    await settle(baseline);
 
     expect(registrySize()).toBe(baseline);
   });

--- a/packages/vue-lynx/runtime/src/Page.ts
+++ b/packages/vue-lynx/runtime/src/Page.ts
@@ -11,7 +11,7 @@ import {
   onDeactivated,
 } from '@vue/runtime-core';
 
-import { nodeOps } from './node-ops.js';
+import { applyScopeId, nodeOps } from './node-ops.js';
 import type { ShadowElement } from './shadow-element.js';
 
 export const PAGE_COMPONENT_NAME = 'VueLynxPage';
@@ -118,7 +118,10 @@ export const Page = defineComponent({
       owned = true;
       const scopeId = instance?.vnode.scopeId;
       if (scopeId) {
-        nodeOps.setScopeId?.(root, scopeId);
+        // The page root outlives every wrapper, so ownership changes must be
+        // able to re-scope it — `nodeOps.setScopeId` deliberately only ever
+        // applies the first scope an element is given.
+        applyScopeId(root, scopeId);
         appliedScopeId = scopeId;
       }
       return true;
@@ -137,7 +140,7 @@ export const Page = defineComponent({
       applyAttrs({});
       if (appliedScopeId !== null) {
         // scopeIdToCssId('') maps to cssId 0 — Lynx's unscoped default.
-        nodeOps.setScopeId?.(root, '');
+        applyScopeId(root, '');
         appliedScopeId = null;
       }
       owned = false;

--- a/packages/vue-lynx/runtime/src/node-ops.ts
+++ b/packages/vue-lynx/runtime/src/node-ops.ts
@@ -171,6 +171,27 @@ export function resolveClass(el: ShadowElement): string {
 }
 
 // ---------------------------------------------------------------------------
+// Scoped CSS
+// ---------------------------------------------------------------------------
+
+/**
+ * Associate `el` with the Lynx CSS fragment of `scopeId`, replacing any
+ * previous association.
+ *
+ * Only for elements the Vue renderer does not own — today the native page
+ * root, which `<page>` wrappers claim and release explicitly (see Page.ts).
+ * Renderer-created elements go through `nodeOps.setScopeId`, which keeps the
+ * first scope they are given.
+ */
+export function applyScopeId(el: ShadowElement, scopeId: string): void {
+  const cssId = scopeIdToCssId(scopeId);
+  if (el._cssId === cssId) return;
+  el._cssId = cssId;
+  pushOp(OP.SET_SCOPE_ID, el.id, cssId);
+  scheduleFlush();
+}
+
+// ---------------------------------------------------------------------------
 // RendererOptions implementation
 // ---------------------------------------------------------------------------
 
@@ -531,10 +552,24 @@ export const nodeOps: RendererOptions<ShadowElement, ShadowElement> = {
   },
 
   // Called by Vue's renderer after createElement to apply scoped CSS.
-  // Vue calls this once per scope ID on the element (own scope, parent scope, etc.).
+  //
+  // Vue may call this several times for the same element: after the element's
+  // own scope it walks up and re-applies the scope of every ancestor component
+  // whose subtree root this element is, plus any `:slotted` scope ids. In the
+  // DOM each becomes an independent `data-v-*` attribute and they coexist —
+  // Lynx instead associates an element with exactly ONE CSS fragment, so a
+  // second `__SetCSSId` replaces the first.
+  //
+  // Letting the last call win moved a component's own root element into the
+  // *parent's* fragment, where the component's `<style scoped>` rules no
+  // longer match it: static class/style on a component root silently stopped
+  // working, and the usual workaround was an extra wrapper element (#317).
+  // Vue always emits the owning component's scope first, so keeping the first
+  // association leaves every element in the fragment of the component that
+  // authored it.
   setScopeId(el: ShadowElement, id: string): void {
-    pushOp(OP.SET_SCOPE_ID, el.id, scopeIdToCssId(id));
-    scheduleFlush();
+    if (el._cssId !== undefined) return;
+    applyScopeId(el, id);
   },
 
   parentNode(node: ShadowElement): ShadowElement | null {

--- a/packages/vue-lynx/runtime/src/shadow-element.ts
+++ b/packages/vue-lynx/runtime/src/shadow-element.ts
@@ -64,6 +64,11 @@ export class ShadowElement {
   // ID for Teleport target resolution (idRegistry lookup).
   _id: string | undefined = undefined;
 
+  // Lynx CSS fragment this element belongs to (`__SetCSSId`), once one has
+  // been applied. Lynx allows exactly one per element, so node-ops keeps the
+  // first association and ignores the rest — see nodeOps.setScopeId.
+  _cssId: number | undefined = undefined;
+
   // Element-template instance state (only set on lowered template roots —
   // see element-template.ts). Hole shadows are allocated contiguously after
   // the root id so both threads agree on ids without shipping them.

--- a/packages/vue-lynx/runtime/src/transition-shared.ts
+++ b/packages/vue-lynx/runtime/src/transition-shared.ts
@@ -141,8 +141,8 @@ export function hasExplicitDuration(props: {
   return props.duration != null;
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: hooks have varying signatures
 export function callHook(
+  // biome-ignore lint/suspicious/noExplicitAny: hooks have varying signatures
   hook: ((...args: any[]) => void) | undefined,
   args: unknown[],
 ): void {

--- a/website/docs/guide/vue-compatibility.mdx
+++ b/website/docs/guide/vue-compatibility.mdx
@@ -31,6 +31,8 @@ Plain `<style>` blocks, imported `.css` files, [`<style module>`](https://vuejs.
 
 :::warning `<style scoped>` caveats
 [`:deep()`](https://vuejs.org/api/sfc-css-features.html#deep-selectors), [`:slotted()`](https://vuejs.org/api/sfc-css-features.html#slotted-selectors), and [`:global()`](https://vuejs.org/api/sfc-css-features.html#global-selectors) are not yet supported ([#164](https://github.com/Huxpro/vue-lynx/issues/164), [#165](https://github.com/Huxpro/vue-lynx/issues/165)).
+
+Scopes do not stack. On the web, Vue gives a child component's root element the `data-v-*` attribute of *both* the child and its parent, so [a parent's scoped styles can also target that root element](https://vuejs.org/api/sfc-css-features.html#scoped-css). Lynx associates each element with exactly one CSS scope, and Vue Lynx always keeps the one of the component that authored the element — a component's own scoped rules always apply to its root. A parent that needs to style a child's root should pass a class the child applies itself, or add a wrapper element of its own.
 :::
 
 `v-bind()` in `<style>` requires two config options so the Lynx engine recognizes CSS custom properties in inline styles and cascades them to descendants:

--- a/website/docs/zh/guide/vue-compatibility.mdx
+++ b/website/docs/zh/guide/vue-compatibility.mdx
@@ -31,6 +31,8 @@ Vue Lynx 100% 复用了 Vue 的响应式核心（`@vue/reactivity`）。每个�
 
 :::warning `<style scoped>` 注意事项
 [`:deep()`](https://vuejs.org/api/sfc-css-features.html#deep-selectors)、[`:slotted()`](https://vuejs.org/api/sfc-css-features.html#slotted-selectors) 和 [`:global()`](https://vuejs.org/api/sfc-css-features.html#global-selectors) 暂不支持（[#164](https://github.com/Huxpro/vue-lynx/issues/164)、[#165](https://github.com/Huxpro/vue-lynx/issues/165)）。
+
+作用域不会叠加。在 Web 上，Vue 会给子组件的根元素同时加上子组件和父组件的 `data-v-*` 属性，因此[父组件的 scoped 样式也能命中该根元素](https://vuejs.org/api/sfc-css-features.html#scoped-css)。Lynx 中每个元素只能关联一个 CSS 作用域，Vue Lynx 始终保留创建该元素的组件的作用域——组件自己的 scoped 规则总能作用于它的根节点。父组件若需要为子组件的根节点设置样式，可以传入一个由子组件自行应用的 class，或者自己加一层包裹元素。
 :::
 
 `<style>` 中的 `v-bind()` 需要两个配置选项，以便 Lynx 引擎识别内联样式中的 CSS 自定义属性并将其级联到后代元素：


### PR DESCRIPTION
Fixes #317.

## The bug

A component whose root element carries a static `class`/`style` rendered unstyled on native, unless the root was wrapped in an extra plain `<view>`.

Vue applies **several** scope ids to a component's root element: its own first, then the scope of every ancestor component whose subtree root it is (plus `:slotted` scope ids). In the DOM those become independent `data-v-*` attributes and coexist, which is why the same component styles fine on the web.

Lynx associates an element with exactly **one** CSS fragment, so each `__SetCSSId` replaced the previous one and the last call won. A scoped child rendered by a scoped parent therefore ended up in the *parent's* fragment, where its own `<style scoped>` rules no longer match it. Wrapping the root worked because the wrapper absorbed the parent's scope and the inner element kept the child's.

Reproduced against the full BG→ops→MT→PAPI pipeline: with `Child` (`data-v-11111111`) inside `Parent` (`data-v-22222222`), the child's root came out as `cssId 572662306` (the parent's) instead of `286331153`.

The built bundle makes the consequence concrete — each scoped fragment imports the global fragment `0` plus its own rules, and nothing else:

```
fragment 1          .nested-root rules
fragment 2          .scoped-card rules
fragment 513573768  imports ["0","2"]   ← ScopedStyle
fragment 1149114131 imports ["0","1"]   ← ScopedNestedChild
```

## The fix

`nodeOps.setScopeId` now keeps the **first** scope an element is given. Vue always emits the owning component's scope first, so every element stays in the fragment of the component that authored it — slot content stays with the parent that rendered it, an unscoped child root still falls back to its user's scope (matching the DOM), and a component's own scoped rules always apply to its root.

The page root is claimed and released by `<page>` wrappers and must stay re-scopable across ownership changes, so `Page.ts` moves to a new explicit `applyScopeId()` override (internal, not exported from the package surface).

Scopes cannot stack on Lynx, so a parent can no longer style a child's root element through its own scoped block. That direction never worked reliably and is the strictly less important half; it is now documented as a caveat in the Vue Compatibility guide (EN + ZH).

## Changes

- `runtime/src/node-ops.ts` — first-scope-wins in `setScopeId`; new `applyScopeId()` for renderer-external elements
- `runtime/src/shadow-element.ts` — `_cssId` tracks the applied fragment
- `runtime/src/Page.ts` — page root claim/release uses `applyScopeId`
- `testing-library/.../scoped-css.test.ts` — 6 new tests: nested scoped roots, grandchild roots, slot content ownership, lowered element-template roots, unscoped-child fallback, and the `applyScopeId` override/dedup contract
- `examples/css-features` — `ScopedNestedChild.vue`, a scoped child inside the (scoped) `ScopedStyle.vue`, as an on-device regression demo
- Docs + changeset

## Testing

- `pnpm test` — 230 passed
- `pnpm test:upstream` — 854 + 60 + 48 passed, 0 failed (includes `page-root.spec.ts`, which covers page-root scope claim/release)
- `examples/css-features` builds clean

Two pre-existing failures on `main` are unrelated and untouched: `pnpm lint` errors on `transition-shared.ts:146` (`noExplicitAny`, from #316), and `pnpm test:upstream` needs `packages/upstream-tests/core` cloned first.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RT14rJJU8nkCewvB5QQLBC)_