### PR TITLE
feat(performance): integrate the Lynx Performance API pipeline

### DIFF
--- a/packages/upstream-tests/src/performance.spec.ts
+++ b/packages/upstream-tests/src/performance.spec.ts
@@ -1,0 +1,281 @@
+/**
+ * Lynx Performance API integration — background and main thread.
+ *
+ * The contract under test is the one the engine relies on: a pipeline context
+ * is created once, carried with the changes it describes across the thread
+ * boundary, attached to the flush that submits those changes, and never
+ * attached to anything else.
+ */
+
+import { createApp, h, nextTick, ref, resetForTesting } from 'vue-lynx';
+import { PIPELINE_ORIGIN_UPDATE_BTS, TIMING_FLAG_ATTR } from 'vue-lynx/internal/ops';
+
+import {
+  beginUpdatePipeline,
+  markTiming,
+  notePipelineBatchDispatched,
+  observeTimingFlagProp,
+  resetPerformanceState,
+  takePipeline,
+} from '../../vue-lynx/runtime/src/performance.js';
+import {
+  flushElementTree,
+  resetPerformanceState as resetMtPerformanceState,
+  setPageElement,
+  setPendingLoadPipeline,
+  setPipeline,
+} from '../../vue-lynx/main-thread/src/performance.js';
+
+interface PipelineOptionsLike {
+  pipelineID: string;
+  pipelineOrigin?: string;
+  needTimestamps?: boolean;
+  dsl?: string;
+  stage?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Engine stubs
+// ---------------------------------------------------------------------------
+
+const g = globalThis as Record<string, unknown>;
+
+let nextPipelineId = 1;
+let started: PipelineOptionsLike[] = [];
+let marks: Array<[string, string]> = [];
+let boundFlags: Array<[string, string]> = [];
+let flushes: Array<{ root: unknown; options: unknown }> = [];
+let sentPayloads: Array<{ data: string; pipelineOptions?: PipelineOptionsLike }> =
+  [];
+
+const performanceStub = {
+  _generatePipelineOptions(): PipelineOptionsLike {
+    return { pipelineID: `p${nextPipelineId++}` };
+  },
+  _onPipelineStart(pipelineID: string, options?: PipelineOptionsLike): void {
+    started.push(options ?? { pipelineID });
+  },
+  _markTiming(pipelineID: string, key: string): void {
+    marks.push([pipelineID, key]);
+  },
+  _bindPipelineIdWithTimingFlag(pipelineID: string, flag: string): void {
+    boundFlags.push([pipelineID, flag]);
+  },
+};
+
+const originalLynx = g['lynx'];
+
+beforeEach(() => {
+  nextPipelineId = 1;
+  started = [];
+  marks = [];
+  boundFlags = [];
+  flushes = [];
+  sentPayloads = [];
+
+  // The shared local-test-setup stub captures ops but has no Performance API
+  // and drops the rest of the payload; wrap it so both are observable.
+  g['lynx'] = {
+    performance: performanceStub,
+    getNativeApp() {
+      return {
+        callLepusMethod(
+          _method: string,
+          params: { data: string; pipelineOptions?: PipelineOptionsLike },
+          callback: () => void,
+        ) {
+          sentPayloads.push(params);
+          callback();
+        },
+      };
+    },
+  };
+  // Version gate for the two-argument `_onPipelineStart`.
+  g['SystemInfo'] = { lynxSdkVersion: '4.0.1' };
+  g['__FlushElementTree'] = (root?: unknown, options?: unknown) => {
+    flushes.push({ root, options });
+  };
+
+  resetForTesting();
+  resetPerformanceState();
+  resetMtPerformanceState();
+});
+
+afterEach(() => {
+  g['lynx'] = originalLynx;
+  delete g['SystemInfo'];
+  delete g['__FlushElementTree'];
+});
+
+// ---------------------------------------------------------------------------
+// Background thread
+// ---------------------------------------------------------------------------
+
+describe('background thread pipeline lifecycle', () => {
+  it('leaves the first batch to the engine load pipeline', async () => {
+    const count = ref(0);
+    createApp({
+      render: () => h('view', null, [h('text', null, String(count.value))]),
+    }).mount();
+    await nextTick();
+
+    expect(sentPayloads).toHaveLength(1);
+    expect(sentPayloads[0]!.pipelineOptions).toBeUndefined();
+    expect(started).toHaveLength(0);
+  });
+
+  it('opens exactly one framework pipeline per update batch', async () => {
+    const count = ref(0);
+    createApp({
+      render: () => h('text', null, String(count.value)),
+    }).mount();
+    await nextTick();
+
+    count.value++;
+    await nextTick();
+
+    expect(started).toHaveLength(1);
+    expect(started[0]!.pipelineOrigin).toBe(PIPELINE_ORIGIN_UPDATE_BTS);
+    expect(started[0]!.dsl).toBe('vue');
+    expect(started[0]!.stage).toBe('update');
+    expect(started[0]!.needTimestamps).toBe(false);
+
+    const sent = sentPayloads[1]!;
+    expect(sent.pipelineOptions?.pipelineID).toBe(started[0]!.pipelineID);
+  });
+
+  it('carries a distinct pipeline on each subsequent update', async () => {
+    const count = ref(0);
+    createApp({ render: () => h('text', null, String(count.value)) }).mount();
+    await nextTick();
+
+    count.value++;
+    await nextTick();
+    count.value++;
+    await nextTick();
+
+    const ids = sentPayloads
+      .map(p => p.pipelineOptions?.pipelineID)
+      .filter(Boolean);
+    expect(ids).toHaveLength(2);
+    expect(new Set(ids).size).toBe(2);
+  });
+
+  it('marks the framework rendering window only when timestamps are wanted', async () => {
+    const count = ref(0);
+    createApp({ render: () => h('text', null, String(count.value)) }).mount();
+    await nextTick();
+
+    count.value++;
+    await nextTick();
+
+    // `diffVdomStart` is forced so a pipeline that turns out to be flagged
+    // still reports a start; the rest stay off for an unflagged update.
+    expect(marks.map(m => m[1])).toEqual(['diffVdomStart']);
+  });
+
+  it('reports the full framework window once a Timing Flag is present', async () => {
+    const flag = ref('');
+    createApp({
+      render: () =>
+        h('view', flag.value ? { [TIMING_FLAG_ATTR]: flag.value } : null),
+    }).mount();
+    await nextTick();
+
+    flag.value = 'feed-ready';
+    await nextTick();
+
+    const keys = marks.map(m => m[1]);
+    expect(keys).toEqual([
+      'diffVdomStart',
+      'diffVdomEnd',
+      'packChangesStart',
+      'packChangesEnd',
+    ]);
+    // The engine reads the flag off the element itself — binding it here as
+    // well would attribute the same flag twice.
+    expect(boundFlags).toHaveLength(0);
+    expect(sentPayloads[1]!.pipelineOptions?.needTimestamps).toBe(true);
+  });
+
+  it('drops a pipeline whose tick produced no element changes', () => {
+    notePipelineBatchDispatched();
+    beginUpdatePipeline();
+    expect(started).toHaveLength(1);
+
+    // A tick that mutates nothing observable still schedules a flush; the
+    // context it opened must not survive into the next update.
+    expect(takePipeline()?.pipelineID).toBe('p1');
+    expect(takePipeline()).toBeUndefined();
+  });
+
+  it('ignores marks and flags when no pipeline is open', () => {
+    markTiming('diffVdomEnd', true);
+    observeTimingFlagProp(TIMING_FLAG_ATTR, 'x');
+    expect(marks).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Main thread
+// ---------------------------------------------------------------------------
+
+describe('main thread pipeline association', () => {
+  const page = { page: true } as unknown as Parameters<
+    typeof setPageElement
+  >[0];
+
+  beforeEach(() => {
+    setPageElement(page);
+  });
+
+  it('preserves the original call shape when nothing is associated', () => {
+    flushElementTree();
+    flushElementTree(page);
+    expect(flushes).toEqual([
+      { root: undefined, options: undefined },
+      { root: page, options: undefined },
+    ]);
+  });
+
+  it('attaches a retained load pipeline to the first real-content flush', () => {
+    const load = { pipelineID: 'load-1', pipelineOrigin: 'loadBundle' };
+    setPendingLoadPipeline(load);
+
+    flushElementTree();
+    expect(flushes[0]!.options).toEqual({ pipelineOptions: load });
+
+    // Committed once: a later flush must not resubmit it.
+    flushElementTree();
+    expect(flushes[1]!.options).toBeUndefined();
+  });
+
+  it('lets the load pipeline win over an update pipeline on the same flush', () => {
+    const load = { pipelineID: 'load-1' };
+    setPendingLoadPipeline(load);
+    setPipeline({ pipelineID: 'update-1' });
+
+    flushElementTree();
+    expect(flushes[0]!.options).toEqual({ pipelineOptions: load });
+
+    flushElementTree();
+    expect(flushes[1]!.options).toBeUndefined();
+  });
+
+  it('merges the pipeline into caller-owned flush options', () => {
+    setPipeline({ pipelineID: 'u1' });
+    flushElementTree(page, { triggerLayout: false });
+    expect(flushes[0]).toEqual({
+      root: page,
+      options: { triggerLayout: false, pipelineOptions: { pipelineID: 'u1' } },
+    });
+  });
+
+  it('never overwrites a caller-owned option with the pipeline', () => {
+    setPipeline({ pipelineID: 'u1' });
+    flushElementTree(page, { triggerLayout: true, listID: 7 });
+    const options = flushes[0]!.options as Record<string, unknown>;
+    expect(options['triggerLayout']).toBe(true);
+    expect(options['listID']).toBe(7);
+  });
+});

--- a/packages/vue-lynx/internal/src/ops.ts
+++ b/packages/vue-lynx/internal/src/ops.ts
@@ -115,6 +115,88 @@ export const IFR_MOUNT_APPS_GLOBAL = '__vueLynxIfrMountApps';
 /** MT executor registry for element-template create() functions. */
 export const TPL_EXECUTOR_REGISTRY_GLOBAL = '__vueLynxRegisterTemplate';
 
+// ---------------------------------------------------------------------------
+// Performance API integration — the BG/MT half of the contract that both
+// threads must agree on.
+//
+// A "Lynx Pipeline" is the attribution unit that runs from a rendering trigger
+// to the pixels it produces. The engine correlates framework work with the
+// pixel pipeline through a `PipelineOptions` object that the framework must
+// carry, unchanged, alongside the UI changes it describes — across the BG→MT
+// hop and into the `__FlushElementTree` call that submits them.
+//
+// See `plans/0817-1-performance-api-integration.md`.
+// ---------------------------------------------------------------------------
+
+/**
+ * Engine-generated correlation context for one Lynx Pipeline.
+ *
+ * Only `pipelineID` is engine-owned and immutable; the rest is framework
+ * metadata populated before `_onPipelineStart`. Unknown fields must survive
+ * the BG→MT transfer, which is why the whole object is forwarded rather than
+ * just the id.
+ */
+export interface PipelineOptions {
+  /** Engine-generated. Never invent, replace, or reuse this value. */
+  pipelineID: string;
+  /** What initiated the pipeline — see {@link PIPELINE_ORIGIN_UPDATE_BTS}. */
+  pipelineOrigin?: string;
+  /** Whether the engine should record detailed framework timing points. */
+  needTimestamps?: boolean;
+  /** Stable identifier of the framework that produced the changes. */
+  dsl?: string;
+  /** Framework rendering stage — `hydrate` or `update`. */
+  stage?: string;
+  [key: string]: unknown;
+}
+
+/** Framework-facing subset of the engine's `__FlushElementTree` options. */
+export interface FlushOptions {
+  triggerLayout?: boolean;
+  pipelineOptions?: PipelineOptions;
+  [key: string]: unknown;
+}
+
+/**
+ * Standard framework rendering timing keys.
+ *
+ * `diffVdom*` is named for ReactLynx's virtual-DOM diff. Vue Lynx records the
+ * same window — from the first tree mutation of a scheduler tick to the point
+ * the ops buffer is taken — for both the vdom renderer and Vapor, where no
+ * virtual DOM exists at all. Vue Lynx never emits `hydrateParseSnapshot*` (it
+ * re-renders rather than parsing a snapshot) or the deprecated `update*` keys.
+ */
+export type FrameworkTimingKey =
+  | 'diffVdomStart'
+  | 'diffVdomEnd'
+  | 'packChangesStart'
+  | 'packChangesEnd'
+  | 'parseChangesStart'
+  | 'parseChangesEnd'
+  | 'patchChangesStart'
+  | 'patchChangesEnd';
+
+/**
+ * The only pipeline origin a custom framework may assign. Every other origin
+ * in the Performance API is created by the engine or by native integrations,
+ * and `reactLynxHydrate` is ReactLynx-private.
+ */
+export const PIPELINE_ORIGIN_UPDATE_BTS = 'updateTriggeredByBts';
+
+/** `PipelineOptions.stage` values with a defined public meaning. */
+export const PIPELINE_STAGE_UPDATE = 'update';
+
+/** `PipelineOptions.dsl` reported by the virtual-DOM renderer. */
+export const DSL_VUE = 'vue';
+
+/**
+ * Attribute through which an application marks the pipeline it cares about.
+ * The engine reads it off the element and emits a `PipelineEntry` whose
+ * `identifier` is the flag; the framework's only job is to raise
+ * `needTimestamps` on the pipeline the flagged content rides in.
+ */
+export const TIMING_FLAG_ATTR = '__lynx_timing_flag';
+
 /**
  * Convert a Vue scope ID (data-v-xxxxx) to a Lynx cssId (numeric).
  * Vue uses 8-char hex hash strings.  Lynx engine uses int32 for cssId,

--- a/packages/vue-lynx/main-thread/src/entry-main.ts
+++ b/packages/vue-lynx/main-thread/src/entry-main.ts
@@ -23,7 +23,25 @@ import { elements, setPageUniqueId } from './element-registry.js';
 import { registerTemplate } from './element-templates.js';
 import { interceptPatchUpdate, runIfrRender } from './ifr.js';
 import { applyOps, resetMainThreadState } from './ops-apply.js';
+import {
+  flushElementTree,
+  markTiming,
+  setPageElement,
+  setPendingLoadPipeline,
+  setPipeline,
+} from './performance.js';
 import { runOnBackground } from './run-on-background-mt.js';
+
+import type { FlushOptions, PipelineOptions } from 'vue-lynx/internal/ops';
+
+/**
+ * Options the engine passes to the page lifecycle callbacks. Only the field
+ * this integration consumes is named; the engine owns the rest and they are
+ * forwarded untouched.
+ */
+interface EnginePageOptions extends FlushOptions {
+  pipelineOptions?: PipelineOptions;
+}
 
 const g = globalThis as Record<string, unknown>;
 
@@ -76,11 +94,15 @@ g['processData'] = function(data: unknown, _processorName?: string): unknown {
 // Lynx calls renderPage on the Main Thread first (before Background JS runs).
 // We create the root page element and store it as id=1 so Background ops that
 // target the root can resolve it correctly.
-g['renderPage'] = function(_data: unknown): void {
+g['renderPage'] = function(
+  _data: unknown,
+  options?: EnginePageOptions,
+): void {
   // Clear all element state from the previous page. This is essential for:
   // 1. Testing: prevents duplicate batch detection from skipping ops
   //    when ShadowElement IDs restart from 2 between test renders.
   // 2. Hot reload: ensures stale element handles don't persist.
+  // It also discards any pipeline held for the page being replaced.
   resetMainThreadState();
   const page = __CreatePage('0', 0);
   // Set global CSS scope on page so its style_sheet_manager_ is populated.
@@ -88,31 +110,87 @@ g['renderPage'] = function(_data: unknown): void {
   __SetCSSId([page], 0);
   setPageUniqueId(__GetElementUniqueID(page));
   elements.set(PAGE_ROOT_ID, page);
+  setPageElement(page);
+  // The engine started a `loadBundle` pipeline before this call. Retain it:
+  // whether it is committed here or by a later batch depends on which of them
+  // submits the actual first screen.
+  setPendingLoadPipeline(options ? options.pipelineOptions : undefined);
   // IFR: mount any Vue app that user code registered on this thread and
   // paint the first frame synchronously.  No-op in non-IFR bundles (user
   // code on the MT layer is stripped to worklet registrations, so no app
   // ever registers).
-  runIfrRender();
-  __FlushElementTree(page);
+  const rendered = runIfrRender();
+  // IFR built the real first screen here, so this flush is the one that
+  // submits it and the load pipeline goes with it. Without IFR the page is
+  // still empty — a placeholder — and the pipeline stays pending for the
+  // background thread's first batch.
+  if (rendered) {
+    flushElementTree(page);
+  } else {
+    __FlushElementTree(page);
+  }
 };
 
-// Lynx may call updatePage / updateGlobalProps after data changes.
-// We have no data binding on Main Thread, so these are no-ops.
-g['updatePage'] = function(_data: unknown): void {
-  // no-op: Vue Main Thread has no direct data binding
+// Lynx may call updatePage / updateGlobalProps after data changes. The Vue
+// main thread has no data binding, so neither produces element changes — but
+// an engine-initiated pipeline arriving with one still has to reach a flush,
+// otherwise it never completes and no entry is ever reported for it.
+g['updatePage'] = function(
+  _data: unknown,
+  options?: EnginePageOptions,
+): void {
+  forwardEnginePipeline(options);
 };
 
-g['updateGlobalProps'] = function(_data: unknown): void {
-  // no-op
+g['updateGlobalProps'] = function(
+  _data: unknown,
+  options?: EnginePageOptions,
+): void {
+  forwardEnginePipeline(options);
 };
 
-// Called by the BG Thread via callLepusMethod('vuePatchUpdate', { data }).
-g['vuePatchUpdate'] = function({ data }: { data: string }): void {
+function forwardEnginePipeline(options?: EnginePageOptions): void {
+  if (!options) return;
+  const page = elements.get(PAGE_ROOT_ID);
+  if (!page) return;
+  // Forward the engine's own options verbatim — they are the flush options for
+  // this update, `pipelineOptions` included.
+  __FlushElementTree(page, options);
+}
+
+// Called by the BG Thread via callLepusMethod('vuePatchUpdate', payload).
+g['vuePatchUpdate'] = function(
+  { data, pipelineOptions }: {
+    data: string;
+    pipelineOptions?: PipelineOptions;
+  },
+): void {
+  // Adopt the background thread's pipeline before any main-thread work so the
+  // stages recorded below land on it. `undefined` is normal: the first batch
+  // rides the engine's load pipeline instead.
+  setPipeline(pipelineOptions);
+
   // IFR hydration: the background thread's initial batches replay the
   // main-thread first-screen render — skip/patch them instead of applying.
-  if (interceptPatchUpdate(data)) return;
+  if (interceptPatchUpdate(data)) {
+    // Hydration consumed the batch; whatever it submitted it did on its own
+    // terms. Release this batch's pipeline rather than let it ride a later
+    // update — but leave any pending load pipeline alone, it is still waiting
+    // for the flush that submits real content.
+    setPipeline(undefined);
+    return;
+  }
+
+  markTiming('parseChangesStart');
   const ops = JSON.parse(data) as unknown[];
-  applyOps(ops);
+  markTiming('parseChangesEnd');
+
+  if (!applyOps(ops)) {
+    // An empty or already-applied batch submits nothing. It must not consume
+    // the load pipeline waiting for real content — but a background pipeline
+    // that came with it has nowhere to go.
+    setPipeline(undefined);
+  }
 };
 
 // Worklet registrations are included in this bundle via webpack's dependency

--- a/packages/vue-lynx/main-thread/src/ifr.ts
+++ b/packages/vue-lynx/main-thread/src/ifr.ts
@@ -184,9 +184,13 @@ function recordAndApply(ops: unknown[]): void {
  * Run the deferred main-thread mount(s).  Called from `renderPage` right
  * after the page root element is created.  No-op unless {@link enableIFR}
  * ran and user code registered an app on this thread.
+ *
+ * @returns Whether a first screen was actually built on this thread. `false`
+ *   means `renderPage` leaves an empty page behind, so the engine's load
+ *   pipeline still belongs to whichever later flush submits real content.
  */
-export function runIfrRender(): void {
-  if (phase === 'inactive') return;
+export function runIfrRender(): boolean {
+  if (phase === 'inactive') return false;
 
   // renderPage may fire again in the same context (test envs, reload paths);
   // start every render from a clean slate.
@@ -198,7 +202,7 @@ export function runIfrRender(): void {
   const trigger = (globalThis as Record<string, unknown>)[
     IFR_MOUNT_APPS_GLOBAL
   ] as (() => void) | undefined;
-  if (!trigger) return;
+  if (!trigger) return false;
 
   try {
     // Mounting is fully synchronous: Vue renders, the runtime's flush hook
@@ -207,6 +211,9 @@ export function runIfrRender(): void {
     inSyncRender = true;
     trigger();
     phase = 'rendered';
+    // An app that rendered nothing (opted out of the IFR mount, or rendered
+    // an empty tree) leaves the same empty page a non-IFR build would.
+    return recordedBatches.length > 0;
   } catch (err) {
     // A failed first-screen render must not take down renderPage — tear down
     // whatever was partially applied and let the background thread render
@@ -217,6 +224,7 @@ export function runIfrRender(): void {
     );
     teardownIfrTree();
     phase = 'hydrated';
+    return false;
   } finally {
     inSyncRender = false;
   }

--- a/packages/vue-lynx/main-thread/src/ops-apply.ts
+++ b/packages/vue-lynx/main-thread/src/ops-apply.ts
@@ -28,6 +28,7 @@ import {
   resetListState,
   setPlatformInfoProp,
 } from './list-apply.js';
+import { dropPipelines, flushElementTree, markTiming } from './performance.js';
 import {
   applyInitMtRef,
   applySetMtRef,
@@ -73,10 +74,13 @@ function createTypedElement(
  *   The IFR render passes `false` for batches applied synchronously inside
  *   `renderPage`, which presents the whole frame with a single flush at the
  *   end instead of one per batch.
+ * @returns Whether this call submitted the batch to the engine. A batch that
+ *   was empty or already applied submits nothing, and must therefore not
+ *   consume a pipeline that is waiting for real content.
  */
-export function applyOps(ops: unknown[], flush = true): void {
+export function applyOps(ops: unknown[], flush = true): boolean {
   const len = ops.length;
-  if (len === 0) return;
+  if (len === 0) return false;
 
   // Detect duplicate batch from double BG bundle evaluation.
   // Each __init_card_bundle__ invocation gets a fresh webpack module cache, so
@@ -89,10 +93,11 @@ export function applyOps(ops: unknown[], flush = true): void {
   ) {
     const firstId = ops[1] as number;
     if (elements.has(firstId)) {
-      return;
+      return false;
     }
   }
 
+  markTiming('patchChangesStart');
   let i = 0;
 
   while (i < len) {
@@ -313,9 +318,12 @@ export function applyOps(ops: unknown[], flush = true): void {
   }
 
   flushListUpdates();
+  markTiming('patchChangesEnd');
 
-  // Flush all pending PAPI changes to the native layer in one shot.
-  if (flush) __FlushElementTree();
+  // Flush all pending PAPI changes to the native layer in one shot, carrying
+  // the pipeline these changes belong to.
+  if (flush) flushElementTree();
+  return flush;
 }
 
 /** Expose elements map so entry-main.ts can seed the page-root entry. */
@@ -327,4 +335,7 @@ export function resetMainThreadState(): void {
   setPageUniqueId(1);
   resetListState();
   resetWorkletState();
+  // A pipeline retained for the page being replaced can never be committed —
+  // the content it was waiting for belongs to a tree that no longer exists.
+  dropPipelines();
 }

--- a/packages/vue-lynx/main-thread/src/performance.ts
+++ b/packages/vue-lynx/main-thread/src/performance.ts
@@ -1,0 +1,190 @@
+// Copyright 2026 Xuan Huang (huxpro). All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * Main Thread half of the Lynx Performance API integration.
+ *
+ * This side never creates a pipeline. It receives them — from the engine
+ * (`renderPage`, `updatePage`, `updateGlobalProps`) and from the background
+ * thread (`vuePatchUpdate`) — marks the framework rendering stages that happen
+ * here, and attaches the right one to the `__FlushElementTree` call that
+ * actually submits the corresponding content.
+ *
+ * ## Which pipeline rides which flush
+ *
+ * Two can be in play at once, so this module arbitrates:
+ *
+ * - **The load pipeline** is engine-initiated and arrives at `renderPage`. In
+ *   a non-IFR build `renderPage` creates nothing but an empty page root, which
+ *   is a placeholder in the Performance API's sense — the first screen is the
+ *   background thread's first batch. So the load pipeline is *retained* and
+ *   attached to the first flush that submits real content. An empty batch, a
+ *   duplicate batch, or a reload must not consume it.
+ * - **An update pipeline** is framework-initiated on the background thread and
+ *   travels with the batch it describes.
+ *
+ * When both are present the load pipeline wins: it is the one that produces
+ * `pipeline.loadBundle` and the first-screen metrics, and the background
+ * thread deliberately does not open a pipeline for its first batch (see
+ * `runtime/src/performance.ts`) so this case only arises if a build reorders
+ * the handshake.
+ *
+ * ## LEPUS constraints
+ *
+ * The main-thread bundle is compiled to ES2019 bytecode: no optional chaining,
+ * no nullish coalescing. Everything here is written accordingly.
+ */
+
+import type {
+  FlushOptions,
+  FrameworkTimingKey,
+  PipelineOptions,
+} from 'vue-lynx/internal/ops';
+
+/**
+ * `lynx` in the Lepus realm. Typed locally rather than through the shared
+ * shim so the Performance API surface is explicit, and read through `typeof`
+ * guards so the web preview and unit tests stay silent no-ops.
+ */
+interface LynxPerformanceApi {
+  _markTiming?: (pipelineID: string, key: string) => void;
+}
+
+function performanceApi(): LynxPerformanceApi | undefined {
+  if (typeof lynx === 'undefined' || !lynx) return undefined;
+  return (lynx as { performance?: LynxPerformanceApi }).performance;
+}
+
+/** Pipeline carried by the batch currently being applied. */
+let current: PipelineOptions | undefined;
+
+/** Engine load pipeline awaiting the flush that submits the first screen. */
+let pendingLoad: PipelineOptions | undefined;
+
+/**
+ * Adopt the pipeline that arrived with the batch about to be applied. Pass
+ * `undefined` when the batch carries none (old background bundle, or the
+ * background thread's first batch).
+ */
+export function setPipeline(options: PipelineOptions | undefined): void {
+  current = options;
+}
+
+/**
+ * Retain an engine-initiated load pipeline until real content is submitted.
+ *
+ * Called from `renderPage` with `options.pipelineOptions`. A second call
+ * replaces the previous one: `renderPage` firing again means the old page is
+ * gone, and its pipeline with it.
+ */
+export function setPendingLoadPipeline(
+  options: PipelineOptions | undefined,
+): void {
+  pendingLoad = options;
+}
+
+/**
+ * Record a framework rendering timing point on the pipeline being applied.
+ * The engine samples the clock at the call; no timestamp is passed in.
+ */
+export function markTiming(key: FrameworkTimingKey, force?: boolean): void {
+  const options = current;
+  if (!options) return;
+  if (!force && !options.needTimestamps) return;
+  const perf = performanceApi();
+  if (!perf || !perf._markTiming) return;
+  perf._markTiming(options.pipelineID, key);
+}
+
+/**
+ * Take the pipeline that the *next* real-content flush should carry, clearing
+ * it so it can never be attached to a second submission.
+ */
+export function takeFlushPipeline(): PipelineOptions | undefined {
+  let options = pendingLoad;
+  if (options) {
+    pendingLoad = undefined;
+    // A batch that also carried an update pipeline loses it here: one flush
+    // submits one pipeline, and the load pipeline is the meaningful one.
+    current = undefined;
+    return options;
+  }
+  options = current;
+  current = undefined;
+  return options;
+}
+
+/**
+ * Submit pending element changes, associating them with the pipeline that
+ * produced them.
+ *
+ * `root` mirrors the flush scope the caller already used before performance
+ * integration existed — the integration must never change it. `extra` carries
+ * flush options the caller owns (engine-provided update options, for
+ * instance); `pipelineOptions` is merged in without overwriting them.
+ */
+export function flushElementTree(
+  root?: LynxElement,
+  extra?: FlushOptions,
+): void {
+  const pipelineOptions = takeFlushPipeline();
+  if (!pipelineOptions && !extra) {
+    // Preserve the exact pre-integration call shape when there is nothing to
+    // associate: `__FlushElementTree()` and `__FlushElementTree(root)` are the
+    // calls this renderer has always made.
+    if (root) {
+      __FlushElementTree(root);
+    } else {
+      __FlushElementTree();
+    }
+    return;
+  }
+
+  const options: FlushOptions = {};
+  if (extra) {
+    for (const key in extra) options[key] = extra[key];
+  }
+  if (pipelineOptions) options.pipelineOptions = pipelineOptions;
+
+  // The two-argument overload needs a root. The page is the scope every
+  // pipeline-carrying flush in this renderer already used, whether it was
+  // spelled `__FlushElementTree()` (whole tree) or `__FlushElementTree(page)`.
+  __FlushElementTree(root ? root : getPageElement(), options);
+}
+
+let pageElement: LynxElement | undefined;
+
+/** Remember the page root so pipeline-carrying flushes have a scope to name. */
+export function setPageElement(page: LynxElement): void {
+  pageElement = page;
+}
+
+function getPageElement(): LynxElement {
+  // `renderPage` always runs before any flush, so this is set in practice.
+  return pageElement as LynxElement;
+}
+
+/**
+ * Drop every pipeline held by this thread.
+ *
+ * Reload and page destruction invalidate a retained load pipeline: the content
+ * it was waiting for will never be submitted, and attaching it to the *next*
+ * page's first batch would attribute one page's pixels to another's load.
+ */
+export function dropPipelines(): void {
+  current = undefined;
+  pendingLoad = undefined;
+}
+
+/** Whether a load pipeline is still waiting for real content. */
+export function hasPendingLoadPipeline(): boolean {
+  return pendingLoad !== undefined;
+}
+
+/** Reset module state – for testing only. */
+export function resetPerformanceState(): void {
+  current = undefined;
+  pendingLoad = undefined;
+  pageElement = undefined;
+}

--- a/packages/vue-lynx/runtime/src/flush.ts
+++ b/packages/vue-lynx/runtime/src/flush.ts
@@ -8,6 +8,13 @@ import { IFR_APPLY_OPS_GLOBAL } from 'vue-lynx/internal/ops';
 
 import { isIfrMainThread } from './ifr-env.js';
 import { takeOps } from './ops.js';
+import {
+  beginUpdatePipeline,
+  dropPipeline,
+  markTiming,
+  notePipelineBatchDispatched,
+  takePipeline,
+} from './performance.js';
 
 /**
  * Schedule a flush of the ops buffer via Vue's post-flush hook.
@@ -107,6 +114,11 @@ export function waitForFlush(): Promise<void> {
 export function scheduleFlush(): void {
   if (scheduled) return;
   scheduled = true;
+  // First mutation of this tick — the framework rendering window that the
+  // pipeline attributes starts here. Vue's scheduler exposes no "a render is
+  // about to run" hook, so this is the earliest point both the virtual-DOM
+  // renderer and Vapor reach on every update.
+  beginUpdatePipeline();
   queuePostFlushCb(doFlush);
 }
 
@@ -123,7 +135,17 @@ export function resetFlushState(): void {
 function doFlush(): void {
   scheduled = false;
   const ops = takeOps();
-  if (ops.length === 0) return;
+  if (ops.length === 0) {
+    // The tick produced no element changes after all. A pipeline opened for it
+    // has nothing to submit — drop it rather than let it ride an unrelated
+    // later update.
+    dropPipeline();
+    return;
+  }
+
+  // All renders for this tick are done (queuePostFlushCb runs after the
+  // scheduler drains), so the framework rendering window closes here.
+  markTiming('diffVdomEnd');
 
   // IFR main-thread render: the Vue app is running *on* the main thread, so
   // ops are applied locally and synchronously — no cross-thread call, no ack
@@ -135,6 +157,10 @@ function doFlush(): void {
     ] as ((ops: unknown[]) => void) | undefined;
     if (applyLocal) {
       applyLocal(ops);
+      // renderPage submits this render, carrying the engine's load pipeline.
+      // There is no framework pipeline on this path (beginUpdatePipeline bails
+      // out in the IFR main-thread realm), so nothing is left to release.
+      notePipelineBatchDispatched();
       return;
     }
   }
@@ -169,10 +195,19 @@ function doFlush(): void {
     }
   });
 
+  // Serialising the batch is framework rendering work the pipeline should
+  // account for, and it is the last thing that happens to the ops on this
+  // thread — so the pipeline travels with the payload it describes.
+  markTiming('packChangesStart');
+  const data = JSON.stringify(ops);
+  markTiming('packChangesEnd');
+  const pipelineOptions = takePipeline();
+  notePipelineBatchDispatched();
+
   const app = lynx?.getNativeApp?.();
   app?.callLepusMethod?.(
     'vuePatchUpdate',
-    { data: JSON.stringify(ops) },
+    { data, pipelineOptions },
     () => {
       // Main thread has finished applying the ops — resolve the promise and
       // latch that this engine delivers callbacks.

--- a/packages/vue-lynx/runtime/src/index.ts
+++ b/packages/vue-lynx/runtime/src/index.ts
@@ -67,6 +67,7 @@ import { registerMount, resetAppRegistry } from './app-registry.js';
 import { runOnMainThread } from './cross-thread.js';
 import { resetRegistry } from './event-registry.js';
 import { resetFlushState, scheduleFlush, waitForFlush } from './flush.js';
+import { resetPerformanceState } from './performance.js';
 import { resetFunctionCallState } from './function-call.js';
 import { isIfrMainThread } from './ifr-env.js';
 import {
@@ -1458,6 +1459,16 @@ export { nodeOps };
 export { takeOps };
 
 /**
+ * Override the `dsl` reported to the Lynx Performance API for pipelines this
+ * renderer initiates. Defaults to `'vue'`; an alternative rendering strategy
+ * built on the same ops protocol (Vapor) reports itself separately so the two
+ * stay distinguishable in pipeline data.
+ *
+ * @internal
+ */
+export { setFrameworkDsl } from './performance.js';
+
+/**
  * Reset all module-level state between tests.
  * Must be called before each test to ensure isolation.
  * @internal
@@ -1466,6 +1477,7 @@ export function resetForTesting(): void {
   resetRegistry();
   resetNodeOpsState();
   resetFlushState();
+  resetPerformanceState();
   resetMainThreadRefState();
   resetFunctionCallState();
   resetRunOnBackgroundState();

--- a/packages/vue-lynx/runtime/src/node-ops.ts
+++ b/packages/vue-lynx/runtime/src/node-ops.ts
@@ -13,6 +13,7 @@ import { register, unregister, updateHandler } from './event-registry.js';
 import { scheduleFlush } from './flush.js';
 import { isIfrMainThread } from './ifr-env.js';
 import { OP, pushOp } from './ops.js';
+import { observeTimingFlagProp } from './performance.js';
 import { registerWorkletCtx } from './run-on-background.js';
 import { scopeIdToCssId } from './scope-bridge.js';
 import { ShadowElement } from './shadow-element.js';
@@ -545,6 +546,10 @@ export const nodeOps: RendererOptions<ShadowElement, ShadowElement> = {
       if (el._id) idRegistry.set(el._id, el);
       pushOp(OP.SET_ID, el.id, nextValue);
     } else {
+      // An application Timing Flag makes the pipeline this batch rides in
+      // reportable — the engine reads the attribute off the element, the
+      // framework only has to ask for timestamps.
+      observeTimingFlagProp(key, nextValue);
       pushOp(OP.SET_PROP, el.id, key, nextValue);
     }
 

--- a/packages/vue-lynx/runtime/src/performance.ts
+++ b/packages/vue-lynx/runtime/src/performance.ts
@@ -1,0 +1,227 @@
+// Copyright 2026 Xuan Huang (huxpro). All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+/**
+ * Background Thread half of the Lynx Performance API integration.
+ *
+ * Owns the *framework-initiated* pipeline: every scheduler tick that produces
+ * ops asks the engine for a fresh `PipelineOptions`, starts it, marks the
+ * framework rendering stages that happen on this thread, and hands the whole
+ * object to {@link takePipeline} so `flush.ts` can ship it to the main thread
+ * with the batch it describes.
+ *
+ * Two rules shape everything here:
+ *
+ *  1. **One pipeline per logical change, carried to its own flush.** The
+ *     context is created when a tick starts producing mutations and released
+ *     when that tick's batch leaves the thread. It is never reused, and a tick
+ *     that produces no batch never creates one.
+ *  2. **The first batch is not ours.** Lynx starts a `loadBundle` pipeline
+ *     before any framework code runs and hands it to the main thread's
+ *     `renderPage`. In a non-IFR build the page that `renderPage` creates is
+ *     empty — the first screen is the background thread's first batch — so
+ *     that batch must ride the *engine's* load pipeline, not a framework one.
+ *     The main thread arbitrates (see `main-thread/src/performance.ts`); this
+ *     side simply does not open a pipeline for its first flush.
+ *
+ * This module is renderer-agnostic on purpose: it hooks the ops pipeline
+ * (`scheduleFlush` / `doFlush`), which both the virtual-DOM renderer and Vapor
+ * funnel every mutation through.
+ */
+
+import {
+  DSL_VUE,
+  type FrameworkTimingKey,
+  PIPELINE_ORIGIN_UPDATE_BTS,
+  PIPELINE_STAGE_UPDATE,
+  type PipelineOptions,
+  TIMING_FLAG_ATTR,
+} from 'vue-lynx/internal/ops';
+
+import { isIfrMainThread } from './ifr-env.js';
+
+// `lynx` is injected by RuntimeWrapperWebpackPlugin as a parameter to the
+// tt.define() AMD callback — it is NOT on globalThis. Declare it ambiently so
+// TypeScript accepts the bare identifier, and read it through `typeof` guards
+// so non-Lynx realms (vitest, the web preview) stay silent no-ops.
+// eslint-disable-next-line no-var
+declare var lynx:
+  | {
+    performance?: {
+      _generatePipelineOptions?(): PipelineOptions | undefined;
+      _onPipelineStart?(pipelineID: string, options?: PipelineOptions): void;
+      _markTiming?(pipelineID: string, key: string): void;
+      _bindPipelineIdWithTimingFlag?(
+        pipelineID: string,
+        timingFlag: string,
+      ): void;
+    };
+  }
+  | null
+  | undefined;
+
+type LynxPerformance = NonNullable<
+  NonNullable<typeof lynx>['performance']
+>;
+
+function performanceApi(): LynxPerformance | undefined {
+  if (typeof lynx === 'undefined' || !lynx) return undefined;
+  return lynx.performance;
+}
+
+/**
+ * `_onPipelineStart(pipelineID, options)` — the two-argument form that carries
+ * `dsl`/`stage`/`pipelineOrigin` — landed in Lynx 3.1. Older engines accept
+ * only the id, and passing a second argument to them is not defined behavior.
+ */
+function supportsPipelineStartOptions(): boolean {
+  const info = (globalThis as { SystemInfo?: { lynxSdkVersion?: string } })
+    .SystemInfo;
+  const version = info?.lynxSdkVersion;
+  if (!version) return false;
+  const parts = version.split('.');
+  const major = Number(parts[0]);
+  const minor = Number(parts[1]);
+  if (Number.isNaN(major)) return false;
+  return major > 3 || (major === 3 && minor >= 1);
+}
+
+let current: PipelineOptions | undefined;
+let dsl: string = DSL_VUE;
+let firstBatchDispatched = false;
+
+/**
+ * Override the `dsl` reported for framework-initiated pipelines.
+ *
+ * The ops protocol is shared by the virtual-DOM renderer and Vapor, but they
+ * are different rendering strategies with different cost profiles — reporting
+ * them under one identifier would make the two indistinguishable in pipeline
+ * data. Vapor calls this at app-creation time.
+ */
+export function setFrameworkDsl(value: string): void {
+  dsl = value;
+}
+
+/**
+ * Open a framework-initiated pipeline for the tick that is about to produce
+ * ops. Called from `scheduleFlush()` on the transition into "a batch is
+ * pending", which is the first tree mutation of the tick.
+ *
+ * Idempotent within a tick, and a no-op when the engine has no Performance
+ * API, when this realm is the IFR main thread (the engine's load pipeline
+ * owns that render), or for the first batch (see the module comment).
+ */
+export function beginUpdatePipeline(): void {
+  if (current !== undefined) return;
+  if (!firstBatchDispatched) return;
+  if (isIfrMainThread()) return;
+
+  const perf = performanceApi();
+  if (!perf || !perf._generatePipelineOptions || !perf._onPipelineStart) return;
+
+  const options = perf._generatePipelineOptions();
+  if (!options) return;
+
+  options.pipelineOrigin = PIPELINE_ORIGIN_UPDATE_BTS;
+  // Detailed timing is opt-in per pipeline: raised only when the batch turns
+  // out to carry a Timing Flag (see observeTimingFlagProp). Marking every
+  // update would report timestamps for every keystroke.
+  options.needTimestamps = false;
+  options.dsl = dsl;
+  options.stage = PIPELINE_STAGE_UPDATE;
+
+  current = options;
+  if (supportsPipelineStartOptions()) {
+    perf._onPipelineStart(options.pipelineID, options);
+  } else {
+    perf._onPipelineStart(options.pipelineID);
+  }
+
+  // The diff window opens *before* the flag that enables timestamps can be
+  // discovered — this mark is forced so a flagged pipeline still reports a
+  // start. `force` is exactly what ReactLynx does for the same reason.
+  markTiming('diffVdomStart', true);
+}
+
+/**
+ * Record a framework rendering timing point on the open pipeline.
+ *
+ * The engine samples the wall clock when this is called; a timestamp is never
+ * passed in. Marks are dropped when no pipeline is open or when the pipeline
+ * did not ask for timestamps.
+ */
+export function markTiming(
+  key: FrameworkTimingKey,
+  force = false,
+): void {
+  const options = current;
+  if (!options) return;
+  if (!force && !options.needTimestamps) return;
+  const perf = performanceApi();
+  if (!perf || !perf._markTiming) return;
+  perf._markTiming(options.pipelineID, key);
+}
+
+/**
+ * Raise `needTimestamps` when a prop write puts an application Timing Flag
+ * into the batch under construction.
+ *
+ * The framework does *not* bind the flag to the pipeline: the engine reads
+ * `__lynx_timing_flag` off the element once it is applied and uses it as the
+ * `PipelineEntry.identifier` itself. Binding here as well would attribute the
+ * same flag twice. (`_bindPipelineIdWithTimingFlag` exists for flags a
+ * framework synthesizes, which Vue Lynx has none of.)
+ */
+export function observeTimingFlagProp(key: string, value: unknown): void {
+  if (key !== TIMING_FLAG_ATTR) return;
+  if (value === undefined || value === null || value === '') return;
+  // The flag may be the very first mutation of the tick, in which case the
+  // renderer has not reached its `scheduleFlush()` yet. Opening the pipeline
+  // here is idempotent and keeps the mark order correct.
+  beginUpdatePipeline();
+  if (current === undefined) return;
+  current.needTimestamps = true;
+}
+
+/**
+ * Hand the open pipeline to the batch that is leaving the thread, closing it
+ * on this side. Returns `undefined` when no pipeline is open — an ordinary
+ * outcome for the first batch and for engines without the Performance API.
+ */
+export function takePipeline(): PipelineOptions | undefined {
+  const options = current;
+  current = undefined;
+  return options;
+}
+
+/**
+ * Discard the open pipeline without committing it.
+ *
+ * Used when a tick's batch cannot be submitted after all, so the context can
+ * never be attached to an unrelated later update.
+ */
+export function dropPipeline(): void {
+  current = undefined;
+}
+
+/**
+ * Record that a batch has left this thread. Until this has happened once, the
+ * engine's `loadBundle` pipeline still owns the first screen and this side
+ * must not open one of its own.
+ */
+export function notePipelineBatchDispatched(): void {
+  firstBatchDispatched = true;
+}
+
+/** Whether a framework-initiated pipeline is currently open. */
+export function hasOpenPipeline(): boolean {
+  return current !== undefined;
+}
+
+/** Reset module state – for testing only. */
+export function resetPerformanceState(): void {
+  current = undefined;
+  dsl = DSL_VUE;
+  firstBatchDispatched = false;
+}

--- a/plans/0817-1-performance-api-integration.md
+++ b/plans/0817-1-performance-api-integration.md
@@ -1,0 +1,294 @@
+# Feature: Lynx Performance API integration (Pipeline / Timing)
+
+**Date**: 2026-08-17
+**Status**: Implemented on `main` (vdom), ported to `vapor`
+
+---
+
+## Background
+
+Lynx attributes rendering work to a **Lynx Pipeline** — the unit that runs from a
+rendering trigger to the pixels it produces. The engine records the pixel half
+itself, but the framework half (diff, serialization, cross-thread transfer,
+element mutation) is invisible to it unless the framework opts in. A framework
+that does not integrate produces no `PipelineEntry` for its own updates and no
+`pipeline.loadBundle` correlation for its first screen: `PerformanceObserver`
+fires, but the entries are hollow.
+
+lynx-family/lynx-website#1311 is the first public specification of what that
+opt-in looks like for a framework that is *not* ReactLynx. It adds:
+
+- `PipelineOptions` — the correlation context (`pipelineID`, `pipelineOrigin`,
+  `needTimestamps`, `dsl`, `stage`)
+- `__FlushElementTree(root?, options?)` — the submission boundary, with
+  `options.pipelineOptions` as the association point
+- four framework hooks on `lynx.performance`: `_generatePipelineOptions`,
+  `_onPipelineStart`, `_markTiming`, `_bindPipelineIdWithTimingFlag`
+- an integration guide with lifecycle rules, timing keys, and a conformance list
+
+Reference implementation studied: `@lynx-js/react` in lynx-stack —
+`packages/react/runtime/src/core/performance.ts` (pipeline lifecycle),
+`snapshot/lifecycle/patch/commit.ts` (BTS commit), `patch/updateMainThread.ts`
+(MTS apply), `snapshot/lynx/calledByNative.ts` (engine callbacks), and the newer
+`element-template/` backend, which routes the same context through a different
+transport.
+
+## Design
+
+The integration is a **property of the ops pipeline, not of the renderer**.
+Vue Lynx's background thread funnels every mutation through `scheduleFlush()` →
+`doFlush()` → `callLepusMethod('vuePatchUpdate', …)`, and the main thread through
+`vuePatchUpdate` → `applyOps()` → `__FlushElementTree()`. Those four points are
+where a pipeline is opened, marked, transferred, and committed — and they are the
+same four points whether the tree above them is produced by the virtual-DOM
+renderer or by Vapor. So the integration lives entirely in the ops layer and is
+shared verbatim by both.
+
+### Pipeline ownership
+
+| Pipeline | Initiator | How Vue Lynx handles it |
+|---|---|---|
+| `loadBundle` (first screen) | Engine | Arrives at `renderPage`. **Retained**, then attached to whichever flush submits real content. |
+| `updateTriggeredByBts` (update) | Vue Lynx (BG) | Created per scheduler tick that produces ops, transferred with the batch, committed by the flush that applies it. |
+| `updatePage` / `updateGlobalProps` | Engine / Native | Forwarded verbatim to a flush so the pipeline completes. |
+
+**The first background batch is deliberately not a framework pipeline.** This is
+the structural difference from ReactLynx. ReactLynx's `renderPage` builds the
+real element tree synchronously on the main thread, so the engine's load pipeline
+is consumed there, and the background thread's first message is *hydration* —
+which ReactLynx opens as its own `reactLynxHydrate` pipeline. In a non-IFR Vue
+Lynx build, `renderPage` creates nothing but an empty page root: that page is a
+**placeholder** in exactly the sense the integration guide defines, and the first
+screen is the background thread's first batch. If the background thread opened a
+framework pipeline for it, two pipelines would compete for one flush and the
+`loadBundle` correlation — the one that produces first-screen metrics — would
+lose. So the background side skips its first batch, and the main thread attaches
+the retained load pipeline to it.
+
+With IFR the load pipeline is consumed by `renderPage` instead, because the first
+screen really is built there. Both cases are handled by the same rule: *the load
+pipeline rides the first flush that submits real content*, and `runIfrRender()`
+now reports whether that flush is `renderPage`'s own.
+
+### Timing keys
+
+Marked where the corresponding work happens:
+
+| Thread | Window | Keys |
+|---|---|---|
+| BG | first mutation of a tick → post-flush | `diffVdomStart` / `diffVdomEnd` |
+| BG | `JSON.stringify(ops)` | `packChangesStart` / `packChangesEnd` |
+| MT | `JSON.parse(data)` | `parseChangesStart` / `parseChangesEnd` |
+| MT | ops interpreter + list flush | `patchChangesStart` / `patchChangesEnd` |
+
+`diffVdomStart` is forced (`needTimestamps` bypassed) because the Timing Flag
+that enables timestamps can only be discovered *during* the diff — the same
+reason ReactLynx forces it. Everything else is gated, so an unflagged update
+costs one `_generatePipelineOptions` + `_onPipelineStart` + one mark, and no
+per-stage engine calls.
+
+Vue Lynx never emits `hydrateParseSnapshot*` (it re-renders rather than parsing a
+snapshot), `mtsRender*` (not in the public key list), or the deprecated
+`update*`-prefixed keys.
+
+### Timing Flags
+
+An application marks content with `__lynx_timing_flag="..."`. The framework's
+only job is to raise `needTimestamps` on the pipeline that batch rides in — the
+engine reads the attribute off the element and uses it as the
+`PipelineEntry.identifier` itself. Vue Lynx does **not** call
+`_bindPipelineIdWithTimingFlag`; binding there as well would attribute the same
+flag twice. (ReactLynx behaves identically: `prepareSpreadForCommit` sets
+`needTimestamps` and nothing else. It reserves `_bindPipelineIdWithTimingFlag`
+for the flag it synthesizes for its own hydrate pipeline, `react_lynx_hydrate`,
+which Vue Lynx has no equivalent of.)
+
+Because the flag can be the *first* mutation of a tick — before the renderer
+reaches its `scheduleFlush()` — `observeTimingFlagProp` opens the pipeline itself
+if needed; `beginUpdatePipeline` is idempotent within a tick.
+
+### Lifecycle guarantees
+
+The guide's cancellation rules map onto existing code paths:
+
+| Condition | Behavior |
+|---|---|
+| Tick produces no ops | `doFlush` drops the pipeline instead of carrying it forward |
+| Empty batch on MT | `applyOps` returns `false`; pending load pipeline untouched |
+| Duplicate batch (double bundle eval) | same as above |
+| IFR hydration consumed the batch | batch pipeline released, load pipeline untouched |
+| Reload / page replacement | `resetMainThreadState()` drops every held pipeline |
+| Engine supplies no options | flush calls keep their exact pre-integration shape |
+
+`flushElementTree()` preserves the caller's flush scope (`__FlushElementTree()`
+vs `__FlushElementTree(page)`) when there is nothing to associate, and merges
+`pipelineOptions` into caller-owned options rather than replacing them.
+
+### Version gating
+
+`_onPipelineStart(pipelineID, options)` — the form that carries `dsl`/`stage` —
+landed in Lynx 3.1. Below that, only the id is passed. Every hook is called
+through an optional-call guard, so an engine without `lynx.performance` degrades
+to the pre-integration behavior with no branches in the hot path beyond one
+undefined check.
+
+## Change
+
+### Shared (`internal/src/ops.ts`)
+
+`PipelineOptions`, `FlushOptions`, `FrameworkTimingKey`, and the constants
+`PIPELINE_ORIGIN_UPDATE_BTS`, `PIPELINE_STAGE_UPDATE`, `DSL_VUE`,
+`TIMING_FLAG_ATTR`. This module is already the single wire-protocol source both
+bundles import, and the pipeline context is part of that wire protocol now.
+
+### Background thread
+
+- **`runtime/src/performance.ts`** (new) — pipeline lifecycle: open, mark,
+  observe flags, take, drop. Renderer-agnostic.
+- **`runtime/src/flush.ts`** — `scheduleFlush()` opens the pipeline;
+  `doFlush()` marks `diffVdomEnd` / `packChanges*`, attaches the context to the
+  `callLepusMethod` payload, drops it on an empty batch.
+- **`runtime/src/node-ops.ts`** — `patchProp` reports `__lynx_timing_flag`.
+- **`runtime/src/index.ts`** — `setFrameworkDsl` (internal), reset wiring.
+
+### Main thread
+
+- **`main-thread/src/performance.ts`** (new) — receives pipelines, arbitrates
+  between the retained load pipeline and a batch pipeline, and owns
+  `flushElementTree()`. ES2019 only (LEPUS bytecode constraint).
+- **`main-thread/src/entry-main.ts`** — `renderPage` retains
+  `options.pipelineOptions`; `updatePage` / `updateGlobalProps` forward engine
+  options to a flush instead of being no-ops; `vuePatchUpdate` adopts the
+  batch pipeline and marks `parseChanges*`.
+- **`main-thread/src/ops-apply.ts`** — marks `patchChanges*`, flushes through
+  `flushElementTree()`, returns whether it submitted; `resetMainThreadState()`
+  drops held pipelines.
+- **`main-thread/src/ifr.ts`** — `runIfrRender()` returns whether a first screen
+  was painted on this thread.
+
+### Wire format
+
+`callLepusMethod('vuePatchUpdate', { data })` → `{ data, pipelineOptions? }`.
+Additive and both-ways compatible: an older main thread ignores the extra field,
+and an older background thread simply sends `undefined`.
+
+## vdom vs Vapor
+
+The two are structurally the same integration. Everything above — both new
+modules, the flush wiring, the wire format, the lifecycle rules — is byte-for-byte
+identical on `main` and `vapor`. The differences are three, and all of them are
+small:
+
+1. **Where the timing flag is observed.** The vdom renderer has one generic
+   attribute path (`node-ops.ts` `patchProp`'s final `else`). Vapor writes
+   attributes from several places — `ShadowElement.setAttribute`, the template
+   clone path, and its own `node-ops` — so the observation call appears at each
+   of them. Same one-line call, more call sites.
+2. **`dsl`.** The vapor branch runs both rendering strategies, so it reports
+   `vue-vapor` for Vapor apps via `setFrameworkDsl()` and leaves `vue` for the
+   vdom renderer. Keeping them distinct is the whole point: the two have very
+   different framework-rendering cost profiles, and merging them under one `dsl`
+   would make pipeline data unable to tell them apart.
+3. **What `diffVdomStart`/`diffVdomEnd` actually measure.** Under vdom it is a
+   virtual-DOM diff. Under Vapor there is no virtual DOM at all — it is the
+   window in which reactive effects write directly into the ops buffer. The keys
+   are the same because the public key list has no other name for "framework
+   rendering work on the background thread" (see the feedback below).
+
+That the seam is the ops pipeline rather than the renderer is what makes this
+work. A renderer-level integration — hooking Vue's component render, the way
+ReactLynx hooks Preact's `options._render` — would have had to be written twice
+and would not have survived the vdom→Vapor change.
+
+## Feedback for lynx-family/lynx-website#1311
+
+The PR is a genuinely good spec — the ownership tables and the pipeline/flush
+distinction are the parts a framework author actually needs, and they are right.
+The following came up while implementing against it.
+
+**1. The Timing Flag procedure contradicts the reference implementation.**
+`_bindPipelineIdWithTimingFlag`'s "Usage requirements" tell a framework to
+(1) set `needTimestamps`, (2) bind the flag, (3) submit. ReactLynx does only (1)
+and (3) for application flags; the engine derives `identifier` from the element
+attribute. Following the documented procedure would bind the same flag twice.
+The page should say that `_bindPipelineIdWithTimingFlag` is for
+*framework-synthesized* flags (ReactLynx's `react_lynx_hydrate`), and that an
+application `__lynx_timing_flag` needs `needTimestamps` only. This is the single
+most likely thing for an integrator to get wrong, because the current wording is
+imperative and specific.
+
+**2. `renderPage(data, options?)` is documented as the load-pipeline entry point,
+but ReactLynx's own `LynxCallByNative` types it as `(data) => void`.** The guide
+marks the callback contract "To be added" and CFP-04 tracks the signature, but a
+reader will not notice that the *only* validated path today is the engine's
+implicit flush inside `renderPage`. Frameworks whose `renderPage` produces a
+placeholder — which the guide itself describes at length — have no documented way
+to obtain the load pipeline at all. Worth stating plainly which SDK versions pass
+the second argument, since the whole placeholder section depends on it.
+
+**3. The placeholder case deserves promotion, not a subsection.** A
+background-driven framework whose `renderPage` creates only a page root is not an
+edge case — it is the default shape for anything that isn't ReactLynx-with-IFR.
+The guide handles it correctly (retain, don't consume with empty batches), but it
+reads as an exception to the synchronous case. Recommend leading with it.
+
+**4. `FrameworkTimingKey` is vdom-vocabulary in a framework-neutral contract.**
+`diffVdomStart` / `diffVdomEnd` are the only keys for "framework rendering work
+before serialization", and they are unusable as written by any framework without
+a virtual DOM — signal-based frameworks, Vue Vapor, Svelte-style compilers. We
+emit them anyway because there is no alternative, which makes the reported data
+mildly dishonest. CFP-09 asks for framework-neutral `hydrate`/`update`
+*semantics*; the same treatment is needed for the *key names*. A neutral alias
+(`frameworkRenderStart`/`End`) with the `diffVdom*` names retained for
+compatibility would fix it.
+
+**5. `stage` has no value for "first screen".** The enumerated values are
+`hydrate` and `update`. A framework-initiated pipeline that submits the first
+screen is neither: it is not reconciling against an existing representation, and
+it is not "ordinary rendering after initialization". We avoid the question by
+letting the engine's `loadBundle` pipeline own the first screen, but a framework
+that must open its own would have to pick a wrong value or invent one, which
+§`stage` forbids.
+
+**6. `_markTiming`'s "Typical runtime" table implies a thread the key does not
+enforce.** It lists change parsing and element mutation as Main Thread. Nothing
+in the API prevents a main-thread-rendering framework from recording
+`diffVdomStart` on the main thread, and the guide elsewhere says a framework "may
+use Main Thread Rendering". Recommend framing the table as "the runtime that
+performs the work", which the prose already says, and dropping the implication
+that keys are thread-bound.
+
+**7. Two guide-level gaps worth an explicit sentence each.**
+   - *One flush, one pipeline.* `FlushOptions.pipelineOptions` is singular, but a
+     framework can hold a retained load pipeline and receive an update pipeline
+     for the same batch. The guide never says which wins, and the answer
+     (`loadBundle`, because first-screen metrics depend on it) is not obvious.
+   - *Flush scope.* `__FlushElementTree(root, options)` has no
+     `(options)`-only overload, so a framework that has always called
+     `__FlushElementTree()` with no arguments must start naming a root the moment
+     it attaches a pipeline. The guide says not to change the flush scope; it
+     should acknowledge that the no-argument form makes that impossible and state
+     that the page element is the correct substitute.
+
+**8. Minor.** `_generatePipelineOptions()` is documented as returning
+`PipelineOptions`, but ReactLynx calls it as `lynx.performance?._generatePipelineOptions?.()`
+and null-checks the result — the reference should say it may be absent on older
+engines rather than leaving every integrator to discover the guard. And
+`CUSTOM_FRAMEWORK_PERFORMANCE_API_OPEN_ISSUES.md` sits at the repository root; it
+looks like a working file that should not ship in the merge.
+
+## Follow-ups
+
+- **A `hydrate`-stage pipeline for IFR.** The background thread's first batch in
+  an IFR build is genuinely hydration and could carry `stage: 'hydrate'`, the way
+  ReactLynx does. It is skipped today because the background side cannot tell an
+  IFR build from a non-IFR one on `main` (`vapor` has `isIfrEnabled()`, `main`
+  does not), and getting it wrong would cost the `loadBundle` correlation.
+- **Earlier `diffVdomStart`.** The mark lands on the first tree mutation of a
+  tick, not the first component render, because Vue exposes no public
+  "a render is about to run" hook. Component-render time before the first
+  mutation is therefore unattributed.
+- **Conformance.** CFP-11's suite does not exist yet; `performance.spec.ts`
+  covers the twelve scenarios from the guide's testing section that can be
+  exercised without a device. Device validation (Android/iOS release builds,
+  `PerformanceObserver` + `onPerformanceEvent`) is untested.


### PR DESCRIPTION
Implements the custom-framework Performance API contract specified in [lynx-family/lynx-website#1311](https://github.com/lynx-family/lynx-website/pull/1311). Vapor port: `claude/performance-system-integration-7exguf-vapor` (branched off `vapor`).

## Why

Lynx attributes rendering work to a **Lynx Pipeline** — the unit that runs from a rendering trigger to the pixels it produces. The engine records the pixel half itself, but the framework half (diff, serialization, cross-thread transfer, element mutation) is invisible to it unless the framework opts in. Today a Vue Lynx app gets no `PipelineEntry` for its own updates and no `pipeline.loadBundle` correlation for its first screen: `PerformanceObserver` fires, but the entries are hollow.

## What

The integration hooks the **ops pipeline, not the renderer**: `scheduleFlush` / `doFlush` on the background thread, `vuePatchUpdate` / `applyOps` / `__FlushElementTree` on the main thread. Those four points are where a pipeline is opened, marked, transferred, and committed — and they are the same points regardless of what produces the tree above them, which is why the Vapor port needs no new plumbing.

| Pipeline | Initiator | Handling |
|---|---|---|
| `loadBundle` | Engine | Arrives at `renderPage`, **retained**, attached to whichever flush submits real content |
| `updateTriggeredByBts` | Vue Lynx (BG) | Created per scheduler tick that produces ops, transferred with the batch, committed by the flush that applies it |
| `updatePage` / `updateGlobalProps` | Engine / Native | Forwarded verbatim to a flush so the pipeline completes |

**The first background batch is deliberately not a framework pipeline.** This is the structural difference from ReactLynx, whose `renderPage` builds the real tree on the main thread. In a non-IFR Vue Lynx build `renderPage` creates only an empty page root — a *placeholder* in exactly the sense the integration guide defines — so the first screen is the background thread's first batch and must ride the engine's load pipeline. With IFR the first screen really is painted in `renderPage`, so it is committed there instead; `runIfrRender()` now reports which case applies.

Timing keys are marked where the work happens (`diffVdom*` / `packChanges*` on BG, `parseChanges*` / `patchChanges*` on MT) and gated on `needTimestamps`, so an unflagged update costs one `_generatePipelineOptions` + `_onPipelineStart` + one forced `diffVdomStart`. An application `__lynx_timing_flag` raises `needTimestamps` and nothing else — the engine derives `PipelineEntry.identifier` from the element attribute, so binding it again would attribute the same flag twice (ReactLynx behaves identically).

Lifecycle rules from the guide map onto existing paths: a tick with no ops drops its pipeline, an empty or duplicate batch does not consume the pending load pipeline, and `resetMainThreadState()` discards everything on reload or page replacement. Flush calls keep their exact pre-integration shape when there is nothing to associate, and `pipelineOptions` is merged into caller-owned flush options rather than replacing them.

## Changes

- `internal/src/ops.ts` — `PipelineOptions` / `FlushOptions` / `FrameworkTimingKey` and the origin, stage, dsl, and timing-flag constants
- `runtime/src/performance.ts` (new) — background pipeline lifecycle; `flush.ts`, `node-ops.ts`, `index.ts` wiring
- `main-thread/src/performance.ts` (new) — pipeline arbitration and `flushElementTree()`; `entry-main.ts`, `ops-apply.ts`, `ifr.ts` wiring
- Wire payload: `callLepusMethod('vuePatchUpdate', { data })` → `{ data, pipelineOptions? }`, additive in both directions
- `plans/0817-1-performance-api-integration.md` — design notes, the vdom/Vapor comparison, and eight pieces of feedback on the spec PR
- `packages/upstream-tests/src/performance.spec.ts` — 12 tests covering the guide's testing section

## Testing

`pnpm test:local` (60 passed) and `pnpm test:dom` (1 passed) in `packages/upstream-tests`; `pnpm build` in `packages/vue-lynx`; `tsc` and `biome check` add no new errors. Compiled main-thread output verified free of ES2020 syntax for the LEPUS bytecode compiler.

**Not tested**: device validation. Confirming `pipeline.loadBundle`, a flagged update pipeline, and `frameworkPipelineTiming` end-to-end needs Android/iOS release builds with `PerformanceObserver` and `onPerformanceEvent`, which this environment cannot run.

## Notes for the spec PR

The plan doc's feedback section covers, in short: the `_bindPipelineIdWithTimingFlag` usage requirements contradict ReactLynx's actual behavior for application flags; `renderPage(data, options?)` is the documented load-pipeline entry point but ReactLynx types it as `(data) => void`, leaving placeholder-style frameworks with no documented way to obtain it; `FrameworkTimingKey` is vdom vocabulary in a framework-neutral contract (unusable as written by Vapor or any signal-based framework); `stage` has no value for "first screen"; and the guide never states which pipeline wins when a retained load pipeline and an update pipeline reach the same flush.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G5WLe8y2EucqmgE2W2N2yy)_