### PR TITLE
perf(runtime): share empty class state

### DIFF
--- a/.changeset/lazy-shadow-class-state.md
+++ b/.changeset/lazy-shadow-class-state.md
@@ -1,0 +1,6 @@
+---
+"vue-lynx": patch
+---
+
+Reduce per-element Background Thread memory by sharing the immutable empty
+scope and transition class state until a class is first added.

--- a/packages/testing-library/src/__tests__/shadow-element-lazy-state.test.ts
+++ b/packages/testing-library/src/__tests__/shadow-element-lazy-state.test.ts
@@ -62,33 +62,43 @@ describe('ShadowElement lazy class state', () => {
   it('copy-on-writes scoped CSS and preserves removal isolation', () => {
     const first = new ShadowElement('view');
     const second = new ShadowElement('view');
-    const shared = first._scopeClasses;
 
     first.setAttribute('data-v-first', '');
     first.setAttribute('data-v-first', '');
-    expect(first._scopeClasses).not.toBe(shared);
-    expect(second._scopeClasses).toBe(shared);
+    expect(first._getScopeClasses()).not.toBe(second._getScopeClasses());
+    expect(second._getScopeClasses().size).toBe(0);
     expect(resolveClass(first)).toBe('data-v-first');
     expect(takeOps().filter((value) => value === OP.SET_CLASS)).toHaveLength(1);
 
     first.removeAttribute('data-v-first');
     expect(first._scopeClasses.size).toBe(0);
-    expect(second._scopeClasses).toBe(shared);
+    expect(second._getScopeClasses().size).toBe(0);
   });
 
   it('copy-on-writes transition classes and removes from owned state', () => {
     const first = new ShadowElement('view');
     const second = new ShadowElement('view');
-    const shared = first._transitionClasses;
 
     removeTransitionClass(first, 'v-enter-from');
-    expect(first._transitionClasses).toBe(shared);
+    expect(first._getTransitionClasses().size).toBe(0);
     addTransitionClass(first, 'v-enter-from');
-    expect(first._transitionClasses).not.toBe(shared);
-    expect(second._transitionClasses).toBe(shared);
+    expect(first._getTransitionClasses()).not.toBe(second._getTransitionClasses());
+    expect(second._getTransitionClasses().size).toBe(0);
     expect(resolveClass(first)).toBe('v-enter-from');
     removeTransitionClass(first, 'v-enter-from');
     expect(first._transitionClasses.size).toBe(0);
+  });
+
+  it('preserves direct transition-hook mutation without leaking to siblings', () => {
+    const first = new ShadowElement('view');
+    const second = new ShadowElement('view');
+
+    first._transitionClasses.add('hook-before-enter');
+    addTransitionClass(first, 'v-enter-from');
+
+    expect(resolveClass(first)).toBe('hook-before-enter v-enter-from');
+    expect(resolveClass(second)).toBe('');
+    expect(second._getTransitionClasses().size).toBe(0);
   });
 
   it('isolates granular clone scope state', () => {

--- a/packages/testing-library/src/__tests__/shadow-element-lazy-state.test.ts
+++ b/packages/testing-library/src/__tests__/shadow-element-lazy-state.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { OP, type VaporTreeAddressing } from 'vue-lynx/internal/ops';
+import { takeOps } from '../../../vue-lynx/runtime/src/ops.js';
+import {
+  ShadowElement,
+  resetTemplateState,
+  setPendingVaporAddressing,
+} from '../../../vue-lynx/runtime/src/shadow-element.js';
+import {
+  addTransitionClass,
+  removeTransitionClass,
+} from '../../../vue-lynx/runtime/src/transition-shared.js';
+import { resolveClass } from '../../../vue-lynx/runtime/src/tree-ops.js';
+
+function proto(): ShadowElement {
+  const root = new ShadowElement('view');
+  root._inert = true;
+  root._addScopeClass('data-v-proto');
+  const text = new ShadowElement('text');
+  text._inert = true;
+  const value = new ShadowElement('#text');
+  value._inert = true;
+  value._text = 'x';
+  text._link(value, null);
+  root._link(text, null);
+  return root;
+}
+
+function clone(
+  meta?: VaporTreeAddressing,
+): [ShadowElement, ShadowElement, ShadowElement] {
+  const source = proto();
+  setPendingVaporAddressing(meta);
+  const first = source.cloneNode(true);
+  setPendingVaporAddressing(meta);
+  const second = source.cloneNode(true);
+  return [source, first, second];
+}
+
+function expectScopeIsolation(
+  source: ShadowElement,
+  first: ShadowElement,
+  second: ShadowElement,
+): void {
+  expect(first._scopeClasses).toEqual(new Set(['data-v-proto']));
+  expect(first._scopeClasses).not.toBe(source._scopeClasses);
+  expect(first._scopeClasses).not.toBe(second._scopeClasses);
+  first.removeAttribute('data-v-proto');
+  expect(first._scopeClasses.size).toBe(0);
+  expect(source._scopeClasses).toContain('data-v-proto');
+  expect(second._scopeClasses).toContain('data-v-proto');
+}
+
+beforeEach(() => {
+  resetTemplateState();
+  ShadowElement.nextUid = 2;
+  takeOps();
+});
+
+describe('ShadowElement lazy class state', () => {
+  it('copy-on-writes scoped CSS and preserves removal isolation', () => {
+    const first = new ShadowElement('view');
+    const second = new ShadowElement('view');
+    const shared = first._scopeClasses;
+
+    first.setAttribute('data-v-first', '');
+    first.setAttribute('data-v-first', '');
+    expect(first._scopeClasses).not.toBe(shared);
+    expect(second._scopeClasses).toBe(shared);
+    expect(resolveClass(first)).toBe('data-v-first');
+    expect(takeOps().filter((value) => value === OP.SET_CLASS)).toHaveLength(1);
+
+    first.removeAttribute('data-v-first');
+    expect(first._scopeClasses.size).toBe(0);
+    expect(second._scopeClasses).toBe(shared);
+  });
+
+  it('copy-on-writes transition classes and removes from owned state', () => {
+    const first = new ShadowElement('view');
+    const second = new ShadowElement('view');
+    const shared = first._transitionClasses;
+
+    removeTransitionClass(first, 'v-enter-from');
+    expect(first._transitionClasses).toBe(shared);
+    addTransitionClass(first, 'v-enter-from');
+    expect(first._transitionClasses).not.toBe(shared);
+    expect(second._transitionClasses).toBe(shared);
+    expect(resolveClass(first)).toBe('v-enter-from');
+    removeTransitionClass(first, 'v-enter-from');
+    expect(first._transitionClasses.size).toBe(0);
+  });
+
+  it('isolates granular clone scope state', () => {
+    const source = proto();
+    const first = source._cloneNodeGranular();
+    const second = source._cloneNodeGranular();
+    expectScopeIsolation(source, first, second);
+  });
+
+  it('isolates dense template clone scope state', () => {
+    expectScopeIsolation(...clone());
+  });
+
+  it('isolates sparse template clone scope state', () => {
+    const meta = {
+      holes: [1],
+      addressed: [0, 1],
+      slotCount: 2,
+      tags: ['view', 'text'],
+    };
+    expectScopeIsolation(...clone(meta));
+  });
+});

--- a/packages/vue-lynx/runtime/src/shadow-element.ts
+++ b/packages/vue-lynx/runtime/src/shadow-element.ts
@@ -203,8 +203,8 @@ function createClassList(el: ShadowElement): ClassListFacade {
   };
 }
 
-const EMPTY_SCOPE_CLASSES = new Set<string>();
-const EMPTY_TRANSITION_CLASSES = new Set<string>();
+const EMPTY_SCOPE_CLASSES: ReadonlySet<string> = new Set();
+const EMPTY_TRANSITION_CLASSES: ReadonlySet<string> = new Set();
 
 export class ShadowElement {
   static nextUid = 2; // 1 is reserved for the page root
@@ -241,8 +241,26 @@ export class ShadowElement {
   // _transitionClasses: classes added/removed by <Transition> hooks.
   // The effective class sent to MT = base + scopes + transitions.
   _baseClass = '';
-  _scopeClasses: ReadonlySet<string> = EMPTY_SCOPE_CLASSES;
-  _transitionClasses: ReadonlySet<string> = EMPTY_TRANSITION_CLASSES;
+  declare private _scopeClassesState?: Set<string>;
+  get _scopeClasses(): Set<string> {
+    return this._scopeClassesState ??= new Set();
+  }
+  set _scopeClasses(classes: Set<string>) {
+    this._scopeClassesState = classes;
+  }
+  _getScopeClasses(): ReadonlySet<string> {
+    return this._scopeClassesState ?? EMPTY_SCOPE_CLASSES;
+  }
+  declare private _transitionClassesState?: Set<string>;
+  get _transitionClasses(): Set<string> {
+    return this._transitionClassesState ??= new Set();
+  }
+  set _transitionClasses(classes: Set<string>) {
+    this._transitionClassesState = classes;
+  }
+  _getTransitionClasses(): ReadonlySet<string> {
+    return this._transitionClassesState ?? EMPTY_TRANSITION_CLASSES;
+  }
   // Generation counter bumped each time whenTransitionEnds() starts waiting
   // on this element. Lets a stale/superseded finish() (fired by the fallback
   // timeout after a newer transition has already started) detect it's stale
@@ -632,8 +650,9 @@ export class ShadowElement {
     } else {
       pushOp(OP.CREATE, clone.uid, this.tag);
       clone._baseClass = this._baseClass;
-      if (this._scopeClasses.size > 0) {
-        clone._scopeClasses = new Set(this._scopeClasses);
+      const scopeClasses = this._getScopeClasses();
+      if (scopeClasses.size > 0) {
+        clone._scopeClasses = new Set(scopeClasses);
       }
       const resolvedClass = resolveClass(clone);
       if (resolvedClass) pushOp(OP.SET_CLASS, clone.uid, resolvedClass);
@@ -842,16 +861,14 @@ export class ShadowElement {
   }
 
   hasAttribute(key: string): boolean {
-    if (key.startsWith('data-v-')) return this._scopeClasses.has(key);
+    if (key.startsWith('data-v-')) return this._getScopeClasses().has(key);
     return this.getAttribute(key) != null;
   }
 
   /** Add a Vue scope token without allowing duplicate class emission. */
   _addScopeClass(scopeClass: string): void {
-    if (this._scopeClasses.has(scopeClass)) return;
-    const scopeClasses = this._scopeClasses === EMPTY_SCOPE_CLASSES
-      ? (this._scopeClasses = new Set())
-      : this._scopeClasses as Set<string>;
+    const scopeClasses = this._scopeClasses;
+    if (scopeClasses.has(scopeClass)) return;
     scopeClasses.add(scopeClass);
     if (!this._inert) {
       pushOp(OP.SET_CLASS, this.uid, resolveClass(this));
@@ -861,23 +878,17 @@ export class ShadowElement {
 
   /** @internal */
   _removeScopeClass(scopeClass: string): boolean {
-    return this._scopeClasses !== EMPTY_SCOPE_CLASSES
-      && (this._scopeClasses as Set<string>).delete(scopeClass);
+    return this._scopeClassesState?.delete(scopeClass) ?? false;
   }
 
   /** @internal */
   _addTransitionClass(transitionClass: string): void {
-    const transitionClasses =
-      this._transitionClasses === EMPTY_TRANSITION_CLASSES
-        ? (this._transitionClasses = new Set())
-        : this._transitionClasses as Set<string>;
-    transitionClasses.add(transitionClass);
+    this._transitionClasses.add(transitionClass);
   }
 
   /** @internal */
   _removeTransitionClass(transitionClass: string): boolean {
-    return this._transitionClasses !== EMPTY_TRANSITION_CLASSES
-      && (this._transitionClasses as Set<string>).delete(transitionClass);
+    return this._transitionClassesState?.delete(transitionClass) ?? false;
   }
 
   // --- class / style -------------------------------------------------------------
@@ -1195,8 +1206,9 @@ function buildShadowClone(
   }
 
   clone._baseClass = proto._baseClass;
-  if (proto._scopeClasses.size > 0) {
-    clone._scopeClasses = new Set(proto._scopeClasses);
+  const scopeClasses = proto._getScopeClasses();
+  if (scopeClasses.size > 0) {
+    clone._scopeClasses = new Set(scopeClasses);
   }
   if (hasAnyKey(proto._style)) clone._style = { ...proto._style };
   if (proto._attrs) clone._attrs = new Map(proto._attrs);
@@ -1281,8 +1293,9 @@ function buildShadowCloneSparse(
   }
 
   clone._baseClass = proto._baseClass;
-  if (proto._scopeClasses.size > 0) {
-    clone._scopeClasses = new Set(proto._scopeClasses);
+  const scopeClasses = proto._getScopeClasses();
+  if (scopeClasses.size > 0) {
+    clone._scopeClasses = new Set(scopeClasses);
   }
   if (hasAnyKey(proto._style)) clone._style = { ...proto._style };
   if (proto._attrs) clone._attrs = new Map(proto._attrs);

--- a/packages/vue-lynx/runtime/src/shadow-element.ts
+++ b/packages/vue-lynx/runtime/src/shadow-element.ts
@@ -203,6 +203,9 @@ function createClassList(el: ShadowElement): ClassListFacade {
   };
 }
 
+const EMPTY_SCOPE_CLASSES = new Set<string>();
+const EMPTY_TRANSITION_CLASSES = new Set<string>();
+
 export class ShadowElement {
   static nextUid = 2; // 1 is reserved for the page root
 
@@ -238,8 +241,8 @@ export class ShadowElement {
   // _transitionClasses: classes added/removed by <Transition> hooks.
   // The effective class sent to MT = base + scopes + transitions.
   _baseClass = '';
-  _scopeClasses: Set<string> = new Set();
-  _transitionClasses: Set<string> = new Set();
+  _scopeClasses: ReadonlySet<string> = EMPTY_SCOPE_CLASSES;
+  _transitionClasses: ReadonlySet<string> = EMPTY_TRANSITION_CLASSES;
   // Generation counter bumped each time whenTransitionEnds() starts waiting
   // on this element. Lets a stale/superseded finish() (fired by the fallback
   // timeout after a newer transition has already started) detect it's stale
@@ -629,7 +632,9 @@ export class ShadowElement {
     } else {
       pushOp(OP.CREATE, clone.uid, this.tag);
       clone._baseClass = this._baseClass;
-      clone._scopeClasses = new Set(this._scopeClasses);
+      if (this._scopeClasses.size > 0) {
+        clone._scopeClasses = new Set(this._scopeClasses);
+      }
       const resolvedClass = resolveClass(clone);
       if (resolvedClass) pushOp(OP.SET_CLASS, clone.uid, resolvedClass);
       if (Object.keys(this._style).length > 0) {
@@ -811,7 +816,7 @@ export class ShadowElement {
         setIdAttr(this, null);
       }
     } else if (key.startsWith('data-v-')) {
-      if (!this._scopeClasses.delete(key)) return;
+      if (!this._removeScopeClass(key)) return;
       if (!this._inert) {
         pushOp(OP.SET_CLASS, this.uid, resolveClass(this));
         scheduleFlush();
@@ -844,11 +849,35 @@ export class ShadowElement {
   /** Add a Vue scope token without allowing duplicate class emission. */
   _addScopeClass(scopeClass: string): void {
     if (this._scopeClasses.has(scopeClass)) return;
-    this._scopeClasses.add(scopeClass);
+    const scopeClasses = this._scopeClasses === EMPTY_SCOPE_CLASSES
+      ? (this._scopeClasses = new Set())
+      : this._scopeClasses as Set<string>;
+    scopeClasses.add(scopeClass);
     if (!this._inert) {
       pushOp(OP.SET_CLASS, this.uid, resolveClass(this));
       scheduleFlush();
     }
+  }
+
+  /** @internal */
+  _removeScopeClass(scopeClass: string): boolean {
+    return this._scopeClasses !== EMPTY_SCOPE_CLASSES
+      && (this._scopeClasses as Set<string>).delete(scopeClass);
+  }
+
+  /** @internal */
+  _addTransitionClass(transitionClass: string): void {
+    const transitionClasses =
+      this._transitionClasses === EMPTY_TRANSITION_CLASSES
+        ? (this._transitionClasses = new Set())
+        : this._transitionClasses as Set<string>;
+    transitionClasses.add(transitionClass);
+  }
+
+  /** @internal */
+  _removeTransitionClass(transitionClass: string): boolean {
+    return this._transitionClasses !== EMPTY_TRANSITION_CLASSES
+      && (this._transitionClasses as Set<string>).delete(transitionClass);
   }
 
   // --- class / style -------------------------------------------------------------
@@ -1166,7 +1195,9 @@ function buildShadowClone(
   }
 
   clone._baseClass = proto._baseClass;
-  clone._scopeClasses = new Set(proto._scopeClasses);
+  if (proto._scopeClasses.size > 0) {
+    clone._scopeClasses = new Set(proto._scopeClasses);
+  }
   if (hasAnyKey(proto._style)) clone._style = { ...proto._style };
   if (proto._attrs) clone._attrs = new Map(proto._attrs);
   if (proto._id !== undefined) {
@@ -1250,7 +1281,9 @@ function buildShadowCloneSparse(
   }
 
   clone._baseClass = proto._baseClass;
-  clone._scopeClasses = new Set(proto._scopeClasses);
+  if (proto._scopeClasses.size > 0) {
+    clone._scopeClasses = new Set(proto._scopeClasses);
+  }
   if (hasAnyKey(proto._style)) clone._style = { ...proto._style };
   if (proto._attrs) clone._attrs = new Map(proto._attrs);
   if (proto._id !== undefined) {

--- a/packages/vue-lynx/runtime/src/transition-shared.ts
+++ b/packages/vue-lynx/runtime/src/transition-shared.ts
@@ -39,13 +39,13 @@ const FALLBACK_TIMEOUT_MS = 4000;
 let endId = 0;
 
 export function addTransitionClass(el: ShadowElement, cls: string): void {
-  el._transitionClasses.add(cls);
+  el._addTransitionClass(cls);
   pushOp(OP.SET_CLASS, el.uid, resolveClass(el));
   scheduleFlush();
 }
 
 export function removeTransitionClass(el: ShadowElement, cls: string): void {
-  el._transitionClasses.delete(cls);
+  el._removeTransitionClass(cls);
   pushOp(OP.SET_CLASS, el.uid, resolveClass(el));
   scheduleFlush();
 }

--- a/packages/vue-lynx/runtime/src/tree-ops.ts
+++ b/packages/vue-lynx/runtime/src/tree-ops.ts
@@ -52,8 +52,8 @@ export function releaseSubtree(el: ShadowElement): void {
 export function resolveClass(el: ShadowElement): string {
   const parts: string[] = [];
   if (el._baseClass) parts.push(el._baseClass);
-  for (const cls of el._scopeClasses) parts.push(cls);
-  for (const cls of el._transitionClasses) parts.push(cls);
+  for (const cls of el._getScopeClasses()) parts.push(cls);
+  for (const cls of el._getTransitionClasses()) parts.push(cls);
   return parts.join(' ');
 }
 


### PR DESCRIPTION
## Summary

Share immutable empty scope-class and transition-class state across newly
created `ShadowElement`s. Each collection switches to an owned `Set` only on
its first mutation, preserving existing APIs and clone behavior.

## Benchmark result

Same-host Web A/B in both execution orders:

- BTS heap with 10k rows: 53.90 MB → 47.82 MB (**-11.3%** in both orders)
- create10k BTS CPU: **-5.8% / -4.2%**
- Web/Lynx gzip: **+0.2%**
- No stable interaction-latency, MTS heap, wire, or startup-FCP claim

Aries Android Native, five repetitions per order:

- create1k latency: **-5.1% / -4.5%**
- create10k latency: **-1.4% / -1.1%**

Raw runs and the complete candidate ledger are in the companion benchmark
evidence PR (`docs/VUE_VDOM_GRIND_2026-08-16.md`).

## Validation

- Copy-on-write ownership and clone isolation tests
- Direct `_transitionClasses.add()` hook compatibility and sibling isolation
- vue-lynx testing-library suite
- runtime-local upstream suite
- internal TypeScript and runtime library builds

## Stack

Base: `vapor`. The lazy-style PR is stacked on this branch.
