### PR TITLE
test(examples): add :deep/:slotted/:global verification cases to css-features

### DIFF
--- a/examples/css-features/src/App.vue
+++ b/examples/css-features/src/App.vue
@@ -6,6 +6,9 @@ import VBindCSS from './VBindCSS.vue'
 import VBindThreads from './VBindThreads.vue'
 import CSSVarsWorkaround from './CSSVarsWorkaround.vue'
 import ImportedCSS from './ImportedCSS.vue'
+import DeepSelector from './DeepSelector.vue'
+import SlottedSelector from './SlottedSelector.vue'
+import GlobalSelector from './GlobalSelector.vue'
 </script>
 
 <template>
@@ -37,5 +40,17 @@ import ImportedCSS from './ImportedCSS.vue'
 
     <!-- 6. Imported .css file — WORKS -->
     <ImportedCSS />
+
+    <!-- 7. :deep() in <style scoped> — #165 / PR #379 -->
+    <DeepSelector />
+
+    <!-- 8. :slotted() in <style scoped> — #165 / PR #379 -->
+    <SlottedSelector />
+
+    <!-- 9. :global() in <style scoped> — #164 / PR #381 -->
+    <GlobalSelector />
+    <!-- Probe styled ONLY by GlobalSelector's :global() rule. It lives here,
+         outside that component, so color proves the rule escaped its scope. -->
+    <text class="global-probe">:global() — should be TEAL if :global() works</text>
   </scroll-view>
 </template>

--- a/examples/css-features/src/DeepChild.vue
+++ b/examples/css-features/src/DeepChild.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+// Deliberately style-free child: the ONLY way `.deep-target` below can get
+// colored is via the parent's `:deep()` rule (issue #165).
+</script>
+
+<template>
+  <view class="deep-child-root">
+    <text class="deep-target">:deep() — should be RED if :deep() works</text>
+  </view>
+</template>

--- a/examples/css-features/src/DeepSelector.vue
+++ b/examples/css-features/src/DeepSelector.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+// Test: :deep() in <style scoped> (issue #165, PR #379)
+//
+// Vue compiles `.deep-wrap :deep(.deep-target)` to
+// `.deep-wrap[data-v-x] .deep-target`. The build routes this rule to the
+// common CSS fragment as `.deep-wrap.v-x .deep-target`, and the runtime adds
+// the `v-x` scope class, so the rule can reach into DeepChild.
+//
+// Control: `.deep-target` OUTSIDE `.deep-wrap` must stay gray — the rule is
+// still scoped by the ancestor `.deep-wrap.v-x` compound.
+import DeepChild from './DeepChild.vue'
+</script>
+
+<template>
+  <view class="deep-card">
+    <text class="deep-title">:deep()</text>
+    <view class="deep-wrap">
+      <DeepChild />
+    </view>
+    <!-- Same class, same component, but not under .deep-wrap. -->
+    <text class="deep-target">control — must stay GRAY (not red)</text>
+  </view>
+</template>
+
+<style scoped>
+.deep-card {
+  display: flex;
+  flex-direction: column;
+  background-color: #ffebee;
+  padding: 12px;
+  border-radius: 8px;
+  margin-bottom: 12px;
+}
+.deep-title {
+  font-size: 15px;
+  font-weight: bold;
+  color: #b71c1c;
+  margin-bottom: 4px;
+}
+.deep-wrap :deep(.deep-target) {
+  color: #d32f2f;
+  font-size: 13px;
+}
+.deep-target {
+  font-size: 12px;
+  color: #9e9e9e;
+}
+</style>

--- a/examples/css-features/src/GlobalSelector.vue
+++ b/examples/css-features/src/GlobalSelector.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+// Test: :global() in <style scoped> (issue #164, PR #381)
+//
+// Vue lowers `:global(.global-probe)` to a bare `.global-probe` with no
+// scope attribute. The split loader routes it through a `common=true`
+// sibling request so it lands in common CSS (fragment 0) instead of this
+// component's @cssId fragment.
+//
+// The `.global-probe` element lives in App.vue — OUTSIDE this component —
+// so it can only turn teal if the rule truly escaped the scope. The scoped
+// `.global-title` rule in the same block must keep working (mixed routing).
+</script>
+
+<template>
+  <view class="global-card">
+    <text class="global-title">:global() — this title must be TEAL (scoped rule intact)</text>
+    <text class="global-desc">
+      The probe line below this card lives in App.vue and is styled only by a
+      :global() rule declared here.
+    </text>
+  </view>
+</template>
+
+<style scoped>
+.global-card {
+  display: flex;
+  flex-direction: column;
+  background-color: #e0f2f1;
+  padding: 12px;
+  border-radius: 8px;
+  margin-bottom: 4px;
+}
+.global-title {
+  font-size: 15px;
+  font-weight: bold;
+  color: #00695c;
+  margin-bottom: 4px;
+}
+.global-desc {
+  font-size: 12px;
+  color: #555;
+}
+:global(.global-probe) {
+  color: #00897b;
+  font-size: 13px;
+  font-weight: bold;
+}
+</style>

--- a/examples/css-features/src/SlotHost.vue
+++ b/examples/css-features/src/SlotHost.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+// Test: :slotted() in <style scoped> (issue #165, PR #379)
+//
+// Vue compiles `:slotted(.slot-item)` to `.slot-item[data-v-x-s]` and calls
+// setScopeId with the `-s` suffixed scope on slot content. The build routes
+// the rule to common CSS as `.slot-item.v-x-s`; the runtime must add the
+// `v-x-s` class to slotted elements WITHOUT stealing their native cssId.
+</script>
+
+<template>
+  <view class="slot-host">
+    <slot />
+    <!-- Same class but authored HERE, not slotted: must stay gray. -->
+    <text class="slot-item">control — must stay GRAY (not purple)</text>
+  </view>
+</template>
+
+<style scoped>
+.slot-host {
+  display: flex;
+  flex-direction: column;
+  background-color: #fff;
+  padding: 8px;
+  border-radius: 4px;
+}
+:slotted(.slot-item) {
+  color: #7b1fa2;
+  font-size: 13px;
+}
+.slot-item {
+  font-size: 12px;
+  color: #9e9e9e;
+}
+</style>

--- a/examples/css-features/src/SlottedSelector.vue
+++ b/examples/css-features/src/SlottedSelector.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+// Test: :slotted() — the parent side. The slotted <text> below is authored by
+// THIS component, so Vue tags it with SlotHost's `-s` scope at runtime.
+// SlotHost's `:slotted(.slot-item)` rule must color it purple.
+import SlotHost from './SlotHost.vue'
+</script>
+
+<template>
+  <view class="slotted-card">
+    <text class="slotted-title">:slotted()</text>
+    <SlotHost>
+      <text class="slot-item">:slotted() — should be PURPLE if :slotted() works</text>
+    </SlotHost>
+  </view>
+</template>
+
+<style scoped>
+.slotted-card {
+  display: flex;
+  flex-direction: column;
+  background-color: #f3e5f5;
+  padding: 12px;
+  border-radius: 8px;
+  margin-bottom: 12px;
+}
+.slotted-title {
+  font-size: 15px;
+  font-weight: bold;
+  color: #4a148c;
+  margin-bottom: 4px;
+}
+</style>


### PR DESCRIPTION
## Summary

On-device verification suite for #164 (`:global()`, PR #381) and #165 (`:deep()`/`:slotted()`, PR #379), added to `examples/css-features`. Each case is self-describing (the expected color is spelled out in the text) and pairs a positive probe with a leak control:

- **`DeepSelector` + style-free `DeepChild`** — `:deep()` must color the child's text **red**; the same `.deep-target` class outside `.deep-wrap` must stay **gray** (scope-leak control).
- **`SlottedSelector` + `SlotHost`** — slotted content must turn **purple** via the host's `:slotted()` rule; the host's own `.slot-item` must stay **gray** (the `-s` scope must not apply to host-authored elements).
- **`GlobalSelector` + a `.global-probe` in `App.vue`** — the probe lives *outside* the declaring component and must turn **teal** via `:global()`, while a scoped rule in the same style block keeps working (mixed-rule routing).

On `main` these cases intentionally render unstyled (gray/default); they go green once #379 and #381 land. To verify a PR branch on device, merge this branch into it (or cherry-pick the single commit) and run the `css-features` example.

## Verification

- Example-only change (5 new `.vue` files + `App.vue` wiring); no build run here — meant to be exercised on device against the PR branches.
- Left as **draft** until #379/#381 merge, since the probes are red-by-design on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VftKCUjFjiMivXQNAEyHuX

---
_Generated by [Claude Code](https://claude.ai/code/session_01VftKCUjFjiMivXQNAEyHuX)_