### PR TITLE
fix(benchmark): schedule storms on native Lynx

### DIFF
--- a/packages/benchmark/apps/ui-react/src/App.tsx
+++ b/packages/benchmark/apps/ui-react/src/App.tsx
@@ -16,23 +16,28 @@ const INITIAL_ROWS = __BENCH_AUTOROWS__ > 0
   ? buildDataSeeded(__BENCH_AUTOROWS__)
   : [];
 
-// -- storms: N sequential state→render→DOM ticks from one click --------------
-// Each tick runs in its own macrotask (MessageChannel avoids the nested
-// setTimeout 4ms clamp) so every mutation goes through a full render cycle
-// instead of batching. Mirrors apps/ui-vdom/src/App.vue.
+// -- storms: N sequential state→render→tree ticks from one click -------------
+// Each tick runs in its own macrotask so every mutation goes through a full
+// render cycle instead of batching. Browsers use MessageChannel to avoid the
+// nested setTimeout 4ms clamp; native Lynx has no MessageChannel and uses its
+// native timer queue. Mirrors apps/ui-vdom/src/App.vue.
 const STORM_UPDATE_TICKS = 50;
 const STORM_SELECT_TICKS = 30;
 
-const _stormChannel = new MessageChannel();
+const _stormChannel = typeof MessageChannel === 'function'
+  ? new MessageChannel()
+  : null;
 let _stormPending: (() => void) | null = null;
-_stormChannel.port1.onmessage = () => {
+function flushMacrotask() {
   const cb = _stormPending;
   _stormPending = null;
   if (cb) cb();
-};
+}
+if (_stormChannel) _stormChannel.port1.onmessage = flushMacrotask;
 function nextMacrotask(cb: () => void) {
   _stormPending = cb;
-  _stormChannel.port2.postMessage(0);
+  if (_stormChannel) _stormChannel.port2.postMessage(0);
+  else lynx.setTimeout(flushMacrotask, 0);
 }
 
 // Module-scope storm driver — mirrors AppNaive.tsx (the tick counter must not

--- a/packages/benchmark/apps/ui-react/src/AppNaive.tsx
+++ b/packages/benchmark/apps/ui-react/src/AppNaive.tsx
@@ -13,16 +13,20 @@ import './App.css';
 const STORM_UPDATE_TICKS = 50;
 const STORM_SELECT_TICKS = 30;
 
-const _stormChannel = new MessageChannel();
+const _stormChannel = typeof MessageChannel === 'function'
+  ? new MessageChannel()
+  : null;
 let _stormPending: (() => void) | null = null;
-_stormChannel.port1.onmessage = () => {
+function flushMacrotask() {
   const cb = _stormPending;
   _stormPending = null;
   if (cb) cb();
-};
+}
+if (_stormChannel) _stormChannel.port1.onmessage = flushMacrotask;
 function nextMacrotask(cb: () => void) {
   _stormPending = cb;
-  _stormChannel.port2.postMessage(0);
+  if (_stormChannel) _stormChannel.port2.postMessage(0);
+  else lynx.setTimeout(flushMacrotask, 0);
 }
 
 // Module-scope storm driver: the tick counter must not be a mutated binding

--- a/packages/benchmark/apps/ui-vapor/src/App.vue
+++ b/packages/benchmark/apps/ui-vapor/src/App.vue
@@ -79,25 +79,30 @@ function clear() {
   selected.value = undefined
 }
 
-// -- storms: N sequential state→render→DOM ticks from one click --------------
-// Each tick runs in its own macrotask (MessageChannel avoids the nested
-// setTimeout 4ms clamp) so every mutation goes through a full render cycle
-// instead of batching. Total wall time to the final DOM state is a
-// throughput measure that amplifies sub-frame update costs above the
-// harness's one-frame observation floor.
+// -- storms: N sequential state→render→tree ticks from one click -------------
+// Each tick runs in its own macrotask so every mutation goes through a full
+// render cycle instead of batching. Browsers use MessageChannel to avoid the
+// nested setTimeout 4ms clamp; native Lynx has no MessageChannel and uses its
+// native timer queue. Total wall time to the final rendered state is a
+// throughput measure that amplifies sub-frame update costs above the harness's
+// one-frame observation floor.
 const STORM_UPDATE_TICKS = 50
 const STORM_SELECT_TICKS = 30
 
-const _stormChannel = new MessageChannel()
+const _stormChannel = typeof MessageChannel === 'function'
+  ? new MessageChannel()
+  : null
 let _stormPending: (() => void) | null = null
-_stormChannel.port1.onmessage = () => {
+function flushMacrotask() {
   const cb = _stormPending
   _stormPending = null
   if (cb) cb()
 }
+if (_stormChannel) _stormChannel.port1.onmessage = flushMacrotask
 function nextMacrotask(cb: () => void) {
   _stormPending = cb
-  _stormChannel.port2.postMessage(0)
+  if (_stormChannel) _stormChannel.port2.postMessage(0)
+  else lynx.setTimeout(flushMacrotask, 0)
 }
 
 function stormUpdate() {

--- a/packages/benchmark/apps/ui-vdom/src/App.vue
+++ b/packages/benchmark/apps/ui-vdom/src/App.vue
@@ -78,25 +78,30 @@ function clear() {
   selected.value = undefined
 }
 
-// -- storms: N sequential state→render→DOM ticks from one click --------------
-// Each tick runs in its own macrotask (MessageChannel avoids the nested
-// setTimeout 4ms clamp) so every mutation goes through a full render cycle
-// instead of batching. Total wall time to the final DOM state is a
-// throughput measure that amplifies sub-frame update costs above the
-// harness's one-frame observation floor.
+// -- storms: N sequential state→render→tree ticks from one click -------------
+// Each tick runs in its own macrotask so every mutation goes through a full
+// render cycle instead of batching. Browsers use MessageChannel to avoid the
+// nested setTimeout 4ms clamp; native Lynx has no MessageChannel and uses its
+// native timer queue. Total wall time to the final rendered state is a
+// throughput measure that amplifies sub-frame update costs above the harness's
+// one-frame observation floor.
 const STORM_UPDATE_TICKS = 50
 const STORM_SELECT_TICKS = 30
 
-const _stormChannel = new MessageChannel()
+const _stormChannel = typeof MessageChannel === 'function'
+  ? new MessageChannel()
+  : null
 let _stormPending: (() => void) | null = null
-_stormChannel.port1.onmessage = () => {
+function flushMacrotask() {
   const cb = _stormPending
   _stormPending = null
   if (cb) cb()
 }
+if (_stormChannel) _stormChannel.port1.onmessage = flushMacrotask
 function nextMacrotask(cb: () => void) {
   _stormPending = cb
-  _stormChannel.port2.postMessage(0)
+  if (_stormChannel) _stormChannel.port2.postMessage(0)
+  else lynx.setTimeout(flushMacrotask, 0)
 }
 
 function stormUpdate() {


### PR DESCRIPTION
## Summary

- keep the browser benchmark on `MessageChannel`, preserving its unclamped macrotask behavior
- use the public `lynx.setTimeout` queue when `MessageChannel` is unavailable in native Lynx
- apply the same scheduler to React hooks, React naive, Vue VDOM, and generated Vue Vapor workloads

This was found while validating Huxpro/octane#289 on the official Lynx 4.1.0 Explorer. The previous module-scope `new MessageChannel()` threw before any benchmark tree could mount, so every native comparator was a DNF rather than a performance result.

## Validation

- `pnpm build`
- `pnpm --filter vue-lynx-benchmark exec node harness/build-unified.mjs --only=react,react-naive,vdom,vapor`
- ReactLynx 0.126 Element Template production bundle on official Lynx 4.1.0 Android Explorer (`LynxExplorer-noasan-release.apk`, SHA-256 `6ae29787a2166974c29c2f23d87f3b20a137abcf9a8c17903ad19f3fb7f00cb6`): mounted, created 1,000 rows, and completed all 50 update-storm ticks; native screenshot showed rows 1/11/21/31 at `bench 50`
- `git diff --check`

`pnpm lint` remains blocked by five pre-existing errors outside `packages/benchmark` in `internal/src/matrix.ts`, `plugin/src/compiler/vapor-addressing.ts`, and `main-thread/src/ops-apply.ts`.