### PR TITLE
fix(scoped-css): support deep and slotted selectors

### DIFF
--- a/packages/testing-library/src/__tests__/scope-strip-css-plugin.test.ts
+++ b/packages/testing-library/src/__tests__/scope-strip-css-plugin.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+
+import { vueScopeStripCSSPlugin } from '../../../vue-lynx/plugin/src/plugins/vue-scope-strip-css-plugin.js';
+import { routeVueScopedCSS } from '../../../vue-lynx/plugin/src/plugins/vue-scoped-cssid-plugin.js';
+
+interface TestNode {
+  type: string;
+  name?: string | { name?: string };
+  children?: TestList;
+  prelude?: TestNode;
+  block?: TestNode;
+}
+
+interface TestItem {
+  data: TestNode;
+  next: TestItem | null;
+  prev: TestItem | null;
+}
+
+class TestList {
+  head: TestItem | null = null;
+  tail: TestItem | null = null;
+
+  constructor(nodes: TestNode[] = []) {
+    for (const node of nodes) this.appendData(node);
+  }
+
+  appendData(data: TestNode): void {
+    const item: TestItem = { data, next: null, prev: this.tail };
+    if (this.tail) this.tail.next = item;
+    else this.head = item;
+    this.tail = item;
+  }
+
+  remove(item: TestItem): void {
+    if (item.prev) item.prev.next = item.next;
+    else this.head = item.next;
+    if (item.next) item.next.prev = item.prev;
+    else this.tail = item.prev;
+    item.next = null;
+    item.prev = null;
+  }
+
+  toArray(): TestNode[] {
+    const nodes: TestNode[] = [];
+    let item = this.head;
+    while (item) {
+      nodes.push(item.data);
+      item = item.next;
+    }
+    return nodes;
+  }
+}
+
+const classSelector = (name: string): TestNode => ({
+  type: 'ClassSelector',
+  name,
+});
+
+const scopeSelector = (name: string): TestNode => ({
+  type: 'AttributeSelector',
+  name: { name },
+});
+
+const combinator = (): TestNode => ({ type: 'Combinator', name: ' ' });
+
+function rule(...selectorNodes: TestNode[]): TestNode {
+  return {
+    type: 'Rule',
+    prelude: {
+      type: 'SelectorList',
+      children: new TestList([
+        { type: 'Selector', children: new TestList(selectorNodes) },
+      ]),
+    },
+    block: { type: 'Block', children: new TestList() },
+  };
+}
+
+function selectorKinds(ruleNode: TestNode): string[] {
+  const selector = ruleNode.prelude?.children?.head?.data;
+  return selector?.children?.toArray().map((node) => {
+    const name = typeof node.name === 'string' ? node.name : node.name?.name;
+    return `${node.type}:${name ?? ''}`;
+  }) ?? [];
+}
+
+describe('vueScopeStripCSSPlugin', () => {
+  it('routes only deep and slotted rules out of the cssId block', () => {
+    const extracted = `@cssId "123" "Component.vue" {
+      .box[data-v-hash] { color: blue; }
+      .outer[data-v-hash] .inner[data-v-hash] { color: purple; }
+      .parent[data-v-hash] .child { color: red; }
+      .item[data-v-hash-s] { color: green; }
+    }`;
+
+    const routed = routeVueScopedCSS(extracted);
+
+    expect(routed).toContain(
+      '@cssId "123" "Component.vue" {\n      .box[data-v-hash] { color: blue; }',
+    );
+    expect(routed).toContain(
+      '.outer[data-v-hash] .inner[data-v-hash] { color: purple; }',
+    );
+    expect(routed).not.toContain(
+      '@cssId "123" "Component.vue" {\n      .parent[data-v-hash] .child',
+    );
+    expect(routed).toContain(
+      '.parent[data-v-hash] .child { color: red; }',
+    );
+    expect(routed).toContain(
+      '.item[data-v-hash-s] { color: green; }',
+    );
+  });
+
+  it('moves deep and slotted rules to common CSS as scope-class selectors', () => {
+    const ordinary = rule(classSelector('box'), scopeSelector('data-v-hash'));
+    const ordinaryDescendant = rule(
+      classSelector('outer'),
+      scopeSelector('data-v-hash'),
+      combinator(),
+      classSelector('inner'),
+      scopeSelector('data-v-hash'),
+    );
+    const deep = rule(
+      classSelector('parent'),
+      scopeSelector('data-v-hash'),
+      combinator(),
+      classSelector('child'),
+    );
+    const slotted = rule(
+      classSelector('item'),
+      scopeSelector('data-v-hash-s'),
+    );
+    const cssIdBlock: TestNode = {
+      type: 'Block',
+      children: new TestList([ordinary, ordinaryDescendant, deep, slotted]),
+    };
+    const ast: TestNode = {
+      type: 'StyleSheet',
+      children: cssIdBlock.children,
+    };
+
+    vueScopeStripCSSPlugin.phaseStandard(ast as never);
+
+    expect(cssIdBlock.children?.toArray()).toEqual([
+      ordinary,
+      ordinaryDescendant,
+      deep,
+      slotted,
+    ]);
+    expect(selectorKinds(ordinary)).toEqual(['ClassSelector:box']);
+    expect(selectorKinds(ordinaryDescendant)).toEqual([
+      'ClassSelector:outer',
+      'Combinator: ',
+      'ClassSelector:inner',
+    ]);
+    expect(selectorKinds(deep)).toEqual([
+      'ClassSelector:parent',
+      'ClassSelector:v-hash',
+      'Combinator: ',
+      'ClassSelector:child',
+    ]);
+    expect(selectorKinds(slotted)).toEqual([
+      'ClassSelector:item',
+      'ClassSelector:v-hash-s',
+    ]);
+  });
+});

--- a/packages/testing-library/src/__tests__/scoped-css.test.ts
+++ b/packages/testing-library/src/__tests__/scoped-css.test.ts
@@ -21,7 +21,11 @@ import {
   registerElementTemplate,
 } from 'vue-lynx';
 import { OP } from '../../../vue-lynx/internal/src/ops.js';
-import { applyScopeId, nodeOps } from '../../../vue-lynx/runtime/src/node-ops.js';
+import {
+  applyScopeId,
+  nodeOps,
+  resolveClass,
+} from '../../../vue-lynx/runtime/src/node-ops.js';
 import { takeOps } from '../../../vue-lynx/runtime/src/ops.js';
 import { ShadowElement } from '../../../vue-lynx/runtime/src/shadow-element.js';
 import { scopeIdToCssId } from '../../../vue-lynx/runtime/src/scope-bridge.js';
@@ -77,6 +81,43 @@ describe('SET_SCOPE_ID (nodeOps)', () => {
       OP.SET_SCOPE_ID,
       10,
       scopeIdToCssId('data-v-aaa00001'),
+      OP.SET_CLASS,
+      10,
+      'v-aaa00001',
+      OP.SET_CLASS,
+      10,
+      'v-aaa00001 v-bbb00002',
+    ]);
+  });
+
+  it('composes deep and slotted scope classes without losing the cssId fast path', () => {
+    const el = new ShadowElement('view', 13);
+
+    nodeOps.patchProp!(el, 'class', null, 'item');
+    takeOps();
+
+    // Vue emits the ordinary scope for elements authored by the component.
+    // It is both the native cssId fast path for ordinary rules and the class
+    // targeted by Vue-compiled deep selectors such as
+    // `.parent[data-v-8f634878] .child`.
+    nodeOps.setScopeId!(el, 'data-v-8f634878');
+    // Slot content receives the separate `-s` scope. It participates only in
+    // common CSS through `.v-8f634878-s`; it must not replace cssId.
+    nodeOps.setScopeId!(el, 'data-v-8f634878-s');
+
+    expect(resolveClass(el)).toBe(
+      'item v-8f634878 v-8f634878-s',
+    );
+    expect(takeOps()).toEqual([
+      OP.SET_SCOPE_ID,
+      13,
+      scopeIdToCssId('data-v-8f634878'),
+      OP.SET_CLASS,
+      13,
+      'item v-8f634878',
+      OP.SET_CLASS,
+      13,
+      'item v-8f634878 v-8f634878-s',
     ]);
   });
 
@@ -92,6 +133,7 @@ describe('SET_SCOPE_ID (nodeOps)', () => {
     const ops = takeOps();
     expect(ops).toEqual([
       OP.SET_SCOPE_ID, 11, scopeIdToCssId('data-v-aaa00001'),
+      OP.SET_CLASS, 11, 'v-aaa00001',
       OP.SET_SCOPE_ID, 11, scopeIdToCssId('data-v-bbb00002'),
       OP.SET_SCOPE_ID, 11, 0,
     ]);

--- a/packages/vue-lynx/plugin/src/plugins/vue-scope-strip-css-plugin.ts
+++ b/packages/vue-lynx/plugin/src/plugins/vue-scope-strip-css-plugin.ts
@@ -3,14 +3,15 @@
 // LICENSE file in the root directory of this source tree.
 
 /**
- * CSS-tree plugin that strips Vue scoped `[data-v-xxx]` attribute selectors
- * from the serialized CSS AST.
+ * CSS-tree plugin that adapts Vue scoped `[data-v-xxx]` attribute selectors
+ * for Lynx's hybrid scoped-CSS model.
  *
  * Vue's `<style scoped>` adds `[data-v-{hash}]` to every selector.
  * Lynx's CSS engine doesn't support attribute selectors, and scoping is
- * handled by the native `cssId` mechanism instead.  This plugin removes
- * the attribute selectors during template encoding (via `cssPlugins`
- * on LynxTemplatePlugin / CssExtractPlugin).
+ * handled by the native `cssId` mechanism for ordinary scoped rules. Deep
+ * and slotted selectors cannot be expressed by one cssId per element, so
+ * those rules are moved to common CSS and their scope attributes become
+ * matching classes supplied by the runtime.
  *
  * Plugin format: `{ phaseStandard(ast, ctx) }` — invoked by
  * `@lynx-js/css-serializer`'s `parse()` on the css-tree AST.
@@ -31,38 +32,107 @@ interface List {
 
 interface ASTNode {
   type: string;
-  name?: { name?: string };
+  name?: string | { name?: string };
   children?: List;
   prelude?: ASTNode;
   block?: ASTNode;
   [key: string]: unknown;
 }
 
-function stripVueScopeFromAST(node: ASTNode): void {
+function nodeName(node: ASTNode): string | undefined {
+  return typeof node.name === 'string' ? node.name : node.name?.name;
+}
+
+function scopeIdToClass(scopeId: string): string {
+  return scopeId.slice('data-'.length);
+}
+
+function isVueScopeSelector(node: ASTNode): boolean {
+  return node.type === 'AttributeSelector'
+    && nodeName(node)?.startsWith('data-v-') === true;
+}
+
+function ruleNeedsCommonCSS(node: ASTNode): boolean {
+  if (node.type === 'Selector' && node.children) {
+    let item = node.children.head;
+    let lastOrdinaryScope: ListItem | null = null;
+    while (item) {
+      if (isVueScopeSelector(item.data)) {
+        const scopeId = nodeName(item.data)!;
+        if (scopeId.endsWith('-s')) return true;
+        lastOrdinaryScope = item;
+      }
+      item = item.next;
+    }
+
+    // Ordinary descendant selectors have another scope marker on their final
+    // compound (`.parent[data-v-x] .child[data-v-x]`). A Vue-compiled deep
+    // selector ends with an unscoped compound instead, so only a combinator
+    // after the LAST scope marker requires the common-CSS fallback.
+    let rest = lastOrdinaryScope?.next ?? null;
+    while (rest) {
+      if (rest.data.type === 'Combinator') return true;
+      rest = rest.next;
+    }
+  }
+
+  if (node.children) {
+    let item = node.children.head;
+    while (item) {
+      if (ruleNeedsCommonCSS(item.data)) return true;
+      item = item.next;
+    }
+  }
+  if (node.prelude && ruleNeedsCommonCSS(node.prelude)) return true;
+  return node.block ? ruleNeedsCommonCSS(node.block) : false;
+}
+
+function adaptVueScopeSelectors(node: ASTNode, useClasses: boolean): void {
   // Walk children (css-tree uses linked lists)
   if (node.children) {
     let item = node.children.head;
     while (item) {
       const next = item.next;
-      if (
-        item.data.type === 'AttributeSelector'
-        && item.data.name?.name?.startsWith('data-v-')
-      ) {
-        node.children.remove(item);
+      if (isVueScopeSelector(item.data)) {
+        if (useClasses) {
+          item.data = {
+            type: 'ClassSelector',
+            name: scopeIdToClass(nodeName(item.data)!),
+          };
+        } else {
+          node.children.remove(item);
+        }
       } else {
-        stripVueScopeFromAST(item.data);
+        adaptVueScopeSelectors(item.data, useClasses);
       }
       item = next;
     }
   }
   // Walk named sub-trees (Rule.prelude = SelectorList, Rule.block = Block)
-  if (node.prelude) stripVueScopeFromAST(node.prelude);
-  if (node.block) stripVueScopeFromAST(node.block);
+  if (node.prelude) adaptVueScopeSelectors(node.prelude, useClasses);
+  if (node.block) adaptVueScopeSelectors(node.block, useClasses);
+}
+
+function adaptStyleSheet(ast: ASTNode): void {
+  if (ast.type === 'Rule') {
+    adaptVueScopeSelectors(ast, ruleNeedsCommonCSS(ast));
+    return;
+  }
+
+  if (ast.children) {
+    let item = ast.children.head;
+    while (item) {
+      adaptStyleSheet(item.data);
+      item = item.next;
+    }
+  }
+  if (ast.prelude) adaptStyleSheet(ast.prelude);
+  if (ast.block) adaptStyleSheet(ast.block);
 }
 
 export const vueScopeStripCSSPlugin = {
   name: 'vue-scope-strip',
   phaseStandard(ast: ASTNode): void {
-    stripVueScopeFromAST(ast);
+    adaptStyleSheet(ast);
   },
 };

--- a/packages/vue-lynx/plugin/src/plugins/vue-scoped-cssid-plugin.ts
+++ b/packages/vue-lynx/plugin/src/plugins/vue-scoped-cssid-plugin.ts
@@ -6,6 +6,178 @@ import { scopeIdToCssId } from 'vue-lynx/internal/ops';
 
 const PLUGIN_NAME = 'lynx:vue-scoped-cssid';
 
+function findBlockEnd(css: string, openBrace: number): number {
+  let depth = 1;
+  let quote = '';
+  let escaped = false;
+  let comment = false;
+
+  for (let index = openBrace + 1; index < css.length; index++) {
+    const char = css[index];
+    const next = css[index + 1];
+    if (comment) {
+      if (char === '*' && next === '/') {
+        comment = false;
+        index++;
+      }
+      continue;
+    }
+    if (quote) {
+      if (escaped) escaped = false;
+      else if (char === '\\') escaped = true;
+      else if (char === quote) quote = '';
+      continue;
+    }
+    if (char === '/' && next === '*') {
+      comment = true;
+      index++;
+    } else if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === '{') {
+      depth++;
+    } else if (char === '}' && --depth === 0) {
+      return index;
+    }
+  }
+  return css.length - 1;
+}
+
+function findStatementEnd(
+  css: string,
+  start: number,
+): { index: number; block: boolean } {
+  let quote = '';
+  let escaped = false;
+  let comment = false;
+  let parentheses = 0;
+
+  for (let index = start; index < css.length; index++) {
+    const char = css[index];
+    const next = css[index + 1];
+    if (comment) {
+      if (char === '*' && next === '/') {
+        comment = false;
+        index++;
+      }
+      continue;
+    }
+    if (quote) {
+      if (escaped) escaped = false;
+      else if (char === '\\') escaped = true;
+      else if (char === quote) quote = '';
+      continue;
+    }
+    if (char === '/' && next === '*') {
+      comment = true;
+      index++;
+    } else if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === '(') {
+      parentheses++;
+    } else if (char === ')') {
+      parentheses--;
+    } else if (parentheses === 0 && char === '{') {
+      return { index, block: true };
+    } else if (parentheses === 0 && char === ';') {
+      return { index, block: false };
+    }
+  }
+  return { index: css.length, block: false };
+}
+
+function selectorNeedsCommonCSS(selector: string): boolean {
+  for (const branch of selector.split(',')) {
+    const scopePattern = /\[data-v-[a-zA-Z0-9]+(-s)?\]/g;
+    let match: RegExpExecArray | null;
+    let lastOrdinaryScopeEnd = -1;
+    while ((match = scopePattern.exec(branch))) {
+      if (match[1]) return true;
+      lastOrdinaryScopeEnd = scopePattern.lastIndex;
+    }
+    if (
+      lastOrdinaryScopeEnd !== -1
+      && /(?:\s|[>+~])/.test(branch.slice(lastOrdinaryScopeEnd).trimEnd())
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+interface SplitCSS {
+  scoped: string;
+  common: string;
+}
+
+function splitScopedBlock(css: string): SplitCSS {
+  let scoped = '';
+  let common = '';
+  let index = 0;
+
+  while (index < css.length) {
+    const end = findStatementEnd(css, index);
+    if (end.index >= css.length) {
+      scoped += css.slice(index);
+      break;
+    }
+
+    if (!end.block) {
+      scoped += css.slice(index, end.index + 1);
+      index = end.index + 1;
+      continue;
+    }
+
+    const closeBrace = findBlockEnd(css, end.index);
+    const header = css.slice(index, end.index);
+    const body = css.slice(end.index + 1, closeBrace);
+    if (header.trimStart().startsWith('@')) {
+      const nested = splitScopedBlock(body);
+      if (nested.scoped) scoped += `${header}{${nested.scoped}}`;
+      if (nested.common) common += `${header}{${nested.common}}`;
+    } else if (selectorNeedsCommonCSS(header)) {
+      common += css.slice(index, closeBrace + 1);
+    } else {
+      scoped += css.slice(index, closeBrace + 1);
+    }
+    index = closeBrace + 1;
+  }
+
+  return { scoped, common };
+}
+
+/**
+ * Lift Vue-compiled deep/slotted rules out of extracted @cssId blocks. Lynx's
+ * debundler treats rules outside those blocks as common CSS (fragment 0),
+ * which every numeric cssId fragment imports.
+ */
+export function routeVueScopedCSS(css: string): string {
+  let output = '';
+  let index = 0;
+
+  while (index < css.length) {
+    const end = findStatementEnd(css, index);
+    if (end.index >= css.length) return output + css.slice(index);
+    if (!end.block) {
+      output += css.slice(index, end.index + 1);
+      index = end.index + 1;
+      continue;
+    }
+
+    const closeBrace = findBlockEnd(css, end.index);
+    const header = css.slice(index, end.index);
+    if (/^\s*@cssid\b/i.test(header)) {
+      const body = css.slice(end.index + 1, closeBrace);
+      const { scoped, common } = splitScopedBlock(body);
+      output += `${header}{${scoped}}${common}`;
+    } else {
+      output += css.slice(index, closeBrace + 1);
+    }
+    index = closeBrace + 1;
+  }
+
+  return output;
+}
+
 function extractCssIdFromQuery(query: string): number | null {
   if (!query.includes('type=style') || !query.includes('scoped')) return null;
   if (query.includes('cssId=')) return null;
@@ -39,6 +211,29 @@ export class VueScopedCSSIdPlugin {
             });
           } catch {
             loaderContext.resourceQuery = newQuery;
+          }
+        },
+      );
+
+      const Compilation = compiler.webpack?.Compilation;
+      const RawSource = compiler.webpack?.sources?.RawSource;
+      if (!Compilation || !RawSource || !compilation.hooks.processAssets) return;
+
+      compilation.hooks.processAssets.tap(
+        {
+          name: PLUGIN_NAME,
+          // LynxTemplatePlugin encodes CSS at OPTIMIZE_HASH. Route rules one
+          // stage earlier, after CSS extraction/minification has completed.
+          stage: Compilation.PROCESS_ASSETS_STAGE_OPTIMIZE_HASH - 1,
+        },
+        () => {
+          for (const asset of compilation.getAssets()) {
+            if (!asset.name.endsWith('.css')) continue;
+            const source = asset.source.source().toString();
+            const routed = routeVueScopedCSS(source);
+            if (routed !== source) {
+              compilation.updateAsset(asset.name, new RawSource(routed));
+            }
           }
         },
       );

--- a/packages/vue-lynx/runtime/src/node-ops.ts
+++ b/packages/vue-lynx/runtime/src/node-ops.ts
@@ -14,7 +14,11 @@ import { scheduleFlush } from './flush.js';
 import { isIfrMainThread } from './ifr-env.js';
 import { OP, pushOp } from './ops.js';
 import { registerWorkletCtx } from './run-on-background.js';
-import { scopeIdToCssId } from './scope-bridge.js';
+import {
+  isSlottedScopeId,
+  scopeIdToClass,
+  scopeIdToCssId,
+} from './scope-bridge.js';
 import { ShadowElement } from './shadow-element.js';
 import type { Worklet } from './worklet-types.js';
 
@@ -163,9 +167,13 @@ function resolveMainThreadAnchor(
 // ---------------------------------------------------------------------------
 
 export function resolveClass(el: ShadowElement): string {
-  if (el._transitionClasses.size === 0) return el._baseClass;
+  if (
+    el._scopeClasses.size === 0
+    && el._transitionClasses.size === 0
+  ) return el._baseClass;
   const parts: string[] = [];
   if (el._baseClass) parts.push(el._baseClass);
+  for (const cls of el._scopeClasses) parts.push(cls);
   for (const cls of el._transitionClasses) parts.push(cls);
   return parts.join(' ');
 }
@@ -566,10 +574,19 @@ export const nodeOps: RendererOptions<ShadowElement, ShadowElement> = {
   // working, and the usual workaround was an extra wrapper element (#317).
   // Vue always emits the owning component's scope first, so keeping the first
   // association leaves every element in the fragment of the component that
-  // authored it.
+  // authored it. Every scope is additionally retained as a class so rules
+  // containing :deep() and :slotted(), promoted to common CSS at build time,
+  // can compose all scopes exactly like Vue's data-v attributes do in DOM.
   setScopeId(el: ShadowElement, id: string): void {
-    if (el._cssId !== undefined) return;
-    applyScopeId(el, id);
+    if (!isSlottedScopeId(id) && el._cssId === undefined) {
+      applyScopeId(el, id);
+    }
+
+    const scopeClass = scopeIdToClass(id);
+    if (!scopeClass || el._scopeClasses.has(scopeClass)) return;
+    el._scopeClasses.add(scopeClass);
+    pushOp(OP.SET_CLASS, el.id, resolveClass(el));
+    scheduleFlush();
   },
 
   parentNode(node: ShadowElement): ShadowElement | null {

--- a/packages/vue-lynx/runtime/src/scope-bridge.ts
+++ b/packages/vue-lynx/runtime/src/scope-bridge.ts
@@ -9,3 +9,13 @@
  * and the scoped-CSS build plugin must derive identical ids.
  */
 export { scopeIdToCssId } from 'vue-lynx/internal/ops';
+
+/** Scope class shared by Vue-compiled deep/slotted CSS and runtime elements. */
+export function scopeIdToClass(scopeId: string): string | null {
+  return scopeId.startsWith('data-v-') ? scopeId.slice('data-'.length) : null;
+}
+
+/** Slotted scope ids participate in common CSS only, never native cssId. */
+export function isSlottedScopeId(scopeId: string): boolean {
+  return scopeIdToClass(scopeId)?.endsWith('-s') === true;
+}

--- a/packages/vue-lynx/runtime/src/shadow-element.ts
+++ b/packages/vue-lynx/runtime/src/shadow-element.ts
@@ -48,6 +48,10 @@ export class ShadowElement {
   // _transitionClasses: classes added/removed by <Transition> hooks.
   // The effective class sent to MT = _baseClass + _transitionClasses joined.
   _baseClass = '';
+  // Vue scope ids are also emitted as classes for selectors that native
+  // cssId cannot represent (`:deep()` and `:slotted()`). They are kept
+  // separately so dynamic :class updates cannot erase them.
+  _scopeClasses: Set<string> = new Set();
   _transitionClasses: Set<string> = new Set();
   // Generation counter bumped each time whenTransitionEnds() starts waiting
   // on this element. Lets a stale/superseded finish() (fired by the fallback


### PR DESCRIPTION
## Summary

- retain native numeric `cssId` scoping for ordinary scoped rules
- route Vue-compiled deep and slotted rules to common CSS and rewrite their scope attributes to composable `v-*` classes
- compose ordinary and `-s` scope classes at runtime without losing dynamic or transition classes

## Verification

- `pnpm --filter vue-lynx-testing-library exec vitest run src/__tests__/scoped-css.test.ts src/__tests__/scope-strip-css-plugin.test.ts` (16 tests)
- `(cd packages/vue-lynx/runtime && npx rslib build)`
- `(cd packages/vue-lynx/plugin && npx rslib build)`
- built `@vue-lynx-example/css-features` with temporary deep/slotted probes and verified both fallback selectors landed in style fragment `0`, while ordinary scoped rules remained in their numeric fragment

Fixes #165