### PR TITLE
chore(website): upgrade @lynx-js/go-web to 0.11.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,7 +48,7 @@ importers:
         version: 0.4.6
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
+        version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.8))
       '@lynx-js/tailwind-preset':
         specifier: ^0.4.0
         version: 0.4.0(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))
@@ -66,7 +66,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.9.5)(jiti@2.6.1)(jsdom@26.1.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.9.5)(jiti@1.21.7)(jsdom@26.1.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.2)
       vue:
         specifier: ^3.5.0
         version: 3.5.30(typescript@5.9.3)
@@ -126,7 +126,7 @@ importers:
         version: 0.4.6
       '@lynx-js/rspeedy':
         specifier: ^0.13.5
-        version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4(postcss@8.5.8))
+        version: 0.13.5(@rspack/core@1.7.8(@swc/helpers@0.5.19))(typescript@5.9.3)(webpack@5.105.4)
       '@lynx-js/tailwind-preset':
         specifier: ^0.4.0
         version: 0.4.0(tailwindcss@3.4.19(tsx@4.21.0)(yaml@2.8.2))
@@ -821,6 +821,8 @@ importers:
         specifier: ^5.0.0
         version: 5.9.3
 
+  packages/vue-lynx-sparkling-template: {}
+
   website:
     dependencies:
       '@douyinfe/semi-icons':
@@ -830,8 +832,8 @@ importers:
         specifier: ^2.75.0
         version: 2.92.2(@floating-ui/dom@1.7.6)(@tiptap/suggestion@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@lynx-js/go-web':
-        specifier: ^0.9.0
-        version: 0.9.0(@douyinfe/semi-icons@2.92.2(react@19.2.4))(@douyinfe/semi-ui@2.92.2(@floating-ui/dom@1.7.6)(@tiptap/suggestion@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@lynx-js/web-core@0.22.1(tslib@2.8.1))(@rspress/core@2.0.5(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.47.0)(micromark-util-types@2.0.2)(micromark@4.0.2))(@shikijs/transformers@3.23.0)(qrcode.react@4.2.0(react@19.2.4))(react-copy-to-clipboard@5.1.1(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(swr@2.4.1(react@19.2.4))(vscode-icons-js@11.6.1)
+        specifier: ^0.11.0
+        version: 0.11.0(@douyinfe/semi-icons@2.92.2(react@19.2.4))(@douyinfe/semi-ui@2.92.2(@floating-ui/dom@1.7.6)(@tiptap/suggestion@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@lynx-js/web-core@0.22.1(tslib@2.8.1))(@rspress/core@2.0.5(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.47.0)(micromark-util-types@2.0.2)(micromark@4.0.2))(@shikijs/transformers@3.23.0)(qrcode.react@4.2.0(react@19.2.4))(react-copy-to-clipboard@5.1.1(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(swr@2.4.1(react@19.2.4))(vscode-icons-js@11.6.1)
       '@lynx-js/web-core':
         specifier: ^0.22.1
         version: 0.22.1(tslib@2.8.1)
@@ -1417,8 +1419,8 @@ packages:
   '@lynx-js/css-serializer@0.1.4':
     resolution: {integrity: sha512-yG3sC1fH+rBQhbdvPCweaGjmFmOBdi2rbt7xs9laMfu5Z5dOXL1OB7pZZN0vodptBO0/ctVfMCKH2EKhq0GtTA==}
 
-  '@lynx-js/go-web@0.9.0':
-    resolution: {integrity: sha512-JLRkS3zd9rRmL3Eqk8FoB98rcf3TqvxEjeM7nwvTFmRU+kw2Wsv1B88Oozifq9TwiDSRd9oyOewR95uUzDo8Tg==}
+  '@lynx-js/go-web@0.11.0':
+    resolution: {integrity: sha512-llruqMiSdbGzHfMwzbcM1Kren30+9qWhp0R3c8mFW4VZnNkzphjizHanKWYov+sBgFX6yFxXk044Pgd52LTlCA==}
     engines: {node: ^22 || ^24}
     peerDependencies:
       '@douyinfe/semi-icons': '>=2.74.0'
@@ -6806,7 +6808,7 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
-  '@lynx-js/go-web@0.9.0(@douyinfe/semi-icons@2.92.2(react@19.2.4))(@douyinfe/semi-ui@2.92.2(@floating-ui/dom@1.7.6)(@tiptap/suggestion@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@lynx-js/web-core@0.22.1(tslib@2.8.1))(@rspress/core@2.0.5(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.47.0)(micromark-util-types@2.0.2)(micromark@4.0.2))(@shikijs/transformers@3.23.0)(qrcode.react@4.2.0(react@19.2.4))(react-copy-to-clipboard@5.1.1(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(swr@2.4.1(react@19.2.4))(vscode-icons-js@11.6.1)':
+  '@lynx-js/go-web@0.11.0(@douyinfe/semi-icons@2.92.2(react@19.2.4))(@douyinfe/semi-ui@2.92.2(@floating-ui/dom@1.7.6)(@tiptap/suggestion@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@lynx-js/web-core@0.22.1(tslib@2.8.1))(@rspress/core@2.0.5(@types/mdast@4.0.4)(@types/react@19.2.14)(core-js@3.47.0)(micromark-util-types@2.0.2)(micromark@4.0.2))(@shikijs/transformers@3.23.0)(qrcode.react@4.2.0(react@19.2.4))(react-copy-to-clipboard@5.1.1(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(swr@2.4.1(react@19.2.4))(vscode-icons-js@11.6.1)':
     dependencies:
       '@douyinfe/semi-icons': 2.92.2(react@19.2.4)
       '@douyinfe/semi-ui': 2.92.2(@floating-ui/dom@1.7.6)(@tiptap/suggestion@3.20.1(@tiptap/core@3.20.1(@tiptap/pm@3.20.1))(@tiptap/pm@3.20.1))(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -8409,6 +8411,14 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.3.3
       tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.9.5)(jiti@1.21.7)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@25.9.5)(jiti@1.21.7)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.9.5)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
@@ -12345,6 +12355,27 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@3.2.4(@types/node@25.9.5)(jiti@1.21.7)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.1(@types/node@25.9.5)(jiti@1.21.7)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite-node@3.2.4(@types/node@25.9.5)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       cac: 6.7.14
@@ -12366,6 +12397,24 @@ snapshots:
       - tsx
       - yaml
 
+  vite@7.3.1(@types/node@25.9.5)(jiti@1.21.7)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.8
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 25.9.5
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      sass: 1.98.0
+      sass-embedded: 1.98.0
+      terser: 5.49.0
+      tsx: 4.21.0
+      yaml: 2.8.2
+
   vite@7.3.1(@types/node@25.9.5)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.3
@@ -12383,6 +12432,49 @@ snapshots:
       terser: 5.49.0
       tsx: 4.21.0
       yaml: 2.8.2
+
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.9.5)(jiti@1.21.7)(jsdom@26.1.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.2):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.9.5)(jiti@1.21.7)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.1(@types/node@25.9.5)(jiti@1.21.7)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite-node: 3.2.4(@types/node@25.9.5)(jiti@1.21.7)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 25.9.5
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.9.5)(jiti@2.6.1)(jsdom@25.0.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
@@ -12413,49 +12505,6 @@ snapshots:
       '@types/debug': 4.1.12
       '@types/node': 25.9.5
       jsdom: 25.0.1
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.9.5)(jiti@2.6.1)(jsdom@26.1.0)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.2):
-    dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.9.5)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.2))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 3.10.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.15
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@25.9.5)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.2)
-      vite-node: 3.2.4(@types/node@25.9.5)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.49.0)(tsx@4.21.0)(yaml@2.8.2)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/debug': 4.1.12
-      '@types/node': 25.9.5
-      jsdom: 26.1.0
     transitivePeerDependencies:
       - jiti
       - less

--- a/website/package.json
+++ b/website/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@douyinfe/semi-icons": "^2.74.0",
     "@douyinfe/semi-ui": "^2.75.0",
-    "@lynx-js/go-web": "^0.9.0",
+    "@lynx-js/go-web": "^0.11.0",
     "@lynx-js/web-core": "^0.22.1",
     "@lynx-js/web-elements": "^0.12.5",
     "@rspress/core": "^2.0.3",


### PR DESCRIPTION
Bumps `@lynx-js/go-web` from `^0.9.0` to `^0.11.0` in `website/package.json`, the repo's only dependent on the package.

## What 0.11.0 changes

A minor release whose single user-visible change ([lynx-community/go-web#85](https://github.com/lynx-community/go-web/pull/85)) is a small `<Go/>` mark in every embed's footer, sitting between the file-tree button and the `example > file` breadcrumb:

- **At rest:** printed in the same tertiary ink as the lettering around it — no badge, no button.
- **On hover:** lights up in link blue with a soft glow, linking to https://github.com/lynx-community/go-web, with a tooltip reading "Powered by `<Go/>` / Want one on your own site? Open the repo".

The point is discoverability. Nothing in an embed previously named the surrounding widget, so a reader who wanted the same code-plus-live-preview pane on their own site had no name to search for and nowhere to click.

**No breaking API changes.** The release adds one optional config field, `GoConfig.poweredBy` (`false` hides the mark, a string retargets its URL). It is deliberately left unset in `website/src/components/go/Go.tsx`, so the mark is visible on this site — the intended behaviour.

## Scope of the diff

- `website/package.json` — `^0.9.0` → `^0.11.0`, keeping the existing caret range style.
- `pnpm-lock.yaml` — refreshed via `pnpm install` (pnpm 10, the repo's committed lockfile format; not regenerated from scratch).

A grep for other places the version might be written down (docs, README, version tables, example snippets) found none — every other `go-web` mention is an import path or a prose reference in a code comment, with no version number attached. No source changes were needed.

### A note on incidental lockfile churn

Beyond the `go-web` entries, the lockfile diff contains ~30 lines that are not from this bump:

- `packages/vue-lynx-sparkling-template: {}` — pre-existing drift; that workspace was added in #92 without a lockfile refresh. A `pnpm install --lockfile-only` on unmodified `main` produces this same line on its own.
- Peer-key reshuffling between `examples/*` workspaces with identical dependency sets (`webpack@5.105.4` vs `webpack@5.105.4(postcss@8.5.8)`, `jiti@2.6.1` vs `jiti@1.21.7`, `jsdom@25.0.1` vs `26.1.0`) plus the matching `vite`/`vite-node`/`@vitest/mocker` snapshot entries. These are the same underlying package versions swapped between two variants; pnpm re-emits them whenever any dependency change triggers a full re-resolve.

This is what the repo's own package manager produces for a normal install, so it is left as generated rather than hand-edited. The lockfile is stable — a second `pnpm install` produces no further changes.

## Verification

Every job in `.github/workflows/ci.yml` was run locally against the upgrade, plus the website build (which is the actual consumer of `go-web` and is not covered by CI):

| Command | Result |
| --- | --- |
| `pnpm install` | clean; re-running produces no further lockfile changes |
| `pnpm lint` (`biome check .`) | pass — 108 files checked, no fixes applied |
| `pnpm build` | pass |
| `pnpm test` (testing-library) | pass — 23 files, 234 tests |
| `pnpm test:upstream` (all three configs, against `vuejs/core@v3.5.12`) | pass — 60 + 48 passed, 41 skipped |
| `pnpm test:dev-smoke` | pass — `examples/basic` built for web and lynx |
| `pnpm changeset status --since=origin/main` | pass — no packages to bump (`website` is private and the change is outside `src/**`) |
| `pnpm build` in `website/` | pass — full docs site built, 17.1 MB output |

Nothing broke, so no fixes were needed.

Additionally confirmed the upgrade actually took effect end to end: `@lynx-js/go-web` resolves to `0.11.0` in `website/node_modules`, and the built output contains the new footer mark — `lynx-community/go-web` and the "Powered by" tooltip appear in `doc_build/` pages and in the emitted JS chunk, confirming the mark renders with `poweredBy` unset.

---
_Generated by [Claude Code](https://claude.ai/code/session_011QbENFU5vAsvzXgMpHVi3h)_