### PR TITLE
fix(touch-fx): align touches and react to taps

### DIFF
--- a/examples/touch-fx/harness/index.html
+++ b/examples/touch-fx/harness/index.html
@@ -10,7 +10,7 @@
     #phone {
       width: 390px;
       height: 844px;
-      margin: 0 auto;
+      margin: 72px auto 0;
       background: #000;
       position: relative;
       overflow: hidden;

--- a/examples/touch-fx/harness/verify.mjs
+++ b/examples/touch-fx/harness/verify.mjs
@@ -25,6 +25,8 @@ fs.mkdirSync(SHOTS, { recursive: true });
 const PORT = Number(process.env.PORT || 8976);
 const W = 390;
 const H = 844;
+const PAGE_W = 520;
+const PAGE_H = 980;
 
 // --- static server -----------------------------------------------------------
 const server = spawn(process.execPath, [path.join(HARNESS, 'serve.mjs')], {
@@ -40,7 +42,9 @@ const browser = await chromium.launch({
   args: ['--no-sandbox', '--disable-dev-shm-usage'],
 });
 const ctx = await browser.newContext({
-  viewport: { width: W, height: H },
+  // Deliberately embed the LynxView away from the browser viewport origin.
+  // This catches accidental use of window-relative clientX/clientY.
+  viewport: { width: PAGE_W, height: PAGE_H },
   deviceScaleFactor: 1,
   hasTouch: true,
 });
@@ -95,20 +99,40 @@ async function stats(png, poi) {
 }
 
 async function shot(name, poi) {
-  const png = await page.screenshot({ clip: { x: 0, y: 0, width: W, height: H } });
+  const png = await page.screenshot({
+    clip: {
+      x: viewRect.left,
+      y: viewRect.top,
+      width: viewRect.width,
+      height: viewRect.height,
+    },
+  });
   fs.writeFileSync(path.join(SHOTS, name), png);
   return await stats(png, poi);
 }
 
 const cdp = await ctx.newCDPSession(page);
+let viewRect;
 const touch = (type, points) =>
   cdp.send('Input.dispatchTouchEvent', {
     type,
-    touchPoints: points.map(([x, y]) => ({ x, y })),
+    touchPoints: points.map(([x, y]) => ({
+      x: x + viewRect.left,
+      y: y + viewRect.top,
+    })),
   });
 
 // --- boot ---------------------------------------------------------------------
 await page.goto(`http://localhost:${PORT}/`, { waitUntil: 'load' });
+viewRect = await page.locator('lynx-view').evaluate((view) => {
+  const rect = view.getBoundingClientRect();
+  return {
+    left: rect.left,
+    top: rect.top,
+    width: rect.width,
+    height: rect.height,
+  };
+});
 
 // Poll until the orb is painted (green pixels near the orb's home position).
 const HOME = { x: W / 2, y: H * 0.42, r: 170 };
@@ -126,6 +150,42 @@ const check = (name, ok, detail) => {
 };
 
 check('boot: orb visible at home', idle.near > 2000, `green near home=${idle.near}, total=${idle.total}`);
+
+// --- tap + embedded-coordinate regression -------------------------------------
+// The LynxView is intentionally offset within the browser viewport. A quick
+// tap near its top-left must paint at the same *local* point, not at the
+// window-relative client coordinates.
+const PROBE = { x: 52, y: 66 };
+await touch('touchStart', [[PROBE.x, PROBE.y]]);
+await page.waitForTimeout(32);
+const preciseTap = await shot('01-tap-precise.png', {
+  x: PROBE.x,
+  y: PROBE.y,
+  r: 34,
+});
+check(
+  'embedded coordinates: tap feedback is centered under the finger',
+  preciseTap.near > 120,
+  `green within 34px of finger=${preciseTap.near}`,
+);
+await touch('touchEnd', []);
+await page.waitForTimeout(1600);
+
+// A stationary tap on the orb must visibly compress it even without a move.
+await touch('touchStart', [[HOME.x, HOME.y]]);
+await page.waitForTimeout(32);
+const tappedTransform = await page.locator('lynx-view').evaluate((view) => {
+  return view.shadowRoot?.querySelector('.orb')?.style.transform ?? '';
+});
+const scaleX = Number(tappedTransform.match(/scaleX\(([^)]+)\)/)?.[1] ?? 1);
+const scaleY = Number(tappedTransform.match(/scaleY\(([^)]+)\)/)?.[1] ?? 1);
+check(
+  'tap without drag: orb visibly compresses',
+  Math.abs(scaleX - 1) > 0.04 || Math.abs(scaleY - 1) > 0.04,
+  `scaleX=${scaleX.toFixed(3)} scaleY=${scaleY.toFixed(3)}`,
+);
+await touch('touchEnd', []);
+await page.waitForTimeout(1600);
 
 // --- long circular drag (the continuity test) ----------------------------------
 // ~4s of continuous dragging around an ellipse; sample every ~600ms and

--- a/examples/touch-fx/src/App.vue
+++ b/examples/touch-fx/src/App.vue
@@ -30,12 +30,21 @@ type MTElement = {
 type MTRef<T> = { current: T };
 type LynxTouch = {
   identifier?: number;
+  pageX?: number;
+  pageY?: number;
   clientX?: number;
   clientY?: number;
   x?: number;
   y?: number;
 };
-type LynxTouchEvent = { touches?: LynxTouch[]; changedTouches?: LynxTouch[] };
+type LynxTouchEvent = {
+  touches?: LynxTouch[];
+  changedTouches?: LynxTouch[];
+  detail?: {
+    x?: number;
+    y?: number;
+  };
+};
 
 // ---------------------------------------------------------------------------
 // Main Thread engine
@@ -48,12 +57,27 @@ type LynxTouchEvent = { touches?: LynxTouch[]; changedTouches?: LynxTouch[] };
 
 const touchX = (t: LynxTouch): number => {
   'main thread';
-  return (t.clientX ?? t.x ?? 0) as number;
+  // pageX/pageY are relative to the current LynxView. clientX/clientY are
+  // window-relative in the website's embedded <Go> preview, which shifts
+  // every effect by the host view's screen position.
+  return (t.pageX ?? t.x ?? t.clientX ?? 0) as number;
 };
 
 const touchY = (t: LynxTouch): number => {
   'main thread';
-  return (t.clientY ?? t.y ?? 0) as number;
+  return (t.pageY ?? t.y ?? t.clientY ?? 0) as number;
+};
+
+const eventX = (e: LynxTouchEvent, t: LynxTouch): number => {
+  'main thread';
+  // TouchEvent.detail is normalized to the current LynxView even when the
+  // Web preview itself is offset or scaled inside the documentation page.
+  return (e.detail?.x ?? touchX(t)) as number;
+};
+
+const eventY = (e: LynxTouchEvent, t: LynxTouch): number => {
+  'main thread';
+  return (e.detail?.y ?? touchY(t)) as number;
 };
 
 const getEngine = () => {
@@ -92,6 +116,7 @@ const getEngine = () => {
     si: 0, // spark pool cursor
     frame: 0,
     sinceRipple: 1e9,
+    poke: 0,
     running: false,
   };
 
@@ -162,19 +187,27 @@ const getEngine = () => {
     const speed = Math.sqrt(st.vx * st.vx + st.vy * st.vy);
     // Squash & stretch along the velocity vector — the "alive blob" feel.
     const s = Math.min(speed * 0.012, 0.42);
+    const poke = st.poke;
+    st.poke *= 0.78;
+    if (st.poke < 0.01) st.poke = 0;
     const ang = Math.atan2(st.vy, st.vx) * (180 / Math.PI);
+    const scaleX = (1 + s) * (1 - poke * 0.14);
+    const scaleY = (1 - s * 0.6) * (1 + poke * 0.2);
     const orb = orbEl();
     if (orb) {
       orb.setStyleProperty(
         'transform',
         `translate(${st.ox - halfOrb}px, ${st.oy - halfOrb}px) `
-          + `rotate(${ang}deg) scaleX(${1 + s}) scaleY(${1 - s * 0.6}) rotate(${-ang}deg)`,
+          + `rotate(${ang}deg) scaleX(${scaleX}) scaleY(${scaleY}) rotate(${-ang}deg)`,
       );
     }
     const flare = flareEl();
     if (flare) {
       // Glow flares up with movement, breathes back down at rest.
-      flare.setStyleProperty('opacity', String(Math.min(0.25 + speed * 0.05, 1)));
+      flare.setStyleProperty(
+        'opacity',
+        String(Math.min(0.25 + speed * 0.05 + poke * 0.65, 1)),
+      );
     }
 
     // --- Ripples: expanding, fading rings ----------------------------------
@@ -236,7 +269,7 @@ const getEngine = () => {
 
     // Keep looping while touching, while particles live, or while the orb
     // still has meaningful momentum; park the loop when everything settles.
-    if (st.grabbed || alive > 0 || speed > 0.05) {
+    if (st.grabbed || alive > 0 || speed > 0.05 || st.poke > 0) {
       requestAnimationFrame(step);
     } else {
       st.running = false;
@@ -244,6 +277,7 @@ const getEngine = () => {
       st.oy = st.homeY;
       st.vx = 0;
       st.vy = 0;
+      st.poke = 0;
       if (orb) {
         orb.setStyleProperty(
           'transform',
@@ -269,8 +303,8 @@ const onTouchStart = (e: LynxTouchEvent) => {
   const st = getEngine() as Record<string, any>;
   const touches = e.touches ?? [];
   if (touches.length === 0) return;
-  const x = touchX(touches[0]);
-  const y = touchY(touches[0]);
+  const x = eventX(e, touches[0]);
+  const y = eventY(e, touches[0]);
   st.grabbed = true;
   st.tx = x;
   st.ty = y;
@@ -278,6 +312,7 @@ const onTouchStart = (e: LynxTouchEvent) => {
   st.fy = y;
   st.pfx = x;
   st.pfy = y;
+  st.poke = 1;
   st.spawnRipple(x, y, true);
   st.burst(x, y, 12, 5.5);
   // Extra fingers each get their own splash.
@@ -293,8 +328,8 @@ const onTouchMove = (e: LynxTouchEvent) => {
   const st = getEngine() as Record<string, any>;
   const touches = e.touches ?? [];
   if (touches.length === 0) return;
-  st.fx = touchX(touches[0]);
-  st.fy = touchY(touches[0]);
+  st.fx = eventX(e, touches[0]);
+  st.fy = eventY(e, touches[0]);
   st.tx = st.fx;
   st.ty = st.fy;
   // Secondary fingers sprinkle sparks too.
@@ -346,8 +381,8 @@ const onTouchEnd = (e: LynxTouchEvent) => {
   st.ty = st.homeY;
   // Goodbye firework at the release point.
   const last = (e.changedTouches ?? [])[0];
-  const x = last ? touchX(last) : st.fx;
-  const y = last ? touchY(last) : st.fy;
+  const x = last ? eventX(e, last) : st.fx;
+  const y = last ? eventY(e, last) : st.fy;
   st.spawnRipple(x, y, true);
   st.burst(x, y, 20, 7.5);
   st.wake();


### PR DESCRIPTION
## What changed

- use LynxView-normalized `TouchEvent.detail.x/y` for the primary touch, with touch-coordinate fallbacks
- add an immediate poke/compression and flare response on touchstart, so stationary taps feel responsive
- offset the Web harness container and add regressions for embedded coordinates and tap-only feedback

## Root cause

The example preferred `clientX/clientY`. In the Website `<Go>` preview those coordinates are relative to the browser viewport, while the effect layer is relative to the embedded LynxView. This double-counted the host view's `left/top` offset. The same coordinate-space mismatch could also appear on Native when the LynxView did not start at the screen origin.

## Impact

Touch ripples, particles, and the orb now stay under the finger in embedded Web and Native layouts. A simple tap produces visible compression, glow, ripple, and particles without requiring a drag.

## Validation

- `pnpm --dir examples/touch-fx build`
- `CHROMIUM_PATH='/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' pnpm --dir examples/touch-fx web:verify` — 9/9 checks passed
- `pnpm --dir website build`
- Website `<Go>` CDP measurement: LynxView at `(410, 228.39)`; touch at local `(112, 92)` rendered ripple at `translate(52px, 32px)` (120px ripple), exactly centered under the finger
- worklet registrations: BG 8 / MT 8, exact hash match

Follow-up to #349.