### PR TITLE
feat(benchmark): add native list fixtures

### DIFF
--- a/packages/benchmark/apps/ui-react/lynx.config.ts
+++ b/packages/benchmark/apps/ui-react/lynx.config.ts
@@ -6,6 +6,10 @@ import { defineConfig } from '@lynx-js/rspeedy';
 // variable explicitly and records the selected capability in its manifest.
 const useElementTemplate = process.env.BENCH_ENABLE_ET === '1';
 const autoRows = Number(process.env.BENCH_AUTOROWS ?? '0');
+const listRows = Number(process.env.BENCH_LIST_ROWS ?? '0');
+if (autoRows > 0 && listRows > 0) {
+  throw new TypeError('BENCH_AUTOROWS and BENCH_LIST_ROWS are mutually exclusive.');
+}
 
 export default defineConfig({
   environments: {
@@ -14,12 +18,14 @@ export default defineConfig({
   },
   source: {
     entry: {
-      main: './src/index.tsx',
+      main: listRows > 0 ? './src/list-index.tsx' : './src/index.tsx',
     },
     define: {
       __BENCH_AUTOROWS__: JSON.stringify(autoRows),
+      __BENCH_LIST_ROWS__: JSON.stringify(listRows),
     },
   },
+  output: listRows > 0 ? { distPath: { root: `dist-list-rows${listRows}` } } : {},
   plugins: [
     pluginReactLynx({
       experimental_useElementTemplate: useElementTemplate,

--- a/packages/benchmark/apps/ui-react/src/List.css
+++ b/packages/benchmark/apps/ui-react/src/List.css
@@ -1,0 +1,35 @@
+.bench-list-page {
+  width: 390px;
+  height: 640px;
+  background-color: #fff;
+}
+
+.bench-list-viewport {
+  width: 390px;
+  height: 640px;
+}
+
+.bench-list-cell {
+  width: 390px;
+  height: 40px;
+}
+
+.bench-list-cell-body {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 390px;
+  height: 40px;
+  padding: 0 8px;
+}
+
+.bench-list-key {
+  width: 92px;
+  font-size: 12px;
+  color: #333;
+}
+
+.bench-list-label {
+  font-size: 12px;
+  color: #111;
+}

--- a/packages/benchmark/apps/ui-react/src/ListApp.tsx
+++ b/packages/benchmark/apps/ui-react/src/ListApp.tsx
@@ -1,0 +1,42 @@
+import './List.css';
+
+declare const __BENCH_LIST_ROWS__: number;
+
+interface ListRowData {
+  readonly id: string;
+  readonly label: string;
+}
+
+const rows: readonly ListRowData[] = Array.from(
+  { length: __BENCH_LIST_ROWS__ },
+  (_, index) => ({ id: `row-${index}`, label: `Row ${index}` }),
+);
+
+export function ListApp() {
+  return (
+    <view className='bench-list-page'>
+      <list
+        className='bench-list-viewport'
+        list-type='single'
+        span-count={1}
+        preload-buffer-count={2}
+        scroll-orientation='vertical'
+      >
+        {rows.map((row) => (
+          <list-item
+            key={row.id}
+            className='bench-list-cell'
+            item-key={row.id}
+            reuse-identifier='bench-list-row'
+            estimated-main-axis-size-px={40}
+          >
+            <view className='bench-list-cell-body'>
+              <text className='bench-list-key'>{row.id}</text>
+              <text className='bench-list-label'>{row.label}</text>
+            </view>
+          </list-item>
+        ))}
+      </list>
+    </view>
+  );
+}

--- a/packages/benchmark/apps/ui-react/src/list-index.tsx
+++ b/packages/benchmark/apps/ui-react/src/list-index.tsx
@@ -1,0 +1,5 @@
+import { root } from '@lynx-js/react';
+
+import { ListApp } from './ListApp';
+
+root.render(<ListApp />);

--- a/packages/benchmark/apps/ui-vapor/lynx.config.ts
+++ b/packages/benchmark/apps/ui-vapor/lynx.config.ts
@@ -22,6 +22,10 @@ import { pluginVueLynx } from 'vue-lynx/plugin';
  */
 const cell = process.env.BENCH_CELL ?? 'off';
 const autoRows = Number(process.env.BENCH_AUTOROWS ?? '0');
+const listRows = Number(process.env.BENCH_LIST_ROWS ?? '0');
+if (autoRows > 0 && listRows > 0) {
+  throw new TypeError('BENCH_AUTOROWS and BENCH_LIST_ROWS are mutually exclusive.');
+}
 const enableIFR =
   cell === 'ifr' || cell === 'ifr-dense' || cell === 'ifr-sparse'
   || cell === 'ifr-engine-et' || cell === 'ifr-code-paint';
@@ -41,7 +45,8 @@ const ifrPaint = cell === 'ifr-engine-et'
   ? 'code-paint' as const
   : undefined;
 const modeLabel = cell === 'off' ? 'vapor' : `vapor-${cell}`;
-const distRoot = cell === 'off' ? 'dist' : `dist-${cell}`;
+const distRoot = (cell === 'off' ? 'dist' : `dist-${cell}`)
+  + (listRows > 0 ? `-list-rows${listRows}` : '');
 
 export default defineConfig({
   environments: {
@@ -55,11 +60,12 @@ export default defineConfig({
   },
   source: {
     entry: {
-      main: './src/index.ts',
+      main: listRows > 0 ? './src/list-index.ts' : './src/index.ts',
     },
     define: {
       __BENCH_MODE__: JSON.stringify(modeLabel),
       __BENCH_AUTOROWS__: JSON.stringify(autoRows),
+      __BENCH_LIST_ROWS__: JSON.stringify(listRows),
     },
   },
   plugins: [

--- a/packages/benchmark/apps/ui-vapor/src/ListApp.vue
+++ b/packages/benchmark/apps/ui-vapor/src/ListApp.vue
@@ -1,0 +1,68 @@
+<!-- GENERATED from apps/ui-vdom/src/ListApp.vue — do not edit -->
+<script setup vapor lang="ts">
+declare const __BENCH_LIST_ROWS__: number
+
+const rows = Array.from(
+  { length: __BENCH_LIST_ROWS__ },
+  (_, index) => ({ id: `row-${index}`, label: `Row ${index}` }),
+)
+</script>
+
+<template>
+  <view class="bench-list-page">
+    <list
+      class="bench-list-viewport"
+      list-type="single"
+      :span-count="1"
+      :preload-buffer-count="2"
+      scroll-orientation="vertical"
+    >
+      <list-item
+        v-for="row in rows"
+        :key="row.id"
+        class="bench-list-cell"
+        :item-key="row.id"
+        reuse-identifier="bench-list-row"
+        :estimated-main-axis-size-px="40"
+      >
+        <view class="bench-list-cell-body">
+          <text class="bench-list-key">{{ row.id }}</text>
+          <text class="bench-list-label">{{ row.label }}</text>
+        </view>
+      </list-item>
+    </list>
+  </view>
+</template>
+
+<style>
+.bench-list-page {
+  width: 390px;
+  height: 640px;
+  background-color: #fff;
+}
+.bench-list-viewport {
+  width: 390px;
+  height: 640px;
+}
+.bench-list-cell {
+  width: 390px;
+  height: 40px;
+}
+.bench-list-cell-body {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 390px;
+  height: 40px;
+  padding: 0 8px;
+}
+.bench-list-key {
+  width: 92px;
+  font-size: 12px;
+  color: #333;
+}
+.bench-list-label {
+  font-size: 12px;
+  color: #111;
+}
+</style>

--- a/packages/benchmark/apps/ui-vapor/src/list-index.ts
+++ b/packages/benchmark/apps/ui-vapor/src/list-index.ts
@@ -1,0 +1,6 @@
+import { createApp } from 'vue-lynx/vapor';
+
+// @ts-expect-error .vue resolution is handled by the bundler
+import ListApp from './ListApp.vue';
+
+createApp(ListApp).mount();

--- a/packages/benchmark/apps/ui-vdom/lynx.config.ts
+++ b/packages/benchmark/apps/ui-vdom/lynx.config.ts
@@ -7,6 +7,10 @@ import { pluginVueLynx } from 'vue-lynx/plugin';
 // create-benefit cell (#321/#325).
 const cell = process.env.BENCH_CELL ?? 'off';
 const autoRows = Number(process.env.BENCH_AUTOROWS ?? '0');
+const listRows = Number(process.env.BENCH_LIST_ROWS ?? '0');
+if (autoRows > 0 && listRows > 0) {
+  throw new TypeError('BENCH_AUTOROWS and BENCH_LIST_ROWS are mutually exclusive.');
+}
 const enableIFR = cell === 'ifr' || cell === 'ifr-et';
 const enableElementTemplates = cell === 'ifr-et' || cell === 'et';
 const modeLabel =
@@ -18,13 +22,13 @@ const modeLabel =
     ? 'vdom-et'
     : 'vdom-ifr-et';
 const distRoot =
-  cell === 'off'
+  (cell === 'off'
     ? 'dist'
     : cell === 'ifr'
     ? 'dist-ifr'
     : cell === 'et'
     ? 'dist-et'
-    : 'dist-ifr-et';
+    : 'dist-ifr-et') + (listRows > 0 ? `-list-rows${listRows}` : '');
 
 export default defineConfig({
   environments: {
@@ -38,11 +42,12 @@ export default defineConfig({
   },
   source: {
     entry: {
-      main: './src/index.ts',
+      main: listRows > 0 ? './src/list-index.ts' : './src/index.ts',
     },
     define: {
       __BENCH_MODE__: JSON.stringify(modeLabel),
       __BENCH_AUTOROWS__: JSON.stringify(autoRows),
+      __BENCH_LIST_ROWS__: JSON.stringify(listRows),
     },
   },
   plugins: [

--- a/packages/benchmark/apps/ui-vdom/src/ListApp.vue
+++ b/packages/benchmark/apps/ui-vdom/src/ListApp.vue
@@ -1,0 +1,67 @@
+<!-- BENCH_LIST_MODE_SCRIPT --><script setup lang="ts">
+declare const __BENCH_LIST_ROWS__: number
+
+const rows = Array.from(
+  { length: __BENCH_LIST_ROWS__ },
+  (_, index) => ({ id: `row-${index}`, label: `Row ${index}` }),
+)
+</script>
+
+<template>
+  <view class="bench-list-page">
+    <list
+      class="bench-list-viewport"
+      list-type="single"
+      :span-count="1"
+      :preload-buffer-count="2"
+      scroll-orientation="vertical"
+    >
+      <list-item
+        v-for="row in rows"
+        :key="row.id"
+        class="bench-list-cell"
+        :item-key="row.id"
+        reuse-identifier="bench-list-row"
+        :estimated-main-axis-size-px="40"
+      >
+        <view class="bench-list-cell-body">
+          <text class="bench-list-key">{{ row.id }}</text>
+          <text class="bench-list-label">{{ row.label }}</text>
+        </view>
+      </list-item>
+    </list>
+  </view>
+</template>
+
+<style>
+.bench-list-page {
+  width: 390px;
+  height: 640px;
+  background-color: #fff;
+}
+.bench-list-viewport {
+  width: 390px;
+  height: 640px;
+}
+.bench-list-cell {
+  width: 390px;
+  height: 40px;
+}
+.bench-list-cell-body {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 390px;
+  height: 40px;
+  padding: 0 8px;
+}
+.bench-list-key {
+  width: 92px;
+  font-size: 12px;
+  color: #333;
+}
+.bench-list-label {
+  font-size: 12px;
+  color: #111;
+}
+</style>

--- a/packages/benchmark/apps/ui-vdom/src/list-index.ts
+++ b/packages/benchmark/apps/ui-vdom/src/list-index.ts
@@ -1,0 +1,6 @@
+import { createApp } from 'vue-lynx';
+
+// @ts-expect-error .vue resolution is handled by the bundler
+import ListApp from './ListApp.vue';
+
+createApp(ListApp).mount();


### PR DESCRIPTION
## Summary
- add production ReactLynx, Vue VDOM, and Vue Vapor `<list>` fixtures at 1k/10k scales
- keep `key` and `item-key` identical and freeze a 390×640 viewport with two-row preload buffer
- add mutually exclusive `BENCH_LIST_ROWS` build selection and scale-specific output directories

## Validation
- `CI=true corepack pnpm@10.28.2 install --frozen-lockfile --ignore-scripts`
- `BENCH_ROWS=0 node ../lynx-benchmark-list-291/scripts/build-vue-m4.mjs .` (18 production cells, including 12 list cells)
- `git diff --check`

Benchmark-only; no published package or runtime behavior changes.