### PR TITLE
fix(examples): let the gallery list fill its wrapper

### DIFF
--- a/.changeset/gallery-list-fills-wrapper.md
+++ b/.changeset/gallery-list-fills-wrapper.md
@@ -1,0 +1,7 @@
+---
+"vue-lynx": patch
+---
+
+Let the gallery example's list fill its wrapper instead of leaving a 48px black band.
+
+`.list` was `height: calc(100% - 48px)` inside a black `.gallery-wrapper`, and every scrollbar step derived its viewport from `SystemInfo.pixelHeight / SystemInfo.pixelRatio - 48`. That 48 is Lynx Explorer's title bar, but `100%` is already the page area below it, so the example subtracted it twice — leaving the band on Lynx for Web, in Explorer's fullscreen mode, and under the title bar itself. The scrollbar now takes its viewport from `event.detail.listHeight`, the list's own box, falling back to the page height where Lynx for Web reports 0.

--- a/examples/gallery/src/GalleryComplete/Gallery.vue
+++ b/examples/gallery/src/GalleryComplete/Gallery.vue
@@ -18,19 +18,30 @@ const listRef = useTemplateRef<ShadowElement>('listRef');
 function adjustScrollbarMTS(
   scrollTop: number,
   scrollHeight: number,
+  listHeight: number,
   ref: { current?: { setStyleProperty?(k: string, v: string): void } },
 ) {
   'main thread';
-  const listHeight = SystemInfo.pixelHeight / SystemInfo.pixelRatio - 48;
   const scrollbarHeight = listHeight * (listHeight / scrollHeight);
   const scrollbarTop = listHeight * (scrollTop / scrollHeight);
   ref.current?.setStyleProperty?.('height', `${scrollbarHeight}px`);
   ref.current?.setStyleProperty?.('top', `${scrollbarTop}px`);
 }
 
-const onScrollMTS = (event: { detail: { scrollTop: number; scrollHeight: number } }) => {
+const onScrollMTS = (event: {
+  detail: { scrollTop: number; scrollHeight: number; listHeight?: number };
+}) => {
   'main thread';
-  adjustScrollbarMTS(event.detail.scrollTop, event.detail.scrollHeight, scrollbarThumbRef);
+  // `listHeight` is the list's own box. Native engines report it; Lynx for Web
+  // reports 0, and there the list fills the page, so the page height is the
+  // same number.
+  const listHeight = event.detail.listHeight || SystemInfo.pixelHeight / SystemInfo.pixelRatio;
+  adjustScrollbarMTS(
+    event.detail.scrollTop,
+    event.detail.scrollHeight,
+    listHeight,
+    scrollbarThumbRef,
+  );
 };
 
 onMounted(() => {

--- a/examples/gallery/src/GalleryScrollbar/Gallery.vue
+++ b/examples/gallery/src/GalleryScrollbar/Gallery.vue
@@ -11,10 +11,16 @@ import NiceScrollbar from './NiceScrollbar.vue';
 const scrollbarRef = ref<InstanceType<typeof NiceScrollbar> | null>(null);
 const listRef = useTemplateRef<ShadowElement>('listRef');
 
-function onScroll(event: { detail?: { scrollTop?: number; scrollHeight?: number } }) {
+function onScroll(event: {
+  detail?: { scrollTop?: number; scrollHeight?: number; listHeight?: number };
+}) {
   const scrollTop = event.detail?.scrollTop ?? 0;
   const scrollHeight = event.detail?.scrollHeight ?? 0;
-  scrollbarRef.value?.adjustScrollbar(scrollTop, scrollHeight);
+  // `listHeight` is the list's own box. Native engines report it; Lynx for Web
+  // reports 0, and there the list fills the page, so the page height is the
+  // same number.
+  const listHeight = event.detail?.listHeight || SystemInfo.pixelHeight / SystemInfo.pixelRatio;
+  scrollbarRef.value?.adjustScrollbar(scrollTop, scrollHeight, listHeight);
 }
 
 onMounted(() => {

--- a/examples/gallery/src/GalleryScrollbar/NiceScrollbar.vue
+++ b/examples/gallery/src/GalleryScrollbar/NiceScrollbar.vue
@@ -6,8 +6,7 @@ declare const SystemInfo: { pixelHeight: number; pixelRatio: number };
 const scrollbarHeight = ref(0);
 const scrollbarTop = ref(0);
 
-function adjustScrollbar(scrollTop: number, scrollHeight: number) {
-  const listHeight = SystemInfo.pixelHeight / SystemInfo.pixelRatio - 48;
+function adjustScrollbar(scrollTop: number, scrollHeight: number, listHeight: number) {
   scrollbarHeight.value = listHeight * (listHeight / scrollHeight);
   scrollbarTop.value = listHeight * (scrollTop / scrollHeight);
 }

--- a/examples/gallery/src/GalleryScrollbarCompare/Gallery.vue
+++ b/examples/gallery/src/GalleryScrollbarCompare/Gallery.vue
@@ -16,29 +16,40 @@ const scrollbarThumbRef = useMainThreadRef(null);
 const listRef = useTemplateRef<ShadowElement>('listRef');
 
 // BTS scroll handler
-function onScroll(event: { detail?: { scrollTop?: number; scrollHeight?: number } }) {
+function onScroll(event: {
+  detail?: { scrollTop?: number; scrollHeight?: number; listHeight?: number };
+}) {
   const scrollTop = event.detail?.scrollTop ?? 0;
   const scrollHeight = event.detail?.scrollHeight ?? 0;
-  scrollbarRef.value?.adjustScrollbar(scrollTop, scrollHeight);
+  const listHeight = event.detail?.listHeight || SystemInfo.pixelHeight / SystemInfo.pixelRatio;
+  scrollbarRef.value?.adjustScrollbar(scrollTop, scrollHeight, listHeight);
 }
 
 // MTS scrollbar adjuster — runs directly on Main Thread (no -48 offset, full height)
 function adjustScrollbarCompare(
   scrollTop: number,
   scrollHeight: number,
+  listHeight: number,
   ref: { current?: { setStyleProperty?(k: string, v: string): void } },
 ) {
   'main thread';
-  const listHeight = SystemInfo.pixelHeight / SystemInfo.pixelRatio;
   const scrollbarHeight = listHeight * (listHeight / scrollHeight);
   const scrollbarTop = listHeight * (scrollTop / scrollHeight);
   ref.current?.setStyleProperty?.('height', `${scrollbarHeight}px`);
   ref.current?.setStyleProperty?.('top', `${scrollbarTop}px`);
 }
 
-const onScrollMTS = (event: { detail: { scrollTop: number; scrollHeight: number } }) => {
+const onScrollMTS = (event: {
+  detail: { scrollTop: number; scrollHeight: number; listHeight?: number };
+}) => {
   'main thread';
-  adjustScrollbarCompare(event.detail.scrollTop, event.detail.scrollHeight, scrollbarThumbRef);
+  const listHeight = event.detail.listHeight || SystemInfo.pixelHeight / SystemInfo.pixelRatio;
+  adjustScrollbarCompare(
+    event.detail.scrollTop,
+    event.detail.scrollHeight,
+    listHeight,
+    scrollbarThumbRef,
+  );
 };
 
 onMounted(() => {

--- a/examples/gallery/src/gallery.css
+++ b/examples/gallery/src/gallery.css
@@ -67,7 +67,7 @@
   padding-bottom: 20px;
   padding-left: 20px;
   padding-right: 20px;
-  height: calc(100% - 48px);
+  height: 100%;
   list-main-axis-gap: 10px;
   list-cross-axis-gap: 10px;
 }

--- a/website/docs/guide/tutorial-gallery.mdx
+++ b/website/docs/guide/tutorial-gallery.mdx
@@ -104,7 +104,7 @@ Since the focus of this tutorial is not on how to style your UI, you may just sa
   padding-bottom: 20px;
   padding-left: 20px;
   padding-right: 20px;
-  height: calc(100% - 48px);
+  height: 100%;
   list-main-axis-gap: 10px;
   list-cross-axis-gap: 10px;
 }

--- a/website/docs/zh/guide/tutorial-gallery.mdx
+++ b/website/docs/zh/guide/tutorial-gallery.mdx
@@ -104,7 +104,7 @@ export default defineConfig({
   padding-bottom: 20px;
   padding-left: 20px;
   padding-right: 20px;
-  height: calc(100% - 48px);
+  height: 100%;
   list-main-axis-gap: 10px;
   list-cross-axis-gap: 10px;
 }


### PR DESCRIPTION
## What

The gallery example leaves a 48px black band under the grid, in every environment.

## Why

`.list` is `height: calc(100% - 48px)` inside a `.gallery-wrapper` that is
`height: 100%` with a black background, and every scrollbar step derives its
viewport from `SystemInfo.pixelHeight / SystemInfo.pixelRatio - 48`.

That 48 is **Lynx Explorer's title bar** — the upstream ReactLynx tutorial's QR
schema turns it on with `?title=Popular Furniture`. But `100%` is already the page
area *below* that bar, so the example subtracts it a second time. A shorter list
would not move content out from under a *top* bar anyway, so the 48px only ever
shows up as dead space at the bottom: on Lynx for Web, in Explorer's fullscreen
mode, and under the title bar itself.

Inherited from the ReactLynx tutorial this example ports, where it has been
present since that repo's initial commit.

## How

- `.list` fills its wrapper (`height: 100%`).
- Every scrollbar step — `GalleryScrollbar`, `GalleryScrollbarCompare` and
  `GalleryComplete` — takes its viewport from `event.detail.listHeight`, the
  list's own box, instead of guessing from the screen.
- Lynx for Web reports `listHeight` as `0`, so the page height is the fallback
  (`||`, not `??`) — the same number once the list fills the page.
- `website/docs/{,zh/}guide/tutorial-gallery.mdx` quote the CSS, so both locales
  are updated to match.

## Verification

`pnpm build` passes for both the `lynx` and `web` environments.

Measured through `@lynx-js/web-core` in headless Chromium, `GalleryComplete`:

| | before | after |
| --- | --- | --- |
| `.gallery-wrapper` height | 700 | 700 |
| `.list` height | 652 | **700** |
| band at bottom | **48px** | **0** |
| scrollbar inline style | — | `height: 69.3px; top: 54.7px` |

The scrollbar grows because its viewport is now the full 700px list rather than
652px, which is the point of the change.

## Related

Same fix, same measurements, in the two sibling ports:

- lynx-family/lynx-examples#396 (ReactLynx — the tutorial this ports)
- octanejs/octane#616 (Octane)
