### PR TITLE
feat(examples): touch-fx — Main Thread touch playground (+ worklet registration scanner fix)

### DIFF
--- a/.changeset/fix-worklet-registration-comment-scan.md
+++ b/.changeset/fix-worklet-registration-comment-scan.md
@@ -1,0 +1,5 @@
+---
+"vue-lynx": patch
+---
+
+Fix `'main thread'` worklet registrations being silently dropped when a worklet body contains a comment with an apostrophe, quote, or unpaired paren (e.g. `// the finger's position`). The LEPUS transform preserves user comments, and worklet-loader-mt's balanced-paren scan treated quote characters inside them as string delimiters — derailing the scan and discarding every registration after the offending one, which surfaced at runtime as `TypeError: cannot read property 'bind' of undefined` on the Main Thread. The scanner now skips line and block comments. Also adds the `touch-fx` example — a Main Thread touch playground (spring-chasing orb, continuous water ripples, firework sparks) with a headless-browser verification harness.

--- a/examples/touch-fx/.gitignore
+++ b/examples/touch-fx/.gitignore
@@ -1,0 +1,1 @@
+harness/shots/

--- a/examples/touch-fx/README.md
+++ b/examples/touch-fx/README.md
@@ -1,0 +1,52 @@
+# touch-fx — a Main Thread touch playground
+
+A black stage, a glowing green orb, and a finger.
+
+- **The orb chases your finger** with a damped spring, squashing and
+  stretching along its velocity vector — poke it, drag it, flick it.
+- **Water ripples** pulse continuously under your finger for the entire
+  drag (a fresh ring every ~150 ms, endlessly re-triggerable).
+- **Firework sparks** burst on touch-down and release, and an ember trail
+  follows every move. Multi-touch: each extra finger splashes on its own.
+
+Everything animated — orb spring physics, ripple rings, spark particles —
+runs **on the Main Thread** via `'main thread'` worklets and a
+`requestAnimationFrame` loop, so there is zero BG↔MT round-trip between
+your finger and the pixels. The Background Thread only renders the static
+element pools once at startup.
+
+## How it works
+
+- `src/App.vue` — one `MainThreadRef` per pooled element (10 ripples,
+  64 sparks, orb layers) plus one `engRef` holding the whole engine state
+  on the Main Thread. Touch handlers (`main-thread-bindtouchstart/move/end`)
+  feed finger positions in; a self-rescheduling rAF loop integrates the
+  spring + particles and writes styles via `setStyleProperty`. The loop
+  parks itself when everything settles and wakes on the next touch.
+- `src/touch-fx.css` — the look: layered radial gradients for the orb,
+  a CSS `breathe` keyframe for the idle glow (independent of the MT
+  transform, which lives on a different element).
+
+## Run it
+
+```bash
+pnpm dev        # LynxExplorer / native
+pnpm build      # produces dist/main.{lynx,web}.bundle
+```
+
+## Verify on the web (headless)
+
+```bash
+pnpm build
+pnpm web:verify   # builds nothing; drives real CDP touch events in
+                  # headless Chromium and pixel-checks the effects
+```
+
+`harness/verify.mjs` performs a 4-second circular drag and asserts that
+green effect pixels track the finger at **every** sample along the way
+(the continuity requirement), that fireworks fire on release, that the
+system settles back to idle, and that a rapid zigzag still spawns effects
+(particle pool recycling). Screenshots land in `harness/shots/`.
+
+`pnpm web:serve` serves the harness at <http://localhost:8976/> for
+interactive play in a normal browser (use touch emulation in devtools).

--- a/examples/touch-fx/harness/debug.mjs
+++ b/examples/touch-fx/harness/debug.mjs
@@ -1,0 +1,44 @@
+// One-touch debug run: full pageerror stacks + worker console.
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const HARNESS = path.dirname(fileURLToPath(import.meta.url));
+const PORT = 8977;
+
+const server = spawn(process.execPath, [path.join(HARNESS, 'serve.mjs')], {
+  stdio: 'pipe',
+  env: { ...process.env, PORT: String(PORT) },
+});
+await new Promise((r) => server.stdout.once('data', r));
+
+const browser = await chromium.launch({
+  executablePath: process.env.CHROMIUM_PATH || '/opt/pw-browsers/chromium',
+  headless: true,
+  args: ['--no-sandbox', '--disable-dev-shm-usage'],
+});
+const ctx = await browser.newContext({
+  viewport: { width: 390, height: 844 },
+  hasTouch: true,
+});
+const page = await ctx.newPage();
+page.on('pageerror', (err) => console.log('[pageerror]', err.stack ?? String(err)));
+page.on('console', (msg) => console.log(`[console.${msg.type()}]`, msg.text().slice(0, 500)));
+page.on('worker', (w) => {
+  console.log('[worker]', w.url());
+});
+
+await page.goto(`http://localhost:${PORT}/`, { waitUntil: 'load' });
+await page.waitForTimeout(4000);
+
+const cdp = await ctx.newCDPSession(page);
+await cdp.send('Input.dispatchTouchEvent', { type: 'touchStart', touchPoints: [{ x: 200, y: 500 }] });
+await page.waitForTimeout(300);
+await cdp.send('Input.dispatchTouchEvent', { type: 'touchMove', touchPoints: [{ x: 220, y: 520 }] });
+await page.waitForTimeout(300);
+await cdp.send('Input.dispatchTouchEvent', { type: 'touchEnd', touchPoints: [] });
+await page.waitForTimeout(500);
+
+await browser.close();
+server.kill();

--- a/examples/touch-fx/harness/index.html
+++ b/examples/touch-fx/harness/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>touch-fx — Lynx for Web preview</title>
+  <link rel="stylesheet" href="/static/css/client.css" />
+  <style>
+    html, body { margin: 0; padding: 0; background: #000; }
+    #phone {
+      width: 390px;
+      height: 844px;
+      margin: 0 auto;
+      background: #000;
+      position: relative;
+      overflow: hidden;
+    }
+    lynx-view {
+      width: 100%;
+      height: 100%;
+      display: block;
+      container-type: size;
+      --rpx-unit: calc(100cqw / 750);
+      --vh-unit: 1cqh;
+      --vw-unit: 1cqw;
+    }
+  </style>
+</head>
+<body>
+  <div id="phone"></div>
+  <script type="module" src="/static/js/client.js"></script>
+  <script type="module">
+    // Same wiring as @lynx-js/go-web's WebIframe: rewrite the webpack
+    // publicPath inside the bundle (it points at the production CDN) and
+    // shim __webpack_require__ when the lepus root lacks a local runtime.
+    const WEBPACK_PUBLIC_PATH_RE = /\.p=\\"[^"]*\\"/g;
+
+    const view = document.createElement('lynx-view');
+    view.browserConfig = {
+      pixelWidth: 390 * devicePixelRatio,
+      pixelHeight: 844 * devicePixelRatio,
+    };
+    view.customTemplateLoader = async (url) => {
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`HTTP ${res.status} loading ${url}`);
+      const text = await res.text();
+      const baseUrl = new URL(url, location.href);
+      const base = baseUrl.href.substring(0, baseUrl.href.lastIndexOf('/') + 1);
+      const rewritten = text.replace(WEBPACK_PUBLIC_PATH_RE, `.p=\\"${base}\\"`);
+      const template = JSON.parse(rewritten);
+      if (template.lepusCode?.root) {
+        const root = template.lepusCode.root;
+        if (
+          typeof root === 'string' &&
+          root.includes('__webpack_require__') &&
+          !root.includes('function __webpack_require__')
+        ) {
+          template.lepusCode.root =
+            `var __webpack_require__={p:"${base}"};` + root;
+        }
+      }
+      return template;
+    };
+    view.addEventListener('error', (e) => {
+      console.error('[lynx-view error]', e.detail ?? e);
+    });
+    const params = new URLSearchParams(location.search);
+    view.url = params.get('bundle') || '/dist/main.web.bundle';
+    document.getElementById('phone').appendChild(view);
+  </script>
+</body>
+</html>

--- a/examples/touch-fx/harness/serve.mjs
+++ b/examples/touch-fx/harness/serve.mjs
@@ -1,0 +1,57 @@
+// Static file server for the Lynx-for-Web harness:
+//   /            → harness/index.html
+//   /static/*    → @lynx-js/web-core client_prod assets
+//   /dist/*      → examples/touch-fx/dist (the built bundles)
+import http from 'node:http';
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HARNESS = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+const WEB_CORE_STATIC = path.resolve(
+  path.dirname(require.resolve('@lynx-js/web-core/client.prod.js')),
+  '..',
+);
+const DIST = process.env.TOUCH_FX_DIST || path.resolve(HARNESS, '../dist');
+const PORT = Number(process.env.PORT || 8976);
+
+const MIME = {
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.wasm': 'application/wasm',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.bundle': 'application/octet-stream',
+};
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://localhost:${PORT}`);
+  let file;
+  if (url.pathname === '/' || url.pathname === '/index.html') {
+    file = path.join(HARNESS, 'index.html');
+  } else if (url.pathname.startsWith('/static/')) {
+    file = path.join(WEB_CORE_STATIC, url.pathname.slice('/static/'.length));
+  } else if (url.pathname.startsWith('/dist/')) {
+    file = path.join(DIST, url.pathname.slice('/dist/'.length));
+  }
+
+  if (!file || !fs.existsSync(file) || !fs.statSync(file).isFile()) {
+    res.writeHead(404);
+    res.end('not found: ' + url.pathname);
+    return;
+  }
+
+  res.writeHead(200, {
+    'Content-Type': MIME[path.extname(file)] ?? 'application/octet-stream',
+    'Cache-Control': 'no-store',
+  });
+  fs.createReadStream(file).pipe(res);
+});
+
+server.listen(PORT, () => {
+  console.log(`[touch-fx harness] http://localhost:${PORT}/`);
+});

--- a/examples/touch-fx/harness/verify.mjs
+++ b/examples/touch-fx/harness/verify.mjs
@@ -1,0 +1,210 @@
+// Headless verification of the touch-fx interaction:
+//   node harness/verify.mjs
+//
+// Drives real CDP touch events through <lynx-view> (shadow DOM is closed to
+// selectors, so everything is coordinate + pixel based) and asserts:
+//   1. the app boots (green orb visible on the black stage)
+//   2. effects spawn at touchstart
+//   3. CONTINUITY — during one long drag, green effect pixels keep tracking
+//      the finger at every sample point, start to finish
+//   4. a firework burst appears at release
+//   5. the system settles back to idle afterwards
+//   6. a second rapid zigzag drag still spawns effects (pool recycling)
+//
+// Screenshots land in harness/shots/ for eyeballing.
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const HARNESS = path.dirname(fileURLToPath(import.meta.url));
+const SHOTS = path.join(HARNESS, 'shots');
+fs.mkdirSync(SHOTS, { recursive: true });
+
+const PORT = Number(process.env.PORT || 8976);
+const W = 390;
+const H = 844;
+
+// --- static server -----------------------------------------------------------
+const server = spawn(process.execPath, [path.join(HARNESS, 'serve.mjs')], {
+  stdio: 'pipe',
+  env: { ...process.env, PORT: String(PORT) },
+});
+await new Promise((r) => server.stdout.once('data', r));
+
+// --- browser -----------------------------------------------------------------
+const browser = await chromium.launch({
+  executablePath: process.env.CHROMIUM_PATH || '/opt/pw-browsers/chromium',
+  headless: true,
+  args: ['--no-sandbox', '--disable-dev-shm-usage'],
+});
+const ctx = await browser.newContext({
+  viewport: { width: W, height: H },
+  deviceScaleFactor: 1,
+  hasTouch: true,
+});
+const page = await ctx.newPage();
+page.on('pageerror', (err) => console.log('[pageerror]', String(err).slice(0, 400)));
+page.on('console', (msg) => {
+  const t = msg.text();
+  if (/error|warn/i.test(msg.type()) && !/favicon/.test(t)) {
+    console.log(`[console.${msg.type()}]`, t.slice(0, 400));
+  }
+});
+
+// Pixel analysis runs in a second blank page: draw the screenshot on a canvas
+// and count green-ish pixels (globally and near a point of interest).
+const lab = await ctx.newPage();
+async function stats(png, poi) {
+  const dataUrl = 'data:image/png;base64,' + png.toString('base64');
+  return await lab.evaluate(
+    async ({ dataUrl, poi }) => {
+      const img = new Image();
+      img.src = dataUrl;
+      await img.decode();
+      const c = document.createElement('canvas');
+      c.width = img.width;
+      c.height = img.height;
+      const g2d = c.getContext('2d', { willReadFrequently: true });
+      g2d.drawImage(img, 0, 0);
+      const { data } = g2d.getImageData(0, 0, c.width, c.height);
+      let total = 0;
+      let near = 0;
+      const r2 = poi ? poi.r * poi.r : 0;
+      for (let y = 0; y < c.height; y++) {
+        for (let x = 0; x < c.width; x++) {
+          const i = (y * c.width + x) * 4;
+          const R = data[i];
+          const G = data[i + 1];
+          const B = data[i + 2];
+          if (G > 70 && G > R * 1.15 && G > B * 1.15) {
+            total++;
+            if (poi) {
+              const dx = x - poi.x;
+              const dy = y - poi.y;
+              if (dx * dx + dy * dy <= r2) near++;
+            }
+          }
+        }
+      }
+      return { total, near };
+    },
+    { dataUrl, poi: poi ? { x: poi.x, y: poi.y, r: poi.r ?? 150 } : null },
+  );
+}
+
+async function shot(name, poi) {
+  const png = await page.screenshot({ clip: { x: 0, y: 0, width: W, height: H } });
+  fs.writeFileSync(path.join(SHOTS, name), png);
+  return await stats(png, poi);
+}
+
+const cdp = await ctx.newCDPSession(page);
+const touch = (type, points) =>
+  cdp.send('Input.dispatchTouchEvent', {
+    type,
+    touchPoints: points.map(([x, y]) => ({ x, y })),
+  });
+
+// --- boot ---------------------------------------------------------------------
+await page.goto(`http://localhost:${PORT}/`, { waitUntil: 'load' });
+
+// Poll until the orb is painted (green pixels near the orb's home position).
+const HOME = { x: W / 2, y: H * 0.42, r: 170 };
+let idle;
+for (let i = 0; i < 40; i++) {
+  await page.waitForTimeout(500);
+  idle = await shot('00-idle.png', HOME);
+  if (idle.near > 2000) break;
+}
+
+const results = [];
+const check = (name, ok, detail) => {
+  results.push({ name, ok, detail });
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}  ${detail}`);
+};
+
+check('boot: orb visible at home', idle.near > 2000, `green near home=${idle.near}, total=${idle.total}`);
+
+// --- long circular drag (the continuity test) ----------------------------------
+// ~4s of continuous dragging around an ellipse; sample every ~600ms and
+// require effect pixels near the CURRENT finger position at every sample.
+const cx = W / 2;
+const cy = H / 2;
+const rx = 120;
+const ry = 260;
+const pos = (t) => [cx + rx * Math.cos(t), cy + ry * Math.sin(t)];
+
+let p = pos(0);
+await touch('touchStart', [p]);
+await page.waitForTimeout(120);
+const startFx = await shot('01-touchstart.png', { x: p[0], y: p[1], r: 150 });
+check('touchstart: splash spawns', startFx.near > 300, `green near finger=${startFx.near}`);
+
+const STEPS = 96;
+const dragSamples = [];
+for (let i = 1; i <= STEPS; i++) {
+  const t = (i / STEPS) * Math.PI * 2;
+  p = pos(t);
+  await touch('touchMove', [p]);
+  await page.waitForTimeout(28);
+  if (i % 16 === 0) {
+    const s = await shot(`02-drag-${String(i).padStart(2, '0')}.png`, { x: p[0], y: p[1], r: 160 });
+    dragSamples.push({ i, ...s });
+  }
+}
+const weakest = dragSamples.reduce((a, b) => (a.near < b.near ? a : b));
+check(
+  'continuity: effects track the finger at EVERY drag sample',
+  dragSamples.length === 6 && dragSamples.every((s) => s.near > 300),
+  dragSamples.map((s) => `@${s.i}:${s.near}`).join(' ') + ` (weakest=${weakest.near})`,
+);
+check(
+  'drag adds energy vs idle',
+  dragSamples.every((s) => s.total > idle.total * 1.05),
+  `drag totals=${dragSamples.map((s) => s.total).join(',')} vs idle=${idle.total}`,
+);
+
+// --- release firework -----------------------------------------------------------
+await touch('touchEnd', []);
+await page.waitForTimeout(200);
+const boom = await shot('03-firework.png', { x: p[0], y: p[1], r: 200 });
+check('release: firework burst at release point', boom.near > 300, `green near release=${boom.near}`);
+
+// --- settle ----------------------------------------------------------------------
+// Frame-based animation timing: headless Chromium can run well below 60fps,
+// so poll (up to 15s wall clock) instead of assuming a fixed decay time.
+let settled;
+for (let i = 0; i < 15; i++) {
+  await page.waitForTimeout(1000);
+  settled = await shot('04-settled.png', HOME);
+  if (settled.near > 2000 && settled.total < idle.total * 1.35) break;
+}
+check(
+  'settle: orb returns home, particles die out',
+  settled.near > 2000 && settled.total < idle.total * 1.35,
+  `near home=${settled.near}, total=${settled.total} (idle=${idle.total})`,
+);
+
+// --- rapid zigzag (pool recycling under stress) -----------------------------------
+let z = [60, 700];
+await touch('touchStart', [z]);
+for (let i = 1; i <= 60; i++) {
+  z = [60 + (i % 2 ? 270 : 0) + i * 0.5, 700 - i * 8];
+  await touch('touchMove', [z]);
+  await page.waitForTimeout(16);
+}
+const zig = await shot('05-zigzag.png', { x: z[0], y: z[1], r: 170 });
+await touch('touchEnd', []);
+check('stress: effects still spawn at end of rapid zigzag', zig.near > 300, `green near finger=${zig.near}`);
+await page.waitForTimeout(400);
+await shot('06-zigzag-boom.png');
+
+// --- summary -----------------------------------------------------------------------
+const failed = results.filter((r) => !r.ok);
+console.log(`\n${results.length - failed.length}/${results.length} checks passed; shots in ${SHOTS}`);
+
+await browser.close();
+server.kill();
+process.exit(failed.length ? 1 : 0);

--- a/examples/touch-fx/lynx.config.ts
+++ b/examples/touch-fx/lynx.config.ts
@@ -1,0 +1,28 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from '@lynx-js/rspeedy';
+import { pluginVueLynx } from 'vue-lynx/plugin';
+
+const exampleName = path.basename(path.dirname(fileURLToPath(import.meta.url)));
+
+export default defineConfig({
+  environments: {
+    web: {},
+    lynx: {},
+  },
+  source: {
+    entry: {
+      main: './src/index.ts',
+    },
+  },
+  plugins: [
+    pluginVueLynx({
+      optionsApi: false,
+      enableCSSSelector: true,
+    }),
+  ],
+  output: {
+    filename: '[name].[platform].bundle',
+    assetPrefix: `https://vue.lynxjs.org/examples/${exampleName}/dist/`,
+  },
+});

--- a/examples/touch-fx/package.json
+++ b/examples/touch-fx/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@vue-lynx-example/touch-fx",
+  "version": "0.2.9",
+  "private": false,
+  "description": "Vue-Lynx touch playground — a green orb that chases your finger, with water ripples and firework sparks driven entirely on the Main Thread",
+  "license": "Apache-2.0",
+  "type": "module",
+  "files": [
+    "dist",
+    "src",
+    "lynx.config.ts",
+    "tsconfig.json"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Huxpro/vue-lynx",
+    "directory": "examples/touch-fx"
+  },
+  "scripts": {
+    "build": "rspeedy build",
+    "dev": "rspeedy dev",
+    "web:serve": "node harness/serve.mjs",
+    "web:verify": "node harness/verify.mjs"
+  },
+  "dependencies": {
+    "vue-lynx": "workspace:*"
+  },
+  "devDependencies": {
+    "@lynx-js/rspeedy": "^0.13.5",
+    "@lynx-js/web-core": "^0.22.1",
+    "@rsbuild/plugin-vue": "^1.2.6",
+    "playwright": "^1.49.0",
+    "typescript": "^5.0.0"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/examples/touch-fx/src/App.vue
+++ b/examples/touch-fx/src/App.vue
@@ -28,7 +28,13 @@ type MTElement = {
   setStyleProperties(styles: Record<string, string>): void;
 };
 type MTRef<T> = { current: T };
-type LynxTouch = { clientX?: number; clientY?: number; x?: number; y?: number };
+type LynxTouch = {
+  identifier?: number;
+  clientX?: number;
+  clientY?: number;
+  x?: number;
+  y?: number;
+};
 type LynxTouchEvent = { touches?: LynxTouch[]; changedTouches?: LynxTouch[] };
 
 // ---------------------------------------------------------------------------
@@ -308,7 +314,25 @@ const onTouchMove = (e: LynxTouchEvent) => {
 const onTouchEnd = (e: LynxTouchEvent) => {
   'main thread';
   const st = getEngine() as Record<string, any>;
-  const remaining = e.touches ?? [];
+  // Platform discrepancy: on the Web, `touches` already excludes the lifted
+  // finger at touchend; on native Lynx it can still contain it. Subtract
+  // `changedTouches` (the lifted fingers) by identifier — correct under both
+  // semantics. Without this, native never sees an empty `touches`, the
+  // hand-over branch below re-grabs the orb, and it stays glued to the
+  // release point instead of springing home.
+  const touches = e.touches ?? [];
+  const ended = e.changedTouches ?? [];
+  const remaining: LynxTouch[] = [];
+  for (let i = 0; i < touches.length; i++) {
+    let lifted = false;
+    for (let j = 0; j < ended.length; j++) {
+      if (touches[i].identifier === ended[j].identifier) {
+        lifted = true;
+        break;
+      }
+    }
+    if (!lifted) remaining.push(touches[i]);
+  }
   if (remaining.length > 0) {
     // Another finger is still down — hand the orb over to it.
     st.fx = touchX(remaining[0]);

--- a/examples/touch-fx/src/App.vue
+++ b/examples/touch-fx/src/App.vue
@@ -1,0 +1,371 @@
+<script setup lang="ts">
+import { useMainThreadRef } from 'vue-lynx';
+
+declare const SystemInfo: { pixelWidth: number; pixelHeight: number; pixelRatio: number };
+
+// Logical screen size (captured into the worklets as plain numbers).
+const W = SystemInfo.pixelWidth / SystemInfo.pixelRatio;
+const H = SystemInfo.pixelHeight / SystemInfo.pixelRatio;
+
+const RIPPLE_POOL = 10;
+const SPARK_POOL = 64;
+const RIPPLE_SIZE = 120; // px, matches .ripple in CSS
+const ORB_SIZE = 200; // px, matches .orb in CSS
+
+// One MainThreadRef per animated element — hydrated to PAPI element handles
+// inside the worklets. Plus one ref holding the whole engine state on MT.
+const orbRef = useMainThreadRef<unknown>(null);
+const flareRef = useMainThreadRef<unknown>(null);
+const engRef = useMainThreadRef<Record<string, unknown> | null>(null);
+const rippleRefs = Array.from({ length: RIPPLE_POOL }, () => useMainThreadRef<unknown>(null));
+const sparkRefs = Array.from({ length: SPARK_POOL }, () => useMainThreadRef<unknown>(null));
+
+// Spark hues: four green shades assigned round-robin via CSS classes.
+const sparkClass = (i: number) => `spark spark-${i % 4}`;
+
+type MTElement = {
+  setStyleProperty(k: string, v: string): void;
+  setStyleProperties(styles: Record<string, string>): void;
+};
+type MTRef<T> = { current: T };
+type LynxTouch = { clientX?: number; clientY?: number; x?: number; y?: number };
+type LynxTouchEvent = { touches?: LynxTouch[]; changedTouches?: LynxTouch[] };
+
+// ---------------------------------------------------------------------------
+// Main Thread engine
+//
+// Everything below the `'main thread'` directives runs on the Main Thread —
+// zero cross-thread round-trips between your finger and the pixels. State
+// lives in `engRef.current` (persisted by the worklet-runtime's ref map), and
+// per-frame updates run on `requestAnimationFrame` on the Main Thread.
+// ---------------------------------------------------------------------------
+
+const touchX = (t: LynxTouch): number => {
+  'main thread';
+  return (t.clientX ?? t.x ?? 0) as number;
+};
+
+const touchY = (t: LynxTouch): number => {
+  'main thread';
+  return (t.clientY ?? t.y ?? 0) as number;
+};
+
+const getEngine = () => {
+  'main thread';
+  const eng = engRef as unknown as MTRef<Record<string, any> | null>;
+  if (eng.current) return eng.current;
+
+  const homeX = W / 2;
+  const homeY = H * 0.42;
+  const el = (r: unknown) => (r as MTRef<MTElement | null>).current;
+  // NOTE: captured arrays may arrive on the Main Thread as objects with
+  // numeric keys (the web platform's event path does not preserve
+  // Array prototypes), so pools are built by index, never by Array methods.
+  const refAt = (refs: unknown, i: number) => (refs as Record<number, unknown>)[i];
+
+  const st: Record<string, any> = {
+    // Orb spring state: position, velocity, target, grab flag.
+    ox: homeX,
+    oy: homeY,
+    vx: 0,
+    vy: 0,
+    tx: homeX,
+    ty: homeY,
+    homeX,
+    homeY,
+    grabbed: false,
+    // Finger tracking (for velocity-biased spark trails).
+    fx: 0,
+    fy: 0,
+    pfx: 0,
+    pfy: 0,
+    // Pools. `t` counts frames since spawn; a huge value means inactive.
+    ripples: [] as Record<string, any>[],
+    sparks: [] as Record<string, any>[],
+    ri: 0, // ripple pool cursor
+    si: 0, // spark pool cursor
+    frame: 0,
+    sinceRipple: 1e9,
+    running: false,
+  };
+
+  for (let i = 0; i < RIPPLE_POOL; i++) {
+    st.ripples.push({ el: el(refAt(rippleRefs, i)), t: 1e9, x: 0, y: 0, big: false });
+  }
+  for (let i = 0; i < SPARK_POOL; i++) {
+    st.sparks.push({ el: el(refAt(sparkRefs, i)), t: 1e9, life: 1, x: 0, y: 0, vx: 0, vy: 0, size: 1 });
+  }
+
+  st.spawnRipple = (x: number, y: number, big: boolean) => {
+    const rp = st.ripples[st.ri % st.ripples.length];
+    st.ri++;
+    rp.t = 0;
+    rp.x = x;
+    rp.y = y;
+    rp.big = big;
+    st.sinceRipple = 0;
+  };
+
+  st.spawnSpark = (x: number, y: number, vx: number, vy: number, life: number, size: number) => {
+    const sp = st.sparks[st.si % st.sparks.length];
+    st.si++;
+    sp.t = 0;
+    sp.life = life;
+    sp.x = x;
+    sp.y = y;
+    sp.vx = vx;
+    sp.vy = vy;
+    sp.size = size;
+  };
+
+  // Firework: radial burst of sparks. Pseudo-random angles derived from the
+  // pool cursor (Math.random is unavailable in worklets — and determinism is
+  // a feature here anyway).
+  st.burst = (x: number, y: number, n: number, speed: number) => {
+    for (let i = 0; i < n; i++) {
+      const a = ((st.si * 37 + i * 137 + st.frame * 7) % 360) * (Math.PI / 180);
+      const v = speed * (0.45 + ((st.si * 13 + i * 29) % 100) / 100 * 0.85);
+      st.spawnSpark(
+        x,
+        y,
+        Math.cos(a) * v,
+        Math.sin(a) * v,
+        34 + ((st.si * 11 + i * 17) % 26),
+        0.7 + ((st.si * 7 + i * 23) % 100) / 100 * 0.9,
+      );
+    }
+  };
+
+  const orbEl = () => el(orbRef);
+  const flareEl = () => el(flareRef);
+  const halfOrb = ORB_SIZE / 2;
+  const halfRipple = RIPPLE_SIZE / 2;
+
+  const step = () => {
+    st.frame++;
+    st.sinceRipple++;
+
+    // --- Orb: critically-ish damped spring chasing its target -------------
+    const k = st.grabbed ? 0.085 : 0.055;
+    const damp = st.grabbed ? 0.82 : 0.88;
+    st.vx = (st.vx + (st.tx - st.ox) * k) * damp;
+    st.vy = (st.vy + (st.ty - st.oy) * k) * damp;
+    st.ox += st.vx;
+    st.oy += st.vy;
+
+    const speed = Math.sqrt(st.vx * st.vx + st.vy * st.vy);
+    // Squash & stretch along the velocity vector — the "alive blob" feel.
+    const s = Math.min(speed * 0.012, 0.42);
+    const ang = Math.atan2(st.vy, st.vx) * (180 / Math.PI);
+    const orb = orbEl();
+    if (orb) {
+      orb.setStyleProperty(
+        'transform',
+        `translate(${st.ox - halfOrb}px, ${st.oy - halfOrb}px) `
+          + `rotate(${ang}deg) scaleX(${1 + s}) scaleY(${1 - s * 0.6}) rotate(${-ang}deg)`,
+      );
+    }
+    const flare = flareEl();
+    if (flare) {
+      // Glow flares up with movement, breathes back down at rest.
+      flare.setStyleProperty('opacity', String(Math.min(0.25 + speed * 0.05, 1)));
+    }
+
+    // --- Ripples: expanding, fading rings ----------------------------------
+    let alive = 0;
+    for (const rp of st.ripples) {
+      const dur = rp.big ? 62 : 46;
+      if (rp.t > dur) continue;
+      const p = rp.t / dur;
+      const eased = 1 - (1 - p) * (1 - p) * (1 - p); // easeOutCubic
+      const scale = 0.18 + eased * (rp.big ? 4.4 : 2.9);
+      const op = (1 - p) * (1 - p) * 0.9;
+      if (rp.el) {
+        rp.el.setStyleProperties({
+          transform: `translate(${rp.x - halfRipple}px, ${rp.y - halfRipple}px) scale(${scale})`,
+          opacity: String(op),
+        });
+      }
+      rp.t++;
+      alive++;
+    }
+
+    // --- Sparks: tiny glowing embers with drag + a whiff of gravity --------
+    for (const sp of st.sparks) {
+      if (sp.t > sp.life) continue;
+      const p = sp.t / sp.life;
+      sp.vx *= 0.962;
+      sp.vy = sp.vy * 0.962 + 0.055;
+      sp.x += sp.vx;
+      sp.y += sp.vy;
+      if (sp.el) {
+        sp.el.setStyleProperties({
+          transform: `translate(${sp.x - 5}px, ${sp.y - 5}px) scale(${sp.size * (1 - p * 0.72)})`,
+          opacity: String((1 - p) * (1 - p * 0.35)),
+        });
+      }
+      sp.t++;
+      alive++;
+    }
+
+    // --- Continuous feed while the finger is down ---------------------------
+    if (st.grabbed) {
+      // Water rings keep pulsing under the finger for the entire drag.
+      if (st.sinceRipple >= 9) st.spawnRipple(st.fx, st.fy, false);
+      // Ember trail biased along finger velocity.
+      const fvx = st.fx - st.pfx;
+      const fvy = st.fy - st.pfy;
+      const j = st.frame;
+      st.spawnSpark(
+        st.fx,
+        st.fy,
+        fvx * 0.18 + Math.cos(j * 2.4) * 1.6,
+        fvy * 0.18 + Math.sin(j * 1.7) * 1.6,
+        26 + (j * 13) % 18,
+        0.5 + ((j * 29) % 100) / 100 * 0.7,
+      );
+      st.pfx = st.fx;
+      st.pfy = st.fy;
+    }
+
+    // Keep looping while touching, while particles live, or while the orb
+    // still has meaningful momentum; park the loop when everything settles.
+    if (st.grabbed || alive > 0 || speed > 0.05) {
+      requestAnimationFrame(step);
+    } else {
+      st.running = false;
+      st.ox = st.homeX;
+      st.oy = st.homeY;
+      st.vx = 0;
+      st.vy = 0;
+      if (orb) {
+        orb.setStyleProperty(
+          'transform',
+          `translate(${st.homeX - halfOrb}px, ${st.homeY - halfOrb}px)`,
+        );
+      }
+      if (flare) flare.setStyleProperty('opacity', '0.25');
+    }
+  };
+
+  st.wake = () => {
+    if (st.running) return;
+    st.running = true;
+    requestAnimationFrame(step);
+  };
+
+  eng.current = st;
+  return st;
+};
+
+const onTouchStart = (e: LynxTouchEvent) => {
+  'main thread';
+  const st = getEngine() as Record<string, any>;
+  const touches = e.touches ?? [];
+  if (touches.length === 0) return;
+  const x = touchX(touches[0]);
+  const y = touchY(touches[0]);
+  st.grabbed = true;
+  st.tx = x;
+  st.ty = y;
+  st.fx = x;
+  st.fy = y;
+  st.pfx = x;
+  st.pfy = y;
+  st.spawnRipple(x, y, true);
+  st.burst(x, y, 12, 5.5);
+  // Extra fingers each get their own splash.
+  for (let i = 1; i < touches.length; i++) {
+    st.spawnRipple(touchX(touches[i]), touchY(touches[i]), false);
+    st.burst(touchX(touches[i]), touchY(touches[i]), 8, 4.5);
+  }
+  st.wake();
+};
+
+const onTouchMove = (e: LynxTouchEvent) => {
+  'main thread';
+  const st = getEngine() as Record<string, any>;
+  const touches = e.touches ?? [];
+  if (touches.length === 0) return;
+  st.fx = touchX(touches[0]);
+  st.fy = touchY(touches[0]);
+  st.tx = st.fx;
+  st.ty = st.fy;
+  // Secondary fingers sprinkle sparks too.
+  for (let i = 1; i < touches.length; i++) {
+    st.spawnSpark(
+      touchX(touches[i]),
+      touchY(touches[i]),
+      Math.cos(st.frame * 1.3) * 2,
+      Math.sin(st.frame * 2.1) * 2,
+      24,
+      0.8,
+    );
+  }
+  st.wake();
+};
+
+const onTouchEnd = (e: LynxTouchEvent) => {
+  'main thread';
+  const st = getEngine() as Record<string, any>;
+  const remaining = e.touches ?? [];
+  if (remaining.length > 0) {
+    // Another finger is still down — hand the orb over to it.
+    st.fx = touchX(remaining[0]);
+    st.fy = touchY(remaining[0]);
+    st.tx = st.fx;
+    st.ty = st.fy;
+    return;
+  }
+  st.grabbed = false;
+  st.tx = st.homeX;
+  st.ty = st.homeY;
+  // Goodbye firework at the release point.
+  const last = (e.changedTouches ?? [])[0];
+  const x = last ? touchX(last) : st.fx;
+  const y = last ? touchY(last) : st.fy;
+  st.spawnRipple(x, y, true);
+  st.burst(x, y, 20, 7.5);
+  st.wake();
+};
+</script>
+
+<template>
+  <view
+    class="stage"
+    :main-thread-bindtouchstart="onTouchStart"
+    :main-thread-bindtouchmove="onTouchMove"
+    :main-thread-bindtouchend="onTouchEnd"
+    :main-thread-bindtouchcancel="onTouchEnd"
+  >
+    <!-- Water ripples -->
+    <view
+      v-for="(r, i) in rippleRefs"
+      :key="`r${i}`"
+      class="ripple"
+      :main-thread-ref="r"
+    />
+
+    <!-- Firework sparks -->
+    <view
+      v-for="(s, i) in sparkRefs"
+      :key="`s${i}`"
+      :class="sparkClass(i)"
+      :main-thread-ref="s"
+    />
+
+    <!-- The orb — chases your finger with a springy squash & stretch -->
+    <view
+      class="orb"
+      :main-thread-ref="orbRef"
+      :style="{ transform: `translate(${W / 2 - 100}px, ${H * 0.42 - 100}px)` }"
+    >
+      <view class="orb-glow" />
+      <view class="orb-flare" :main-thread-ref="flareRef" />
+      <view class="orb-ring" />
+      <view class="orb-core" />
+    </view>
+
+    <text class="hint">touch · drag · flick</text>
+  </view>
+</template>

--- a/examples/touch-fx/src/index.ts
+++ b/examples/touch-fx/src/index.ts
@@ -1,0 +1,6 @@
+import { createApp } from 'vue-lynx';
+
+import './touch-fx.css';
+import App from './App.vue';
+
+createApp(App).mount();

--- a/examples/touch-fx/src/shims-vue.d.ts
+++ b/examples/touch-fx/src/shims-vue.d.ts
@@ -1,0 +1,6 @@
+declare module '*.vue' {
+  import type { Component } from 'vue-lynx';
+
+  const component: Component;
+  export default component;
+}

--- a/examples/touch-fx/src/touch-fx.css
+++ b/examples/touch-fx/src/touch-fx.css
@@ -1,0 +1,172 @@
+.stage {
+  width: 100%;
+  height: 100%;
+  background-color: #000;
+  position: relative;
+  overflow: hidden;
+}
+
+/* ---------------------------------------------------------------------------
+ * The orb — layered radial gradients, MT-driven transform on .orb itself.
+ * ------------------------------------------------------------------------- */
+
+.orb {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 200px;
+  height: 200px;
+}
+
+/* Soft outer aura, breathing via CSS keyframes (independent of MT transform) */
+.orb-glow {
+  position: absolute;
+  left: -60px;
+  top: -60px;
+  width: 320px;
+  height: 320px;
+  border-radius: 160px;
+  background: radial-gradient(
+    50% 50% at 50% 50%,
+    rgba(154, 230, 80, 0.32) 0%,
+    rgba(120, 200, 50, 0.12) 45%,
+    rgba(120, 200, 50, 0) 70%
+  );
+  animation: breathe 3.6s ease-in-out infinite;
+}
+
+/* Movement flare — MT drives opacity up as the orb accelerates */
+.orb-flare {
+  position: absolute;
+  left: -40px;
+  top: -40px;
+  width: 280px;
+  height: 280px;
+  border-radius: 140px;
+  opacity: 0.25;
+  background: radial-gradient(
+    50% 50% at 50% 50%,
+    rgba(198, 255, 120, 0.5) 0%,
+    rgba(154, 230, 80, 0.18) 40%,
+    rgba(154, 230, 80, 0) 68%
+  );
+}
+
+/* The bright rim — dark heart, luminous edge (the reference-image look) */
+.orb-ring {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 200px;
+  height: 200px;
+  border-radius: 100px;
+  background: radial-gradient(
+    50% 50% at 50% 50%,
+    rgba(8, 16, 2, 0.9) 0%,
+    rgba(30, 60, 10, 0.5) 42%,
+    rgba(130, 216, 52, 0.85) 66%,
+    rgba(168, 240, 80, 0.95) 74%,
+    rgba(168, 240, 80, 0.25) 84%,
+    rgba(168, 240, 80, 0) 94%
+  );
+}
+
+/* Inner sheen */
+.orb-core {
+  position: absolute;
+  left: 30px;
+  top: 30px;
+  width: 140px;
+  height: 140px;
+  border-radius: 70px;
+  background: radial-gradient(
+    50% 50% at 50% 50%,
+    rgba(190, 255, 130, 0.16) 0%,
+    rgba(190, 255, 130, 0.05) 45%,
+    rgba(190, 255, 130, 0) 70%
+  );
+  animation: breathe 3.6s ease-in-out -1.8s infinite;
+}
+
+@keyframes breathe {
+  0% {
+    transform: scale(1);
+    opacity: 0.8;
+  }
+  50% {
+    transform: scale(1.1);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 0.8;
+  }
+}
+
+/* ---------------------------------------------------------------------------
+ * Water ripples — 120px rings, scaled/faded from the Main Thread.
+ * ------------------------------------------------------------------------- */
+
+.ripple {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 120px;
+  height: 120px;
+  border-radius: 60px;
+  border-width: 3px;
+  border-style: solid;
+  border-color: rgba(170, 255, 100, 0.85);
+  background: radial-gradient(
+    50% 50% at 50% 50%,
+    rgba(170, 255, 100, 0) 55%,
+    rgba(170, 255, 100, 0.14) 82%,
+    rgba(170, 255, 100, 0) 100%
+  );
+  opacity: 0;
+}
+
+/* ---------------------------------------------------------------------------
+ * Firework sparks — 10px glowing dots in four green shades.
+ * ------------------------------------------------------------------------- */
+
+.spark {
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 10px;
+  height: 10px;
+  border-radius: 5px;
+  opacity: 0;
+}
+
+.spark-0 {
+  background: radial-gradient(50% 50% at 50% 50%, #d8ffa0 0%, rgba(168, 240, 80, 0.9) 45%, rgba(168, 240, 80, 0) 100%);
+}
+
+.spark-1 {
+  background: radial-gradient(50% 50% at 50% 50%, #f2ffd0 0%, rgba(200, 255, 110, 0.9) 45%, rgba(200, 255, 110, 0) 100%);
+}
+
+.spark-2 {
+  background: radial-gradient(50% 50% at 50% 50%, #b8ff88 0%, rgba(120, 220, 60, 0.9) 45%, rgba(120, 220, 60, 0) 100%);
+}
+
+.spark-3 {
+  background: radial-gradient(50% 50% at 50% 50%, #eaffea 0%, rgba(140, 255, 170, 0.9) 45%, rgba(140, 255, 170, 0) 100%);
+}
+
+/* ---------------------------------------------------------------------------
+ * Hint
+ * ------------------------------------------------------------------------- */
+
+.hint {
+  position: absolute;
+  left: 0;
+  bottom: 56px;
+  width: 100%;
+  text-align: center;
+  font-size: 14px;
+  letter-spacing: 4px;
+  color: rgba(170, 255, 120, 0.38);
+}

--- a/examples/touch-fx/tsconfig.json
+++ b/examples/touch-fx/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+  },
+  "include": ["src", "lynx.config.ts"],
+}

--- a/packages/testing-library/src/__tests__/worklet-utils.test.ts
+++ b/packages/testing-library/src/__tests__/worklet-utils.test.ts
@@ -4,9 +4,32 @@
 
 import { describe, it, expect } from 'vitest';
 import {
+  extractRegistrations,
   extractTemplateRegistrations,
   stripStyleImports,
 } from '../../../vue-lynx/plugin/src/loaders/worklet-utils.js';
+
+describe('extractRegistrations', () => {
+  it('survives quotes, apostrophes, and parens inside worklet-body comments', () => {
+    // The LEPUS transform preserves user comments inside worklet bodies.
+    // An apostrophe (or stray quote/paren) in a comment must not derail the
+    // balanced-paren scan — it used to silently drop every registration
+    // after the offending one.
+    const src = [
+      'registerWorkletInternal("main-thread", "aa:bb:1", function() {',
+      "  // the finger's position (x) — note the \"unpaired paren :)",
+      '  /* block comment with an apostrophe: it\'s fine ( */',
+      '  return f(1, 2);',
+      '});',
+      'registerWorkletInternal("main-thread", "aa:bb:2", function() {',
+      '  return 2;',
+      '});',
+    ].join('\n');
+    const out = extractRegistrations(src);
+    expect(out).toContain('"aa:bb:1"');
+    expect(out).toContain('"aa:bb:2"');
+  });
+});
 
 describe('extractTemplateRegistrations', () => {
   it('re-emits real registrations and ignores JSDoc examples', () => {

--- a/packages/vue-lynx/plugin/src/loaders/worklet-utils.ts
+++ b/packages/vue-lynx/plugin/src/loaders/worklet-utils.ts
@@ -486,8 +486,11 @@ function isInsideComment(code: string, index: number): boolean {
  *
  * String/template literals are skipped so parens inside embedded text (e.g.
  * a baked `__SetAttribute(e, 'text', "call us :)")`) don't unbalance the
- * scan. Comments are not handled — the scanned sources are compiler output,
- * which never embeds parens in comments between call arguments.
+ * scan. Comments are skipped too: the LEPUS transform preserves user
+ * comments inside worklet bodies, so an apostrophe or paren in a comment
+ * (`// the finger's position (x)`) must not derail the literal-skipper —
+ * before this, one such comment silently dropped every registration after
+ * it in the module.
  */
 function findBalancedEnd(code: string, openIndex: number): number {
   let depth = 0;
@@ -498,6 +501,14 @@ function findBalancedEnd(code: string, openIndex: number): number {
         if (code[i] === '\\') i++;
         else if (code[i] === ch) break;
       }
+    } else if (ch === '/' && code[i + 1] === '/') {
+      const end = code.indexOf('\n', i + 2);
+      if (end === -1) return -1;
+      i = end;
+    } else if (ch === '/' && code[i + 1] === '*') {
+      const end = code.indexOf('*/', i + 2);
+      if (end === -1) return -1;
+      i = end + 1;
     } else if (ch === '(') {
       depth++;
     } else if (ch === ')') {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,10 +26,10 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.8))
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
-        version: 1.2.7(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -431,10 +431,10 @@ importers:
     devDependencies:
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.8))
+        version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
-        version: 1.2.7(@rsbuild/core@1.7.3)(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+        version: 1.2.7(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.8(@swc/helpers@0.5.19))
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -578,6 +578,28 @@ importers:
       '@rsbuild/plugin-vue':
         specifier: ^1.2.6
         version: 1.2.7(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+
+  examples/touch-fx:
+    dependencies:
+      vue-lynx:
+        specifier: workspace:*
+        version: link:../../packages/vue-lynx
+    devDependencies:
+      '@lynx-js/rspeedy':
+        specifier: ^0.13.5
+        version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
+      '@lynx-js/web-core':
+        specifier: ^0.22.1
+        version: 0.22.1(tslib@2.8.1)
+      '@rsbuild/plugin-vue':
+        specifier: ^1.2.6
+        version: 1.2.7(@rsbuild/core@2.0.0-beta.6(core-js@3.47.0))(@rspack/core@1.7.8(@swc/helpers@0.5.19))
+      playwright:
+        specifier: ^1.49.0
+        version: 1.62.0
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -3628,6 +3650,11 @@ packages:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -4642,6 +4669,16 @@ packages:
   playwright-core@1.61.1:
     resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
     engines: {node: '>=18'}
+    hasBin: true
+
+  playwright-core@1.62.0:
+    resolution: {integrity: sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.0:
+    resolution: {integrity: sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==}
+    engines: {node: '>=20'}
     hasBin: true
 
   possible-typed-array-names@1.1.0:
@@ -9480,6 +9517,9 @@ snapshots:
       jsonfile: 4.0.0
       universalify: 0.1.2
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -10830,6 +10870,14 @@ snapshots:
   pirates@4.0.7: {}
 
   playwright-core@1.61.1: {}
+
+  playwright-core@1.62.0: {}
+
+  playwright@1.62.0:
+    dependencies:
+      playwright-core: 1.62.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 

--- a/website/docs/guide/touch-fx.mdx
+++ b/website/docs/guide/touch-fx.mdx
@@ -1,0 +1,33 @@
+# Playground: Touch FX
+
+A black stage, a glowing green orb, and your finger. Poke it, drag it, flick it — it reacts like a cat toy:
+
+- **The orb chases your finger** with a damped spring, squashing & stretching along its velocity vector. Flick and release, and it wobbles back home.
+- **Water ripples** pulse continuously under your finger for the *entire* drag — a fresh ring every ~150 ms, endlessly re-triggerable.
+- **Firework sparks** burst on touch-down and release, and an ember trail follows every move. Multi-touch works too: each extra finger splashes on its own.
+
+<Go example="touch-fx" defaultFile="src/App.vue" />
+
+:::tip Test it on your phone
+This demo is all about touch latency, so it feels best on a real device. Switch the preview above to the **QR code** tab and scan it with [LynxExplorer](https://lynxjs.org/guide/start/quick-start.html) — the native `main.lynx.bundle` is served right from this site. On desktop, the Web preview responds to touch only; enable touch emulation in your browser devtools (or open this page on your phone's browser).
+:::
+
+## Why it feels instant
+
+Every animated thing on this page — the spring physics, the ripple rings, the two particle pools (10 ripples / 64 sparks) — runs **on the Main Thread**, driven by [`'main thread'` worklets](/guide/main-thread-script) and a single `requestAnimationFrame` loop:
+
+- Touch handlers (`main-thread-bindtouchstart/move/end`) run on the Main Thread, so there is **zero cross-thread round-trip** between your finger and the pixels.
+- Element pools are pre-rendered once by the Background Thread; each pooled element is bound to a [`MainThreadRef`](/guide/api/vue-lynx/Function.useMainThreadRef), and the engine recycles them with direct `setStyleProperty` writes (only `transform` and `opacity` — cheap to composite).
+- The engine state lives in a value-only `MainThreadRef`; the rAF loop **parks itself** when the orb settles and every particle has died, and wakes on the next touch.
+
+The continuous ripple feed is the part to steal for your own apps: on every frame while a finger is down, the loop spawns trail sparks and re-arms a ripple every 9 frames — which is why the effects never stop mid-drag, no matter how long or fast you scribble.
+
+## Verify it headlessly
+
+The example ships with a Lynx-for-Web harness (`examples/touch-fx/harness/`) that drives **real CDP touch events** through headless Chromium and pixel-checks the frames — including a continuity assertion that effect pixels track the finger at *every* sample of a 4-second drag:
+
+```bash
+cd examples/touch-fx
+pnpm build
+pnpm web:verify   # 7/7 checks: boot, splash, continuity, energy, firework, settle, stress
+```

--- a/website/docs/zh/guide/touch-fx.mdx
+++ b/website/docs/zh/guide/touch-fx.mdx
@@ -1,0 +1,33 @@
+# 玩一玩：触摸特效
+
+黑色舞台、一颗发光的绿色光球，和你的手指。戳它、拖它、甩它——它像逗猫棒一样回应你：
+
+- **光球会追着手指跑**：阻尼弹簧物理，沿速度方向挤压拉伸（squash & stretch）。甩出去松手，它会晃晃悠悠地弹回原位。
+- **水波纹**在手指下持续泛开——整个拖动过程中每 ~150 ms 冒出一圈新涟漪，无限次触发。
+- **烟花火花**在按下和松开时炸开，拖动时还有一串火花尾迹跟着手指。支持多点触控：每根手指都有自己的水花。
+
+<Go example="touch-fx" defaultFile="src/App.vue" />
+
+:::tip 用手机真机测试
+这个演示的核心就是触摸延迟，真机手感最佳。把上面的预览切到 **二维码** 标签，用 [LynxExplorer](https://lynxjs.org/zh/guide/start/quick-start.html) 扫码——原生 `main.lynx.bundle` 就由本站直接下发。桌面端 Web 预览只响应触摸事件；请在浏览器 devtools 里开启触摸模拟（或直接用手机浏览器打开本页）。
+:::
+
+## 为什么手感是"零延迟"的
+
+页面上所有会动的东西——弹簧物理、涟漪圆环、两个粒子池（10 个涟漪 / 64 个火花）——全部运行在**主线程**上，由 [`'main thread'` 主线程脚本](/zh/guide/main-thread-script)和一个 `requestAnimationFrame` 循环驱动：
+
+- 触摸处理器（`main-thread-bindtouchstart/move/end`）在主线程执行，手指到像素之间**没有任何跨线程往返**。
+- 元素池由后台线程一次性预渲染；每个池化元素绑定一个 [`MainThreadRef`](/zh/guide/api/vue-lynx/Function.useMainThreadRef)，引擎用 `setStyleProperty` 直写样式循环复用它们（只改 `transform` 和 `opacity`，合成开销极低）。
+- 引擎状态存放在一个值类型的 `MainThreadRef` 里；光球归位、粒子全部熄灭后，rAF 循环会**自动停车**，下次触摸再被唤醒。
+
+最值得抄走的是"持续供给"这部分：手指按住期间，循环每帧生成尾迹火花、每 9 帧重新点一圈涟漪——所以无论你划多久、划多快，效果都不会中途断掉。
+
+## 无头浏览器验证
+
+示例自带 Lynx for Web 验证工具（`examples/touch-fx/harness/`），在无头 Chromium 里派发**真实 CDP 触摸事件**并做逐帧像素检查——包括一条连续性断言：4 秒拖动的*每一个*采样点上，特效像素都必须跟着当前手指位置：
+
+```bash
+cd examples/touch-fx
+pnpm build
+pnpm web:verify   # 7/7 检查：启动、水花、连续性、能量、烟花、回归、压力
+```

--- a/website/rspress.config.ts
+++ b/website/rspress.config.ts
@@ -102,6 +102,7 @@ export default defineConfig({
         { text: 'Instant First-Frame Rendering (IFR)', link: '/guide/ifr', tag: 'v0.5' },
         { text: 'Tutorial: Product Gallery', link: '/guide/tutorial-gallery' },
         { text: 'Tutorial: Product Swiper', link: '/guide/tutorial-swiper' },
+        { text: 'Playground: Touch FX', link: '/guide/touch-fx' },
         { text: 'scroll-view vs list', link: '/guide/scroll-view-vs-list' },
         {
           dividerType: 'solid',
@@ -148,6 +149,7 @@ export default defineConfig({
         { text: '首屏直出（IFR）', link: '/zh/guide/ifr', tag: 'v0.5' },
         { text: '教程：商品画廊', link: '/zh/guide/tutorial-gallery' },
         { text: '教程：商品轮播', link: '/zh/guide/tutorial-swiper' },
+        { text: '玩一玩：触摸特效', link: '/zh/guide/touch-fx' },
         { text: 'scroll-view 与 list', link: '/zh/guide/scroll-view-vs-list' },
         {
           dividerType: 'solid',


### PR DESCRIPTION
## What

A new example, `examples/touch-fx`: a black stage with a glowing green orb (inspired by the reference screenshot) that reacts to touch like a cat toy:

- **The orb chases your finger** with a damped spring, squashing & stretching along its velocity vector; flicking it sends it wobbling back home.
- **Water ripples** pulse continuously under the finger for the *entire* drag — a fresh ring every ~150 ms, endlessly re-triggerable.
- **Firework sparks** burst on touch-down and release; an ember trail follows every move. Extra fingers splash on their own (multi-touch).

All animation — spring physics, ripple rings, two particle pools (10 ripples / 64 sparks) — runs **on the Main Thread** via `'main thread'` worklets and a self-parking `requestAnimationFrame` loop. The Background Thread renders the static element pools once at startup; after that there is zero BG↔MT traffic between finger and pixels.

## Framework fix included

Building the example surfaced a latent bug in `worklet-loader-mt`: the LEPUS transform preserves user comments inside worklet bodies, and `findBalancedEnd`'s string-literal skipper treated an apostrophe/quote inside a comment (e.g. `// the web platform's event path`) as a string delimiter. The derailed scan silently dropped **every** `registerWorkletInternal()` call after the offending one, surfacing at runtime as `TypeError: cannot read property 'bind' of undefined` on the Main Thread. The scanner now skips line/block comments; regression test + changeset included.

Also documented in-code: captured arrays may arrive on the web MT as numeric-keyed objects (Array prototype not preserved through the wasm event path), so the engine builds its pools by index instead of `Array.map`.

## Headless verification (Lynx for Web)

`examples/touch-fx/harness/` serves the built `main.web.bundle` through `@lynx-js/web-core` and drives **real CDP touch events** in headless Chromium (`pnpm web:verify`), pixel-checking the rendered frames:

```
PASS  boot: orb visible at home                                 green near home=16462
PASS  touchstart: splash spawns                                 green near finger=13790
PASS  continuity: effects track the finger at EVERY drag sample @16:26728 @32:23669 @48:22875 @64:21766 @80:23083 @96:24121
PASS  drag adds energy vs idle                                  totals 23k–33k vs idle 16.6k
PASS  release: firework burst at release point                  green near release=26361
PASS  settle: orb returns home, particles die out               total back to 17.6k
PASS  stress: effects still spawn at end of rapid zigzag        green near finger=12556
7/7 checks passed
```

The continuity check is the core requirement: a 4-second circular drag sampled six times, each sample requiring effect pixels near the *current* finger position — proving ripples/sparks keep firing through the whole gesture, not just at its start.

## Test plan

- [x] `pnpm build` (web + lynx bundles)
- [x] `pnpm web:verify` — 7/7 headless interaction checks
- [x] `pnpm test` — 231 tests pass (22 files), including the new scanner regression test
- [ ] Real-device check in LynxExplorer (`pnpm dev`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E4wFMKraZjD5HgsCcU7GYE

---
_Generated by [Claude Code](https://claude.ai/code/session_01E4wFMKraZjD5HgsCcU7GYE)_