### PR TITLE
perf(vapor): cache sparse clone indexes

### DIFF
--- a/packages/testing-library/src/__tests__/vapor-sparse-clone.test.ts
+++ b/packages/testing-library/src/__tests__/vapor-sparse-clone.test.ts
@@ -21,11 +21,15 @@ import {
   resetMainThreadState,
 } from '../../../vue-lynx/main-thread/src/ops-apply.js';
 
+const G = globalThis as Record<string, unknown>;
+
 afterEach(() => {
   resetTemplateState();
   resetMainThreadState();
   takeOps();
   ShadowElement.nextUid = 2;
+  delete G['__VUE_LYNX_IFR_PAINT__'];
+  delete G['__VUE_LYNX_IFR_MT__'];
 });
 
 /** Collect block uids on a sparse/dense BG clone (skip aliased-only #text). */
@@ -123,6 +127,35 @@ describe('sparse A2 cloneTemplatePrototype', () => {
 
     const cloneIdx = ops.indexOf(OP.CLONE_TREE);
     expect(ops[cloneIdx + 2]).toBe(base);
+  });
+
+  it('does not mutate frozen addressing and preserves cached clone uids', () => {
+    const proto = buildInertProto();
+    ShadowElement.nextUid = 2;
+    takeOps();
+
+    const addressed = Object.freeze([2, 0]) as unknown as number[];
+    const holes = Object.freeze([2]) as unknown as number[];
+    setPendingVaporAddressing({
+      holes,
+      addressed,
+      slotCount: 4,
+      tags: ['text', 'view'],
+    });
+
+    const first = proto.cloneNode(true) as ShadowElement;
+    setPendingVaporAddressing(undefined);
+    const second = proto.cloneNode(true) as ShadowElement;
+    const ops = takeOps();
+
+    expect(addressed).toEqual([2, 0]);
+    expect(holes).toEqual([2]);
+    expect(ops[ops.indexOf(OP.REGISTER_TREE) + 3]).toEqual([0, 2]);
+    expect(ops.filter((value) => value === OP.REGISTER_TREE)).toHaveLength(1);
+    expect(first.firstChild!.uid).toBe(first.uid + 1);
+    expect(second.firstChild!.uid).toBe(second.uid + 1);
+    expect(first.firstChild!.next).toBeNull();
+    expect(second.firstChild!.next).toBeNull();
   });
 
   it('falls back to dense naming without addressing metadata', () => {
@@ -380,5 +413,39 @@ describe('BG↔MT named-uid parity (review ③)', () => {
       (n) => (n as Element).getAttribute?.('class'),
     );
     expect(classes).toEqual(['hole', 'dynamic', 'static']);
+  });
+});
+
+describe('MT sparse lookup cache lifetime', () => {
+  const structure = [
+    'view',
+    { c: 'card' },
+    [
+      ['text', { c: 'static', t: 'hi' }, []],
+      ['text', { c: 'hole', t: ' ' }, []],
+      ['image', { a: [['src', 'x.png']] }, []],
+    ],
+  ];
+
+  it('snapshots addressed input for data and delayed code-paint clones', () => {
+    const addressed = [0, 2];
+    applyOps([OP.REGISTER_TREE, 71, structure, addressed]);
+    addressed[1] = 1;
+
+    const dataBase = 10100;
+    applyOps([OP.CLONE_TREE, 71, dataBase]);
+
+    G['__VUE_LYNX_IFR_PAINT__'] = 'code-paint';
+    G['__VUE_LYNX_IFR_MT__'] = true;
+    const paintBase = 10200;
+    applyOps([OP.CLONE_TREE, 71, paintBase]);
+
+    expect(addressed).toEqual([0, 1]);
+    expect((elements.get(dataBase + 1) as Element).getAttribute('class')).toBe(
+      'hole',
+    );
+    expect((elements.get(paintBase + 1) as Element).getAttribute('class')).toBe(
+      'hole',
+    );
   });
 });

--- a/packages/vue-lynx/main-thread/src/ops-apply.ts
+++ b/packages/vue-lynx/main-thread/src/ops-apply.ts
@@ -97,8 +97,10 @@ function createTypedElement(
 
 interface RegisteredTree {
   structure: TemplateNode;
-  /** Sparse A2 naming list; undefined → dense A1. */
+  /** Sparse A2 naming snapshot; undefined → dense A1. */
   addressed?: number[];
+  /** Template-lifetime sparse slot lookup; never mutated after registration. */
+  slotToSparse?: ReadonlyMap<number, number>;
 }
 
 const templates = new Map<number, RegisteredTree>();
@@ -257,7 +259,7 @@ function instantiateTemplateSparse(
   node: TemplateNode,
   base: number,
   counter: { value: number },
-  slotToSparse: Map<number, number>,
+  slotToSparse: ReadonlyMap<number, number>,
   parentUid: number | null,
 ): { el: LynxElement; uid: number | null } | null {
   const slot = counter.value++;
@@ -507,20 +509,33 @@ function instantiateRegisteredTree(
   entry: RegisteredTree,
   baseUid: number,
 ): void {
-  if (entry.addressed && entry.addressed.length > 0) {
-    const slotToSparse = new Map(
-      entry.addressed.map((s, i) => [s, i] as const),
-    );
+  if (entry.slotToSparse) {
     instantiateTemplateSparse(
       entry.structure,
       baseUid,
       { value: 0 },
-      slotToSparse,
+      entry.slotToSparse,
       null,
     );
   } else {
     instantiateTemplateDense(entry.structure, baseUid, { value: 0 });
   }
+}
+
+function registeredTree(
+  structure: TemplateNode,
+  addressed: number[] | undefined,
+): RegisteredTree {
+  const addressedSnapshot = addressed ? [...addressed] : undefined;
+  return {
+    structure,
+    addressed: addressedSnapshot,
+    slotToSparse: addressedSnapshot && addressedSnapshot.length > 0
+      ? new Map(
+        addressedSnapshot.map((slot, index) => [slot, index] as const),
+      )
+      : undefined,
+  };
 }
 
 export function applyOps(ops: unknown[], flush = true): void {
@@ -684,7 +699,7 @@ export function applyOps(ops: unknown[], flush = true): void {
           const addressed = Array.isArray(addressedOr0)
             ? addressedOr0
             : undefined;
-          templates.set(tplId, { structure, addressed });
+          templates.set(tplId, registeredTree(structure, addressed));
           // Bundle-delivered structures feed the active staging strategy the
           // same way wire-delivered ones do (engine prototype / compiled
           // ephemeral plan).
@@ -704,7 +719,7 @@ export function applyOps(ops: unknown[], flush = true): void {
         const addressed = Array.isArray(addressedOr0)
           ? addressedOr0
           : undefined;
-        templates.set(tplId, { structure, addressed });
+        templates.set(tplId, registeredTree(structure, addressed));
         // Build any per-template resource for the active staging strategy
         // (engine host-resident prototype, compiled ephemeral plan). The
         // Data-Template default needs none. Fail-safe: engine register is a

--- a/packages/vue-lynx/runtime/src/shadow-element.ts
+++ b/packages/vue-lynx/runtime/src/shadow-element.ts
@@ -1050,6 +1050,8 @@ interface TemplateCache {
   count: number;
   /** Sparse A2 naming list; undefined → dense A1. */
   addressed?: number[];
+  /** Template-lifetime sparse slot lookup; never mutated after creation. */
+  slotToSparse?: ReadonlyMap<number, number>;
   holes?: number[];
   /**
    * Bundle delivery (`+b!`, #338): the verified structure fingerprint. Set
@@ -1248,7 +1250,7 @@ function skipProtoSlots(
  * BG half of the **recovered Data-Template** (legacy "sparse A2") — four-axis
  * coordinate Data / Sparse / recovered / Split (see vue-lynx/internal/matrix).
  *
- * Nav facade: allocate ShadowElements only for slots in `needed`
+ * Nav facade: allocate ShadowElements only for slots in `slotToSparse`
  * (the compiler-recovered addressed closure = holes ∪ root ∪ ancestors ∪
  * prefix siblings). Static subtrees off the vapor `child`/`next` path are
  * skipped — natives still come from CLONE_TREE. Uids are contiguous over
@@ -1259,15 +1261,9 @@ function buildShadowCloneSparse(
   proto: ShadowElement,
   base: number,
   counter: { value: number },
-  needed: Set<number>,
-  slotToSparse: Map<number, number>,
+  slotToSparse: ReadonlyMap<number, number>,
 ): ShadowElement | null {
   const slot = counter.value;
-  if (!needed.has(slot)) {
-    skipProtoSlots(proto, counter);
-    return null;
-  }
-
   const sparseIdx = slotToSparse.get(slot);
   if (sparseIdx === undefined) {
     skipProtoSlots(proto, counter);
@@ -1310,7 +1306,6 @@ function buildShadowCloneSparse(
         child,
         base,
         counter,
-        needed,
         slotToSparse,
       );
       if (childClone) clone._link(childClone, null);
@@ -1344,11 +1339,17 @@ function cloneTemplatePrototype(proto: ShadowElement): ShadowElement {
           + '(slotCount / tag fingerprint) — falling back to dense CLONE_TREE.',
       );
     }
+    const addressed = sparse
+      ? [...meta.addressed].sort((a, b) => a - b)
+      : undefined;
     cache = {
       id: nextTemplateId++,
       structure,
       count: counter.value,
-      addressed: sparse ? [...meta.addressed].sort((a, b) => a - b) : undefined,
+      addressed,
+      slotToSparse: addressed
+        ? new Map(addressed.map((slot, index) => [slot, index] as const))
+        : undefined,
       holes: sparse ? [...meta.holes].sort((a, b) => a - b) : undefined,
     };
 
@@ -1416,15 +1417,12 @@ function cloneTemplatePrototype(proto: ShadowElement): ShadowElement {
     // Sparse A2: reserve one uid per addressed slot only.
     const addressed = cache.addressed;
     ShadowElement.nextUid += addressed.length;
-    const needed = new Set(addressed);
-    const slotToSparse = new Map(addressed.map((s, i) => [s, i]));
     const counter = { value: 0 };
     const root = buildShadowCloneSparse(
       proto,
       base,
       counter,
-      needed,
-      slotToSparse,
+      cache.slotToSparse!,
     );
     if (!root) {
       throw new Error(


### PR DESCRIPTION
Stacked Vue Vapor grind unit: runtime candidate 3/5

This draft is intentionally based on the previous stack branch. It contains no formal performance claim. Landing remains blocked on focused parent-vs-child ABBA, the complete 508-key baseline-to-tip campaign, zero DNF, and cohort/receipt integrity.