### PR TITLE
fix(benchmark): encode startup row scales

### DIFF
--- a/packages/benchmark/apps/ui-react/lynx.config.ts
+++ b/packages/benchmark/apps/ui-react/lynx.config.ts
@@ -5,6 +5,7 @@ import { defineConfig } from '@lynx-js/rspeedy';
 // comparator on the same source and toolchain. The benchmark build sets this
 // variable explicitly and records the selected capability in its manifest.
 const useElementTemplate = process.env.BENCH_ENABLE_ET === '1';
+const autoRows = Number(process.env.BENCH_AUTOROWS ?? '0');
 
 export default defineConfig({
   environments: {
@@ -14,6 +15,9 @@ export default defineConfig({
   source: {
     entry: {
       main: './src/index.tsx',
+    },
+    define: {
+      __BENCH_AUTOROWS__: JSON.stringify(autoRows),
     },
   },
   plugins: [

--- a/packages/benchmark/apps/ui-react/src/App.tsx
+++ b/packages/benchmark/apps/ui-react/src/App.tsx
@@ -4,10 +4,17 @@
 // immutable state updates + memoized row component.
 import { memo, useCallback, useEffect, useRef, useState } from '@lynx-js/react';
 
-import { buildData } from './data';
+import { buildData, buildDataSeeded } from './data';
 import type { RowData } from './data';
 
 import './App.css';
+
+// Startup scale is a build-time cell. A deterministic initializer keeps the
+// main/background first render identical while exercising the real mount path.
+declare const __BENCH_AUTOROWS__: number;
+const INITIAL_ROWS = __BENCH_AUTOROWS__ > 0
+  ? buildDataSeeded(__BENCH_AUTOROWS__)
+  : [];
 
 // -- storms: N sequential state→render→DOM ticks from one click --------------
 // Each tick runs in its own macrotask (MessageChannel avoids the nested
@@ -62,7 +69,7 @@ const Row = memo(function Row({ row, isSelected, onSelect, onRemove }: RowProps)
 });
 
 export function App() {
-  const [rows, setRows] = useState<RowData[]>([]);
+  const [rows, setRows] = useState<RowData[]>(INITIAL_ROWS);
   const [selected, setSelected] = useState<number | undefined>(undefined);
 
   const run = useCallback(() => {

--- a/packages/benchmark/apps/ui-react/src/data.ts
+++ b/packages/benchmark/apps/ui-react/src/data.ts
@@ -41,3 +41,29 @@ export function buildData(count = 1000): RowData[] {
   }
   return data;
 }
+
+// Deterministic mount data is evaluated independently by Lynx's main and
+// background runtimes, so both first renders must receive byte-identical rows.
+export function buildDataSeeded(count: number): RowData[] {
+  let seed = 42 >>> 0;
+  const random = () => {
+    seed = (seed + 0x6d2b79f5) >>> 0;
+    let value = seed;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+  const pick = (max: number) => Math.round(random() * 1000) % max;
+  const data: RowData[] = [];
+  for (let i = 0; i < count; i++) {
+    data.push({
+      id: ID++,
+      label: adjectives[pick(adjectives.length)]
+        + ' '
+        + colours[pick(colours.length)]
+        + ' '
+        + nouns[pick(nouns.length)],
+    });
+  }
+  return data;
+}

--- a/packages/benchmark/apps/ui-vapor/lynx.config.ts
+++ b/packages/benchmark/apps/ui-vapor/lynx.config.ts
@@ -21,6 +21,7 @@ import { pluginVueLynx } from 'vue-lynx/plugin';
  *   frame via the compiled Code-Template create(); measurable on web
  */
 const cell = process.env.BENCH_CELL ?? 'off';
+const autoRows = Number(process.env.BENCH_AUTOROWS ?? '0');
 const enableIFR =
   cell === 'ifr' || cell === 'ifr-dense' || cell === 'ifr-sparse'
   || cell === 'ifr-engine-et' || cell === 'ifr-code-paint';
@@ -58,6 +59,7 @@ export default defineConfig({
     },
     define: {
       __BENCH_MODE__: JSON.stringify(modeLabel),
+      __BENCH_AUTOROWS__: JSON.stringify(autoRows),
     },
   },
   plugins: [

--- a/packages/benchmark/apps/ui-vapor/src/App.vue
+++ b/packages/benchmark/apps/ui-vapor/src/App.vue
@@ -8,13 +8,16 @@
 // by hand. The React variant (apps/ui-react) mirrors these operations with
 // idiomatic React state.
 import { ref, shallowRef, triggerRef } from 'vue'
-import { buildData } from '../../../shared/data'
+import { buildData, buildDataSeeded } from '../../../shared/data'
 import type { RowData } from '../../../shared/data'
 
 const MODE = __BENCH_MODE__
+declare const __BENCH_AUTOROWS__: number
 
 const selected = shallowRef<number | undefined>(undefined)
-const rows = shallowRef<RowData[]>([])
+const rows = shallowRef<RowData[]>(
+  __BENCH_AUTOROWS__ > 0 ? buildDataSeeded(__BENCH_AUTOROWS__) : [],
+)
 const ready = ref('ready')
 
 function run() {

--- a/packages/benchmark/apps/ui-vdom/lynx.config.ts
+++ b/packages/benchmark/apps/ui-vdom/lynx.config.ts
@@ -6,6 +6,7 @@ import { pluginVueLynx } from 'vue-lynx/plugin';
 // 'et' = intrinsic Code-Template WITHOUT IFR — the four-axis matrix's
 // create-benefit cell (#321/#325).
 const cell = process.env.BENCH_CELL ?? 'off';
+const autoRows = Number(process.env.BENCH_AUTOROWS ?? '0');
 const enableIFR = cell === 'ifr' || cell === 'ifr-et';
 const enableElementTemplates = cell === 'ifr-et' || cell === 'et';
 const modeLabel =
@@ -41,6 +42,7 @@ export default defineConfig({
     },
     define: {
       __BENCH_MODE__: JSON.stringify(modeLabel),
+      __BENCH_AUTOROWS__: JSON.stringify(autoRows),
     },
   },
   plugins: [

--- a/packages/benchmark/apps/ui-vdom/src/App.vue
+++ b/packages/benchmark/apps/ui-vdom/src/App.vue
@@ -7,13 +7,16 @@
 // by hand. The React variant (apps/ui-react) mirrors these operations with
 // idiomatic React state.
 import { ref, shallowRef, triggerRef } from 'vue'
-import { buildData } from '../../../shared/data'
+import { buildData, buildDataSeeded } from '../../../shared/data'
 import type { RowData } from '../../../shared/data'
 
 const MODE = __BENCH_MODE__
+declare const __BENCH_AUTOROWS__: number
 
 const selected = shallowRef<number | undefined>(undefined)
-const rows = shallowRef<RowData[]>([])
+const rows = shallowRef<RowData[]>(
+  __BENCH_AUTOROWS__ > 0 ? buildDataSeeded(__BENCH_AUTOROWS__) : [],
+)
 const ready = ref('ready')
 
 function run() {

--- a/packages/benchmark/shared/data.ts
+++ b/packages/benchmark/shared/data.ts
@@ -46,3 +46,31 @@ export function buildData(count = 1000): RowData[] {
   }
   return data;
 }
+
+// Deterministic mount data is evaluated independently by Lynx's main and
+// background runtimes, so both first renders must receive byte-identical rows.
+export function buildDataSeeded(count: number): RowData[] {
+  let seed = 42 >>> 0;
+  const random = () => {
+    seed = (seed + 0x6d2b79f5) >>> 0;
+    let value = seed;
+    value = Math.imul(value ^ (value >>> 15), value | 1);
+    value ^= value + Math.imul(value ^ (value >>> 7), value | 61);
+    return ((value ^ (value >>> 14)) >>> 0) / 4294967296;
+  };
+  const pick = (max: number) => Math.round(random() * 1000) % max;
+  const data: RowData[] = [];
+  for (let i = 0; i < count; i++) {
+    data.push({
+      id: ID++,
+      label: shallowRef(
+        adjectives[pick(adjectives.length)]
+          + ' '
+          + colours[pick(colours.length)]
+          + ' '
+          + nouns[pick(nouns.length)],
+      ),
+    });
+  }
+  return data;
+}


### PR DESCRIPTION
## Summary

- encode `BENCH_AUTOROWS` into the ReactLynx, Vue VDOM, and Vue Vapor production builds
- initialize every comparator through the real mount path with deterministic, dual-thread-safe row data
- keep default behavior unchanged at zero rows

This repairs the startup-scale identity required by Huxpro/octane#283. Before this change, 0/1k/2k/3k/5k/10k builds were byte-identical and every nominal startup scale actually mounted zero rows.

## Evidence

- Built the complete 36-cell M0 production matrix: six configurations × six startup scales, Web + Native.
- Each configuration now has six distinct Web bundle SHA-256 values.
- ReactLynx default/ET, Vue VDOM default/IFR+ET, and Vue Vapor default/IFR differ at every scale.
- ReactLynx best-practices scan: 0 findings.
- `git diff --check` passes.
- Repository-wide `pnpm lint` still reports five pre-existing failures on the feature base in `packages/vue-lynx/internal/src/matrix.ts`, `plugin/src/compiler/vapor-addressing.ts`, and `main-thread/src/ops-apply.ts`; none is in this diff.

No performance result is claimed. The follow-up immutable-artifact PR in Huxpro/lynx-js-framework-benchmark will reject scale/config bundle collisions and run the real Chromium harness at current head.