### PR TITLE
feat(benchmark): add native measurement protocol

### DIFF
--- a/packages/benchmark/UNIFIED.md
+++ b/packages/benchmark/UNIFIED.md
@@ -99,6 +99,26 @@ pnpm --filter vue-lynx-benchmark run bench:unified:full
 
 Outputs land in `results/unified/{latest.json,ANALYSIS.md,report.html,report.zh.html}`.
 
+## Native producer protocol
+
+The table fixtures preserve the existing Lynx-for-Web black-box workload and
+add a versioned receipt only in the Native background VM:
+
+- `lynx-native-bench-v2` measures a real tap-handler entry through the second
+  `lynx.requestAnimationFrame`, with pre/post framework-state snapshots. It
+  reports transport acknowledgement as unavailable instead of inferring it.
+- Storms use `lynx.setTimeout` and prove one native frame barrier per tick, so
+  a batched or incomplete storm cannot be reported as a successful sample.
+- `lynx-native-startup-v1` is a two-frame state receipt, not FCP. The root also
+  carries the public `__lynx_timing_flag="lynx-native-bench-startup"`; formal
+  startup timing must come from the matching engine `PipelineEntry` or
+  `LoadBundleEntry` and is DNF when that host evidence is absent.
+- Producer failures emit `__NATIVE_BENCH_ERROR__`. Instrumentation failures
+  invalidate the sample but never suppress the benchmark action itself.
+
+The marker names, state predicates, SDK identity, and bundle provenance are
+validated by the native benchmark host before a sample is accepted.
+
 **Human-facing report** (the `lynx-js-framework-benchmark` UI system: selectable
 entries, switchable heat-grid baselines, cards, scale charts, and theme toggle):
 

--- a/packages/benchmark/apps/ui-react/src/App.tsx
+++ b/packages/benchmark/apps/ui-react/src/App.tsx
@@ -6,6 +6,10 @@ import { memo, useCallback, useEffect, useRef, useState } from '@lynx-js/react';
 
 import { buildData, buildDataSeeded } from './data';
 import type { RowData } from './data';
+import {
+  NATIVE_STARTUP_TIMING_FLAG,
+  nativeBenchmark,
+} from '../../../shared/native-protocol';
 
 import './App.css';
 
@@ -43,6 +47,7 @@ function nextMacrotask(cb: () => void) {
 // Module-scope storm driver — mirrors AppNaive.tsx (the tick counter must not
 // be a mutated binding captured inside the component; see note there).
 function runStorm(ticks: number, step: (t: number) => void) {
+  if (nativeBenchmark.isNative) return nativeBenchmark.runStorm(ticks, step);
   let t = 0;
   const tick = () => {
     t += 1;
@@ -78,63 +83,85 @@ export function App() {
   const [selected, setSelected] = useState<number | undefined>(undefined);
 
   const run = useCallback(() => {
-    setRows(buildData());
-    setSelected(undefined);
+    nativeBenchmark.measure('create', () => {
+      setRows(buildData());
+      setSelected(undefined);
+    });
   }, []);
   const runLots = useCallback(() => {
-    setRows(buildData(10000));
-    setSelected(undefined);
+    nativeBenchmark.measure('create', () => {
+      setRows(buildData(10000));
+      setSelected(undefined);
+    });
   }, []);
   const run3k = useCallback(() => {
-    setRows(buildData(3000));
-    setSelected(undefined);
+    nativeBenchmark.measure('create', () => {
+      setRows(buildData(3000));
+      setSelected(undefined);
+    });
   }, []);
   const run5k = useCallback(() => {
-    setRows(buildData(5000));
-    setSelected(undefined);
+    nativeBenchmark.measure('create', () => {
+      setRows(buildData(5000));
+      setSelected(undefined);
+    });
   }, []);
   const run20k = useCallback(() => {
-    setRows(buildData(20000));
-    setSelected(undefined);
+    nativeBenchmark.measure('create', () => {
+      setRows(buildData(20000));
+      setSelected(undefined);
+    });
   }, []);
   const run30k = useCallback(() => {
-    setRows(buildData(30000));
-    setSelected(undefined);
+    nativeBenchmark.measure('create', () => {
+      setRows(buildData(30000));
+      setSelected(undefined);
+    });
   }, []);
   const add = useCallback(() => {
-    setRows((prev) => prev.concat(buildData(1000)));
+    nativeBenchmark.measure('append1k', () => {
+      setRows((prev) => prev.concat(buildData(1000)));
+    });
   }, []);
   const update = useCallback(() => {
-    setRows((prev) => {
-      const next = prev.slice();
-      for (let i = 0; i < next.length; i += 10) {
-        next[i] = { id: next[i].id, label: `${next[i].label} !!!` };
-      }
-      return next;
+    nativeBenchmark.measure('update10th', () => {
+      setRows((prev) => {
+        const next = prev.slice();
+        for (let i = 0; i < next.length; i += 10) {
+          next[i] = { id: next[i].id, label: `${next[i].label} !!!` };
+        }
+        return next;
+      });
     });
   }, []);
   const select = useCallback((id: number) => {
-    setSelected(id);
+    nativeBenchmark.measure('select', () => setSelected(id));
   }, []);
   const remove = useCallback((id: number) => {
-    setRows((prev) => {
-      const idx = prev.findIndex((d) => d.id === id);
-      return prev.slice(0, idx).concat(prev.slice(idx + 1));
+    nativeBenchmark.measure('remove', () => {
+      setRows((prev) => {
+        const idx = prev.findIndex((d) => d.id === id);
+        return prev.slice(0, idx).concat(prev.slice(idx + 1));
+      });
     });
   }, []);
   const swapRows = useCallback(() => {
-    setRows((prev) => {
-      if (prev.length <= 998) return prev;
-      const next = prev.slice();
-      const d1 = next[1];
-      next[1] = next[998];
-      next[998] = d1;
-      return next;
+    nativeBenchmark.measure('swap', () => {
+      setRows((prev) => {
+        if (prev.length <= 998) return prev;
+        const next = prev.slice();
+        const d1 = next[1];
+        next[1] = next[998];
+        next[998] = d1;
+        return next;
+      });
     });
   }, []);
   const clear = useCallback(() => {
-    setRows([]);
-    setSelected(undefined);
+    nativeBenchmark.measure('clear', () => {
+      setRows([]);
+      setSelected(undefined);
+    });
   }, []);
 
   const idsRef = useRef<number[]>([]);
@@ -142,23 +169,48 @@ export function App() {
     idsRef.current = rows.map((r) => r.id);
   }, [rows]);
 
+  const rowsRef = useRef(rows);
+  rowsRef.current = rows;
+  const selectedRef = useRef(selected);
+  selectedRef.current = selected;
+  const snapshotGetterRef = useRef(() => {
+    const current = rowsRef.current;
+    return {
+      rowCount: current.length,
+      firstId: current[0]?.id ?? null,
+      secondId: current[1]?.id ?? null,
+      thirdId: current[2]?.id ?? null,
+      row998Id: current[998]?.id ?? null,
+      firstLabel: current[0]?.label ?? null,
+      selectedId: selectedRef.current ?? null,
+    };
+  });
+  const snapshotCleanupRef = useRef<(() => void) | null>(null);
+  if (snapshotCleanupRef.current === null) {
+    // Startup schedules its frame receipt immediately after root.render(), so
+    // the getter must exist during the synchronous mount rather than in a
+    // passive effect.
+    snapshotCleanupRef.current = nativeBenchmark.installSnapshot(snapshotGetterRef.current);
+  }
+  useEffect(() => () => snapshotCleanupRef.current?.(), []);
+
   const stormUpdate = useCallback(() => {
-    runStorm(STORM_UPDATE_TICKS, (t) =>
+    nativeBenchmark.measure('updateStorm', () => runStorm(STORM_UPDATE_TICKS, (t) =>
       setRows((prev) =>
         prev.map((r, i) => (i % 10 === 0 ? { id: r.id, label: `bench ${t}` } : r)),
       ),
-    );
+    ));
   }, []);
 
   const stormSelect = useCallback(() => {
-    runStorm(STORM_SELECT_TICKS, (t) => {
+    nativeBenchmark.measure('selectStorm', () => runStorm(STORM_SELECT_TICKS, (t) => {
       const ids = idsRef.current;
       setSelected(t < STORM_SELECT_TICKS ? ids[(t * 97) % ids.length] : ids[0]);
-    });
+    }));
   }, []);
 
   return (
-    <view className="page">
+    <view className="page" __lynx_timing_flag={NATIVE_STARTUP_TIMING_FLAG}>
       <text className="title">React UI Benchmark on Lynx · ready</text>
       <view className="toolbar">
         <view className="btn" bindtap={run}>

--- a/packages/benchmark/apps/ui-react/src/index.tsx
+++ b/packages/benchmark/apps/ui-react/src/index.tsx
@@ -1,5 +1,8 @@
 import { root } from '@lynx-js/react';
 
 import { App } from './App';
+import { nativeBenchmark } from '../../../shared/native-protocol';
 
+const startup = nativeBenchmark.beginStartup();
 root.render(<App />);
+nativeBenchmark.finishStartup(startup);

--- a/packages/benchmark/apps/ui-vapor/src/App.vue
+++ b/packages/benchmark/apps/ui-vapor/src/App.vue
@@ -1,15 +1,20 @@
 <!-- GENERATED from apps/ui-vdom/src/App.vue — do not edit -->
 <script setup vapor lang="ts">
-// Black-box cross-framework benchmark UI (no instrumentation).
+// Cross-framework benchmark UI. Web keeps the black-box workload unchanged;
+// Native adds only the shared, versioned handler-to-frame receipt.
 // Lynx port of the krausest js-framework-benchmark table app, matching the
 // semantics of vuejs/core packages-private/benchmark client/App.vue.
 // The vapor variant is GENERATED from this file (the build inserts the
 // `vapor` attribute on the script tag). Do not edit apps/ui-vapor/src/App.vue
 // by hand. The React variant (apps/ui-react) mirrors these operations with
 // idiomatic React state.
-import { ref, shallowRef, triggerRef } from 'vue'
+import { onBeforeUnmount, ref, shallowRef, triggerRef } from 'vue'
 import { buildData, buildDataSeeded } from '../../../shared/data'
 import type { RowData } from '../../../shared/data'
+import {
+  NATIVE_STARTUP_TIMING_FLAG,
+  nativeBenchmark,
+} from '../../../shared/native-protocol'
 
 const MODE = __BENCH_MODE__
 declare const __BENCH_AUTOROWS__: number
@@ -21,63 +26,101 @@ const rows = shallowRef<RowData[]>(
 const ready = ref('ready')
 
 function run() {
-  rows.value = buildData()
-  selected.value = undefined
+  nativeBenchmark.measure('create', () => {
+    rows.value = buildData()
+    selected.value = undefined
+  })
 }
 function runLots() {
-  rows.value = buildData(10000)
-  selected.value = undefined
+  nativeBenchmark.measure('create', () => {
+    rows.value = buildData(10000)
+    selected.value = undefined
+  })
 }
 function run3k() {
-  rows.value = buildData(3000)
-  selected.value = undefined
+  nativeBenchmark.measure('create', () => {
+    rows.value = buildData(3000)
+    selected.value = undefined
+  })
 }
 function run5k() {
-  rows.value = buildData(5000)
-  selected.value = undefined
+  nativeBenchmark.measure('create', () => {
+    rows.value = buildData(5000)
+    selected.value = undefined
+  })
 }
 function run20k() {
-  rows.value = buildData(20000)
-  selected.value = undefined
+  nativeBenchmark.measure('create', () => {
+    rows.value = buildData(20000)
+    selected.value = undefined
+  })
 }
 function run30k() {
-  rows.value = buildData(30000)
-  selected.value = undefined
+  nativeBenchmark.measure('create', () => {
+    rows.value = buildData(30000)
+    selected.value = undefined
+  })
 }
 function add() {
-  rows.value.push(...buildData(1000))
-  triggerRef(rows)
+  nativeBenchmark.measure('append1k', () => {
+    rows.value.push(...buildData(1000))
+    triggerRef(rows)
+  })
 }
 function update() {
-  const _rows = rows.value
-  for (let i = 0, len = _rows.length; i < len; i += 10) {
-    _rows[i].label.value += ' !!!'
-  }
+  nativeBenchmark.measure('update10th', () => {
+    const _rows = rows.value
+    for (let i = 0, len = _rows.length; i < len; i += 10) {
+      _rows[i].label.value += ' !!!'
+    }
+  })
 }
 function select(id: number) {
-  selected.value = id
+  nativeBenchmark.measure('select', () => {
+    selected.value = id
+  })
 }
 function remove(id: number) {
-  rows.value.splice(
-    rows.value.findIndex(d => d.id === id),
-    1,
-  )
-  triggerRef(rows)
+  nativeBenchmark.measure('remove', () => {
+    rows.value.splice(
+      rows.value.findIndex(d => d.id === id),
+      1,
+    )
+    triggerRef(rows)
+  })
 }
 function swapRows() {
-  const _rows = rows.value
-  if (_rows.length > 998) {
-    const d1 = _rows[1]
-    const d998 = _rows[998]
-    _rows[1] = d998
-    _rows[998] = d1
-    triggerRef(rows)
-  }
+  nativeBenchmark.measure('swap', () => {
+    const _rows = rows.value
+    if (_rows.length > 998) {
+      const d1 = _rows[1]
+      const d998 = _rows[998]
+      _rows[1] = d998
+      _rows[998] = d1
+      triggerRef(rows)
+    }
+  })
 }
 function clear() {
-  rows.value = []
-  selected.value = undefined
+  nativeBenchmark.measure('clear', () => {
+    rows.value = []
+    selected.value = undefined
+  })
 }
+
+const removeSnapshot = nativeBenchmark.installSnapshot(() => {
+  const current = rows.value
+  return {
+    rowCount: current.length,
+    firstId: current[0]?.id ?? null,
+    secondId: current[1]?.id ?? null,
+    thirdId: current[2]?.id ?? null,
+    row998Id: current[998]?.id ?? null,
+    firstLabel: current[0]?.label.value ?? null,
+    selectedId: selected.value ?? null,
+  }
+})
+onBeforeUnmount(removeSnapshot)
 
 // -- storms: N sequential state→render→tree ticks from one click -------------
 // Each tick runs in its own macrotask so every mutation goes through a full
@@ -106,6 +149,18 @@ function nextMacrotask(cb: () => void) {
 }
 
 function stormUpdate() {
+  if (nativeBenchmark.isNative) {
+    nativeBenchmark.measure('updateStorm', () => nativeBenchmark.runStorm(
+      STORM_UPDATE_TICKS,
+      t => {
+        const _rows = rows.value
+        for (let i = 0, len = _rows.length; i < len; i += 10) {
+          _rows[i].label.value = 'bench ' + t
+        }
+      },
+    ))
+    return
+  }
   let t = 0
   const step = () => {
     t++
@@ -119,6 +174,18 @@ function stormUpdate() {
 }
 
 function stormSelect() {
+  if (nativeBenchmark.isNative) {
+    nativeBenchmark.measure('selectStorm', () => nativeBenchmark.runStorm(
+      STORM_SELECT_TICKS,
+      t => {
+        const _rows = rows.value
+        selected.value = t < STORM_SELECT_TICKS
+          ? _rows[(t * 97) % _rows.length].id
+          : _rows[0].id
+      },
+    ))
+    return
+  }
   let t = 0
   const step = () => {
     t++
@@ -133,7 +200,7 @@ function stormSelect() {
 </script>
 
 <template>
-  <view class="page">
+  <view class="page" :__lynx_timing_flag="NATIVE_STARTUP_TIMING_FLAG">
     <text class="title">Vue ({{ MODE }}) UI Benchmark on Lynx · {{ ready }}</text>
     <view class="toolbar">
       <view class="btn" @tap="run()"><text class="btn-text">Create 1,000 rows</text></view>

--- a/packages/benchmark/apps/ui-vapor/src/index.ts
+++ b/packages/benchmark/apps/ui-vapor/src/index.ts
@@ -2,5 +2,8 @@ import { createApp } from 'vue-lynx/vapor';
 
 // @ts-expect-error .vue resolution is handled by the bundler
 import App from './App.vue';
+import { nativeBenchmark } from '../../../shared/native-protocol';
 
+const startup = nativeBenchmark.beginStartup();
 createApp(App).mount();
+nativeBenchmark.finishStartup(startup);

--- a/packages/benchmark/apps/ui-vdom/src/App.vue
+++ b/packages/benchmark/apps/ui-vdom/src/App.vue
@@ -1,14 +1,19 @@
 <!-- BENCH_MODE_SCRIPT --><script setup lang="ts">
-// Black-box cross-framework benchmark UI (no instrumentation).
+// Cross-framework benchmark UI. Web keeps the black-box workload unchanged;
+// Native adds only the shared, versioned handler-to-frame receipt.
 // Lynx port of the krausest js-framework-benchmark table app, matching the
 // semantics of vuejs/core packages-private/benchmark client/App.vue.
 // The vapor variant is GENERATED from this file (the build inserts the
 // `vapor` attribute on the script tag). Do not edit apps/ui-vapor/src/App.vue
 // by hand. The React variant (apps/ui-react) mirrors these operations with
 // idiomatic React state.
-import { ref, shallowRef, triggerRef } from 'vue'
+import { onBeforeUnmount, ref, shallowRef, triggerRef } from 'vue'
 import { buildData, buildDataSeeded } from '../../../shared/data'
 import type { RowData } from '../../../shared/data'
+import {
+  NATIVE_STARTUP_TIMING_FLAG,
+  nativeBenchmark,
+} from '../../../shared/native-protocol'
 
 const MODE = __BENCH_MODE__
 declare const __BENCH_AUTOROWS__: number
@@ -20,63 +25,101 @@ const rows = shallowRef<RowData[]>(
 const ready = ref('ready')
 
 function run() {
-  rows.value = buildData()
-  selected.value = undefined
+  nativeBenchmark.measure('create', () => {
+    rows.value = buildData()
+    selected.value = undefined
+  })
 }
 function runLots() {
-  rows.value = buildData(10000)
-  selected.value = undefined
+  nativeBenchmark.measure('create', () => {
+    rows.value = buildData(10000)
+    selected.value = undefined
+  })
 }
 function run3k() {
-  rows.value = buildData(3000)
-  selected.value = undefined
+  nativeBenchmark.measure('create', () => {
+    rows.value = buildData(3000)
+    selected.value = undefined
+  })
 }
 function run5k() {
-  rows.value = buildData(5000)
-  selected.value = undefined
+  nativeBenchmark.measure('create', () => {
+    rows.value = buildData(5000)
+    selected.value = undefined
+  })
 }
 function run20k() {
-  rows.value = buildData(20000)
-  selected.value = undefined
+  nativeBenchmark.measure('create', () => {
+    rows.value = buildData(20000)
+    selected.value = undefined
+  })
 }
 function run30k() {
-  rows.value = buildData(30000)
-  selected.value = undefined
+  nativeBenchmark.measure('create', () => {
+    rows.value = buildData(30000)
+    selected.value = undefined
+  })
 }
 function add() {
-  rows.value.push(...buildData(1000))
-  triggerRef(rows)
+  nativeBenchmark.measure('append1k', () => {
+    rows.value.push(...buildData(1000))
+    triggerRef(rows)
+  })
 }
 function update() {
-  const _rows = rows.value
-  for (let i = 0, len = _rows.length; i < len; i += 10) {
-    _rows[i].label.value += ' !!!'
-  }
+  nativeBenchmark.measure('update10th', () => {
+    const _rows = rows.value
+    for (let i = 0, len = _rows.length; i < len; i += 10) {
+      _rows[i].label.value += ' !!!'
+    }
+  })
 }
 function select(id: number) {
-  selected.value = id
+  nativeBenchmark.measure('select', () => {
+    selected.value = id
+  })
 }
 function remove(id: number) {
-  rows.value.splice(
-    rows.value.findIndex(d => d.id === id),
-    1,
-  )
-  triggerRef(rows)
+  nativeBenchmark.measure('remove', () => {
+    rows.value.splice(
+      rows.value.findIndex(d => d.id === id),
+      1,
+    )
+    triggerRef(rows)
+  })
 }
 function swapRows() {
-  const _rows = rows.value
-  if (_rows.length > 998) {
-    const d1 = _rows[1]
-    const d998 = _rows[998]
-    _rows[1] = d998
-    _rows[998] = d1
-    triggerRef(rows)
-  }
+  nativeBenchmark.measure('swap', () => {
+    const _rows = rows.value
+    if (_rows.length > 998) {
+      const d1 = _rows[1]
+      const d998 = _rows[998]
+      _rows[1] = d998
+      _rows[998] = d1
+      triggerRef(rows)
+    }
+  })
 }
 function clear() {
-  rows.value = []
-  selected.value = undefined
+  nativeBenchmark.measure('clear', () => {
+    rows.value = []
+    selected.value = undefined
+  })
 }
+
+const removeSnapshot = nativeBenchmark.installSnapshot(() => {
+  const current = rows.value
+  return {
+    rowCount: current.length,
+    firstId: current[0]?.id ?? null,
+    secondId: current[1]?.id ?? null,
+    thirdId: current[2]?.id ?? null,
+    row998Id: current[998]?.id ?? null,
+    firstLabel: current[0]?.label.value ?? null,
+    selectedId: selected.value ?? null,
+  }
+})
+onBeforeUnmount(removeSnapshot)
 
 // -- storms: N sequential state→render→tree ticks from one click -------------
 // Each tick runs in its own macrotask so every mutation goes through a full
@@ -105,6 +148,18 @@ function nextMacrotask(cb: () => void) {
 }
 
 function stormUpdate() {
+  if (nativeBenchmark.isNative) {
+    nativeBenchmark.measure('updateStorm', () => nativeBenchmark.runStorm(
+      STORM_UPDATE_TICKS,
+      t => {
+        const _rows = rows.value
+        for (let i = 0, len = _rows.length; i < len; i += 10) {
+          _rows[i].label.value = 'bench ' + t
+        }
+      },
+    ))
+    return
+  }
   let t = 0
   const step = () => {
     t++
@@ -118,6 +173,18 @@ function stormUpdate() {
 }
 
 function stormSelect() {
+  if (nativeBenchmark.isNative) {
+    nativeBenchmark.measure('selectStorm', () => nativeBenchmark.runStorm(
+      STORM_SELECT_TICKS,
+      t => {
+        const _rows = rows.value
+        selected.value = t < STORM_SELECT_TICKS
+          ? _rows[(t * 97) % _rows.length].id
+          : _rows[0].id
+      },
+    ))
+    return
+  }
   let t = 0
   const step = () => {
     t++
@@ -132,7 +199,7 @@ function stormSelect() {
 </script>
 
 <template>
-  <view class="page">
+  <view class="page" :__lynx_timing_flag="NATIVE_STARTUP_TIMING_FLAG">
     <text class="title">Vue ({{ MODE }}) UI Benchmark on Lynx · {{ ready }}</text>
     <view class="toolbar">
       <view class="btn" @tap="run()"><text class="btn-text">Create 1,000 rows</text></view>

--- a/packages/benchmark/apps/ui-vdom/src/index.ts
+++ b/packages/benchmark/apps/ui-vdom/src/index.ts
@@ -2,5 +2,8 @@ import { createApp } from 'vue-lynx';
 
 // @ts-expect-error .vue resolution is handled by the bundler
 import App from './App.vue';
+import { nativeBenchmark } from '../../../shared/native-protocol';
 
+const startup = nativeBenchmark.beginStartup();
 createApp(App).mount();
+nativeBenchmark.finishStartup(startup);

--- a/packages/benchmark/package.json
+++ b/packages/benchmark/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "node harness/build.mjs",
     "build:unified": "node harness/build-unified.mjs",
+    "test:native-protocol": "node --test shared/native-protocol.test.mjs",
     "bench": "node harness/run.mjs",
     "bench:quick": "node harness/run.mjs --startup-count 2",
     "bench:cross": "node harness/cross.mjs",

--- a/packages/benchmark/shared/native-protocol.test.mjs
+++ b/packages/benchmark/shared/native-protocol.test.mjs
@@ -1,0 +1,186 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+import ts from 'typescript';
+
+const source = fs.readFileSync(
+  new URL('./native-protocol.ts', import.meta.url),
+  'utf8'
+);
+const compiled = ts.transpileModule(source, {
+  compilerOptions: {
+    module: ts.ModuleKind.ESNext,
+    target: ts.ScriptTarget.ES2022,
+  },
+}).outputText;
+
+async function loadProtocol() {
+  const encoded = Buffer.from(compiled).toString('base64');
+  return import(`data:text/javascript;base64,${encoded}#${Math.random()}`);
+}
+
+function createRuntime({ native = true } = {}) {
+  let time = 100;
+  const reports = [];
+  const runtime = {
+    native,
+    globalObject: {},
+    now: () => time,
+    requestAnimationFrame(callback) {
+      time += 16;
+      queueMicrotask(callback);
+    },
+    setTimeout(callback) {
+      time += 1;
+      queueMicrotask(callback);
+    },
+    report(marker, payload) {
+      reports.push({ marker, payload });
+    },
+  };
+  return { runtime, reports };
+}
+
+async function flushTasks(count = 20) {
+  for (let i = 0; i < count; i++) await Promise.resolve();
+}
+
+const state = (rowCount) => ({
+  rowCount,
+  firstId: rowCount > 0 ? 1 : null,
+  secondId: rowCount > 1 ? 2 : null,
+  thirdId: rowCount > 2 ? 3 : null,
+  row998Id: rowCount > 998 ? 999 : null,
+  firstLabel: rowCount > 0 ? 'pretty red table' : null,
+  selectedId: null,
+});
+
+test('native operation reports the versioned two-frame payload', async () => {
+  const { createNativeBenchmarkProtocol } = await loadProtocol();
+  const { runtime, reports } = createRuntime();
+  const protocol = createNativeBenchmarkProtocol(runtime);
+  let rows = 0;
+  const removeSnapshot = protocol.installSnapshot(() => state(rows));
+  assert.equal(typeof runtime.globalObject.__LYNX_BENCH_SNAPSHOT__, 'function');
+
+  protocol.measure('create', () => {
+    rows = 1000;
+  });
+  await flushTasks();
+
+  assert.equal(reports.length, 1);
+  assert.equal(reports[0].marker, '__NATIVE_BENCH_RESULT__');
+  const payload = JSON.parse(reports[0].payload);
+  assert.equal(payload.protocol, 'lynx-native-bench-v2');
+  assert.equal(payload.boundary, 'native-input-handler-to-second-native-frame');
+  assert.equal(payload.preState.rowCount, 0);
+  assert.equal(payload.postState.rowCount, 1000);
+  assert.equal(payload.renderEvidence.frames, 2);
+  assert.equal(payload.latencyMs, 32);
+  removeSnapshot();
+  assert.equal(runtime.globalObject.__LYNX_BENCH_SNAPSHOT__, undefined);
+});
+
+test('native storm proves one render barrier per completed tick', async () => {
+  const { createNativeBenchmarkProtocol } = await loadProtocol();
+  const { runtime, reports } = createRuntime();
+  const protocol = createNativeBenchmarkProtocol(runtime);
+  let rows = 1000;
+  let completed = 0;
+  protocol.installSnapshot(() => state(rows));
+
+  protocol.measure('updateStorm', () =>
+    protocol.runStorm(3, (tick) => {
+      completed = tick;
+      rows = 1000;
+    })
+  );
+  await flushTasks(40);
+
+  assert.equal(completed, 3);
+  const payload = JSON.parse(reports[0].payload);
+  assert.deepEqual(payload.stormEvidence, {
+    expectedTicks: 3,
+    completedTicks: 3,
+    renderBarriers: 3,
+  });
+  assert.equal(payload.latencyMs, 83);
+});
+
+test('startup receipt is published only after mount and two frames', async () => {
+  const { createNativeBenchmarkProtocol, NATIVE_STARTUP_TIMING_FLAG } =
+    await loadProtocol();
+  const { runtime, reports } = createRuntime();
+  const protocol = createNativeBenchmarkProtocol(runtime);
+  const startup = protocol.beginStartup();
+  protocol.installSnapshot(() => state(1000));
+  protocol.finishStartup(startup);
+  await flushTasks();
+
+  assert.equal(reports[0].marker, '__NATIVE_BENCH_STARTUP__');
+  const payload = JSON.parse(reports[0].payload);
+  assert.equal(payload.protocol, 'lynx-native-startup-v1');
+  assert.equal(payload.postState.rowCount, 1000);
+  assert.equal(payload.firstFrameMs, 116);
+  assert.equal(payload.secondFrameMs, 132);
+  assert.deepEqual(runtime.globalObject.__LYNX_BENCH_STARTUP__, payload);
+  assert.equal(NATIVE_STARTUP_TIMING_FLAG, 'lynx-native-bench-startup');
+});
+
+test('producer failures emit an explicit runtime marker', async () => {
+  const { createNativeBenchmarkProtocol } = await loadProtocol();
+  const { runtime, reports } = createRuntime();
+  const protocol = createNativeBenchmarkProtocol(runtime);
+  protocol.installSnapshot(() => state(0));
+
+  assert.throws(
+    () =>
+      protocol.measure('create', () => {
+        throw new Error('render failed');
+      }),
+    /render failed/
+  );
+  await flushTasks();
+
+  assert.deepEqual(reports, [
+    {
+      marker: '__NATIVE_BENCH_ERROR__',
+      payload: 'create: Error: render failed',
+    },
+  ]);
+});
+
+test('an invalid overlapping sample never suppresses the real action', async () => {
+  const { createNativeBenchmarkProtocol } = await loadProtocol();
+  const { runtime, reports } = createRuntime();
+  const protocol = createNativeBenchmarkProtocol(runtime);
+  let actions = 0;
+  protocol.installSnapshot(() => state(actions));
+
+  protocol.measure('create', () => {
+    actions++;
+  });
+  protocol.measure('create', () => {
+    actions++;
+  });
+  await flushTasks();
+
+  assert.equal(actions, 2);
+  assert.equal(reports[0].marker, '__NATIVE_BENCH_ERROR__');
+  assert.match(reports[0].payload, /overlaps active operation/);
+  assert.equal(reports[1].marker, '__NATIVE_BENCH_RESULT__');
+});
+
+test('web keeps actions synchronous and emits no native receipts', async () => {
+  const { createNativeBenchmarkProtocol } = await loadProtocol();
+  const { runtime, reports } = createRuntime({ native: false });
+  const protocol = createNativeBenchmarkProtocol(runtime);
+  let ran = false;
+  protocol.measure('create', () => {
+    ran = true;
+  });
+
+  assert.equal(ran, true);
+  assert.deepEqual(reports, []);
+  assert.equal(protocol.beginStartup(), null);
+});

--- a/packages/benchmark/shared/native-protocol.ts
+++ b/packages/benchmark/shared/native-protocol.ts
@@ -1,0 +1,239 @@
+export const NATIVE_TABLE_PROTOCOL = 'lynx-native-bench-v2' as const;
+export const NATIVE_STARTUP_PROTOCOL = 'lynx-native-startup-v1' as const;
+export const NATIVE_STARTUP_TIMING_FLAG = 'lynx-native-bench-startup' as const;
+
+export interface BenchmarkSnapshot {
+  rowCount: number;
+  firstId: number | null;
+  secondId: number | null;
+  thirdId: number | null;
+  row998Id: number | null;
+  firstLabel: string | null;
+  selectedId: number | null;
+}
+
+export interface StormEvidence {
+  expectedTicks: number;
+  completedTicks: number;
+  renderBarriers: number;
+}
+
+export interface StartupObservation {
+  protocol: typeof NATIVE_STARTUP_PROTOCOL;
+  moduleStartMs: number;
+  firstFrameMs?: number;
+  secondFrameMs?: number;
+  renderEvidence: {
+    kind: 'native-animation-frame';
+    frames: 2;
+  };
+  postState?: BenchmarkSnapshot;
+}
+
+interface BenchmarkGlobal {
+  __LYNX_BENCH_SNAPSHOT__?: () => BenchmarkSnapshot;
+  __LYNX_BENCH_STARTUP__?: StartupObservation;
+}
+
+export interface NativeBenchmarkRuntime {
+  native: boolean;
+  globalObject: BenchmarkGlobal;
+  now(): number;
+  requestAnimationFrame(callback: () => void): void;
+  setTimeout(callback: () => void): void;
+  report(marker: string, payload: string): void;
+}
+
+type ActionResult = void | StormEvidence | Promise<void | StormEvidence>;
+
+function defaultRuntime(): NativeBenchmarkRuntime {
+  return {
+    // Lynx for Web provides MessageChannel. The Native background VM does not.
+    native: typeof MessageChannel !== 'function',
+    globalObject: globalThis as BenchmarkGlobal,
+    now: () => Date.now(),
+    requestAnimationFrame: (callback) => lynx.requestAnimationFrame(callback),
+    setTimeout: (callback) => lynx.setTimeout(callback, 0),
+    report: (marker, payload) => console.log(marker, payload),
+  };
+}
+
+function errorMessage(scope: string, error: unknown): string {
+  const detail =
+    error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+  return `${scope}: ${detail}`;
+}
+
+function isPromiseLike(
+  value: void | StormEvidence | Promise<void | StormEvidence>
+): value is Promise<void | StormEvidence> {
+  return value != null && typeof (value as Promise<void>).then === 'function';
+}
+
+export function createNativeBenchmarkProtocol(
+  runtime: NativeBenchmarkRuntime = defaultRuntime()
+) {
+  let snapshotGetter: (() => BenchmarkSnapshot) | null = null;
+  let activeOperation: string | null = null;
+
+  const reportError = (scope: string, error: unknown) => {
+    runtime.report('__NATIVE_BENCH_ERROR__', errorMessage(scope, error));
+  };
+
+  const snapshot = (): BenchmarkSnapshot => {
+    const getter =
+      snapshotGetter ?? runtime.globalObject.__LYNX_BENCH_SNAPSHOT__;
+    if (!getter)
+      throw new Error('Native benchmark snapshot producer is unavailable');
+    return getter();
+  };
+
+  const nextFrame = (): Promise<number> =>
+    new Promise((resolve) => {
+      runtime.requestAnimationFrame(() => resolve(runtime.now()));
+    });
+
+  const finishMeasurement = async (
+    name: string,
+    startMs: number,
+    preState: BenchmarkSnapshot,
+    stormEvidence: void | StormEvidence
+  ) => {
+    try {
+      const firstFrameMs = await nextFrame();
+      const endMs = await nextFrame();
+      runtime.report(
+        '__NATIVE_BENCH_RESULT__',
+        JSON.stringify({
+          protocol: NATIVE_TABLE_PROTOCOL,
+          name,
+          source: 'native-tap',
+          boundary: 'native-input-handler-to-second-native-frame',
+          startMs,
+          firstFrameMs,
+          endMs,
+          latencyMs: endMs - startMs,
+          renderEvidence: { kind: 'native-animation-frame', frames: 2 },
+          transportEvidence: { kind: 'not-exposed', acknowledged: false },
+          preState,
+          postState: snapshot(),
+          ...(stormEvidence ? { stormEvidence } : {}),
+        })
+      );
+    } catch (error) {
+      reportError(name, error);
+    } finally {
+      activeOperation = null;
+    }
+  };
+
+  return {
+    isNative: runtime.native,
+
+    installSnapshot(getter: () => BenchmarkSnapshot): () => void {
+      if (!runtime.native) return () => {};
+      snapshotGetter = getter;
+      runtime.globalObject.__LYNX_BENCH_SNAPSHOT__ = getter;
+      return () => {
+        if (snapshotGetter === getter) snapshotGetter = null;
+        if (runtime.globalObject.__LYNX_BENCH_SNAPSHOT__ === getter) {
+          delete runtime.globalObject.__LYNX_BENCH_SNAPSHOT__;
+        }
+      };
+    },
+
+    measure(name: string, action: () => ActionResult): void {
+      if (!runtime.native) {
+        action();
+        return;
+      }
+      if (activeOperation !== null) {
+        reportError(
+          name,
+          new Error(`overlaps active operation ${activeOperation}`)
+        );
+        // Instrumentation must never suppress the user's real action. The
+        // overlapping sample is invalid, but the benchmark UI keeps its
+        // ordinary interaction semantics.
+        action();
+        return;
+      }
+
+      let preState: BenchmarkSnapshot;
+      try {
+        preState = snapshot();
+      } catch (error) {
+        reportError(name, error);
+        action();
+        return;
+      }
+
+      activeOperation = name;
+      const startMs = runtime.now();
+      try {
+        const result = action();
+        if (isPromiseLike(result)) {
+          void result.then(
+            (evidence) => finishMeasurement(name, startMs, preState, evidence),
+            (error) => {
+              reportError(name, error);
+              activeOperation = null;
+            }
+          );
+        } else {
+          void finishMeasurement(name, startMs, preState, result);
+        }
+      } catch (error) {
+        reportError(name, error);
+        activeOperation = null;
+        throw error;
+      }
+    },
+
+    async runStorm(
+      ticks: number,
+      step: (tick: number) => void
+    ): Promise<StormEvidence> {
+      let completedTicks = 0;
+      let renderBarriers = 0;
+      for (let tick = 1; tick <= ticks; tick++) {
+        await new Promise<void>((resolve) => runtime.setTimeout(resolve));
+        step(tick);
+        completedTicks = tick;
+        await nextFrame();
+        renderBarriers++;
+      }
+      return { expectedTicks: ticks, completedTicks, renderBarriers };
+    },
+
+    beginStartup(): StartupObservation | null {
+      if (!runtime.native) return null;
+      const observation: StartupObservation = {
+        protocol: NATIVE_STARTUP_PROTOCOL,
+        moduleStartMs: runtime.now(),
+        renderEvidence: { kind: 'native-animation-frame', frames: 2 },
+      };
+      runtime.globalObject.__LYNX_BENCH_STARTUP__ = observation;
+      return observation;
+    },
+
+    finishStartup(observation: StartupObservation | null): void {
+      if (!observation) return;
+      void (async () => {
+        try {
+          observation.firstFrameMs = await nextFrame();
+          observation.secondFrameMs = await nextFrame();
+          observation.postState = snapshot();
+          runtime.report(
+            '__NATIVE_BENCH_STARTUP__',
+            JSON.stringify(observation)
+          );
+        } catch (error) {
+          reportError('startup', error);
+        }
+      })();
+    },
+  };
+}
+
+export const nativeBenchmark = createNativeBenchmarkProtocol();


### PR DESCRIPTION
## Summary

- add a shared, versioned Native table/startup producer protocol for the Vue VDOM, Vue Vapor, and ReactLynx benchmark fixtures
- measure real Native tap-handler entry through two `lynx.requestAnimationFrame` callbacks with pre/post framework-state evidence
- make Native storms use `lynx.setTimeout` and prove one render barrier for every completed tick while preserving the existing Lynx-for-Web workload
- mark the startup root with the public `__lynx_timing_flag` and keep the two-frame producer receipt explicitly separate from host PipelineEntry/FCP evidence

This supplies the missing producer side for Huxpro/octane#289. It does not make a performance claim by itself.

## Evidence

- `pnpm --dir packages/benchmark test:native-protocol` — 6/6 pass
- production builds pass for Vue VDOM default / ET / IFR+ET, Vue Vapor default / IFR, ReactLynx default, and ReactLynx typed ET
- `bench:cross:quick` passes for VDOM / Vapor / React on Lynx for Web (all table actions and startup)
- official Lynx Explorer 4.1.0 Native diagnostics pass all table cases for Vue ET and ReactLynx ET, including 50/50 update-storm and 30/30 select-storm barriers
- the startup timing flag produces a real Vue engine `PipelineEntry`; it does not expose `lynxFcp`/`totalFcp`, so the current host still reports the FCP metric as DNF instead of relabeling the producer receipt

## Checks

- `git diff --check`
- generated Vapor App matches the VDOM source transform
- `pnpm lint` reaches the repository-wide baseline and reports the same five unrelated existing errors in `matrix.ts`, `vapor-addressing.ts`, and `ops-apply.ts`; none are under `packages/benchmark`

## Measurement contract

- instrumentation errors emit `__NATIVE_BENCH_ERROR__` and invalidate only the sample; the real UI action still runs
- framework state and storm tick counts are mandatory evidence
- transport acknowledgement remains `not-exposed`/`false`
- startup FCP/settled claims require matching Lynx engine performance entries

## Provenance

- [x] An agent produced this diff (`agent-authored`)
