### PR TITLE
fix(runtime): release removed-subtree event handlers

### DIFF
--- a/.changeset/defer-event-prop-subtree-release.md
+++ b/.changeset/defer-event-prop-subtree-release.md
@@ -1,0 +1,8 @@
+---
+"vue-lynx": patch
+---
+
+Release event-prop registrations when a removed subtree reaches the ops-batch
+boundary. This prevents removed VDOM and Vapor trees from retaining handlers
+while preserving registrations when a subtree is detached and reinserted in
+the same batch.

--- a/packages/testing-library/src/__tests__/transition-leak-repro.test.ts
+++ b/packages/testing-library/src/__tests__/transition-leak-repro.test.ts
@@ -49,6 +49,22 @@ async function advance(ms: number): Promise<void> {
   await vi.advanceTimersByTimeAsync(ms);
 }
 
+/**
+ * Drain the registry back to `baseline`. Each cycle advances past the
+ * fallback ceiling (so every pending fallback timer force-finishes) and then
+ * flushes (so a re-render armed during the cascade can finish its own
+ * enter/leave). How many cycles the tail of the re-arm cascade needs depends
+ * on flush cadence, which is scheduling-sensitive — so loop until drained,
+ * bounded, instead of assuming a fixed cycle count. The assertion after the
+ * loop still fails if entries never clear (a real leak).
+ */
+async function settleRegistry(baseline: number): Promise<void> {
+  for (let i = 0; i < 10 && registrySize() !== baseline; i++) {
+    await advance(FALLBACK_TIMEOUT_MS + 100);
+    await flush();
+  }
+}
+
 beforeEach(() => {
   vi.useFakeTimers();
 });
@@ -99,10 +115,9 @@ describe('Transition event-registry leak (fixed)', () => {
     // fires and unregisters its sign. finish()'s unregister() itself runs
     // synchronously once the timer callback executes, but nextFrame()'s own
     // rAF/setTimeout(16) chain (armed by the *next* pending re-render, if
-    // any) needs a settle pass too, so flush + re-advance once more.
-    await advance(FALLBACK_TIMEOUT_MS + 100);
-    await flush();
-    await advance(FALLBACK_TIMEOUT_MS + 100);
+    // any) needs its own settle pass — settleRegistry loops until the
+    // cascade's tail drains.
+    await settleRegistry(baseline);
 
     expect(registrySize()).toBe(baseline);
   });
@@ -131,9 +146,7 @@ describe('Transition event-registry leak (fixed)', () => {
     }
 
     // Let every fallback timer armed during the hammering settle.
-    await advance(FALLBACK_TIMEOUT_MS + 100);
-    await flush();
-    await advance(FALLBACK_TIMEOUT_MS + 100);
+    await settleRegistry(baseline);
 
     expect(registrySize()).toBe(baseline);
   });

--- a/packages/upstream-tests/src/event-prop-teardown.spec.ts
+++ b/packages/upstream-tests/src/event-prop-teardown.spec.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  ShadowElement,
+  nodeOps,
+  resetForTesting,
+  takeOps,
+} from 'vue-lynx';
+import { OP } from 'vue-lynx/internal/ops';
+import { getOnceWrapperCountForTesting } from '../../vue-lynx/runtime/src/event-props.js';
+import {
+  getEventRegistrySizeForTesting,
+  publishEvent,
+} from '../../vue-lynx/runtime/src/event-registry.js';
+import { decodeOps, opsOf } from './vapor/ops-test-utils.js';
+
+type Handler = (data: unknown) => void;
+type Bind = (el: ShadowElement, key: string, value: Handler | null) => void;
+type Insert = (child: ShadowElement, parent: ShadowElement) => void;
+type Remove = (el: ShadowElement) => void;
+
+const paths: ReadonlyArray<readonly [string, Bind, Insert, Remove]> = [
+  [
+    'VDOM',
+    (el, key, value) => nodeOps.patchProp(el, key, null, value),
+    (child, parent) => nodeOps.insert(child, parent),
+    (el) => nodeOps.remove(el),
+  ],
+  [
+    'Vapor',
+    (el, key, value) =>
+      value ? el.setAttribute(key, value) : el.removeAttribute(key),
+    (child, parent) => parent.appendChild(child),
+    (el) => el.remove(),
+  ],
+];
+
+function bindSign(
+  bind: Bind,
+  el: ShadowElement,
+  key: string,
+  name: string,
+  handler: Handler,
+): string {
+  bind(el, key, handler);
+  const event = opsOf(decodeOps(takeOps()), OP.SET_EVENT).find(
+    ({ args }) => args[0] === el.uid && args[2] === name,
+  );
+  expect(event).toBeDefined();
+  return event!.args[3] as string;
+}
+
+function globalCounts(): [number, number] {
+  return [
+    getEventRegistrySizeForTesting(),
+    getOnceWrapperCountForTesting(),
+  ];
+}
+
+beforeEach(() => {
+  resetForTesting();
+});
+
+describe('event-prop subtree teardown', () => {
+  it.each(paths)(
+    'releases nested %s normal/once signs without REMOVE_EVENT frames',
+    (_name, bind, insert, remove) => {
+      const parent = new ShadowElement('view');
+      const root = new ShadowElement('view');
+      const child = new ShadowElement('view');
+      const normal = vi.fn();
+      const once = vi.fn();
+      insert(root, parent);
+      insert(child, root);
+      const normalSign = bindSign(bind, root, 'bindtap', 'tap', normal);
+      const onceSign = bindSign(bind, child, 'onTapOnce', 'tap', once);
+
+      expect([root._eventPropSigns?.size, child._eventPropSigns?.size])
+        .toEqual([1, 1]);
+      remove(root);
+      expect(opsOf(decodeOps(takeOps()), OP.REMOVE_EVENT)).toEqual([]);
+      publishEvent(normalSign, {});
+      publishEvent(onceSign, {});
+      expect([normal.mock.calls.length, once.mock.calls.length]).toEqual([0, 0]);
+      expect(globalCounts()).toEqual([0, 0]);
+      expect('_eventPropSigns' in root || '_eventPropSigns' in child).toBe(false);
+    },
+  );
+
+  it.each(paths)('clears the sparse %s owner after explicit unbind', (
+    _name,
+    bind,
+    insert,
+    remove,
+  ) => {
+    const parent = new ShadowElement('view');
+    const el = new ShadowElement('view');
+    insert(el, parent);
+    const tap = bindSign(bind, el, 'bindtap', 'tap', vi.fn());
+    const once = bindSign(bind, el, 'onLongpressOnce', 'longpress', vi.fn());
+    expect([el._eventPropSigns?.size, ...globalCounts()]).toEqual([2, 2, 1]);
+
+    bind(el, 'bindtap', null);
+    bind(el, 'onLongpressOnce', null);
+    expect(opsOf(decodeOps(takeOps()), OP.REMOVE_EVENT)).toHaveLength(2);
+    expect('_eventPropSigns' in el).toBe(false);
+    expect(globalCounts()).toEqual([0, 0]);
+    publishEvent(tap, {});
+    publishEvent(once, {});
+    remove(el);
+    remove(el);
+    expect(opsOf(decodeOps(takeOps()), OP.REMOVE_EVENT)).toEqual([]);
+  });
+
+  it('keeps once called-state isolated across removed and new uids', () => {
+    const parent = new ShadowElement('view');
+    const calls = [vi.fn(), vi.fn()];
+    const elements = [new ShadowElement('view'), new ShadowElement('view')];
+    parent.appendChild(elements[0]!);
+    const first = bindSign(
+      paths[1]![1], elements[0]!, 'onTapOnce', 'tap', calls[0]!,
+    );
+    publishEvent(first, {});
+    elements[0]!.remove();
+    takeOps();
+    publishEvent(first, {});
+
+    parent.appendChild(elements[1]!);
+    const second = bindSign(
+      paths[1]![1], elements[1]!, 'onTapOnce', 'tap', calls[1]!,
+    );
+    publishEvent(second, {});
+    publishEvent(second, {});
+    expect([calls[0]!.mock.calls.length, calls[1]!.mock.calls.length])
+      .toEqual([1, 1]);
+    expect(second).not.toBe(first);
+  });
+
+  it('leaves nodes without event props on the empty local-field path', () => {
+    const parent = new ShadowElement('view');
+    const root = new ShadowElement('view');
+    const child = new ShadowElement('text');
+    parent.appendChild(root);
+    root.appendChild(child);
+    expect(Object.hasOwn(root, '_eventPropSigns')).toBe(false);
+    expect(Object.hasOwn(child, '_eventPropSigns')).toBe(false);
+    root.remove();
+    expect(globalCounts()).toEqual([0, 0]);
+  });
+});

--- a/packages/upstream-tests/src/event-prop-teardown.spec.ts
+++ b/packages/upstream-tests/src/event-prop-teardown.spec.ts
@@ -196,6 +196,24 @@ describe('event-prop subtree teardown', () => {
     expect(listener).toHaveBeenCalledTimes(1);
   });
 
+  it('restores descendant ids reparented from a pending removed ancestor', () => {
+    const source = new ShadowElement('view');
+    const target = new ShadowElement('view');
+    const root = new ShadowElement('view');
+    const child = new ShadowElement('view');
+    source.appendChild(root);
+    root.appendChild(child);
+    child.setAttribute('id', 'extracted-target');
+    takeOps();
+
+    root.remove();
+    target.appendChild(child);
+
+    expect(nodeOps.querySelector('#extracted-target')).toBe(child);
+    takeOps();
+    expect(nodeOps.querySelector('#extracted-target')).toBe(child);
+  });
+
   it('does not resolve a Teleport target removed earlier in the same patch', async () => {
     const showTarget = ref(true);
     const showTeleport = ref(false);
@@ -220,6 +238,30 @@ describe('event-prop subtree teardown', () => {
     expect(nodeOps.querySelector('#target')).toBeNull();
     expect(target.parent).toBeNull();
     expect(target.firstChild).toBeNull();
+  });
+
+  it('releases event owners stored in element-template holes', () => {
+    const parent = new ShadowElement('view');
+    const root = new ShadowElement('view');
+    const eventHole = new ShadowElement('#tpl-hole');
+    const handler = vi.fn();
+    root._tplHoles = [eventHole];
+    parent.appendChild(root);
+    const sign = bindSign(
+      paths[0]![1],
+      eventHole,
+      'onTap',
+      'tap',
+      handler,
+    );
+
+    root.remove();
+    takeOps();
+
+    expect(globalCounts()).toEqual([0, 0, 0]);
+    expect('_eventPropSigns' in eventHole).toBe(false);
+    publishEvent(sign, {});
+    expect(handler).not.toHaveBeenCalled();
   });
 
   it.each(paths)(

--- a/packages/upstream-tests/src/event-prop-teardown.spec.ts
+++ b/packages/upstream-tests/src/event-prop-teardown.spec.ts
@@ -214,6 +214,18 @@ describe('event-prop subtree teardown', () => {
     expect(nodeOps.querySelector('#extracted-target')).toBe(child);
   });
 
+  it('does not change the existing winner for duplicate ids on ordinary insert', () => {
+    const parent = new ShadowElement('view');
+    const first = new ShadowElement('view');
+    const second = new ShadowElement('view');
+    first.setAttribute('id', 'duplicate');
+    second.setAttribute('id', 'duplicate');
+
+    parent.appendChild(first);
+
+    expect(nodeOps.querySelector('#duplicate')).toBe(second);
+  });
+
   it('does not resolve a Teleport target removed earlier in the same patch', async () => {
     const showTarget = ref(true);
     const showTeleport = ref(false);

--- a/packages/upstream-tests/src/event-prop-teardown.spec.ts
+++ b/packages/upstream-tests/src/event-prop-teardown.spec.ts
@@ -12,26 +12,32 @@ import {
   getEventRegistrySizeForTesting,
   publishEvent,
 } from '../../vue-lynx/runtime/src/event-registry.js';
+import { getRemovedRootCountForTesting } from '../../vue-lynx/runtime/src/tree-ops.js';
 import { decodeOps, opsOf } from './vapor/ops-test-utils.js';
 
 type Handler = (data: unknown) => void;
 type Bind = (el: ShadowElement, key: string, value: Handler | null) => void;
 type Insert = (child: ShadowElement, parent: ShadowElement) => void;
 type Remove = (el: ShadowElement) => void;
+type Clear = (el: ShadowElement) => void;
 
-const paths: ReadonlyArray<readonly [string, Bind, Insert, Remove]> = [
+const paths: ReadonlyArray<readonly [string, Bind, Insert, Remove, Clear]> = [
   [
-    'VDOM',
+    'VDOM-compatible',
     (el, key, value) => nodeOps.patchProp(el, key, null, value),
     (child, parent) => nodeOps.insert(child, parent),
     (el) => nodeOps.remove(el),
+    (el) => nodeOps.setElementText(el, ''),
   ],
   [
-    'Vapor',
+    'Vapor runtime',
     (el, key, value) =>
       value ? el.setAttribute(key, value) : el.removeAttribute(key),
     (child, parent) => parent.appendChild(child),
     (el) => el.remove(),
+    (el) => {
+      el.textContent = '';
+    },
   ],
 ];
 
@@ -50,10 +56,11 @@ function bindSign(
   return event!.args[3] as string;
 }
 
-function globalCounts(): [number, number] {
+function globalCounts(): [number, number, number] {
   return [
     getEventRegistrySizeForTesting(),
     getOnceWrapperCountForTesting(),
+    getRemovedRootCountForTesting(),
   ];
 }
 
@@ -63,7 +70,7 @@ beforeEach(() => {
 
 describe('event-prop subtree teardown', () => {
   it.each(paths)(
-    'releases nested %s normal/once signs without REMOVE_EVENT frames',
+    'keeps nested %s signs across same-parent detach and reinsert',
     (_name, bind, insert, remove) => {
       const parent = new ShadowElement('view');
       const root = new ShadowElement('view');
@@ -78,12 +85,162 @@ describe('event-prop subtree teardown', () => {
       expect([root._eventPropSigns?.size, child._eventPropSigns?.size])
         .toEqual([1, 1]);
       remove(root);
-      expect(opsOf(decodeOps(takeOps()), OP.REMOVE_EVENT)).toEqual([]);
+      expect(globalCounts()).toEqual([2, 1, 1]);
+      insert(root, parent);
+      expect(globalCounts()).toEqual([2, 1, 0]);
+
+      const moveOps = decodeOps(takeOps());
+      expect(moveOps).toEqual([
+        { op: OP.REMOVE, args: [parent.uid, root.uid] },
+        { op: OP.INSERT, args: [parent.uid, root.uid, -1] },
+      ]);
+      publishEvent(normalSign, {});
+      publishEvent(onceSign, {});
+      expect([normal.mock.calls.length, once.mock.calls.length]).toEqual([1, 1]);
+      expect(globalCounts()).toEqual([2, 1, 0]);
+
+      remove(root);
+      expect(globalCounts()).toEqual([2, 1, 1]);
+      const removeOps = decodeOps(takeOps());
+      expect(opsOf(removeOps, OP.REMOVE_EVENT)).toEqual([]);
+      expect(globalCounts()).toEqual([0, 0, 0]);
+      expect('_eventPropSigns' in root || '_eventPropSigns' in child).toBe(false);
+      publishEvent(normalSign, {});
+      publishEvent(onceSign, {});
+      expect([normal.mock.calls.length, once.mock.calls.length]).toEqual([1, 1]);
+    },
+  );
+
+  it.each(paths)(
+    'keeps nested %s signs across detach and reinsert under a new parent',
+    (_name, bind, insert, remove) => {
+      const source = new ShadowElement('view');
+      const target = new ShadowElement('view');
+      const root = new ShadowElement('view');
+      const child = new ShadowElement('view');
+      const normal = vi.fn();
+      const once = vi.fn();
+      insert(root, source);
+      insert(child, root);
+      const normalSign = bindSign(bind, root, 'bindtap', 'tap', normal);
+      const onceSign = bindSign(bind, child, 'onTapOnce', 'tap', once);
+
+      remove(root);
+      expect(globalCounts()).toEqual([2, 1, 1]);
+      insert(root, target);
+      expect(globalCounts()).toEqual([2, 1, 0]);
+
+      const moveOps = decodeOps(takeOps());
+      expect(moveOps).toEqual([
+        { op: OP.REMOVE, args: [source.uid, root.uid] },
+        { op: OP.INSERT, args: [target.uid, root.uid, -1] },
+      ]);
+      expect([root._eventPropSigns?.size, child._eventPropSigns?.size])
+        .toEqual([1, 1]);
+
+      publishEvent(normalSign, {});
+      publishEvent(onceSign, {});
+      expect([normal.mock.calls.length, once.mock.calls.length]).toEqual([1, 1]);
+      expect(globalCounts()).toEqual([2, 1, 0]);
+
+      remove(root);
+      expect(globalCounts()).toEqual([2, 1, 1]);
+      takeOps();
+      expect(globalCounts()).toEqual([0, 0, 0]);
+      publishEvent(normalSign, {});
+      publishEvent(onceSign, {});
+      expect([normal.mock.calls.length, once.mock.calls.length]).toEqual([1, 1]);
+    },
+  );
+
+  it('keeps ids and addEventListener bindings across a same-batch move', () => {
+    const source = new ShadowElement('view');
+    const target = new ShadowElement('view');
+    const root = new ShadowElement('view');
+    const child = new ShadowElement('view');
+    const listener = vi.fn();
+    nodeOps.insert(root, source);
+    nodeOps.insert(child, root);
+    nodeOps.patchProp(child, 'id', null, 'move-target');
+    child.addEventListener('tap', listener);
+
+    const event = opsOf(decodeOps(takeOps()), OP.SET_EVENT).find(
+      ({ args }) => args[0] === child.uid && args[2] === 'tap',
+    );
+    expect(event).toBeDefined();
+    const sign = event!.args[3] as string;
+    expect(nodeOps.querySelector('#move-target')).toBe(child);
+    expect(globalCounts()).toEqual([1, 0, 0]);
+
+    nodeOps.remove(root);
+    nodeOps.insert(root, target);
+    expect(nodeOps.querySelector('#move-target')).toBe(child);
+    expect(globalCounts()).toEqual([1, 0, 0]);
+    takeOps();
+    publishEvent(sign, {});
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    nodeOps.remove(root);
+    expect(nodeOps.querySelector('#move-target')).toBe(child);
+    expect(globalCounts()).toEqual([1, 0, 1]);
+    takeOps();
+    expect(nodeOps.querySelector('#move-target')).toBeNull();
+    expect(globalCounts()).toEqual([0, 0, 0]);
+    publishEvent(sign, {});
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(paths)(
+    'releases nested %s signs after a terminal clear',
+    (_name, bind, insert, _remove, clear) => {
+      const parent = new ShadowElement('view');
+      const root = new ShadowElement('view');
+      const child = new ShadowElement('view');
+      const normal = vi.fn();
+      const once = vi.fn();
+      insert(root, parent);
+      insert(child, root);
+      const normalSign = bindSign(bind, root, 'bindtap', 'tap', normal);
+      const onceSign = bindSign(bind, child, 'onTapOnce', 'tap', once);
+
+      clear(parent);
+      expect(globalCounts()).toEqual([2, 1, 1]);
+      const clearOps = decodeOps(takeOps());
+      expect(opsOf(clearOps, OP.REMOVE_EVENT)).toEqual([]);
+      expect(globalCounts()).toEqual([0, 0, 0]);
+      expect('_eventPropSigns' in root || '_eventPropSigns' in child).toBe(false);
+
       publishEvent(normalSign, {});
       publishEvent(onceSign, {});
       expect([normal.mock.calls.length, once.mock.calls.length]).toEqual([0, 0]);
-      expect(globalCounts()).toEqual([0, 0]);
+    },
+  );
+
+  it.each(paths)(
+    'releases nested %s signs after a terminal remove',
+    (_name, bind, insert, remove) => {
+      const parent = new ShadowElement('view');
+      const root = new ShadowElement('view');
+      const child = new ShadowElement('view');
+      const normal = vi.fn();
+      const once = vi.fn();
+      insert(root, parent);
+      insert(child, root);
+      const normalSign = bindSign(bind, root, 'bindtap', 'tap', normal);
+      const onceSign = bindSign(bind, child, 'onTapOnce', 'tap', once);
+
+      remove(root);
+      expect(globalCounts()).toEqual([2, 1, 1]);
+      const removeOps = decodeOps(takeOps());
+      expect(removeOps).toEqual([
+        { op: OP.REMOVE, args: [parent.uid, root.uid] },
+      ]);
+      expect(globalCounts()).toEqual([0, 0, 0]);
       expect('_eventPropSigns' in root || '_eventPropSigns' in child).toBe(false);
+
+      publishEvent(normalSign, {});
+      publishEvent(onceSign, {});
+      expect([normal.mock.calls.length, once.mock.calls.length]).toEqual([0, 0]);
     },
   );
 
@@ -98,13 +255,14 @@ describe('event-prop subtree teardown', () => {
     insert(el, parent);
     const tap = bindSign(bind, el, 'bindtap', 'tap', vi.fn());
     const once = bindSign(bind, el, 'onLongpressOnce', 'longpress', vi.fn());
-    expect([el._eventPropSigns?.size, ...globalCounts()]).toEqual([2, 2, 1]);
+    expect([el._eventPropSigns?.size, ...globalCounts()])
+      .toEqual([2, 2, 1, 0]);
 
     bind(el, 'bindtap', null);
     bind(el, 'onLongpressOnce', null);
     expect(opsOf(decodeOps(takeOps()), OP.REMOVE_EVENT)).toHaveLength(2);
     expect('_eventPropSigns' in el).toBe(false);
-    expect(globalCounts()).toEqual([0, 0]);
+    expect(globalCounts()).toEqual([0, 0, 0]);
     publishEvent(tap, {});
     publishEvent(once, {});
     remove(el);
@@ -118,7 +276,11 @@ describe('event-prop subtree teardown', () => {
     const elements = [new ShadowElement('view'), new ShadowElement('view')];
     parent.appendChild(elements[0]!);
     const first = bindSign(
-      paths[1]![1], elements[0]!, 'onTapOnce', 'tap', calls[0]!,
+      paths[1]![1],
+      elements[0]!,
+      'onTapOnce',
+      'tap',
+      calls[0]!,
     );
     publishEvent(first, {});
     elements[0]!.remove();
@@ -127,7 +289,11 @@ describe('event-prop subtree teardown', () => {
 
     parent.appendChild(elements[1]!);
     const second = bindSign(
-      paths[1]![1], elements[1]!, 'onTapOnce', 'tap', calls[1]!,
+      paths[1]![1],
+      elements[1]!,
+      'onTapOnce',
+      'tap',
+      calls[1]!,
     );
     publishEvent(second, {});
     publishEvent(second, {});
@@ -145,6 +311,65 @@ describe('event-prop subtree teardown', () => {
     expect(Object.hasOwn(root, '_eventPropSigns')).toBe(false);
     expect(Object.hasOwn(child, '_eventPropSigns')).toBe(false);
     root.remove();
-    expect(globalCounts()).toEqual([0, 0]);
+    expect(globalCounts()).toEqual([0, 0, 1]);
+    takeOps();
+    expect(globalCounts()).toEqual([0, 0, 0]);
   });
+
+  it.each(paths)(
+    'keeps deterministic %s registry accounting across move and clear cycles',
+    (_name, bind, insert, remove, clear) => {
+      const source = new ShadowElement('view');
+      const target = new ShadowElement('view');
+      const roots: ShadowElement[] = [];
+      const eventOwners: ShadowElement[] = [];
+      const staleSigns: string[] = [];
+      const handlers: ReturnType<typeof vi.fn>[] = [];
+      const rootCount = 40;
+
+      for (let index = 0; index < rootCount; index++) {
+        const root = new ShadowElement('view');
+        const child = new ShadowElement('view');
+        const normal = vi.fn();
+        const once = vi.fn();
+        insert(root, source);
+        insert(child, root);
+        staleSigns.push(
+          bindSign(bind, root, 'bindtap', 'tap', normal),
+          bindSign(bind, child, 'onTapOnce', 'tap', once),
+        );
+        roots.push(root);
+        eventOwners.push(root, child);
+        handlers.push(normal, once);
+      }
+
+      expect(globalCounts()).toEqual([rootCount * 2, rootCount, 0]);
+
+      for (let round = 0; round < 25; round++) {
+        for (let index = 0; index < roots.length; index++) {
+          const root = roots[index]!;
+          remove(root);
+          insert(root, (index + round) % 2 === 0 ? source : target);
+        }
+        expect(globalCounts()).toEqual([rootCount * 2, rootCount, 0]);
+        takeOps();
+        expect(globalCounts()).toEqual([rootCount * 2, rootCount, 0]);
+      }
+
+      clear(source);
+      clear(target);
+      expect(globalCounts()).toEqual([rootCount * 2, rootCount, rootCount]);
+      takeOps();
+      expect(globalCounts()).toEqual([0, 0, 0]);
+      expect(
+        eventOwners.every(
+          (owner) => !Object.hasOwn(owner, '_eventPropSigns'),
+        ),
+      ).toBe(true);
+
+      for (const sign of staleSigns) publishEvent(sign, {});
+      expect(handlers.every((handler) => handler.mock.calls.length === 0))
+        .toBe(true);
+    },
+  );
 });

--- a/packages/upstream-tests/src/event-prop-teardown.spec.ts
+++ b/packages/upstream-tests/src/event-prop-teardown.spec.ts
@@ -2,7 +2,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   ShadowElement,
+  Teleport,
+  _render,
+  createPageRoot,
+  h,
+  nextTick,
   nodeOps,
+  ref,
   resetForTesting,
   takeOps,
 } from 'vue-lynx';
@@ -181,13 +187,39 @@ describe('event-prop subtree teardown', () => {
     expect(listener).toHaveBeenCalledTimes(1);
 
     nodeOps.remove(root);
-    expect(nodeOps.querySelector('#move-target')).toBe(child);
+    expect(nodeOps.querySelector('#move-target')).toBeNull();
     expect(globalCounts()).toEqual([1, 0, 1]);
     takeOps();
     expect(nodeOps.querySelector('#move-target')).toBeNull();
     expect(globalCounts()).toEqual([0, 0, 0]);
     publishEvent(sign, {});
     expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not resolve a Teleport target removed earlier in the same patch', async () => {
+    const showTarget = ref(true);
+    const showTeleport = ref(false);
+    const root = createPageRoot();
+    const view = () =>
+      h('view', [
+        showTarget.value ? h('view', { id: 'target' }) : null,
+        showTeleport.value
+          ? h(Teleport, { to: '#target' }, h('text', 'teleported'))
+          : null,
+      ]);
+
+    _render(view(), root);
+    await nextTick();
+    const target = nodeOps.querySelector('#target')!;
+    expect(target).not.toBeNull();
+
+    showTarget.value = false;
+    showTeleport.value = true;
+    _render(view(), root);
+
+    expect(nodeOps.querySelector('#target')).toBeNull();
+    expect(target.parent).toBeNull();
+    expect(target.firstChild).toBeNull();
   });
 
   it.each(paths)(

--- a/packages/vue-lynx/runtime/src/event-props.ts
+++ b/packages/vue-lynx/runtime/src/event-props.ts
@@ -57,10 +57,6 @@ function parseEventProp(key: string): EventSpec | null {
   return null;
 }
 
-// Track the sign registered for each (element, propKey) so we can unregister
-// on prop removal / update.
-const elementEventSigns = new Map<number, Map<string, string>>();
-
 // For once-events (onXxxOnce prop keys): the once-wrapper closes over a
 // mutable `inner` reference so re-renders can update the underlying handler
 // without resetting the `called` state.
@@ -84,7 +80,7 @@ export function patchEventProp(
   const event = parseEventProp(key);
   if (!event) return false;
 
-  let signs = elementEventSigns.get(el.uid);
+  let signs = el._eventPropSigns;
   const oldSign = signs?.get(key);
 
   if (nextValue != null) {
@@ -109,7 +105,7 @@ export function patchEventProp(
         onceWrappers.set(sign, wrapper);
         if (!signs) {
           signs = new Map<string, string>();
-          elementEventSigns.set(el.uid, signs);
+          el._eventPropSigns = signs;
         }
         signs.set(key, sign);
         // Respect _lynxCatch even on once-events (e.g. @tap.once.stop).
@@ -134,7 +130,7 @@ export function patchEventProp(
       const sign = register(handler);
       if (!signs) {
         signs = new Map<string, string>();
-        elementEventSigns.set(el.uid, signs);
+        el._eventPropSigns = signs;
       }
       signs.set(key, sign);
       pushOp(OP.SET_EVENT, el.uid, eventType, event.name, sign);
@@ -144,6 +140,7 @@ export function patchEventProp(
     onceWrappers.delete(oldSign);
     unregister(oldSign);
     signs!.delete(key);
+    if (signs!.size === 0) delete el._eventPropSigns;
     pushOp(OP.REMOVE_EVENT, el.uid, event.type, event.name);
   }
 
@@ -151,8 +148,23 @@ export function patchEventProp(
   return true;
 }
 
+/** Release THIS element's event-prop registrations (non-recursive). */
+export function releaseEventProps(el: ShadowElement): void {
+  const signs = el._eventPropSigns;
+  if (!signs) return;
+  for (const sign of signs.values()) {
+    onceWrappers.delete(sign);
+    unregister(sign);
+  }
+  delete el._eventPropSigns;
+}
+
+/** Inspect retained once wrappers – for testing only. */
+export function getOnceWrapperCountForTesting(): number {
+  return onceWrappers.size;
+}
+
 /** Reset module state – for testing only. */
 export function resetEventPropState(): void {
-  elementEventSigns.clear();
   onceWrappers.clear();
 }

--- a/packages/vue-lynx/runtime/src/event-registry.ts
+++ b/packages/vue-lynx/runtime/src/event-registry.ts
@@ -71,6 +71,11 @@ export function publishEvent(sign: string, data: unknown): void {
   getRegistryState().handlers.get(sign)?.(data);
 }
 
+/** Inspect retained handlers – for testing only. */
+export function getEventRegistrySizeForTesting(): number {
+  return getRegistryState().handlers.size;
+}
+
 /** Reset all state – for testing only. */
 export function resetRegistry(): void {
   const state = getRegistryState();

--- a/packages/vue-lynx/runtime/src/node-ops.ts
+++ b/packages/vue-lynx/runtime/src/node-ops.ts
@@ -22,6 +22,7 @@ import {
   idRegistry,
   insertNode,
   removeNode,
+  resetTreeOpsState,
   resolveClass,
   setElementTextContent,
   setIdAttr,
@@ -276,6 +277,6 @@ export const nodeOps: RendererOptions<ShadowElement, ShadowElement> = {
 
 /** Reset module state – for testing only. */
 export function resetNodeOpsState(): void {
+  resetTreeOpsState();
   resetEventPropState();
-  idRegistry.clear();
 }

--- a/packages/vue-lynx/runtime/src/ops.ts
+++ b/packages/vue-lynx/runtime/src/ops.ts
@@ -5,6 +5,11 @@
 export { OP } from 'vue-lynx/internal/ops';
 
 let buffer: unknown[] = [];
+let beforeTakeOpsHook: (() => void) | null = null;
+
+export function setBeforeTakeOpsHook(hook: (() => void) | null): void {
+  beforeTakeOpsHook = hook;
+}
 
 export function pushOp(...args: unknown[]): void {
   for (const arg of args) {
@@ -13,6 +18,7 @@ export function pushOp(...args: unknown[]): void {
 }
 
 export function takeOps(): unknown[] {
+  beforeTakeOpsHook?.();
   const b = buffer;
   buffer = [];
   return b;

--- a/packages/vue-lynx/runtime/src/shadow-element.ts
+++ b/packages/vue-lynx/runtime/src/shadow-element.ts
@@ -291,6 +291,8 @@ export class ShadowElement {
   declare _eventPropSigns?: Map<string, string>;
   /** Sparse marker for subtree teardown deferred until the ops batch closes. */
   declare _pendingRelease?: boolean;
+  /** Sparse marker for an id removed from the registry while detached. */
+  declare _pendingIdRestore?: boolean;
   /**
    * Inert nodes are template prototypes created by the Vapor HTML parser;
    * they exist only on the Background Thread and never emit ops. Cloning an

--- a/packages/vue-lynx/runtime/src/shadow-element.ts
+++ b/packages/vue-lynx/runtime/src/shadow-element.ts
@@ -289,6 +289,8 @@ export class ShadowElement {
   _events: Map<string, EventBinding> | undefined = undefined;
   /** Sparse event-prop owner; `declare` emits no per-node initialization. */
   declare _eventPropSigns?: Map<string, string>;
+  /** Sparse marker for subtree teardown deferred until the ops batch closes. */
+  declare _pendingRelease?: boolean;
   /**
    * Inert nodes are template prototypes created by the Vapor HTML parser;
    * they exist only on the Background Thread and never emit ops. Cloning an

--- a/packages/vue-lynx/runtime/src/shadow-element.ts
+++ b/packages/vue-lynx/runtime/src/shadow-element.ts
@@ -287,6 +287,8 @@ export class ShadowElement {
   _classList: ClassListFacade | undefined = undefined;
   /** addEventListener bindings, keyed by Lynx event name. */
   _events: Map<string, EventBinding> | undefined = undefined;
+  /** Sparse event-prop owner; `declare` emits no per-node initialization. */
+  declare _eventPropSigns?: Map<string, string>;
   /**
    * Inert nodes are template prototypes created by the Vapor HTML parser;
    * they exist only on the Background Thread and never emit ops. Cloning an

--- a/packages/vue-lynx/runtime/src/tree-ops.ts
+++ b/packages/vue-lynx/runtime/src/tree-ops.ts
@@ -15,6 +15,7 @@
  *   node-ops.ts ──▶ shadow-element.ts ──▶ tree-ops.ts (types only)
  */
 
+import { releaseEventProps } from './event-props.js';
 import { scheduleFlush } from './flush.js';
 import { OP, pushOp } from './ops.js';
 import {
@@ -31,12 +32,13 @@ export const idRegistry: Map<string, ShadowElement> = new Map();
 
 /**
  * Single-walk teardown for a subtree being removed: clean up the Teleport id
- * registry AND release Vapor addEventListener registrations. One recursion
- * instead of two — removal is a hot path (clearing a 10k-row list visits
- * every node).
+ * registry and release event-prop / Vapor addEventListener registrations.
+ * One recursion instead of two — removal is a hot path (clearing a 10k-row
+ * list visits every node).
  */
 export function releaseSubtree(el: ShadowElement): void {
   if (el._id) idRegistry.delete(el._id);
+  if (el._eventPropSigns) releaseEventProps(el);
   el._releaseOwnEvents();
   let child = el.firstChild;
   while (child) {

--- a/packages/vue-lynx/runtime/src/tree-ops.ts
+++ b/packages/vue-lynx/runtime/src/tree-ops.ts
@@ -33,7 +33,10 @@ const removedRoots: ShadowElement[] = [];
 let pendingReleaseCount = 0;
 
 function unregisterSubtreeIds(el: ShadowElement): void {
-  if (el._id && idRegistry.get(el._id) === el) idRegistry.delete(el._id);
+  if (el._id && idRegistry.get(el._id) === el) {
+    idRegistry.delete(el._id);
+    el._pendingIdRestore = true;
+  }
   let child = el.firstChild;
   while (child) {
     unregisterSubtreeIds(child);
@@ -42,7 +45,10 @@ function unregisterSubtreeIds(el: ShadowElement): void {
 }
 
 function registerSubtreeIds(el: ShadowElement): void {
-  if (el._id) idRegistry.set(el._id, el);
+  if (el._pendingIdRestore) {
+    el._pendingIdRestore = false;
+    if (el._id) idRegistry.set(el._id, el);
+  }
   let child = el.firstChild;
   while (child) {
     registerSubtreeIds(child);
@@ -58,6 +64,7 @@ function registerSubtreeIds(el: ShadowElement): void {
  */
 export function releaseSubtree(el: ShadowElement): void {
   if (el._id && idRegistry.get(el._id) === el) idRegistry.delete(el._id);
+  delete el._pendingIdRestore;
   if (el._eventPropSigns) releaseEventProps(el);
   el._releaseOwnEvents();
   for (const hole of el._tplHoles ?? []) {

--- a/packages/vue-lynx/runtime/src/tree-ops.ts
+++ b/packages/vue-lynx/runtime/src/tree-ops.ts
@@ -60,6 +60,9 @@ export function releaseSubtree(el: ShadowElement): void {
   if (el._id && idRegistry.get(el._id) === el) idRegistry.delete(el._id);
   if (el._eventPropSigns) releaseEventProps(el);
   el._releaseOwnEvents();
+  for (const hole of el._tplHoles ?? []) {
+    releaseSubtree(hole);
+  }
   let child = el.firstChild;
   while (child) {
     releaseSubtree(child);
@@ -79,7 +82,6 @@ function cancelSubtreeRelease(el: ShadowElement): void {
   if (!el._pendingRelease) return;
   el._pendingRelease = false;
   pendingReleaseCount--;
-  registerSubtreeIds(el);
 }
 
 function releaseRemovedRoots(): void {
@@ -322,6 +324,7 @@ export function insertNode(
 
   // Always update the shadow tree (Vue needs it for internal diffing).
   parent._link(child, anchor ?? null);
+  registerSubtreeIds(child);
 
   // Shadow-only anchors: comments always, text while empty or under <list>.
   if (child.tag === '#comment') return;

--- a/packages/vue-lynx/runtime/src/tree-ops.ts
+++ b/packages/vue-lynx/runtime/src/tree-ops.ts
@@ -32,6 +32,24 @@ export const idRegistry: Map<string, ShadowElement> = new Map();
 const removedRoots: ShadowElement[] = [];
 let pendingReleaseCount = 0;
 
+function unregisterSubtreeIds(el: ShadowElement): void {
+  if (el._id && idRegistry.get(el._id) === el) idRegistry.delete(el._id);
+  let child = el.firstChild;
+  while (child) {
+    unregisterSubtreeIds(child);
+    child = child.next;
+  }
+}
+
+function registerSubtreeIds(el: ShadowElement): void {
+  if (el._id) idRegistry.set(el._id, el);
+  let child = el.firstChild;
+  while (child) {
+    registerSubtreeIds(child);
+    child = child.next;
+  }
+}
+
 /**
  * Single-walk teardown for a subtree being removed: clean up the Teleport id
  * registry and release event-prop / Vapor addEventListener registrations.
@@ -51,6 +69,7 @@ export function releaseSubtree(el: ShadowElement): void {
 
 function queueSubtreeRelease(el: ShadowElement): void {
   if (el._pendingRelease) return;
+  unregisterSubtreeIds(el);
   el._pendingRelease = true;
   pendingReleaseCount++;
   removedRoots.push(el);
@@ -60,6 +79,7 @@ function cancelSubtreeRelease(el: ShadowElement): void {
   if (!el._pendingRelease) return;
   el._pendingRelease = false;
   pendingReleaseCount--;
+  registerSubtreeIds(el);
 }
 
 function releaseRemovedRoots(): void {

--- a/packages/vue-lynx/runtime/src/tree-ops.ts
+++ b/packages/vue-lynx/runtime/src/tree-ops.ts
@@ -17,7 +17,7 @@
 
 import { releaseEventProps } from './event-props.js';
 import { scheduleFlush } from './flush.js';
-import { OP, pushOp } from './ops.js';
+import { OP, pushOp, setBeforeTakeOpsHook } from './ops.js';
 import {
   normalizeStylePropertyName,
   normalizeStyleValue,
@@ -29,15 +29,17 @@ import type { ShadowElement } from './shadow-element.js';
 // ---------------------------------------------------------------------------
 
 export const idRegistry: Map<string, ShadowElement> = new Map();
+const removedRoots: ShadowElement[] = [];
+let pendingReleaseCount = 0;
 
 /**
  * Single-walk teardown for a subtree being removed: clean up the Teleport id
  * registry and release event-prop / Vapor addEventListener registrations.
- * One recursion instead of two — removal is a hot path (clearing a 10k-row
- * list visits every node).
+ * One recursion instead of multiple independent teardown walks — removal is
+ * a hot path (clearing a 10k-row list visits every node).
  */
 export function releaseSubtree(el: ShadowElement): void {
-  if (el._id) idRegistry.delete(el._id);
+  if (el._id && idRegistry.get(el._id) === el) idRegistry.delete(el._id);
   if (el._eventPropSigns) releaseEventProps(el);
   el._releaseOwnEvents();
   let child = el.firstChild;
@@ -45,6 +47,40 @@ export function releaseSubtree(el: ShadowElement): void {
     releaseSubtree(child);
     child = child.next;
   }
+}
+
+function queueSubtreeRelease(el: ShadowElement): void {
+  if (el._pendingRelease) return;
+  el._pendingRelease = true;
+  pendingReleaseCount++;
+  removedRoots.push(el);
+}
+
+function cancelSubtreeRelease(el: ShadowElement): void {
+  if (!el._pendingRelease) return;
+  el._pendingRelease = false;
+  pendingReleaseCount--;
+}
+
+function releaseRemovedRoots(): void {
+  for (const root of removedRoots) {
+    if (!root._pendingRelease) continue;
+    root._pendingRelease = false;
+    pendingReleaseCount--;
+    releaseSubtree(root);
+  }
+  removedRoots.length = 0;
+}
+
+setBeforeTakeOpsHook(releaseRemovedRoots);
+
+export function getRemovedRootCountForTesting(): number {
+  return pendingReleaseCount;
+}
+
+export function resetTreeOpsState(): void {
+  releaseRemovedRoots();
+  idRegistry.clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -249,6 +285,8 @@ export function insertNode(
   parent: ShadowElement,
   anchor?: ShadowElement | null,
 ): void {
+  cancelSubtreeRelease(child);
+
   // The parent may carry an aliased only-child #text node (Vapor template
   // clone fast path) that has no Main Thread counterpart yet — materialize
   // it before the child list changes structurally.
@@ -308,11 +346,11 @@ export function removeNode(child: ShadowElement): void {
     // component instances inside slots get proper unmount lifecycles.
     if (child._tplSlots) teardownTemplateSlotsHook?.(child);
     parent._unlink(child);
-    releaseSubtree(child);
+    queueSubtreeRelease(child);
     if (materialized) {
       pushRemoveOp(parent, child);
-      scheduleFlush();
     }
+    scheduleFlush();
     if (child.tag === '#text') child._mtInserted = false;
   }
 }
@@ -332,7 +370,7 @@ export function setElementTextContent(el: ShadowElement, text: string): void {
     const child = el.firstChild;
     const materialized = isMaterialized(child);
     el._unlink(child);
-    releaseSubtree(child);
+    queueSubtreeRelease(child);
     if (materialized) pushOp(OP.REMOVE, el.uid, child.uid);
     if (child.tag === '#text') child._mtInserted = false;
   }


### PR DESCRIPTION
## Summary

Move event-prop registration ownership onto the corresponding
`ShadowElement`, then release removed subtrees at the ops-batch boundary.
Detach/reinsert and reparent operations in the same batch cancel teardown, so
KeepAlive/Teleport-style moves retain event props, IDs, and
`addEventListener` registrations.

## Benchmark result

Same-host Web A/B in both execution orders:

- BTS heap after clearing 10k rows: 6.32 MB → 1.16/1.17 MB
  (**-81.6% / -81.5%**)
- clear10k latency: **+12.9% / +5.7%**
- clear10k BTS CPU: **+66.2% / +16.2%**

This is intentionally a separate memory-correctness PR. It does not claim a
clear-throughput win; the teardown work is the disclosed cost of removing the
retained handler registry.

## Validation

- 19 focused VDOM/Vapor teardown, move, Teleport, template-hole, and ID tests
- 38 testing-library files / 460 tests
- 18 runtime-local files / 149 tests
- internal TypeScript and runtime library builds

## Stack

Independent; base is `vapor`.
