### PR TITLE
fix(scoped-css): support :global() in scoped styles

### DIFF
--- a/packages/testing-library/src/__tests__/vue-scoped-cssid-plugin.test.ts
+++ b/packages/testing-library/src/__tests__/vue-scoped-cssid-plugin.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import vueScopedCSSSplitLoader from '../../../vue-lynx/plugin/src/loaders/vue-scoped-css-split-loader.js';
+import { splitVueScopedCSS } from '../../../vue-lynx/plugin/src/plugins/vue-scoped-cssid-plugin.js';
+
+const loaderContext = {
+  context: '/project/src',
+  resourcePath: '/project/src/Example.vue',
+  resourceQuery:
+    '?vue&type=style&index=0&id=abcd1234&scoped=true&lang=css&cssId=734794292',
+};
+
+describe('Vue scoped CSS fragment routing', () => {
+  it('routes a compiled :global rule to common without moving scoped rules', () => {
+    const css = [
+      '.ordinary[data-v-abcd1234] { color: red; }',
+      '.global { color: blue; }',
+    ].join('\n');
+
+    const { component, common } = splitVueScopedCSS(css, 'data-v-abcd1234');
+
+    expect(component).toContain('.ordinary[data-v-abcd1234]');
+    expect(component).not.toContain('.global');
+    expect(common).toContain('.global');
+    expect(common).not.toContain('.ordinary[data-v-abcd1234]');
+  });
+
+  it('emits component and common request variants for mixed scoped CSS', () => {
+    const css = [
+      '.ordinary[data-v-abcd1234] { color: red; }',
+      '.global { color: blue; }',
+    ].join('\n');
+
+    const component = vueScopedCSSSplitLoader.call(loaderContext, css);
+    const common = vueScopedCSSSplitLoader.call(
+      {
+        ...loaderContext,
+        resourceQuery: `${loaderContext.resourceQuery}&common=true`,
+      },
+      css,
+    );
+
+    expect(component).toContain('.ordinary[data-v-abcd1234]');
+    expect(component).not.toContain('.global {');
+    expect(component).toContain('Example.vue?vue&type=style');
+    expect(component).not.toContain('%3Fvue');
+    expect(component).toContain('cssId=734794292&common=true');
+    expect(common).toContain('.global {');
+    expect(common).not.toContain('.ordinary[data-v-abcd1234]');
+    expect(common).not.toContain('@import');
+  });
+
+  it('does not create a common request when every selector is scoped', () => {
+    const css = '.ordinary[data-v-abcd1234] { color: red; }';
+
+    expect(vueScopedCSSSplitLoader.call(loaderContext, css)).toBe(css);
+  });
+
+  it('passes non-scoped style requests through unchanged', () => {
+    const css = '.global { color: blue; }';
+
+    expect(vueScopedCSSSplitLoader.call(
+      {
+        ...loaderContext,
+        resourceQuery: '?vue&type=style&index=0&id=abcd1234&lang=css',
+      },
+      css,
+    )).toBe(css);
+  });
+});

--- a/packages/vue-lynx/plugin/rslib.config.ts
+++ b/packages/vue-lynx/plugin/rslib.config.ts
@@ -12,6 +12,8 @@ export default defineConfig({
     entry: {
       index: './src/index.ts',
       'loaders/ignore-css-loader': './src/loaders/ignore-css-loader.ts',
+      'loaders/vue-scoped-css-split-loader':
+        './src/loaders/vue-scoped-css-split-loader.ts',
       'loaders/worklet-loader': './src/loaders/worklet-loader.ts',
       'loaders/worklet-loader-mt': './src/loaders/worklet-loader-mt.ts',
       'loaders/vue-sfc-script-extractor':

--- a/packages/vue-lynx/plugin/src/css.ts
+++ b/packages/vue-lynx/plugin/src/css.ts
@@ -32,6 +32,7 @@ export interface ApplyCSSOptions {
 }
 
 const _dirname = path.dirname(fileURLToPath(import.meta.url));
+const VUE_SCOPED_CSS_SPLIT_LOADER = 'vue-scoped-css-split-loader';
 
 export function applyCSS(
   api: RsbuildPluginAPI,
@@ -118,6 +119,20 @@ export function applyCSS(
               )
               .end();
           }
+
+          // Vue has already lowered :global() by this point. Split the raw
+          // CSS immediately before css-loader resolves @imports so its common
+          // sibling request flows through the existing extraction pipeline.
+          rule
+            .use(VUE_SCOPED_CSS_SPLIT_LOADER)
+            .after(CHAIN_ID.USE.CSS)
+            .loader(
+              path.resolve(
+                _dirname,
+                './loaders/vue-scoped-css-split-loader',
+              ),
+            )
+            .end();
         });
 
       // Also strip lightningcss from inline CSS rules (Rsbuild ≥1.3.0).

--- a/packages/vue-lynx/plugin/src/entry.ts
+++ b/packages/vue-lynx/plugin/src/entry.ts
@@ -606,8 +606,9 @@ export function applyEntry(
     }
 
     // ------------------------------------------------------------------
-    // VueScopedCSSIdPlugin – inject ?cssId=<N> into vue scoped style
-    // module queries so css-extract-webpack-plugin wraps CSS in @cssId.
+    // VueScopedCSSIdPlugin – inject ?cssId=<N> into Vue scoped-style module
+    // queries. The CSS split loader keeps scoped rules on this request and
+    // routes compiled :global() rules through a common=true sibling request.
     // ------------------------------------------------------------------
     if (isLynx || isWeb) {
       chain

--- a/packages/vue-lynx/plugin/src/loaders/vue-scoped-css-split-loader.ts
+++ b/packages/vue-lynx/plugin/src/loaders/vue-scoped-css-split-loader.ts
@@ -1,0 +1,45 @@
+// Copyright 2026 Xuan Huang (huxpro). All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+import path from 'node:path';
+
+import { splitVueScopedCSS } from '../plugins/vue-scoped-cssid-plugin.js';
+
+interface LoaderContext {
+  context: string;
+  resourcePath: string;
+  resourceQuery: string;
+}
+
+/**
+ * Split a Vue scoped style after Vue has compiled its selectors. The original
+ * request retains the component rules and cssId; a sibling `common=true`
+ * request emits only selectors compiled from `:global()`.
+ */
+export default function vueScopedCSSSplitLoader(
+  this: LoaderContext,
+  source: string,
+): string {
+  const params = new URLSearchParams(
+    this.resourceQuery.startsWith('?')
+      ? this.resourceQuery.slice(1)
+      : this.resourceQuery,
+  );
+  if (!params.has('scoped') || params.get('type') !== 'style') return source;
+
+  const scopeId = params.get('id');
+  if (!scopeId) return source;
+
+  const fragments = splitVueScopedCSS(source, scopeId);
+  if (params.get('common') === 'true') return fragments.common;
+  if (!fragments.common.trim()) return fragments.component;
+
+  params.set('common', 'true');
+  const query = params.toString().replace(/^vue=&/, 'vue&');
+  const relativeResource = path.relative(this.context, this.resourcePath)
+    .split(path.sep)
+    .join('/');
+  const request = `${relativeResource.startsWith('.') ? '' : './'}${relativeResource}?${query}`;
+  return `@import ${JSON.stringify(request)};\n${fragments.component}`;
+}

--- a/packages/vue-lynx/plugin/src/plugins/vue-scoped-cssid-plugin.ts
+++ b/packages/vue-lynx/plugin/src/plugins/vue-scoped-cssid-plugin.ts
@@ -6,6 +6,207 @@ import { scopeIdToCssId } from 'vue-lynx/internal/ops';
 
 const PLUGIN_NAME = 'lynx:vue-scoped-cssid';
 
+export interface VueScopedCSSFragments {
+  component: string;
+  common: string;
+}
+
+const RULE_LIST_AT_RULES = new Set([
+  'container',
+  'document',
+  'layer',
+  'media',
+  'scope',
+  'starting-style',
+  'supports',
+]);
+
+interface Terminator {
+  index: number;
+  kind: '{' | ';';
+}
+
+function findTerminator(css: string, start: number): Terminator | null {
+  let quote = '';
+  let parentheses = 0;
+  let brackets = 0;
+
+  for (let i = start; i < css.length; i++) {
+    const char = css[i];
+    const next = css[i + 1];
+    if (quote) {
+      if (char === '\\') i++;
+      else if (char === quote) quote = '';
+      continue;
+    }
+    if (char === '/' && next === '*') {
+      const end = css.indexOf('*/', i + 2);
+      i = end === -1 ? css.length : end + 1;
+      continue;
+    }
+    if (char === '"' || char === "'") {
+      quote = char;
+      continue;
+    }
+    if (char === '(') parentheses++;
+    else if (char === ')') parentheses--;
+    else if (char === '[') brackets++;
+    else if (char === ']') brackets--;
+    else if (parentheses === 0 && brackets === 0) {
+      if (char === '{' || char === ';') return { index: i, kind: char };
+    }
+  }
+  return null;
+}
+
+function findClosingBrace(css: string, open: number): number {
+  let depth = 1;
+  let quote = '';
+  for (let i = open + 1; i < css.length; i++) {
+    const char = css[i];
+    const next = css[i + 1];
+    if (quote) {
+      if (char === '\\') i++;
+      else if (char === quote) quote = '';
+      continue;
+    }
+    if (char === '/' && next === '*') {
+      const end = css.indexOf('*/', i + 2);
+      i = end === -1 ? css.length : end + 1;
+      continue;
+    }
+    if (char === '"' || char === "'") quote = char;
+    else if (char === '{') depth++;
+    else if (char === '}' && --depth === 0) return i;
+  }
+  return css.length - 1;
+}
+
+function splitSelectors(selectorList: string): string[] {
+  const selectors: string[] = [];
+  let start = 0;
+  let quote = '';
+  let parentheses = 0;
+  let brackets = 0;
+  for (let i = 0; i < selectorList.length; i++) {
+    const char = selectorList[i];
+    if (quote) {
+      if (char === '\\') i++;
+      else if (char === quote) quote = '';
+      continue;
+    }
+    if (char === '"' || char === "'") quote = char;
+    else if (char === '(') parentheses++;
+    else if (char === ')') parentheses--;
+    else if (char === '[') brackets++;
+    else if (char === ']') brackets--;
+    else if (char === ',' && parentheses === 0 && brackets === 0) {
+      selectors.push(selectorList.slice(start, i).trim());
+      start = i + 1;
+    }
+  }
+  selectors.push(selectorList.slice(start).trim());
+  return selectors.filter(Boolean);
+}
+
+function hasComponentScope(selector: string, scopeId: string): boolean {
+  return selector.includes(`[${scopeId}]`)
+    || selector.includes(`[${scopeId}-s]`);
+}
+
+function splitRuleList(css: string, scopeId: string): VueScopedCSSFragments {
+  let component = '';
+  let common = '';
+  let cursor = 0;
+
+  while (cursor < css.length) {
+    const triviaStart = cursor;
+    while (cursor < css.length) {
+      if (/\s/.test(css[cursor])) {
+        cursor++;
+        continue;
+      }
+      if (css[cursor] === '/' && css[cursor + 1] === '*') {
+        const end = css.indexOf('*/', cursor + 2);
+        cursor = end === -1 ? css.length : end + 2;
+        continue;
+      }
+      break;
+    }
+    const trivia = css.slice(triviaStart, cursor);
+    if (cursor >= css.length) {
+      component += trivia;
+      break;
+    }
+
+    const terminator = findTerminator(css, cursor);
+    if (!terminator) {
+      component += trivia + css.slice(cursor);
+      break;
+    }
+    if (terminator.kind === ';') {
+      component += trivia + css.slice(cursor, terminator.index + 1);
+      cursor = terminator.index + 1;
+      continue;
+    }
+
+    const header = css.slice(cursor, terminator.index);
+    const close = findClosingBrace(css, terminator.index);
+    const body = css.slice(terminator.index + 1, close);
+    const end = Math.min(close + 1, css.length);
+    const trimmedHeader = header.trim();
+
+    if (trimmedHeader.startsWith('@')) {
+      const name = /^@([\w-]+)/.exec(trimmedHeader)?.[1]?.toLowerCase();
+      if (name && RULE_LIST_AT_RULES.has(name)) {
+        const nested = splitRuleList(body, scopeId);
+        if (nested.component.trim()) {
+          component += `${trivia}${header}{${nested.component}}`;
+        }
+        if (nested.common.trim()) {
+          common += `${nested.component.trim() ? '' : trivia}${header}{${nested.common}}`;
+        }
+      } else {
+        component += trivia + css.slice(cursor, end);
+      }
+      cursor = end;
+      continue;
+    }
+
+    const selectors = splitSelectors(header);
+    const componentSelectors = selectors.filter(selector =>
+      hasComponentScope(selector, scopeId)
+    );
+    const commonSelectors = selectors.filter(selector =>
+      !hasComponentScope(selector, scopeId)
+    );
+    if (componentSelectors.length > 0) {
+      component += `${trivia}${componentSelectors.join(', ')} {${body}}`;
+    }
+    if (commonSelectors.length > 0) {
+      common += `${componentSelectors.length > 0 ? '' : trivia}${commonSelectors.join(', ')} {${body}}`;
+    }
+    cursor = end;
+  }
+
+  return { component, common };
+}
+
+/**
+ * Partition Vue-compiled scoped CSS into native component and common
+ * fragments. Vue removes the scope attribute from `:global()` selectors,
+ * which gives us an unambiguous post-compile routing marker.
+ */
+export function splitVueScopedCSS(
+  css: string,
+  rawScopeId: string,
+): VueScopedCSSFragments {
+  const scopeId = rawScopeId.startsWith('data-v-')
+    ? rawScopeId
+    : `data-v-${rawScopeId}`;
+  return splitRuleList(css, scopeId);
+}
+
 function extractCssIdFromQuery(query: string): number | null {
   if (!query.includes('type=style') || !query.includes('scoped')) return null;
   if (query.includes('cssId=')) return null;


### PR DESCRIPTION
## Summary

- split Vue-compiled scoped CSS into component and common fragments
- route selectors without the component scope marker through a `common=true` sibling style request
- preserve scoped-only and non-scoped style behavior, with mixed-rule and negative coverage

## Tests

- `pnpm --filter vue-lynx-testing-library exec vitest run src/__tests__/vue-scoped-cssid-plugin.test.ts` — 1 file passed, 4 tests passed
- `../node_modules/.bin/rslib build` from `packages/vue-lynx/plugin` — passed, including declaration generation for `vue-scoped-css-split-loader`
- `../node_modules/.bin/tsc -p tsconfig.build.json --noEmit` from `packages/vue-lynx/plugin` — passed
- `pnpm exec biome check packages/vue-lynx/plugin/rslib.config.ts packages/vue-lynx/plugin/src/css.ts packages/vue-lynx/plugin/src/entry.ts packages/vue-lynx/plugin/src/loaders/vue-scoped-css-split-loader.ts packages/vue-lynx/plugin/src/plugins/vue-scoped-cssid-plugin.ts packages/testing-library/src/__tests__/vue-scoped-cssid-plugin.test.ts` — passed
- `git diff origin/main...HEAD --check` — passed

Fixes #164