### PR TITLE
perf(vapor): batch cloned CSS ID setup

### DIFF
--- a/packages/upstream-tests/src/mt/template-instantiation.spec.ts
+++ b/packages/upstream-tests/src/mt/template-instantiation.spec.ts
@@ -7,7 +7,7 @@
  * contiguous block the BG thread reserves for its shadow clone.
  */
 
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { OP } from 'vue-lynx/internal/ops';
 // Same-process module state as the pipeline set up by runtime-dom-setup.ts.
@@ -19,6 +19,10 @@ let ROOT = 0;
 beforeEach(() => {
   ROOT = nextId++;
   applyOps([OP.CREATE, ROOT, 'view']);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 // <view class=row style=…><text class=cell>(text folded: "hi")</text><!></view>
@@ -37,6 +41,31 @@ function structure() {
 }
 
 describe('MT template instantiation', () => {
+  it('batches clone CSS IDs before granular typed list creation', () => {
+    const tplId = nextTplId++;
+    const base = nextId;
+    nextId += 3;
+    const granular = nextId++;
+    const granularText = nextId++;
+
+    const setCSSId = vi.spyOn(globalThis, '__SetCSSId');
+    applyOps([
+      OP.REGISTER_TREE, tplId, structure(), 0,
+      OP.CLONE_TREE, tplId, base,
+      OP.CREATE, granular, 'list',
+      OP.CREATE_TEXT, granularText,
+    ]);
+
+    expect((elements.get(granular) as Element).tagName.toLowerCase()).toBe(
+      'list',
+    );
+    expect(setCSSId.mock.calls).toEqual([
+      [[elements.get(base), elements.get(base + 1)], 0],
+      [[elements.get(granular)], 0],
+      [[elements.get(granularText)], 0],
+    ]);
+  });
+
   it('instantiates a registered template with pre-order uids', () => {
     const tplId = nextTplId++;
     const base = nextId;
@@ -156,6 +185,51 @@ describe('MT sparse A2 template instantiation (#298)', () => {
       ],
     ];
   }
+
+  it('batches named and anonymous native handles in preorder', () => {
+    const tplId = nextTplId++;
+    const base = nextId;
+    nextId += 2;
+
+    const setCSSId = vi.spyOn(globalThis, '__SetCSSId');
+    applyOps([
+      OP.REGISTER_TREE, tplId, sparseStructure(), [0, 2],
+      OP.CLONE_TREE, tplId, base,
+    ]);
+
+    const root = elements.get(base) as Element;
+    expect(setCSSId.mock.calls).toEqual([[[root, ...root.childNodes], 0]]);
+  });
+
+  it('does not swallow clone or batched CSS initialization errors', () => {
+    const originalSetClasses = globalThis.__SetClasses;
+    const clone = (): void => {
+      const tplId = nextTplId++;
+      const base = nextId;
+      nextId += 2;
+      applyOps([
+        OP.REGISTER_TREE, tplId, sparseStructure(), [0, 2],
+        OP.CLONE_TREE, tplId, base,
+      ]);
+    };
+
+    vi.spyOn(globalThis, '__SetClasses').mockImplementation(
+      (node, value): void => {
+        if (value === 'static') throw new Error('static class rejection');
+        originalSetClasses(node, value);
+      },
+    );
+    const setCSSId = vi.spyOn(globalThis, '__SetCSSId');
+    expect(clone).toThrow('static class rejection');
+    expect(setCSSId).not.toHaveBeenCalled();
+
+    vi.restoreAllMocks();
+    const cssError = new Error('CSS initialization rejection');
+    vi.spyOn(globalThis, '__SetCSSId').mockImplementation(() => {
+      throw cssError;
+    });
+    expect(clone).toThrow(cssError);
+  });
 
   it('names only addressed slots; static skeleton stays anonymous', () => {
     const tplId = nextTplId++;

--- a/packages/vue-lynx/main-thread/src/ops-apply.ts
+++ b/packages/vue-lynx/main-thread/src/ops-apply.ts
@@ -212,12 +212,17 @@ function applyStaticProps(el: LynxElement, props: TemplateNode[1]): void {
  * walk consumes their uid (keeping both sides' pre-order counters in
  * lockstep) but creates no Main Thread element — returns null.
  */
+interface TemplateInstantiationState {
+  value: number;
+  cssIdElements: LynxElement[];
+}
+
 function instantiateTemplateDense(
   node: TemplateNode,
   base: number,
-  counter: { value: number },
+  state: TemplateInstantiationState,
 ): { el: LynxElement; uid: number } | null {
-  const uid = base + counter.value++;
+  const uid = base + state.value++;
   const [tag, props, children] = node;
 
   if (tag === '#comment') return null;
@@ -231,13 +236,17 @@ function instantiateTemplateDense(
   } else {
     el = createTypedElement(tag, pageUniqueId);
   }
-  __SetCSSId([el], 0);
+  state.cssIdElements.push(el);
   elements.set(uid, el);
   installSelectorAttribute(uid, el);
   applyStaticProps(el, props);
 
   for (const childNode of children) {
-    const child = instantiateTemplateDense(childNode, base, counter);
+    const child = instantiateTemplateDense(
+      childNode,
+      base,
+      state,
+    );
     if (child) {
       __AppendElement(el, child.el);
       trackInsert(uid, child.uid);
@@ -258,11 +267,11 @@ function instantiateTemplateDense(
 function instantiateTemplateSparse(
   node: TemplateNode,
   base: number,
-  counter: { value: number },
+  state: TemplateInstantiationState,
   slotToSparse: ReadonlyMap<number, number>,
   parentUid: number | null,
 ): { el: LynxElement; uid: number | null } | null {
-  const slot = counter.value++;
+  const slot = state.value++;
   const [tag, props, children] = node;
 
   if (tag === '#comment') return null;
@@ -276,7 +285,7 @@ function instantiateTemplateSparse(
   } else {
     el = createTypedElement(tag, pageUniqueId);
   }
-  __SetCSSId([el], 0);
+  state.cssIdElements.push(el);
   applyStaticProps(el, props);
 
   const sparseIdx = slotToSparse.get(slot);
@@ -291,7 +300,7 @@ function instantiateTemplateSparse(
     const child = instantiateTemplateSparse(
       childNode,
       base,
-      counter,
+      state,
       slotToSparse,
       uid,
     );
@@ -509,17 +518,22 @@ function instantiateRegisteredTree(
   entry: RegisteredTree,
   baseUid: number,
 ): void {
+  const state: TemplateInstantiationState = {
+    value: 0,
+    cssIdElements: [],
+  };
   if (entry.slotToSparse) {
     instantiateTemplateSparse(
       entry.structure,
       baseUid,
-      { value: 0 },
+      state,
       entry.slotToSparse,
       null,
     );
   } else {
-    instantiateTemplateDense(entry.structure, baseUid, { value: 0 });
+    instantiateTemplateDense(entry.structure, baseUid, state);
   }
+  if (state.cssIdElements.length > 0) __SetCSSId(state.cssIdElements, 0);
 }
 
 function registeredTree(


### PR DESCRIPTION
Introduce `TemplateInstantiationState` with a `cssIdElements` collector. Each `instantiateTemplateDense/Sparse` node pushes to the collector instead of calling `__SetCSSId` individually; one batched call is made after the full tree walk. Reduces N JSI cross-thread calls to 1 per template instantiation. Compatible with the `slotToSparse` cache landed in #386.